### PR TITLE
feat(HoverMenu): add keyboard support following WAI-ARIA menu pattern

### DIFF
--- a/apps/web/components/ui/hover-menu.tsx
+++ b/apps/web/components/ui/hover-menu.tsx
@@ -14,6 +14,8 @@ interface HoverMenuProps {
 const HoverMenu = React.forwardRef<HTMLDivElement, HoverMenuProps>(
   ({ children, content, contentClassName, align = "start" }, ref) => {
     const triggerRef = React.useRef<HTMLDivElement>(null)
+    const menuRef = React.useRef<HTMLDivElement>(null)
+    const suppressFocusOpenRef = React.useRef(false)
     const [isHovered, setIsHovered] = React.useState(false)
     const [position, setPosition] = React.useState<{ top: number; left: number } | null>(null)
     const hoverTimeoutRef = React.useRef<NodeJS.Timeout | null>(null)
@@ -37,6 +39,83 @@ const HoverMenu = React.forwardRef<HTMLDivElement, HoverMenuProps>(
       }
     }, [align])
 
+    const setMenuRefs = React.useCallback(
+      (node: HTMLDivElement | null) => {
+        menuRef.current = node
+
+        if (typeof ref === "function") {
+          ref(node)
+          return
+        }
+
+        if (ref) {
+          ref.current = node
+        }
+      },
+      [ref]
+    )
+
+    const getMenuItems = React.useCallback(() => {
+      if (!menuRef.current) {
+        return []
+      }
+
+      return Array.from(menuRef.current.querySelectorAll<HTMLElement>("[role=\"menuitem\"]"))
+    }, [])
+
+    const focusMenuItemAtIndex = React.useCallback(
+      (index: number) => {
+        const items = getMenuItems()
+
+        if (!items.length) {
+          return
+        }
+
+        const normalizedIndex = ((index % items.length) + items.length) % items.length
+        items[normalizedIndex]?.focus()
+      },
+      [getMenuItems]
+    )
+
+    const openMenu = React.useCallback(() => {
+      if (hoverTimeoutRef.current) {
+        clearTimeout(hoverTimeoutRef.current)
+        hoverTimeoutRef.current = null
+      }
+
+      if (leaveTimeoutRef.current) {
+        clearTimeout(leaveTimeoutRef.current)
+        leaveTimeoutRef.current = null
+      }
+
+      updatePosition()
+      setIsHovered(true)
+    }, [updatePosition])
+
+    const closeMenu = React.useCallback(() => {
+      if (hoverTimeoutRef.current) {
+        clearTimeout(hoverTimeoutRef.current)
+        hoverTimeoutRef.current = null
+      }
+
+      if (leaveTimeoutRef.current) {
+        clearTimeout(leaveTimeoutRef.current)
+        leaveTimeoutRef.current = null
+      }
+
+      setIsHovered(false)
+    }, [])
+
+    const openMenuAndFocusItem = React.useCallback(
+      (index: number) => {
+        openMenu()
+        window.setTimeout(() => {
+          focusMenuItemAtIndex(index)
+        }, 0)
+      },
+      [focusMenuItemAtIndex, openMenu]
+    )
+
     const handleMouseEnter = React.useCallback(() => {
       if (leaveTimeoutRef.current) {
         clearTimeout(leaveTimeoutRef.current)
@@ -59,6 +138,88 @@ const HoverMenu = React.forwardRef<HTMLDivElement, HoverMenuProps>(
       }, 100)
     }, [])
 
+    const handleTriggerBlur = React.useCallback(
+      (event: React.FocusEvent<HTMLDivElement>) => {
+        const nextFocusedElement = event.relatedTarget
+
+        if (nextFocusedElement && menuRef.current?.contains(nextFocusedElement as Node)) {
+          return
+        }
+
+        handleMouseLeave()
+      },
+      [handleMouseLeave]
+    )
+
+    const handleTriggerFocus = React.useCallback(() => {
+      if (suppressFocusOpenRef.current) {
+        suppressFocusOpenRef.current = false
+        return
+      }
+
+      handleMouseEnter()
+    }, [handleMouseEnter])
+
+    const handleTriggerKeyDown = React.useCallback(
+      (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === "Enter" || event.key === " " || event.key === "ArrowDown") {
+          event.preventDefault()
+          openMenuAndFocusItem(0)
+          return
+        }
+
+        if (event.key === "Escape" && isHovered) {
+          event.preventDefault()
+          closeMenu()
+        }
+      },
+      [closeMenu, isHovered, openMenuAndFocusItem]
+    )
+
+    const handleMenuKeyDown = React.useCallback(
+      (event: React.KeyboardEvent<HTMLDivElement>) => {
+        const items = getMenuItems()
+        const currentIndex = items.findIndex((item) => item === document.activeElement)
+
+        if (event.key === "ArrowDown") {
+          event.preventDefault()
+          focusMenuItemAtIndex(currentIndex === -1 ? 0 : currentIndex + 1)
+          return
+        }
+
+        if (event.key === "ArrowUp") {
+          event.preventDefault()
+          focusMenuItemAtIndex(currentIndex === -1 ? items.length - 1 : currentIndex - 1)
+          return
+        }
+
+        if (event.key === "Home") {
+          event.preventDefault()
+          focusMenuItemAtIndex(0)
+          return
+        }
+
+        if (event.key === "End") {
+          event.preventDefault()
+          focusMenuItemAtIndex(items.length - 1)
+          return
+        }
+
+        if (event.key === "Escape") {
+          event.preventDefault()
+          closeMenu()
+          suppressFocusOpenRef.current = true
+          triggerRef.current?.focus()
+          return
+        }
+
+        if (event.key === "Tab") {
+          closeMenu()
+        }
+      },
+      [closeMenu, focusMenuItemAtIndex, getMenuItems]
+    )
+
     React.useEffect(() => {
       return () => {
         if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current)
@@ -75,17 +236,26 @@ const HoverMenu = React.forwardRef<HTMLDivElement, HoverMenuProps>(
           ref={triggerRef}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
+          onFocus={handleTriggerFocus}
+          onBlur={handleTriggerBlur}
+          onKeyDown={handleTriggerKeyDown}
+          tabIndex={0}
+          role="button"
+          aria-haspopup="menu"
+          aria-expanded={isHovered}
         >
           {children}
         </div>
         {shouldRenderPortal && (
           <Portal.Root>
             <div
-              ref={ref}
+              ref={setMenuRefs}
               onMouseEnter={handleMouseEnter}
               onMouseLeave={handleMouseLeave}
+              onKeyDown={handleMenuKeyDown}
+              role="menu"
               style={{
-                position: 'fixed',
+                position: "fixed",
                 top: position.top,
                 left: position.left,
                 transform: align === "end" ? "translateY(-100%)" : align === "center" ? "translateY(-50%)" : undefined,
@@ -151,6 +321,14 @@ const HoverMenuItem = React.forwardRef<HTMLDivElement, HoverMenuItemProps>(
       <div
         ref={ref}
         onClick={onClick}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault()
+            onClick?.()
+          }
+        }}
+        role="menuitem"
+        tabIndex={-1}
         className={cn(
           "px-3 py-2 text-sm text-white/70 hover:text-white hover:bg-white/[0.08] cursor-pointer transition-colors",
           className


### PR DESCRIPTION
## Summary

Adds keyboard support to `HoverMenu` (`apps/web/components/ui/hover-menu.tsx`) following the WAI-ARIA menu button pattern requested in #655. The component now works for keyboard and screen reader users while leaving the existing hover behavior fully intact.

## Why this matters

Per the issue from @swve, `HoverMenu` was mouse-only - no `role`, no `tabIndex`, no `onKeyDown` anywhere in the component. This blocked keyboard users from opening any of the five `HoverMenu` instances in `components/Dashboard/Menus/DashLeftMenu.tsx` (around lines 240, 296, 386, 457, 555), which together cover the dashboard's left-menu navigation surface. The issue spelled out exactly which attributes were missing (`role="menuitem"`, `tabIndex="0"`, `onKeyDown` for Enter/Space/arrows/Escape) and linked the [WAI-ARIA Menu Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/).

## Changes

All changes live in `apps/web/components/ui/hover-menu.tsx`:

- **Trigger div**: `tabIndex={0}`, `role="button"`, `aria-haspopup="menu"`, `aria-expanded={isHovered}`. Added `onFocus` / `onBlur` that mirror the existing hover handlers (opening and timeout-based closing). Added `onKeyDown` that opens the menu and focuses the first item on Enter / Space / ArrowDown, and closes it on Escape.
- **Portal container** (the floating menu root): `role="menu"`, new `onKeyDown` handler for ArrowUp / ArrowDown (cyclic focus move between menu items), Home / End (first / last), Escape (close and return focus to trigger), and Tab (close, let default tab order continue).
- **`HoverMenuItem`**: `role="menuitem"`, `tabIndex={-1}` (focusable programmatically, not in the document tab order), `onKeyDown` that fires `onClick` on Enter or Space. The `asChild` branch is intentionally left untouched - it exists so the consumer can render its own interactive element, and layering roles there would double-wrap.
- Focus management: `menuRef` + `getMenuItems()` query menu items via `[role="menuitem"]`, `focusMenuItemAtIndex` wraps around, a small `suppressFocusOpenRef` prevents the returned focus on Escape from reopening the menu. Blur only fires the close timeout when focus actually leaves the trigger + portal pair.

`HoverMenuLabel` and `HoverMenuSeparator` are intentionally unchanged - they are decorative and should not be in the menu item focus cycle.

## Testing

- `pnpm build` runs clean (verified locally).
- Hover still opens and closes the menu on mouse events (handlers untouched).
- Tab to a `HoverMenu` trigger: it receives focus, menu opens via focus mirror, `aria-expanded` flips to `true`.
- Enter / Space / ArrowDown on the trigger opens the menu and moves focus to the first item; ArrowUp/Down cycle through items; Home / End jump to first / last; Enter on an item fires its `onClick`; Escape closes the menu and returns focus to the trigger.

Closes #655

_This contribution was developed with AI assistance (Codex)._
