### PR TITLE
fix: ensure chapter_id is a string

### DIFF
--- a/apps/web/services/courses/activities.ts
+++ b/apps/web/services/courses/activities.ts
@@ -72,7 +72,7 @@ export async function createExternalVideoActivity(
   access_token: string
 ) {
   // add coursechapter_id to data
-  data.chapter_id = chapter_id
+  data.chapter_id = String(chapter_id)
   data.activity_id = activity.id
   
   // Add video details with null checking


### PR DESCRIPTION
## Bug Fix: External Video Activity Creation - Type Mismatch

### Problem
API endpoint `/activities/external_video` was returning `422 Unprocessable Entity` error when creating external video activities.

**Error Details:**
```json
{
    "detail": [
        {
            "type": "string_type",
            "loc": ["body", "chapter_id"],
            "msg": "Input should be a valid string",
            "input": 1
        }
    ]
}
```

### Root Cause
The backend API expects `chapter_id` as a **string** type, but the frontend was sending it as a **number/integer**.