### PR TITLE
`EditorTop` takes all available space on Firefox-based browsers

### DIFF
--- a/apps/web/components/Objects/Editor/Editor.tsx
+++ b/apps/web/components/Objects/Editor/Editor.tsx
@@ -338,6 +338,7 @@ const EditorTop = styled.div`
   position: fixed;
   z-index: 303;
   width: -webkit-fill-available;
+  width: -moz-available;
 `
 
 // Inside EditorTop


### PR DESCRIPTION
Solves #342 

## Issue (Reason)

According to [icanuse entry on the fill-available](https://caniuse.com/?search=fill%20available) (AKA stretch) style, support is there for most browsers but the naming without prefixing hasn't been agreed upon for whatever reason. 

## Solution

For now, we can just declare a separate width style that targets Firefox-based browsers specifically with `-moz-available` and it works as expected.