### PR TITLE
Fix #608: Dependency Dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,28 +35,25 @@
   "ignoreDeps": ["@icons-pack/react-simple-icons", "prosemirror-transform", "python"],
   "packageRules": [
     {
-      "matchPackageNames": ["next"],
-      "matchPackagePatterns": ["^@next/", "^eslint-config-next$"],
+      "matchPackageNames": ["next", "@next/*", "eslint-config-next"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "Next.js",
       "groupSlug": "nextjs"
     },
     {
-      "matchPackageNames": ["react", "react-dom"],
-      "matchPackagePatterns": ["^@types/react", "^react-"],
+      "matchPackageNames": ["react", "react-dom", "@types/react*", "react-*"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "React",
       "groupSlug": "react"
     },
     {
-      "matchPackageNames": ["typescript"],
-      "matchPackagePatterns": ["^@types/"],
+      "matchPackageNames": ["typescript", "@types/*"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "TypeScript & types",
       "groupSlug": "typescript"
     },
     {
-      "matchPackagePatterns": ["^eslint", "^@eslint/"],
+      "matchPackageNames": ["eslint*", "@eslint/*"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "ESLint",
       "groupSlug": "eslint"


### PR DESCRIPTION
Closes #608

## Motivation

Renovate's `matchPackagePatterns` field (regex-based) is being deprecated in favor of `matchPackageNames` supporting glob syntax. Migrating now avoids future breakage when Renovate drops `matchPackagePatterns` support.

## Changes

All changes are in `renovate.json`, consolidating `matchPackageNames` + `matchPackagePatterns` pairs into single `matchPackageNames` arrays using glob patterns:

- **Next.js rule** (line ~38): Replaced `matchPackagePatterns: ["^@next/", "^eslint-config-next$"]` with glob entries `"@next/*"` and `"eslint-config-next"` directly in `matchPackageNames`.
- **React rule** (line ~44): Replaced `matchPackagePatterns: ["^@types/react", "^react-"]` with globs `"@types/react*"` and `"react-*"` in `matchPackageNames`.
- **TypeScript & types rule** (line ~50): Replaced `matchPackagePatterns: ["^@types/"]` with glob `"@types/*"` in `matchPackageNames`.
- **ESLint rule** (line ~55): Replaced `matchPackagePatterns: ["^eslint", "^@eslint/"]` with globs `"eslint*"` and `"@eslint/*"` in `matchPackageNames`, removing the now-empty `matchPackageNames` field entirely.

## Testing

Verify by triggering a Renovate dry run against the repository — all four grouping rules should match the same package sets as before. The Dependency Dashboard (issue #608) should continue to list updates under the same group names (`Next.js`, `React`, `TypeScript & types`, `ESLint`) with no regressions in grouping or scheduling behavior.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*