### PR TITLE
fix: use uv to run learnhouse-api with dependencies

### DIFF
--- a/extra/start.sh
+++ b/extra/start.sh
@@ -2,7 +2,7 @@
 
 # Start the services
 pm2 start server.js --cwd /app/web --name learnhouse-web > /dev/null 2>&1
-pm2 start app.py --cwd /app/api --name learnhouse-api > /dev/null 2>&1
+pm2 start uv --cwd /app/api --name learnhouse-api -- run app.py 2>&1
 
 # Check if the services are running qnd log the status
 pm2 status


### PR DESCRIPTION
Currently spinning up a fresh build fails with unresolved dependencies although `uv sync -v` tells they are all satisfied

> app-1       | 1|learnhouse-api  | ModuleNotFoundError: No module named 'uvicorn'
> app-1       | PM2               | App [learnhouse-api:1] exited with code [1] via signal [SIGINT]
> app-1       | PM2               | Script /app/api/app.py had too many unstable restarts (16). Stopped. "errored"

Changing the `PM2` startup script from plain python interpreter to `uv run` makes sure the synced dependencies are correctly used

<img width="1026" alt="Screenshot 2025-06-01 at 18 28 15" src="https://github.com/user-attachments/assets/076508d7-ee6a-4228-af0d-5096b743d778" />
