### PR TITLE
fix: use ul/li list structure for navigation items

### DIFF
--- a/apps/web/components/Dashboard/Menus/DashLeftMenu.tsx
+++ b/apps/web/components/Dashboard/Menus/DashLeftMenu.tsx
@@ -247,15 +247,18 @@ function DashLeftMenu() {
       {/* Main Navigation - Vertically Centered */}
       <div className="flex-1 flex flex-col justify-center py-4 px-3">
         <AdminAuthorization authorizationMode="component">
-          <div className="space-y-1">
-            <MenuLink
-              href="/dash"
-              icon={<House size={20} weight="fill" />}
-              label={t('common.home')}
-              isCollapsed={isCollapsed}
-            />
+          <ul className="space-y-1 list-none m-0 p-0">
+            <li>
+              <MenuLink
+                href="/dash"
+                icon={<House size={20} weight="fill" />}
+                label={t('common.home')}
+                isCollapsed={isCollapsed}
+              />
+            </li>
 
             {/* Courses with hover menu */}
+            <li>
             <HoverMenu
               content={
                 <HoverMenuContent className="w-64">
@@ -308,8 +311,10 @@ function DashLeftMenu() {
                 )}
               </button>
             </HoverMenu>
+            </li>
 
             {/* Assignments with hover menu */}
+            <li>
             <HoverMenu
               content={
                 <HoverMenuContent className="w-72">
@@ -365,40 +370,41 @@ function DashLeftMenu() {
                 )}
               </button>
             </HoverMenu>
+            </li>
             {showCommunities && (
-              <MenuLink
+              <li><MenuLink
                 href="/dash/communities"
                 icon={<ChatsCircle size={20} weight="fill" />}
                 label={t('communities.title')}
                 isCollapsed={isCollapsed}
-              />
+              /></li>
             )}
             {showPodcasts && (
-              <MenuLink
+              <li><MenuLink
                 href="/dash/podcasts"
                 icon={<Headphones size={20} weight="fill" />}
                 label={t('podcasts.podcasts')}
                 isCollapsed={isCollapsed}
-              />
+              /></li>
             )}
             {showBoards && (
-              <MenuLink
+              <li><MenuLink
                 href="/dash/boards"
                 icon={<ChalkboardSimple size={20} weight="fill" />}
                 label="Boards"
                 isCollapsed={isCollapsed}
-              />
+              /></li>
             )}
             {showPlaygrounds && (
-              <MenuLink
+              <li><MenuLink
                 href="/dash/playgrounds"
                 icon={<Cube size={20} weight="fill" />}
                 label="Playgrounds"
                 isCollapsed={isCollapsed}
-              />
+              /></li>
             )}
             {/* Users with hover menu */}
-            <HoverMenu
+            <li><HoverMenu
               content={
                 <HoverMenuContent className="w-64">
                   <HoverMenuLabel className="text-white/70 font-medium">{t('common.users')}</HoverMenuLabel>
@@ -456,19 +462,19 @@ function DashLeftMenu() {
                   </>
                 )}
               </button>
-            </HoverMenu>
+            </HoverMenu></li>
 
             {showPayments && (
-              <MenuLink
+              <li><MenuLink
                 href="/dash/payments/overview"
                 icon={<CurrencyCircleDollar size={20} weight="fill" />}
                 label={t('common.payments')}
                 isCollapsed={isCollapsed}
-              />
+              /></li>
             )}
 
             {/* Organization with hover menu */}
-            <HoverMenu
+            <li><HoverMenu
               content={
                 <HoverMenuContent className="w-64">
                   <HoverMenuLabel className="text-white/70 font-medium">{t('common.organization')}</HoverMenuLabel>
@@ -562,10 +568,10 @@ function DashLeftMenu() {
                   </>
                 )}
               </button>
-            </HoverMenu>
+            </HoverMenu></li>
 
             {/* Analytics with hover menu */}
-            <HoverMenu
+            <li><HoverMenu
               content={
                 <HoverMenuContent className="w-64">
                   <HoverMenuLabel className="text-white/70 font-medium">Analytics</HoverMenuLabel>
@@ -605,11 +611,11 @@ function DashLeftMenu() {
                   </>
                 )}
               </button>
-            </HoverMenu>
+            </HoverMenu></li>
 
             {/* Disabled features shown in an "Other" hover menu */}
             {(!showCommunities || !showPodcasts || !showBoards || !showPlaygrounds || !showPayments) && (
-              <HoverMenu
+              <li><HoverMenu
                 content={
                   <HoverMenuContent className="w-64">
                     <HoverMenuLabel className="flex items-center justify-between text-white/70 font-medium">
@@ -682,18 +688,18 @@ function DashLeftMenu() {
                     </>
                   )}
                 </button>
-              </HoverMenu>
+              </HoverMenu></li>
             )}
-          </div>
+          </ul>
         </AdminAuthorization>
       </div>
 
       {/* Bottom Section */}
       <div className="border-t border-white/[0.08] py-3 px-3 shrink-0">
-        <div className="space-y-1">
+        <ul className="space-y-1 list-none m-0 p-0">
           {/* Expand button when collapsed */}
           {isCollapsed && (
-            <Tooltip>
+            <li><Tooltip>
               <TooltipTrigger asChild>
                 <button
                   aria-label="Expand sidebar"
@@ -706,11 +712,11 @@ function DashLeftMenu() {
               <TooltipContent side="right" className="z-tooltip bg-[#1a1a1b] border-white/10 text-white text-xs px-2 py-1 shadow-lg shadow-black/20">
                 {t('common.expand')}
               </TooltipContent>
-            </Tooltip>
+            </Tooltip></li>
           )}
 
           {/* Language Switcher with hover menu */}
-          <HoverMenu
+          <li><HoverMenu
             align="end"
             content={
               <HoverMenuContent className="w-64 max-h-96 overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
@@ -746,10 +752,10 @@ function DashLeftMenu() {
                 <span className="text-sm font-medium">{t('common.language')}</span>
               )}
             </button>
-          </HoverMenu>
+          </HoverMenu></li>
 
           {/* Help with hover menu */}
-          <HoverMenu
+          <li><HoverMenu
             align="end"
             content={
               <HoverMenuContent className="w-56">
@@ -811,10 +817,10 @@ function DashLeftMenu() {
                 <span className="text-sm font-medium">{t('common.help')}</span>
               )}
             </button>
-          </HoverMenu>
+          </HoverMenu></li>
 
           {/* User Menu with hover menu */}
-          <HoverMenu
+          <li><HoverMenu
             align="end"
             content={
               <HoverMenuContent className="w-56">
@@ -858,8 +864,8 @@ function DashLeftMenu() {
                 </div>
               )}
             </button>
-          </HoverMenu>
-        </div>
+          </HoverMenu></li>
+        </ul>
       </div>
     </nav>
 

--- a/apps/web/components/Dashboard/Menus/DashMobileMenu.tsx
+++ b/apps/web/components/Dashboard/Menus/DashMobileMenu.tsx
@@ -22,70 +22,88 @@ function DashMobileMenu() {
 
   return (
     <nav aria-label="Dashboard mobile actions" className="fixed bottom-0 left-0 right-0 bg-black/90 backdrop-blur-lg text-white shadow-xl">
-      <div className="flex justify-around items-center h-16 px-2">
+      <ul className="flex justify-around items-center h-16 px-2 list-none m-0 p-0">
         <AdminAuthorization authorizationMode="component">
-          <ToolTip content={t('common.home')} slateBlack sideOffset={8} side="top">
-            <Link href={`/`} className="flex flex-col items-center p-2" aria-label="Go to dashboard home">
-              <Home size={20} />
-              <span className="text-xs mt-1">{t('common.home')}</span>
-            </Link>
-          </ToolTip>
-          <ToolTip content={t('courses.courses')} slateBlack sideOffset={8} side="top">
-            <Link href={`/dash/courses`} className="flex flex-col items-center p-2" aria-label="Manage courses">
-              <BookCopy size={20} />
-              <span className="text-xs mt-1">{t('courses.courses')}</span>
-            </Link>
-          </ToolTip>
-          <ToolTip content={t('common.assignments')} slateBlack sideOffset={8} side="top">
-            <Link href={`/dash/assignments`} className="flex flex-col items-center p-2" aria-label="Manage assignments">
-              <Backpack size={20} />
-              <span className="text-xs mt-1">{t('common.assignments')}</span>
-            </Link>
-          </ToolTip>
-          {showCommunities && (
-            <ToolTip content={t('communities.title')} slateBlack sideOffset={8} side="top">
-              <Link href={`/dash/communities`} className="flex flex-col items-center p-2" aria-label="Manage communities">
-                <MessagesSquare size={20} />
-                <span className="text-xs mt-1">{t('communities.title')}</span>
+          <li>
+            <ToolTip content={t('common.home')} slateBlack sideOffset={8} side="top">
+              <Link href={`/`} className="flex flex-col items-center p-2" aria-label="Go to dashboard home">
+                <Home size={20} />
+                <span className="text-xs mt-1">{t('common.home')}</span>
               </Link>
             </ToolTip>
+          </li>
+          <li>
+            <ToolTip content={t('courses.courses')} slateBlack sideOffset={8} side="top">
+              <Link href={`/dash/courses`} className="flex flex-col items-center p-2" aria-label="Manage courses">
+                <BookCopy size={20} />
+                <span className="text-xs mt-1">{t('courses.courses')}</span>
+              </Link>
+            </ToolTip>
+          </li>
+          <li>
+            <ToolTip content={t('common.assignments')} slateBlack sideOffset={8} side="top">
+              <Link href={`/dash/assignments`} className="flex flex-col items-center p-2" aria-label="Manage assignments">
+                <Backpack size={20} />
+                <span className="text-xs mt-1">{t('common.assignments')}</span>
+              </Link>
+            </ToolTip>
+          </li>
+          {showCommunities && (
+            <li>
+              <ToolTip content={t('communities.title')} slateBlack sideOffset={8} side="top">
+                <Link href={`/dash/communities`} className="flex flex-col items-center p-2" aria-label="Manage communities">
+                  <MessagesSquare size={20} />
+                  <span className="text-xs mt-1">{t('communities.title')}</span>
+                </Link>
+              </ToolTip>
+            </li>
           )}
           {showPodcasts && (
-            <ToolTip content={t('podcasts.podcasts')} slateBlack sideOffset={8} side="top">
-              <Link href={`/dash/podcasts`} className="flex flex-col items-center p-2" aria-label="Manage podcasts">
-                <Headphones size={20} />
-                <span className="text-xs mt-1">{t('podcasts.podcasts')}</span>
-              </Link>
-            </ToolTip>
+            <li>
+              <ToolTip content={t('podcasts.podcasts')} slateBlack sideOffset={8} side="top">
+                <Link href={`/dash/podcasts`} className="flex flex-col items-center p-2" aria-label="Manage podcasts">
+                  <Headphones size={20} />
+                  <span className="text-xs mt-1">{t('podcasts.podcasts')}</span>
+                </Link>
+              </ToolTip>
+            </li>
           )}
           {showPayments && (
-            <ToolTip content={t('common.payments')} slateBlack sideOffset={8} side="top">
-              <Link href={`/dash/payments/overview`} className="flex flex-col items-center p-2" aria-label="Manage payments and billing">
-                <BadgeDollarSign size={20} />
-                <span className="text-xs mt-1">{t('common.payments')}</span>
+            <li>
+              <ToolTip content={t('common.payments')} slateBlack sideOffset={8} side="top">
+                <Link href={`/dash/payments/overview`} className="flex flex-col items-center p-2" aria-label="Manage payments and billing">
+                  <BadgeDollarSign size={20} />
+                  <span className="text-xs mt-1">{t('common.payments')}</span>
+                </Link>
+              </ToolTip>
+            </li>
+          )}
+          <li>
+            <ToolTip content={t('common.users')} slateBlack sideOffset={8} side="top">
+              <Link href={`/dash/users/settings/users`} className="flex flex-col items-center p-2" aria-label="Manage users">
+                <Users size={20} />
+                <span className="text-xs mt-1">{t('common.users')}</span>
               </Link>
             </ToolTip>
-          )}
-          <ToolTip content={t('common.users')} slateBlack sideOffset={8} side="top">
-            <Link href={`/dash/users/settings/users`} className="flex flex-col items-center p-2" aria-label="Manage users">
-              <Users size={20} />
-              <span className="text-xs mt-1">{t('common.users')}</span>
-            </Link>
-          </ToolTip>
-          <ToolTip content={t('common.organization')} slateBlack sideOffset={8} side="top">
-            <Link href={`/dash/org/settings/general`} className="flex flex-col items-center p-2" aria-label="Organization settings">
-              <School size={20} />
-              <span className="text-xs mt-1">{t('common.organization')}</span>
-            </Link>
-          </ToolTip>
+          </li>
+          <li>
+            <ToolTip content={t('common.organization')} slateBlack sideOffset={8} side="top">
+              <Link href={`/dash/org/settings/general`} className="flex flex-col items-center p-2" aria-label="Organization settings">
+                <School size={20} />
+                <span className="text-xs mt-1">{t('common.organization')}</span>
+              </Link>
+            </ToolTip>
+          </li>
         </AdminAuthorization>
-        <ToolTip content={t('common.settings')} slateBlack sideOffset={8} side="top">
-          <Link href={'/account/general'} className="flex flex-col items-center p-2" aria-label="User account settings">
-            <Settings size={20} />
-            <span className="text-xs mt-1">{t('common.settings')}</span>
-          </Link>
-        </ToolTip>
-      </div>
+        <li>
+          <ToolTip content={t('common.settings')} slateBlack sideOffset={8} side="top">
+            <Link href={'/account/general'} className="flex flex-col items-center p-2" aria-label="User account settings">
+              <Settings size={20} />
+              <span className="text-xs mt-1">{t('common.settings')}</span>
+            </Link>
+          </ToolTip>
+        </li>
+      </ul>
     </nav>
   )
 }


### PR DESCRIPTION
## Summary

- Replaced flat `<div>` containers with semantic `<ul>`/`<li>` list structure in dashboard navigation
- **DashLeftMenu**: Both main navigation (Home, Courses, Assignments, etc.) and bottom section (Language, Help, User) now use proper list semantics
- **DashMobileMenu**: All navigation items wrapped in `<ul>`/`<li>`
- Screen readers will now announce the number of nav items and allow users to jump between them

## Files Changed

| File | Change |
|---|---|
| `components/Dashboard/Menus/DashLeftMenu.tsx` | `<div class="space-y-1">` → `<ul>`, each nav item wrapped in `<li>` |
| `components/Dashboard/Menus/DashMobileMenu.tsx` | `<div>` → `<ul>`, each nav item wrapped in `<li>` |

## Test Plan

- [ ] Verify sidebar renders correctly on desktop (collapsed and expanded states)
- [ ] Verify mobile bottom nav renders correctly
- [ ] Run screen reader and confirm list semantics are announced (e.g. "list, 8 items")
- [ ] Verify no visual regression from `list-none m-0 p-0` utility classes

Fixes #657