### PR TITLE
chore: fix stale dev doc links, add docker disclaimer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,11 @@
 
 Use the Docker Image available in `./Dockerfile`
 
+> Make sure your container runtime has at least 4GB of RAM allocated, as default settings may vary by tool.
+
     docker-compose up -d
 
-Initiate a dev environment, please check the official guide [here](https://docs.learnhouse.app/technical-docs/dev-env)
+Initiate a dev environment, please check the official guide [here](https://docs.learnhouse.app/setup-dev-environment)
 
 ## Frontend Codebase
 
@@ -36,11 +38,11 @@ Use the Docker Image available in `front/Dockerfile`, or install the frontend pa
 
 #### Start the Backend server first
 
-You need to have the backend running, to initiate a dev environment please check the official guide [here](https://docs.learnhouse.app/technical-docs/dev-env)
+You need to have the backend running, to initiate a dev environment please check the official guide [here](https://docs.learnhouse.app/setup-dev-environment)
 
 #### Environment Files
 
-Please check if you initiated your `.env` files, here is a [guide](https://docs.learnhouse.app/technical-docs/dev-env) on how to do it.
+Please check if you initiated your `.env` files, here is a [guide](https://docs.learnhouse.app/setup-dev-environment) on how to do it.
 
 #### Install the frontend package
 


### PR DESCRIPTION
 Hey team! I was getting setup with my local dev environment, and had some hiccups on the way. I fixed two things:

1. `CONTRIBUTING.md` dev docs links now go to the correct URL
2.  Adds explicit disclaimer to prevent [#392](https://github.com/learnhouse/learnhouse/issues/329). I ran across this issue as well. I am using `colima` which by default only allocates 2GB of ram. Increasing memory limit to 4GB solved the issue.

Additionally, I went ahead and made changes over on the docs repo that addresses some env variables problems I had over at PR [#38](https://github.com/learnhouse/docs/pull/38)

Looking forward to contribute!