### PR TITLE
Quick fixes for smoother self-hosting/local dev

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+extra/start.sh text eol=lf

--- a/apps/api/app.py
+++ b/apps/api/app.py
@@ -39,8 +39,10 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-logfire.configure(console=False, service_name=learnhouse_config.site_name,)
-logfire.instrument_fastapi(app)
+### Disable Logfire telemetry by default for local/dev use as it keeps the backend from starting. ###
+### In a production build, Logfire might be useful ###
+# logfire.configure(console=False, service_name=learnhouse_config.site_name,)
+# logfire.instrument_fastapi(app)
 
 # Gzip Middleware (will add brotli later)
 app.add_middleware(GZipMiddleware, minimum_size=1000)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - .:/usr/learnhouse
     env_file:
-      - ./extra/example-learnhouse-conf.env
+      - ./extra/.env
     depends_on:
       db:
         condition: service_healthy

--- a/extra/example-learnhouse-conf.env
+++ b/extra/example-learnhouse-conf.env
@@ -4,8 +4,12 @@ NEXT_PUBLIC_LEARNHOUSE_DEFAULT_ORG=default
 NEXT_PUBLIC_LEARNHOUSE_TOP_DOMAIN=localhost
 NEXTAUTH_SECRET=changeme
 NEXTAUTH_URL=http://localhost
+
 # Backend
 LEARNHOUSE_COOKIE_DOMAIN=.localhost
 LEARNHOUSE_SQL_CONNECTION_STRING=postgresql://learnhouse:learnhouse@db:5432/learnhouse
 LEARNHOUSE_REDIS_CONNECTION_STRING=redis://redis:6379/learnhouse
 LEARNHOUSE_CHROMADB_HOST=chromadb
+
+# Disable Logfire telemetry by default for local/dev use.
+LOGFIRE_IGNORE_NO_CONFIG=1

--- a/extra/start.sh
+++ b/extra/start.sh
@@ -2,7 +2,7 @@
 
 # Start the services
 pm2 start server.js --cwd /app/web --name learnhouse-web > /dev/null 2>&1
-pm2 start app.py --cwd /app/api --name learnhouse-api > /dev/null 2>&1
+pm2 start app.py --cwd /app/api --interpreter /app/api/.venv/bin/python --name learnhouse-api > /dev/null 2>&1
 
 # Check if the services are running qnd log the status
 pm2 status


### PR DESCRIPTION
Addressing several issues for a smoother self-hosting experience on Windows.

- Line endings: Converted`extra/start.sh` to use LF line endings for compatibility with Linux-based Docker containers. Added a `.gitattribute` to make sure Git doesn't automatically convert LF to CRLF on checkout. Should fix #465 
- Python environment: Ensured backend is started with Python in `.venv`, preventing missing dependency errors in Docker.
- Logfire: Commented out Logfire for local dev. This caused learnhouse-api to keep crashing due to Logfire auth error.