### PR TITLE
fixed-menubar-scrolling on small devices

### DIFF
--- a/apps/web/components/Objects/Menu/Menu.tsx
+++ b/apps/web/components/Objects/Menu/Menu.tsx
@@ -24,7 +24,9 @@ export const Menu = (props: any) => {
       <div className="backdrop-blur-lg h-[60px] blur-3xl -z-10" style={{}}>
         
       </div>
-      <div className="backdrop-blur-lg bg-white/90 fixed flex top-0 left-0 right-0 h-[60px] ring-1 ring-inset ring-gray-500/10 items-center space-x-5 shadow-[0px_4px_16px_rgba(0,0,0,0.03)] z-50">
+      <div className="backdrop-blur-lg bg-white/90 fixed flex top-0 left-0 right-0 ring-1 overflow-x-scroll overflow-auto h-[70px] my-auto 
+      scrollbar scrollbar-thumb-white/20 scrollbar-thumb-rounded-full scrollbar-track-rounded-full 
+      ring-inset ring-gray-500/10 items-center space-x-5 shadow-[0px_4px_16px_rgba(0,0,0,0.03)] z-50">
         <div className="flex items-center space-x-5 w-full max-w-screen-2xl mx-auto px-16">
           <div className="logo flex ">
             <Link href={getUriWithOrg(orgslug, '/')}>


### PR DESCRIPTION
what does this PR do : 
it fixes the menu bar which is used in multiple places which is unscrollable on smaller devices/mobile view 

it's a small one line fix but it was important that it's present so thatusers can scroll even on smaller devices! 

Before : 

![before pt2](https://github.com/user-attachments/assets/db823dfc-b29f-4768-af37-b4796dd19c15)

After : 

![afterlast](https://github.com/user-attachments/assets/62145274-5758-42ae-ad39-0656645b30b6)
