### PR TITLE
fix: Added border for selector

### DIFF
--- a/apps/web/components/Objects/Modals/Dash/OrgAccess/OrgInviteCodeGenerate.tsx
+++ b/apps/web/components/Objects/Modals/Dash/OrgAccess/OrgInviteCodeGenerate.tsx
@@ -61,7 +61,7 @@ function OrgInviteCodeGenerate(props: OrgInviteCodeGenerateProps) {
                             <div className='flex space-x-4 items-center'>
                                 <select
                                     defaultValue={usergroup_id}
-                                    className='flex p-2 w-fit  rounded-md text-sm bg-gray-100'>
+                                    className='flex p-2 w-fit  rounded-md text-sm bg-gray-100 border-2 border-slate-300'>
                                     {usergroups?.map((usergroup: any) => (
                                         <option key={usergroup.id} value={usergroup.id}>
                                             {usergroup.name}


### PR DESCRIPTION
Added a border for the user group selector in the generating invitation modal.
This would improve the UX as the selector was barely noticeable without a border. 

Refer to the following page to see the issue : /dash/users/settings/signups
Change the Join method to "Closed" and hit Generate invite code