### PR TITLE
fix: fix bad request made to course updates endpoint

### DIFF
--- a/apps/web/components/Contexts/CourseContext.tsx
+++ b/apps/web/components/Contexts/CourseContext.tsx
@@ -17,7 +17,9 @@ export function CourseProvider({ children, courseuuid }: any) {
   );
 
   const initialState = {
-    courseStructure: {},
+    courseStructure: {
+      course_uuid: courseuuid,
+    },
     courseOrder: {},
     isSaved: true,
     isLoading: true


### PR DESCRIPTION
Close: #352 

Fix bad request made to course updates endpoint because the initial values of courseStructure for the first time when loading page is {}, so course_uuid will be undefined.