### PR TITLE
fix: Invite only signup: Do not redirect to `/login` without orgslug

### DIFF
--- a/apps/web/app/auth/signup/InviteOnlySignUp.tsx
+++ b/apps/web/app/auth/signup/InviteOnlySignUp.tsx
@@ -52,6 +52,7 @@ interface InviteOnlySignUpProps {
 function InviteOnlySignUpComponent(props: InviteOnlySignUpProps) {
   const [isSubmitting, setIsSubmitting] = React.useState(false)
   const org = useOrg() as any
+
   const router = useRouter()
   const [error, setError] = React.useState('')
   const [message, setMessage] = React.useState('')
@@ -110,10 +111,15 @@ function InviteOnlySignUpComponent(props: InviteOnlySignUpProps) {
             <div className="font-bold text-sm">{message}</div>
           </div>
           <hr className="border-green-900/20 800 w-40 border" />
+<<<<<<< Updated upstream
           <Link className="flex space-x-2 items-center" href={
             `/login?orgslug=${org?.slug}`
           } >
             <User size={14} /> <div>Login to your account</div>
+=======
+          <Link className="flex space-x-2 items-center" href={`/login?orgslug=${org.slug}`}>
+            <User size={14} /> <div>Login </div>
+>>>>>>> Stashed changes
           </Link>
         </div>
       )}


### PR DESCRIPTION
Hello,
when setting the instance to invite-only and performing a signup, the message `successfully signed up, want to login` appears as expected.

However, when clicking the `login` button, an error is thrown since the old button did not include the orgslug.
This PR fixes this issue.