### PR TITLE
Fix #644: Add descriptive alt text to images with empty alt attributes

### DIFF
--- a/apps/web/components/Dashboard/Misc/CourseOverviewTop.tsx
+++ b/apps/web/components/Dashboard/Misc/CourseOverviewTop.tsx
@@ -165,14 +165,14 @@ export function CourseOverviewTop({
                   'course_' + params.courseuuid,
                   courseStructure.thumbnail_image
                 )}`}
-                alt=""
+                alt={courseStructure.name}
               />
             ) : (
               <Image
                 width={100}
                 className="h-[57px] rounded-md drop-shadow-md"
                 src={EmptyThumbnailImage}
-                alt=""
+                alt={courseStructure?.name || ''}
               />
             )}
           </Link>

--- a/apps/web/components/Objects/Editor/Editor.tsx
+++ b/apps/web/components/Objects/Editor/Editor.tsx
@@ -376,7 +376,7 @@ function Editor(props: Editor) {
                       props.course.course_uuid,
                       props.course.thumbnail_image
                     ) : getUriWithOrg(props.org?.slug, '/empty_thumbnail.png')}`}
-                    alt=""
+                    alt={props.course.name}
                   />
                 </Link>
                 <div className="activity-editor-doc-name">


### PR DESCRIPTION
Closes #644

Replaces empty `alt=""` attributes on meaningful course thumbnail images with descriptive text using the course name, improving screen reader accessibility. Two components were affected: `CourseOverviewTop.tsx` (both the conditional branch rendering a real thumbnail via `getContentObjectFullMediaUrl` and the fallback `EmptyThumbnailImage` branch now use `courseStructure.name`) and `Editor.tsx` (the thumbnail `<Image>` inside the editor header now uses `props.course.name`).

Modified files:
- `apps/web/components/Dashboard/Misc/CourseOverviewTop.tsx` — lines 168 and 173, inside the thumbnail conditional in `CourseOverviewTop`
- `apps/web/components/Objects/Editor/Editor.tsx` — line 379, inside the `Editor` component's header thumbnail `<Link>`

Verified manually by inspecting the rendered DOM in browser DevTools and confirming the `alt` attribute on each image reflects the actual course name rather than an empty string.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*