### PR TITLE
fix: add ARIA roles and keyboard navigation to CustomSelect

### DIFF
--- a/apps/web/components/Dashboard/Pages/Course/EditCourseGeneral/CustomSelect.tsx
+++ b/apps/web/components/Dashboard/Pages/Course/EditCourseGeneral/CustomSelect.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useId } from 'react';
 import { ChevronDown } from 'lucide-react';
 
 interface CustomSelectProps {
@@ -35,6 +35,11 @@ const CustomSelectContext = React.createContext<{
   setSelectedValue: (value: string) => void;
   onValueChange: (value: string) => void;
   disabled?: boolean;
+  activeIndex: number;
+  setActiveIndex: (index: number) => void;
+  itemValues: string[];
+  registerItem: (value: string) => void;
+  listboxId: string;
 } | null>(null);
 
 export const CustomSelect: React.FC<CustomSelectProps> = ({
@@ -47,17 +52,51 @@ export const CustomSelect: React.FC<CustomSelectProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedValue, setSelectedValue] = useState(value);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const [itemValues, setItemValues] = useState<string[]>([]);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listboxId = useId();
 
   useEffect(() => {
     setSelectedValue(value);
   }, [value]);
+
+  // Reset item registry when dropdown opens
+  useEffect(() => {
+    if (isOpen) {
+      setItemValues([]);
+    }
+  }, [isOpen]);
+
+  const registerItem = useCallback((itemValue: string) => {
+    setItemValues(prev => {
+      if (prev.includes(itemValue)) return prev;
+      return [...prev, itemValue];
+    });
+  }, []);
 
   const handleValueChange = (newValue: string) => {
     if (disabled) return;
     setSelectedValue(newValue);
     onValueChange(newValue);
     setIsOpen(false);
+    setActiveIndex(-1);
   };
+
+  // Close on click outside
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+        setActiveIndex(-1);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen]);
 
   return (
     <CustomSelectContext.Provider
@@ -67,10 +106,15 @@ export const CustomSelect: React.FC<CustomSelectProps> = ({
         selectedValue,
         setSelectedValue,
         onValueChange: handleValueChange,
-        disabled
+        disabled,
+        activeIndex,
+        setActiveIndex,
+        itemValues,
+        registerItem,
+        listboxId,
       }}
     >
-      <div className={`relative ${className}`}>
+      <div ref={containerRef} className={`relative ${className}`}>
         {children}
       </div>
     </CustomSelectContext.Provider>
@@ -87,18 +131,80 @@ export const CustomSelectTrigger: React.FC<CustomSelectTriggerProps> = ({
     throw new Error('CustomSelectTrigger must be used within CustomSelect');
   }
 
-  const { isOpen, setIsOpen, disabled: contextDisabled } = context;
+  const { isOpen, setIsOpen, disabled: contextDisabled, setActiveIndex, itemValues, onValueChange, listboxId } = context;
   const isDisabled = disabled || contextDisabled;
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (isDisabled) return;
+
+    switch (event.key) {
+      case 'Enter':
+      case ' ':
+      case 'ArrowDown':
+        event.preventDefault();
+        if (!isOpen) {
+          setIsOpen(true);
+          setActiveIndex(0);
+        }
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        if (!isOpen) {
+          setIsOpen(true);
+          setActiveIndex(itemValues.length - 1);
+        }
+        break;
+      case 'Escape':
+        event.preventDefault();
+        setIsOpen(false);
+        setActiveIndex(-1);
+        break;
+    }
+
+    // When open, handle arrow navigation
+    if (isOpen) {
+      switch (event.key) {
+        case 'ArrowDown':
+          event.preventDefault();
+          setActiveIndex(prev => Math.min(prev + 1, itemValues.length - 1));
+          break;
+        case 'ArrowUp':
+          event.preventDefault();
+          setActiveIndex(prev => Math.max(prev - 1, 0));
+          break;
+        case 'Enter':
+        case ' ':
+          event.preventDefault();
+          if (context.activeIndex >= 0 && context.activeIndex < itemValues.length) {
+            onValueChange(itemValues[context.activeIndex]);
+          }
+          break;
+        case 'Home':
+          event.preventDefault();
+          setActiveIndex(0);
+          break;
+        case 'End':
+          event.preventDefault();
+          setActiveIndex(itemValues.length - 1);
+          break;
+      }
+    }
+  };
 
   return (
     <button
       type="button"
+      role="combobox"
+      aria-expanded={isOpen}
+      aria-haspopup="listbox"
+      aria-controls={isOpen ? listboxId : undefined}
       disabled={isDisabled}
       className={`flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs ring-offset-background placeholder:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 ${className}`}
       onClick={() => !isDisabled && setIsOpen(!isOpen)}
+      onKeyDown={handleKeyDown}
     >
       {children}
-      <ChevronDown className={`h-4 w-4 opacity-50 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+      <ChevronDown aria-hidden="true" className={`h-4 w-4 opacity-50 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
     </button>
   );
 };
@@ -112,12 +218,16 @@ export const CustomSelectContent: React.FC<CustomSelectContentProps> = ({
     throw new Error('CustomSelectContent must be used within CustomSelect');
   }
 
-  const { isOpen, disabled } = context;
+  const { isOpen, disabled, listboxId } = context;
 
   if (!isOpen || disabled) return null;
 
   return (
-    <div className={`absolute z-dropdown max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 slide-in-from-top-2 ${className}`}>
+    <div
+      role="listbox"
+      id={listboxId}
+      className={`absolute z-dropdown max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 slide-in-from-top-2 ${className}`}
+    >
       <div className="p-1">
         {children}
       </div>
@@ -135,17 +245,36 @@ export const CustomSelectItem: React.FC<CustomSelectItemProps> = ({
     throw new Error('CustomSelectItem must be used within CustomSelect');
   }
 
-  const { selectedValue, onValueChange, disabled } = context;
+  const { selectedValue, onValueChange, disabled, activeIndex, itemValues, registerItem } = context;
+  const itemIndex = itemValues.indexOf(value);
+  const isActive = itemIndex === activeIndex;
+  const isSelected = selectedValue === value;
+  const itemRef = useRef<HTMLDivElement>(null);
+
+  // Register this item's value on mount
+  useEffect(() => {
+    registerItem(value);
+  }, [value, registerItem]);
+
+  // Scroll active item into view
+  useEffect(() => {
+    if (isActive && itemRef.current) {
+      itemRef.current.scrollIntoView({ block: 'nearest' });
+    }
+  }, [isActive]);
 
   return (
     <div
-      className={`relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground hover:bg-accent hover:text-accent-foreground ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`}
+      ref={itemRef}
+      role="option"
+      aria-selected={isSelected}
+      className={`relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-hidden ${isActive ? 'bg-accent text-accent-foreground' : ''} ${!isActive ? 'hover:bg-accent hover:text-accent-foreground' : ''} ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`}
       onClick={() => !disabled && onValueChange(value)}
     >
       {children}
-      {selectedValue === value && (
+      {isSelected && (
         <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
-          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg aria-hidden="true" className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
           </svg>
         </span>
@@ -165,4 +294,4 @@ export const CustomSelectValue: React.FC<{ children?: React.ReactNode }> = ({
   const { selectedValue } = context;
 
   return <span>{children || selectedValue}</span>;
-}; 
+};


### PR DESCRIPTION
## Summary

- Added full [WAI-ARIA Listbox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/) support to CustomSelect component
- The component was previously mouse-only with no ARIA roles or keyboard support

## What Changed

| Feature | Before | After |
|---|---|---|
| Trigger button | No ARIA attributes | `role="combobox"`, `aria-expanded`, `aria-haspopup="listbox"` |
| Dropdown container | Plain `<div>` | `role="listbox"` with unique `id` |
| Items | `<div>` with `onClick` | `role="option"` with `aria-selected` |
| Keyboard: open | Not supported | Enter, Space, ArrowDown/Up |
| Keyboard: navigate | Not supported | ArrowDown/Up, Home, End |
| Keyboard: select | Not supported | Enter, Space |
| Keyboard: close | Not supported | Escape |
| Click outside | Not supported | Closes dropdown |
| Decorative icons | Exposed to screen readers | `aria-hidden="true"` |

## Test Plan

- [ ] Open dropdown with Enter/Space/ArrowDown keys
- [ ] Navigate options with Arrow keys
- [ ] Select option with Enter/Space
- [ ] Close with Escape
- [ ] Click outside closes dropdown
- [ ] Screen reader announces "combobox", options count, selected state
- [ ] Verify no visual regression

Fixes #654