### PR TITLE
fix: use main landmark for page content areas

### DIFF
--- a/apps/web/app/admin/(dashboard)/layout.tsx
+++ b/apps/web/app/admin/(dashboard)/layout.tsx
@@ -12,7 +12,7 @@ export default function AdminDashboardLayout({
     <SuperadminAuthorization>
       <div className="min-h-screen bg-[#0f0f10]">
         <AdminTopMenu />
-        <div>{children}</div>
+        <main>{children}</main>
       </div>
     </SuperadminAuthorization>
   )

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/layout.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/layout.tsx
@@ -75,9 +75,9 @@ function LayoutContent({ children, orgslug }: { children: React.ReactNode; orgsl
       <PageViewTracker />
       <OrgJoinBanner />
       <OrgMenu orgslug={orgslug} />
-      <div className="flex-1 relative" style={{ zIndex: 'var(--z-content)' }}>
+      <main className="flex-1 relative" style={{ zIndex: 'var(--z-content)' }}>
         {children}
-      </div>
+      </main>
       {!isFullBleedPage && <OrgFooter />}
       {!isFullBleedPage && <Watermark />}
     </div>

--- a/apps/web/app/orgs/[orgslug]/dash/ClientAdminLayout.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/ClientAdminLayout.tsx
@@ -24,7 +24,7 @@ function ClientAdminLayout({
                     ) : (
                         <DashLeftMenu />
                     )}
-                    <div className="flex w-full relative isolate">{children}</div>
+                    <main className="flex w-full relative isolate">{children}</main>
                 </div>
             </AdminAuthorization>
         </SessionProvider>

--- a/apps/web/app/orgs/[orgslug]/layout.tsx
+++ b/apps/web/app/orgs/[orgslug]/layout.tsx
@@ -35,13 +35,13 @@ export default async function RootLayout(props: {
   const params = await props.params
 
   return (
-    <div>
+    <main>
       <OrgProvider orgslug={params.orgslug}>
         <NextTopLoader color="#2e2e2e" initialPosition={0.3} height={4} easing={'ease'} speed={500} showSpinner={false} />
         <Toast />
         {props.children}
         <Footer />
       </OrgProvider>
-    </div>
+    </main>
   )
 }


### PR DESCRIPTION
## Summary

- Replaced generic `<div>` content wrappers with semantic `<main>` landmark elements across all layout files
- Screen reader users rely on landmarks to navigate between page sections — this change makes the app properly navigable with assistive technology

## Files Changed

| File | Change |
|---|---|
| `app/orgs/[orgslug]/layout.tsx` | Outer `<div>` → `<main>` |
| `app/orgs/[orgslug]/dash/ClientAdminLayout.tsx` | Content wrapper `<div>` → `<main>` |
| `app/orgs/[orgslug]/(withmenu)/layout.tsx` | Content area `<div>` → `<main>` |
| `app/admin/(dashboard)/layout.tsx` | Children wrapper `<div>` → `<main>` |

## Test Plan

- [ ] Verify pages render correctly in browser
- [ ] Run screen reader (VoiceOver/NVDA) and confirm `main` landmark is detected
- [ ] Check no duplicate `<main>` landmarks exist on any page

Fixes #652