### PR TITLE
fix: use main landmark for page content areas

### DIFF
--- a/apps/web/app/orgs/[orgslug]/dash/ClientAdminLayout.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/ClientAdminLayout.tsx
@@ -24,7 +24,7 @@ function ClientAdminLayout({
                     ) : (
                         <DashLeftMenu />
                     )}
-                    <div className="flex w-full relative isolate">{children}</div>
+                    <main className="flex w-full relative isolate">{children}</main>
                 </div>
             </AdminAuthorization>
         </SessionProvider>

--- a/apps/web/app/orgs/[orgslug]/layout.tsx
+++ b/apps/web/app/orgs/[orgslug]/layout.tsx
@@ -39,7 +39,9 @@ export default async function RootLayout(props: {
       <OrgProvider orgslug={params.orgslug}>
         <NextTopLoader color="#2e2e2e" initialPosition={0.3} height={4} easing={'ease'} speed={500} showSpinner={false} />
         <Toast />
-        {props.children}
+        <main>
+          {props.children}
+        </main>
         <Footer />
       </OrgProvider>
     </div>


### PR DESCRIPTION
## Summary
- Wraps `{children}` in `<main>` in `app/orgs/[orgslug]/layout.tsx` so the page content area is identifiable as a landmark
- Replaces the content wrapper `<div>` with `<main>` in `app/orgs/[orgslug]/dash/ClientAdminLayout.tsx`

Screen reader users rely on landmarks (`<main>`, `<nav>`, `<footer>`, etc.) to jump between page sections. These content areas were previously generic `<div>` elements, invisible to assistive technology navigation.

Closes #652

## Test plan
- [ ] Verify org pages render correctly with the new `<main>` element
- [ ] Verify the admin dashboard layout renders correctly
- [ ] Use a screen reader or browser accessibility inspector to confirm a `main` landmark appears in the landmarks list