### PR TITLE
Fix: client app self hosting installation steps request parameters and runtime errors.

### DIFF
--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -163,9 +163,8 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 .idea/
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+
+
+Pipfile
+Pipfile.lock
+run.py

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -17,3 +17,4 @@ faker
 requests
 pyyaml
 sentry-sdk[fastapi]
+pydantic[email]>=1.8.0,<2.0.0

--- a/apps/api/src/db/users.py
+++ b/apps/api/src/db/users.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, EmailStr
 from sqlmodel import Field, SQLModel
 
 from src.db.roles import RoleRead
@@ -10,12 +10,14 @@ class UserBase(SQLModel):
     username: str
     first_name: str
     last_name: str
-    email: str
+    email: EmailStr
     avatar_image: Optional[str] = ""
     bio: Optional[str] = ""
 
 
 class UserCreate(UserBase):
+    first_name: str = ""
+    last_name: str = ""
     password: str
 
 

--- a/apps/api/src/routers/install/install.py
+++ b/apps/api/src/routers/install/install.py
@@ -41,33 +41,30 @@ async def api_get_latest_install_instance(
 
 @router.post("/default_elements")
 async def api_install_def_elements(
-    request: Request,
     db_session=Depends(get_db_session),
 ):
-    elements = await install_default_elements(request, {}, db_session)
+    elements = await install_default_elements(db_session)
 
     return elements
 
 
 @router.post("/org")
 async def api_install_org(
-    request: Request,
-    org: OrganizationCreate,
-    db_session=Depends(get_db_session),
+        org: OrganizationCreate,
+        db_session=Depends(get_db_session),
 ):
-    organization = await install_create_organization(request, org, db_session)
+    organization = await install_create_organization(org, db_session)
 
     return organization
 
 
 @router.post("/user")
 async def api_install_user(
-    request: Request,
     data: UserCreate,
     org_slug: str,
     db_session=Depends(get_db_session),
 ):
-    user = await install_create_organization_user(request, data, org_slug, db_session)
+    user = await install_create_organization_user(data, org_slug, db_session)
 
     return user
 

--- a/apps/api/src/services/install/install.py
+++ b/apps/api/src/services/install/install.py
@@ -93,7 +93,9 @@ async def update_install_instance(
 
 
 # Install Default roles
-async def install_default_elements( data: dict, db_session: Session):
+async def install_default_elements(db_session: Session):
+    """
+    """
     # remove all default roles
     statement = select(Role).where(Role.role_type == RoleTypeEnum.TYPE_GLOBAL)
     roles = db_session.exec(statement).all()
@@ -315,7 +317,7 @@ async def install_create_organization_user(
 
     if not org.first():
         raise HTTPException(
-            status_code=400,
+            status_code=409,
             detail="Organization does not exist",
         )
 
@@ -325,7 +327,7 @@ async def install_create_organization_user(
 
     if result.first():
         raise HTTPException(
-            status_code=400,
+            status_code=409,
             detail="Username already exists",
         )
 
@@ -335,7 +337,7 @@ async def install_create_organization_user(
 
     if result.first():
         raise HTTPException(
-            status_code=400,
+            status_code=409,
             detail="Email already exists",
         )
 

--- a/apps/api/src/services/install/install.py
+++ b/apps/api/src/services/install/install.py
@@ -31,7 +31,7 @@ async def create_install_instance(request: Request, data: dict, db_session: Sess
     install.install_uuid = str(f"install_{uuid4()}")
     install.update_date = str(datetime.now())
     install.creation_date = str(datetime.now())
-
+    install.step = 1
     # insert install instance
     db_session.add(install)
 

--- a/apps/web/app/install/steps/account_creation.tsx
+++ b/apps/web/app/install/steps/account_creation.tsx
@@ -61,14 +61,12 @@ function AccountCreation() {
             username: '',
         },
         validate,
-        onSubmit: values => {
+        onSubmit: async values => {
             
-            let finalvalues = { ...values, org_slug: install.data[1].slug }
             let finalvalueswithoutpasswords = { ...values, password: '', confirmPassword: '', org_slug: install.data[1].slug }
-            let install_data = { ...install.data, 3: finalvalues }
             let install_data_without_passwords = { ...install.data, 3: finalvalueswithoutpasswords }
-            updateInstall({ ...install_data_without_passwords }, 4)
-            createNewUserInstall(finalvalues)
+            await updateInstall({ ...install_data_without_passwords }, 4)
+            await createNewUserInstall({email:values.email,username:values.username,password:values.password},install.data[1].slug)
 
             // await 2 seconds
             setTimeout(() => {

--- a/apps/web/services/install/install.ts
+++ b/apps/web/services/install/install.ts
@@ -13,8 +13,8 @@ export async function createNewOrgInstall(body: any) {
   return res;
 }
 
-export async function createNewUserInstall(body: any) {
-  const result = await fetch(`${getAPIUrl()}install/user?org_slug=${body.org_slug}`, RequestBody("POST", body, null));
+export async function createNewUserInstall(body: any,org_slug:string) {
+  const result = await fetch(`${getAPIUrl()}install/user?org_slug=${org_slug}`, RequestBody("POST", body, null));
   const res = await errorHandling(result);
   return res;
 }


### PR DESCRIPTION
**Step 1, 2,3** of /install route had mismatched parameters that resulted in a runtime error in the API routes.

**Step 3's** contained unsatisfied request parameters i.e. first_name and last_name inherited from in a pydantic class and were not accommodated on the client side app in step 3. These are replaced with default parameters on the model.
