### PR TITLE
feat(courses): onboarding_config flow — landing, welcome, paywall, thanks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md — LearnHouse Deploy Flow
+
+## Build & deploy pipeline
+
+This repo does **not** host the deploy logic — deploy runs on **Jenkins** in a separate infrastructure repo. This repo only produces images and signals the infra repo when a branch moves.
+
+### Trigger chain
+
+```
+push to main | dev | prod | PR event
+   │
+   ├─► .github/workflows/build-community.yaml
+   │     Builds multi-platform Docker image from ./Dockerfile.
+   │     Pushes to ghcr.io/learnhouse/app:<branch> and :<branch>-<sha7>.
+   │
+   └─► .github/workflows/notify-infra.yaml
+         Repository-dispatch (event type `source-update`) to the infra repo.
+         Payload: { sha, branch, event, pr_number, pr_action, repo }.
+         Secret: INFRA_REPO_PAT · Var: INFRA_REPO.
+```
+
+The infra repo's Jenkins pipeline consumes the `source-update` dispatch, pulls the matching `ghcr.io/learnhouse/app:<branch>` image, and rolls the target environment.
+
+### Branch → environment mapping
+
+Branches that trigger a build/notify: `main`, `dev`, `prod`.
+The actual env-to-branch mapping lives in the infra repo (not visible from here).
+When in doubt, **ask which branch the target host listens to** before merging — do not assume.
+
+### What this means for shared-system actions
+
+- Merging a PR to `dev`/`prod` is a deploy. Treat it as a production action and get explicit user confirmation every time.
+- Alembic migrations run server-side as part of the Jenkins pipeline (api container startup), so merging is also what runs DB migrations on the target env.
+- Never merge without user approval, even in Auto Mode.
+
+## Local repo layout
+
+- `apps/api/` — FastAPI + SQLModel + Alembic.
+- `apps/web/` — Next.js App Router (TypeScript).
+- `apps/api/migrations/versions/` — Alembic revisions.
+- `docker/` — nginx + entrypoint for the combined community image.
+- `Dockerfile` — single image building both api and web.
+
+## Stripe Connect paywall (ee/)
+
+The commercial flow is: `PaymentsConfig → PaymentsOffer → PaymentsGroup → PaymentsGroupSync → UserGroup`.
+Activation side-effects (usergroup add/remove, welcome email) all flow through
+`apps/api/ee/services/payments/payments_enrollments.py::update_enrollment_status`
+— webhooks and admin overrides must call this function rather than flipping status directly.
+
+## Course `onboarding_config`
+
+Editable JSONB on `courses` (migration `n4a5b6c7d8e9`) holds landing/welcome/paywall/thanks copy.
+Upsert via `docs/courses/agentes-ia-negocio/_build/setup_onboarding.py --confirm-remote`.
+Reachable from the public `GET /courses/{uuid}` endpoint, so the frontend can render it without auth.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md — LearnHouse Deploy Flow
+
+## Build & deploy pipeline
+
+This repo does **not** host the deploy logic — deploy runs on **Jenkins** in a separate infrastructure repo. This repo only produces images and signals the infra repo when a branch moves.
+
+### Trigger chain
+
+```
+push to main | dev | prod | PR event
+   │
+   ├─► .github/workflows/build-community.yaml
+   │     Builds multi-platform Docker image from ./Dockerfile.
+   │     Pushes to ghcr.io/learnhouse/app:<branch> and :<branch>-<sha7>.
+   │
+   └─► .github/workflows/notify-infra.yaml
+         Repository-dispatch (event type `source-update`) to the infra repo.
+         Payload: { sha, branch, event, pr_number, pr_action, repo }.
+         Secret: INFRA_REPO_PAT · Var: INFRA_REPO.
+```
+
+The infra repo's Jenkins pipeline consumes the `source-update` dispatch, pulls the matching `ghcr.io/learnhouse/app:<branch>` image, and rolls the target environment.
+
+### Branch → environment mapping
+
+Branches that trigger a build/notify: `main`, `dev`, `prod`.
+The actual env-to-branch mapping lives in the infra repo (not visible from here).
+When in doubt, **ask which branch the target host listens to** before merging — do not assume.
+
+### What this means for shared-system actions
+
+- Merging a PR to `dev`/`prod` is a deploy. Treat it as a production action and get explicit user confirmation every time.
+- Alembic migrations run server-side as part of the Jenkins pipeline (api container startup), so merging is also what runs DB migrations on the target env.
+- Never merge without user approval, even in Auto Mode.
+
+## Local repo layout
+
+- `apps/api/` — FastAPI + SQLModel + Alembic.
+- `apps/web/` — Next.js App Router (TypeScript).
+- `apps/api/migrations/versions/` — Alembic revisions.
+- `docker/` — nginx + entrypoint for the combined community image.
+- `Dockerfile` — single image building both api and web.
+
+## Stripe Connect paywall (ee/)
+
+The commercial flow is: `PaymentsConfig → PaymentsOffer → PaymentsGroup → PaymentsGroupSync → UserGroup`.
+Activation side-effects (usergroup add/remove, welcome email) all flow through
+`apps/api/ee/services/payments/payments_enrollments.py::update_enrollment_status`
+— webhooks and admin overrides must call this function rather than flipping status directly.
+
+## Course `onboarding_config`
+
+Editable JSONB on `courses` (migration `n4a5b6c7d8e9`) holds landing/welcome/paywall/thanks copy.
+Upsert via `docs/courses/agentes-ia-negocio/_build/setup_onboarding.py --confirm-remote`.
+Reachable from the public `GET /courses/{uuid}` endpoint, so the frontend can render it without auth.

--- a/apps/api/ee/services/payments/payments_enrollments.py
+++ b/apps/api/ee/services/payments/payments_enrollments.py
@@ -1,3 +1,4 @@
+import logging
 from fastapi import HTTPException, Request
 from sqlmodel import Session, select
 from datetime import datetime
@@ -8,11 +9,16 @@ from ee.db.payments.payments_enrollments import (
     PaymentsEnrollmentRead,
 )
 from ee.db.payments.payments_offers import PaymentsOffer
-from ee.db.payments.payments_groups import PaymentsGroupSync
+from ee.db.payments.payments_groups import PaymentsGroupSync, PaymentsGroupResource
+from src.db.courses.courses import Course
 from src.db.organizations import Organization
-from src.db.users import AnonymousUser, APITokenUser, InternalUser, PublicUser
+from src.db.users import AnonymousUser, APITokenUser, InternalUser, PublicUser, User
 from src.services.orgs.orgs import rbac_check
 from src.services.users.usergroups import add_users_to_usergroup, remove_users_from_usergroup
+from src.services.users.emails import send_purchase_welcome_email
+from src.services.email.utils import get_base_url_from_request
+
+_enrollment_logger = logging.getLogger(__name__)
 
 
 async def create_enrollment(
@@ -135,6 +141,42 @@ async def update_enrollment_status(
                 current_user=InternalUser(),
                 usergroup_id=ug_id,
                 user_ids=str(enrollment.user_id),
+            )
+
+    # On first activation, send a welcome-to-premium email. Failures are
+    # swallowed so a transient email provider outage never breaks a paid
+    # webhook (the enrollment status change itself is the source of truth).
+    if status in active_statuses and old_status not in active_statuses:
+        try:
+            user_row = db_session.exec(select(User).where(User.id == enrollment.user_id)).first()
+            course_row = None
+            if offer.payments_group_id is not None:
+                group_resource = db_session.exec(
+                    select(PaymentsGroupResource).where(
+                        PaymentsGroupResource.payments_group_id == offer.payments_group_id
+                    )
+                ).first()
+                if group_resource and group_resource.resource_uuid.startswith("course_"):
+                    course_row = db_session.exec(
+                        select(Course).where(Course.course_uuid == group_resource.resource_uuid)
+                    ).first()
+
+            if user_row and user_row.email:
+                base_url = get_base_url_from_request(request)
+                course_name = course_row.name if course_row else offer.name
+                course_url = (
+                    f"{base_url}/course/{course_row.course_uuid}" if course_row else base_url
+                )
+                send_purchase_welcome_email(
+                    email=user_row.email,
+                    username=user_row.username or user_row.first_name or "",
+                    course_name=course_name,
+                    course_url=course_url,
+                    offer_name=offer.name,
+                )
+        except Exception:
+            _enrollment_logger.exception(
+                "Failed to send purchase welcome email for enrollment %s", enrollment.id
             )
 
     return enrollment

--- a/apps/api/migrations/versions/n4a5b6c7d8e9_add_course_onboarding_config.py
+++ b/apps/api/migrations/versions/n4a5b6c7d8e9_add_course_onboarding_config.py
@@ -1,0 +1,27 @@
+"""Add course onboarding_config field
+
+Revision ID: n4a5b6c7d8e9
+Revises: b7c8d9e0f3a4
+Create Date: 2026-04-24 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa  # noqa: F401
+import sqlmodel  # noqa: F401
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'n4a5b6c7d8e9'
+down_revision: Union[str, None] = 'b7c8d9e0f3a4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('course', sa.Column('onboarding_config', postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('course', 'onboarding_config')

--- a/apps/api/src/db/courses/courses.py
+++ b/apps/api/src/db/courses/courses.py
@@ -72,6 +72,7 @@ class Course(CourseBase, table=True):
     creation_date: str = ""
     update_date: str = ""
     seo: Optional[dict] = Field(default=None, sa_column=Column(JSONB))
+    onboarding_config: Optional[dict] = Field(default=None, sa_column=Column(JSONB))
 
 
 class CourseCreate(CourseBase):
@@ -95,6 +96,7 @@ class CourseUpdate(SQLModel):
     published: Optional[bool] = None
     open_to_contributors: Optional[bool] = None
     seo: Optional[dict] = None
+    onboarding_config: Optional[dict] = None
 
 
 class CourseRead(CourseBase):
@@ -108,6 +110,7 @@ class CourseRead(CourseBase):
     thumbnail_image: Optional[str] = Field(default="")
     thumbnail_video: Optional[str] = Field(default="")
     seo: Optional[dict] = None
+    onboarding_config: Optional[dict] = None
 
 
 class FullCourseRead(CourseBase):
@@ -121,6 +124,7 @@ class FullCourseRead(CourseBase):
     thumbnail_image: Optional[str] = Field(default="")
     thumbnail_video: Optional[str] = Field(default="")
     seo: Optional[dict] = None
+    onboarding_config: Optional[dict] = None
     # Chapters, Activities
     chapters: List[ChapterRead]
     authors: List[AuthorWithRole]
@@ -134,6 +138,7 @@ class FullCourseReadWithTrail(CourseBase):
     update_date: Optional[str] = None
     org_id: int = Field(default=None, foreign_key="organization.id")
     seo: Optional[dict] = None
+    onboarding_config: Optional[dict] = None
     authors: List[AuthorWithRole]
     # Chapters, Activities
     chapters: List[ChapterRead]

--- a/apps/api/src/routers/courses/chapters.py
+++ b/apps/api/src/routers/courses/chapters.py
@@ -1,12 +1,15 @@
-from typing import List
-from fastapi import APIRouter, Depends, Request
+from typing import List, Optional
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlmodel import Session, select
 from src.core.events.database import get_db_session
 from src.db.courses.chapters import (
+    Chapter,
     ChapterCreate,
     ChapterRead,
     ChapterUpdate,
     ChapterUpdateOrder,
 )
+from src.db.usergroup_resources import UserGroupResource
 from src.services.courses.chapters import (
     DEPRECEATED_get_course_chapters,
     create_chapter,
@@ -253,3 +256,75 @@ async def api_remove_chapter_usergroup(
     return await remove_usergroup_from_chapter(
         request, chapter_uuid, usergroup_uuid, current_user, db_session
     )
+
+
+@router.get(
+    "/{chapter_uuid}/paywall_offer",
+    summary="Get paywall offer for a locked chapter",
+    description=(
+        "Resolve the purchasable offer (if any) that unlocks a RESTRICTED chapter. "
+        "Walks chapter → UserGroupResource → PaymentsGroupSync → PaymentsOffer. "
+        "Returns 404 when no linked offer exists (free-but-restricted usergroups). "
+        "Public endpoint so anonymous visitors can see the price before signup."
+    ),
+)
+async def api_get_chapter_paywall_offer(
+    request: Request,
+    chapter_uuid: str,
+    db_session: Session = Depends(get_db_session),
+):
+    chapter = db_session.exec(
+        select(Chapter).where(Chapter.chapter_uuid == chapter_uuid)
+    ).first()
+    if not chapter:
+        raise HTTPException(status_code=404, detail="Chapter not found")
+
+    usergroup_ids = db_session.exec(
+        select(UserGroupResource.usergroup_id).where(
+            UserGroupResource.resource_uuid == chapter_uuid
+        )
+    ).all()
+    if not usergroup_ids:
+        raise HTTPException(status_code=404, detail="No paywall offer for this chapter")
+
+    try:
+        from ee.db.payments.payments_groups import PaymentsGroupSync
+        from ee.db.payments.payments_offers import PaymentsOffer
+        from ee.db.payments.payments import PaymentsConfig
+    except Exception:
+        raise HTTPException(status_code=404, detail="Payments module unavailable")
+
+    sync_rows = db_session.exec(
+        select(PaymentsGroupSync).where(PaymentsGroupSync.usergroup_id.in_(usergroup_ids))
+    ).all()
+    if not sync_rows:
+        raise HTTPException(status_code=404, detail="No paywall offer for this chapter")
+
+    payments_group_ids = [s.payments_group_id for s in sync_rows]
+    offers = db_session.exec(
+        select(PaymentsOffer).where(PaymentsOffer.payments_group_id.in_(payments_group_ids))
+    ).all()
+    if not offers:
+        raise HTTPException(status_code=404, detail="No paywall offer for this chapter")
+
+    # If multiple offers match, pick the cheapest one as the primary ("empezar desde…")
+    offer = sorted(offers, key=lambda o: (o.amount or 0))[0]
+
+    config_row = db_session.exec(
+        select(PaymentsConfig).where(PaymentsConfig.id == offer.payments_config_id)
+    ).first()
+
+    return {
+        "offer_uuid": offer.offer_uuid,
+        "name": offer.name,
+        "description": offer.description,
+        "benefits": offer.benefits,
+        "amount": offer.amount,
+        "currency": offer.currency,
+        "offer_type": offer.offer_type,
+        "price_type": offer.price_type,
+        "provider": getattr(config_row, "provider", None) if config_row else None,
+        "org_id": offer.org_id,
+        "chapter_uuid": chapter.chapter_uuid,
+        "course_id": chapter.course_id,
+    }

--- a/apps/api/src/services/users/emails.py
+++ b/apps/api/src/services/users/emails.py
@@ -296,3 +296,49 @@ def send_email_verification_email(
             footer_note="This link expires in 1 hour. If you didn't create a LearnHouse account, you can safely ignore this email.",
         ),
     )
+
+
+def send_purchase_welcome_email(
+    email: EmailStr,
+    username: str,
+    course_name: str,
+    course_url: str,
+    offer_name: str | None = None,
+):
+    """
+    Send a warm welcome email after a successful paywall purchase.
+
+    Called from the enrollment-activation path (Stripe webhook) when status
+    transitions to COMPLETED. Idempotent at the webhook layer.
+    """
+    safe_username = html.escape(username)
+    safe_course = html.escape(course_name)
+    safe_offer = html.escape(offer_name) if offer_name else ""
+
+    offer_line = (
+        f"<p style=\"{STYLES['p']}\">Compra confirmada: <strong>{safe_offer}</strong>.</p>"
+        if safe_offer else ""
+    )
+
+    body_content = f"""
+        <h1 style="{STYLES['h1']}">¡Bienvenido al curso, {safe_username}!</h1>
+        <p style="{STYLES['p']}">
+            Tu acceso completo a <strong>{safe_course}</strong> ya está activo.
+            Los que terminan el curso son los que hacen el ejercicio y el proyecto
+            de cada capítulo. No te saltes esos bloques.
+        </p>
+        {offer_line}
+        <a href="{course_url}" style="{STYLES['button']}">
+            Empezar el siguiente capítulo
+        </a>
+    """
+
+    return send_email(
+        to=email,
+        subject=f"Bienvenido a {course_name} — tu acceso está activo",
+        body=_email_layout(
+            title="Purchase Welcome",
+            body_content=body_content,
+            footer_note="Si tienes cualquier duda, responde a este email y te ayudamos.",
+        ),
+    )

--- a/apps/web/app/auth/signup/OpenSignup.tsx
+++ b/apps/web/app/auth/signup/OpenSignup.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useFormik } from 'formik'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import React, { useEffect } from 'react'
 import FormLayout, {
   FormField,
@@ -52,18 +52,26 @@ function OpenSignUpComponent() {
   const [isSubmitting, setIsSubmitting] = React.useState(false)
   const org = useOrg() as any
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const prefilledEmail = searchParams?.get('email') || ''
+  const nextUrl = searchParams?.get('next') || ''
+  const courseUuid = searchParams?.get('course_uuid') || ''
+  const source = searchParams?.get('source') || ''
   const [error, setError] = React.useState('')
   const [message, setMessage] = React.useState('')
   const formik = useFormik({
     initialValues: {
       org_slug: org?.slug,
       org_id: org?.id,
-      email: '',
+      email: prefilledEmail,
       password: '',
       username: '',
       bio: '',
       first_name: '',
       last_name: '',
+      role: '',
+      business: '',
+      goal: '',
     },
     validate: (values) => validate(values, t),
     enableReinitialize: true,
@@ -71,7 +79,15 @@ function OpenSignUpComponent() {
       setError('')
       setMessage('')
       setIsSubmitting(true)
-      let res = await signup(values)
+      const { role, business, goal, ...rest } = values as any
+      const details: Record<string, any> = { onboarded: false }
+      if (role) details.role = role
+      if (business) details.business = business
+      if (goal) details.goal = goal
+      if (source) details.signup_source = source
+      if (courseUuid) details.signup_course_uuid = courseUuid
+      const payload = { ...rest, details }
+      let res = await signup(payload)
       let message = await res.json()
       if (res.status == 200) {
         setMessage(t('auth.account_created_success'))
@@ -239,6 +255,61 @@ function OpenSignUpComponent() {
             </Form.Control>
           </FormField>
 
+          {courseUuid && (
+            <>
+              <div className="mt-2 mb-1 text-xs uppercase tracking-wide font-semibold text-gray-500">
+                Cuéntanos un poco sobre ti (opcional)
+              </div>
+
+              <FormField name="role">
+                <FormLabelAndMessage label="Tu rol" />
+                <Form.Control asChild>
+                  <select
+                    name="role"
+                    onChange={formik.handleChange}
+                    onBlur={formik.handleBlur}
+                    value={formik.values.role}
+                    className="box-border w-full inline-flex items-center rounded h-[35px] leading-none px-2.5 text-[15px] text-[#7c7c7c] bg-[#fbfdff] shadow-[0_0_0_1px_#edeeef] focus:shadow-[0_0_0_2px_#edeeef] border-none outline-none"
+                  >
+                    <option value="">Selecciona...</option>
+                    <option value="founder">Fundador / Emprendedor</option>
+                    <option value="freelance">Freelance / Consultor</option>
+                    <option value="employee">Empleado</option>
+                    <option value="student">Estudiante</option>
+                    <option value="other">Otro</option>
+                  </select>
+                </Form.Control>
+              </FormField>
+
+              <FormField name="business">
+                <FormLabelAndMessage label="Tipo de negocio" />
+                <Form.Control asChild>
+                  <Input
+                    name="business"
+                    onChange={formik.handleChange}
+                    onBlur={formik.handleBlur}
+                    value={formik.values.business}
+                    type="text"
+                    placeholder="p.ej. agencia de marketing, e-commerce, SaaS..."
+                  />
+                </Form.Control>
+              </FormField>
+
+              <FormField name="goal">
+                <FormLabelAndMessage label="¿Qué quieres conseguir con este curso?" />
+                <Form.Control asChild>
+                  <Textarea
+                    name="goal"
+                    onChange={formik.handleChange}
+                    onBlur={formik.handleBlur}
+                    value={formik.values.goal}
+                    placeholder="p.ej. automatizar la captación de leads, montar mi primer agente..."
+                  />
+                </Form.Control>
+              </FormField>
+            </>
+          )}
+
           <div className="pt-2">
             <Form.Submit asChild>
               <button className="w-full bg-black text-white font-semibold text-center py-2.5 rounded-lg hover:bg-gray-800 transition-colors">
@@ -271,7 +342,10 @@ function OpenSignUpComponent() {
       {/* Login Link */}
       <p className="text-center text-gray-600 mt-6">
         {t('auth.already_have_account')}{' '}
-        <Link href="/login" className="font-semibold text-gray-900 hover:underline">
+        <Link
+          href={nextUrl ? `/login?next=${encodeURIComponent(nextUrl)}` : '/login'}
+          className="font-semibold text-gray-900 hover:underline"
+        >
           {t('auth.login')}
         </Link>
       </p>

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/course/[courseuuid]/activity/[activityid]/activity.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/course/[courseuuid]/activity/[activityid]/activity.tsx
@@ -36,6 +36,8 @@ import MiniInfoTooltip from '@components/Objects/MiniInfoTooltip'
 import GeneralWrapperStyled from '@components/Objects/StyledElements/Wrappers/GeneralWrapper'
 import ActivityIndicators from '@components/Pages/Courses/ActivityIndicators'
 import UserAvatar from '@components/Objects/UserAvatar'
+import PaywallGate from '@components/Pages/Courses/PaywallGate'
+import ThanksModal from '@components/Pages/Courses/ThanksModal'
 import { useTranslation } from 'react-i18next'
 import { useAnalytics } from '@/hooks/useAnalytics'
 
@@ -367,43 +369,68 @@ function ActivityClient(props: ActivityClientProps) {
 
   if (activity?.is_locked) {
     const isAuthenticated = session?.status === 'authenticated'
+    const lockedChapter = (course?.chapters || []).find((ch: any) =>
+      (ch.activities || []).some((a: any) => a.id === activity.id || a.activity_uuid === activity.activity_uuid)
+    )
+    const lockedChapterUuid = lockedChapter?.chapter_uuid
+    const paywallCopy = course?.onboarding_config?.paywall
+
+    const defaultLockedCard = (
+      <div className="max-w-2xl mx-auto my-16 bg-white rounded-2xl border border-gray-200/80 shadow-sm p-8 text-center">
+        <div className="mx-auto w-14 h-14 rounded-full bg-rose-50 flex items-center justify-center mb-4">
+          <Lock className="text-rose-500" size={24} />
+        </div>
+        <h1 className="text-xl font-semibold text-gray-900 mb-2">
+          {t('course.locked_title', 'This activity is locked')}
+        </h1>
+        <p className="text-sm text-gray-500 mb-6 leading-relaxed">
+          {isAuthenticated
+            ? t('course.locked_restricted', 'You need to be a member of the right user group to access this. Ask a course admin to add you.')
+            : t('course.locked_auth_required', 'You need to sign in to access this activity.')}
+        </p>
+        <div className="flex flex-col sm:flex-row gap-2 justify-center">
+          {!isAuthenticated && (
+            <Link
+              href={getUriWithOrg(orgslug, '/login')}
+              className="inline-flex items-center justify-center px-4 py-2 bg-gray-900 text-white rounded-lg text-sm font-semibold hover:bg-gray-800 transition-colors"
+            >
+              {t('auth.sign_in', 'Sign in')}
+            </Link>
+          )}
+          <Link
+            href={getUriWithOrg(orgslug, '') + `/course/${courseuuid}`}
+            className="inline-flex items-center justify-center px-4 py-2 bg-gray-100 text-gray-700 rounded-lg text-sm font-semibold hover:bg-gray-200 transition-colors"
+          >
+            {t('course.back_to_course', 'Back to course')}
+          </Link>
+        </div>
+      </div>
+    )
+
     return (
       <GeneralWrapperStyled>
-        <div className="max-w-2xl mx-auto my-16 bg-white rounded-2xl border border-gray-200/80 shadow-sm p-8 text-center">
-          <div className="mx-auto w-14 h-14 rounded-full bg-rose-50 flex items-center justify-center mb-4">
-            <Lock className="text-rose-500" size={24} />
-          </div>
-          <h1 className="text-xl font-semibold text-gray-900 mb-2">
-            {t('course.locked_title', 'This activity is locked')}
-          </h1>
-          <p className="text-sm text-gray-500 mb-6 leading-relaxed">
-            {isAuthenticated
-              ? t('course.locked_restricted', 'You need to be a member of the right user group to access this. Ask a course admin to add you.')
-              : t('course.locked_auth_required', 'You need to sign in to access this activity.')}
-          </p>
-          <div className="flex flex-col sm:flex-row gap-2 justify-center">
-            {!isAuthenticated && (
-              <Link
-                href={getUriWithOrg(orgslug, '/login')}
-                className="inline-flex items-center justify-center px-4 py-2 bg-gray-900 text-white rounded-lg text-sm font-semibold hover:bg-gray-800 transition-colors"
-              >
-                {t('auth.sign_in', 'Sign in')}
-              </Link>
-            )}
-            <Link
-              href={getUriWithOrg(orgslug, '') + `/course/${courseuuid}`}
-              className="inline-flex items-center justify-center px-4 py-2 bg-gray-100 text-gray-700 rounded-lg text-sm font-semibold hover:bg-gray-200 transition-colors"
-            >
-              {t('course.back_to_course', 'Back to course')}
-            </Link>
-          </div>
-        </div>
+        {lockedChapterUuid ? (
+          <PaywallGate
+            chapterUuid={lockedChapterUuid}
+            orgslug={orgslug}
+            courseUuid={courseuuid}
+            copy={paywallCopy}
+            accessToken={access_token}
+            redirectBackPath={pathname || `/course/${courseuuid}`}
+            fallback={defaultLockedCard}
+          />
+        ) : (
+          defaultLockedCard
+        )}
       </GeneralWrapperStyled>
     )
   }
 
   return (
     <>
+      {course?.onboarding_config?.thanks && (
+        <ThanksModal config={course.onboarding_config.thanks} />
+      )}
       <CourseProvider courseuuid={course?.course_uuid}>
         <Suspense fallback={<LoadingFallback />}>
           <AIChatBotProvider>

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/course/[courseuuid]/course.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/course/[courseuuid]/course.tsx
@@ -24,6 +24,12 @@ import { useTranslation } from 'react-i18next'
 import CourseCommunitySection from '@components/Objects/Communities/CourseCommunitySection'
 import CourseShare from '@components/Objects/Courses/CourseShare/CourseShare'
 import { useAnalytics } from '@/hooks/useAnalytics'
+import LandingHero from '@components/Pages/Courses/LandingHero'
+import WelcomeModal from '@components/Pages/Courses/WelcomeModal'
+import ThanksModal from '@components/Pages/Courses/ThanksModal'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import 'github-markdown-css/github-markdown-light.css'
 
 const CourseClient = (props: any) => {
   const { t } = useTranslation()
@@ -249,6 +255,30 @@ const CourseClient = (props: any) => {
                 { label: course.name }
               ]} />
             </div>
+
+            {course?.onboarding_config?.landing && (
+              <LandingHero
+                config={course.onboarding_config.landing}
+                orgslug={orgslug}
+                courseuuid={courseuuid}
+                isAuthenticated={!!access_token}
+                firstChapterHref={getUriWithOrg(orgslug, `/course/${courseuuid}`)}
+              />
+            )}
+
+            {access_token && session?.data?.user && course?.onboarding_config?.welcome && (
+              <WelcomeModal
+                config={course.onboarding_config.welcome}
+                courseUuid={courseuuid}
+                user={session.data.user}
+                accessToken={access_token}
+              />
+            )}
+
+            {course?.onboarding_config?.thanks && (
+              <ThanksModal config={course.onboarding_config.thanks} />
+            )}
+
             <div className="pb-2 flex flex-col md:flex-row justify-between items-start md:items-center gap-3">
               <h1 className="text-3xl md:text-3xl font-bold">{course.name}</h1>
               <CourseShare
@@ -384,8 +414,10 @@ const CourseClient = (props: any) => {
                 )}
 
                 <div className="course_metadata_left space-y-2">
-                  <div className="">
-                    <p className="py-5 whitespace-pre-line break-words w-full leading-relaxed tracking-normal text-pretty hyphens-auto">{course.about}</p>
+                  <div className="py-5 markdown-body" style={{ backgroundColor: 'transparent' }}>
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                      {course.about || ''}
+                    </ReactMarkdown>
                   </div>
                 </div>
               </div>

--- a/apps/web/components/Pages/Courses/LandingHero.tsx
+++ b/apps/web/components/Pages/Courses/LandingHero.tsx
@@ -1,0 +1,119 @@
+'use client'
+import React, { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { ArrowRight, Check, Sparkles } from 'lucide-react'
+import { getUriWithOrg } from '@services/config/config'
+import 'github-markdown-css/github-markdown-light.css'
+
+interface LandingConfig {
+  hero_markdown?: string
+  benefits?: string[]
+  cta_label?: string
+  preview_image?: string
+}
+
+interface LandingHeroProps {
+  config: LandingConfig
+  orgslug: string
+  courseuuid: string
+  isAuthenticated: boolean
+  firstChapterHref?: string | null
+}
+
+const LandingHero: React.FC<LandingHeroProps> = ({
+  config,
+  orgslug,
+  courseuuid,
+  isAuthenticated,
+  firstChapterHref,
+}) => {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+
+  const heroMd = config?.hero_markdown
+  const benefits = config?.benefits || []
+  const ctaLabel = config?.cta_label || 'Empezar gratis'
+
+  if (!heroMd && benefits.length === 0) return null
+
+  const signupHref = (() => {
+    const next = firstChapterHref || getUriWithOrg(orgslug, `/course/${courseuuid}`)
+    const base = getUriWithOrg(orgslug, `/signup?next=${encodeURIComponent(next)}&course_uuid=${courseuuid}`)
+    return email ? `${base}&email=${encodeURIComponent(email)}` : base
+  })()
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    router.push(signupHref)
+  }
+
+  // Authenticated users see a shorter hero (no email capture, just a "continue" CTA)
+  if (isAuthenticated) {
+    return (
+      <div className="mb-6 rounded-2xl bg-gradient-to-br from-indigo-50 via-white to-rose-50 border border-indigo-100/60 p-6 md:p-8 shadow-sm">
+        <div className="max-w-3xl markdown-body" style={{ backgroundColor: 'transparent' }}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{heroMd || ''}</ReactMarkdown>
+        </div>
+        {firstChapterHref && (
+          <div className="mt-4">
+            <button
+              onClick={() => router.push(firstChapterHref)}
+              className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-black text-white text-sm font-semibold hover:bg-gray-800 transition"
+            >
+              Continuar curso <ArrowRight size={16} />
+            </button>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  // Anonymous users: full hero with email capture
+  return (
+    <div className="mb-8 rounded-2xl bg-gradient-to-br from-indigo-50 via-white to-rose-50 border border-indigo-100/60 p-6 md:p-10 shadow-sm">
+      <div className="flex flex-col md:flex-row gap-8 items-start">
+        <div className="flex-1 min-w-0">
+          <div className="inline-flex items-center gap-1.5 mb-4 px-3 py-1 rounded-full bg-white/80 text-xs font-semibold text-indigo-700 border border-indigo-100">
+            <Sparkles size={12} /> 2 capítulos gratis · empieza ahora
+          </div>
+          <div className="max-w-2xl markdown-body" style={{ backgroundColor: 'transparent' }}>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{heroMd || ''}</ReactMarkdown>
+          </div>
+
+          {benefits.length > 0 && (
+            <ul className="mt-5 space-y-2">
+              {benefits.map((b, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm text-gray-700">
+                  <Check size={16} className="text-emerald-500 mt-0.5 flex-shrink-0" />
+                  <span>{b}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <form onSubmit={handleSubmit} className="mt-6 flex flex-col sm:flex-row gap-2 max-w-md">
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="tu@email.com"
+              className="flex-1 h-11 px-4 rounded-full bg-white border border-gray-200 text-sm outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-100 transition"
+            />
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center gap-2 h-11 px-5 rounded-full bg-black text-white text-sm font-semibold hover:bg-gray-800 transition"
+            >
+              {ctaLabel} <ArrowRight size={16} />
+            </button>
+          </form>
+          <p className="mt-2 text-xs text-gray-500">Sin spam. Solo para crear tu cuenta y guardar tu progreso.</p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default LandingHero

--- a/apps/web/components/Pages/Courses/PaywallGate.tsx
+++ b/apps/web/components/Pages/Courses/PaywallGate.tsx
@@ -1,0 +1,214 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { ArrowRight, Check, Lock, ShieldCheck, Sparkles } from 'lucide-react'
+import { getAPIUrl, getUriWithOrg } from '@services/config/config'
+import { getOfferCheckoutSession } from '@services/payments/offers'
+
+interface PaywallCopy {
+  headline?: string
+  subhead?: string
+  benefits?: string[]
+  price_label?: string
+  price_sub?: string
+  urgency?: string
+  cta_label?: string
+  secondary_label?: string
+  guarantee?: string
+}
+
+interface PaywallOfferApi {
+  offer_uuid: string
+  name: string
+  description: string
+  benefits: string
+  amount: number
+  currency: string
+  org_id: number
+}
+
+interface PaywallGateProps {
+  chapterUuid: string
+  orgslug: string
+  courseUuid: string
+  copy?: PaywallCopy
+  accessToken?: string
+  redirectBackPath?: string
+  fallback?: React.ReactNode
+}
+
+function formatPrice(amount: number, currency: string) {
+  if (typeof amount !== 'number') return ''
+  try {
+    return new Intl.NumberFormat('es-ES', { style: 'currency', currency, maximumFractionDigits: 0 }).format(amount)
+  } catch {
+    return `${amount} ${currency}`
+  }
+}
+
+const PaywallGate: React.FC<PaywallGateProps> = ({
+  chapterUuid,
+  orgslug,
+  courseUuid,
+  copy,
+  accessToken,
+  redirectBackPath,
+  fallback,
+}) => {
+  const [offer, setOffer] = useState<PaywallOfferApi | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [notFound, setNotFound] = useState(false)
+  const [checkoutLoading, setCheckoutLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const run = async () => {
+      try {
+        const res = await fetch(`${getAPIUrl()}chapters/${chapterUuid}/paywall_offer`, {
+          method: 'GET',
+        })
+        if (cancelled) return
+        if (res.status === 404) {
+          setNotFound(true)
+        } else if (res.ok) {
+          const data = await res.json()
+          setOffer(data)
+        } else {
+          setNotFound(true)
+        }
+      } catch {
+        if (!cancelled) setNotFound(true)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    run()
+    return () => { cancelled = true }
+  }, [chapterUuid])
+
+  const handleCheckout = async () => {
+    if (!offer || !accessToken) return
+    setError(null)
+    setCheckoutLoading(true)
+    try {
+      const origin = typeof window !== 'undefined' ? window.location.origin : ''
+      const backPath = redirectBackPath || getUriWithOrg(orgslug, `/course/${courseUuid}`)
+      const redirectUri = `${origin}${backPath}${backPath.includes('?') ? '&' : '?'}paid=1`
+      const res: any = await getOfferCheckoutSession(
+        offer.org_id,
+        offer.offer_uuid,
+        redirectUri,
+        accessToken
+      )
+      if (res?.success && res?.data?.url) {
+        window.location.href = res.data.url
+      } else {
+        setError(res?.HTTPmessage || 'No se pudo iniciar el checkout. Intenta de nuevo.')
+        setCheckoutLoading(false)
+      }
+    } catch (e: any) {
+      setError(e?.message || 'Error iniciando el checkout.')
+      setCheckoutLoading(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="max-w-2xl mx-auto my-16 bg-white rounded-2xl border border-gray-200/80 shadow-sm p-8 text-center animate-pulse">
+        <div className="h-6 bg-gray-100 rounded w-1/2 mx-auto mb-4" />
+        <div className="h-3 bg-gray-100 rounded w-3/4 mx-auto mb-2" />
+        <div className="h-3 bg-gray-100 rounded w-2/3 mx-auto" />
+      </div>
+    )
+  }
+
+  if (notFound || !offer) {
+    return fallback ? <>{fallback}</> : null
+  }
+
+  const headline = copy?.headline || 'Has llegado al contenido premium'
+  const subhead = copy?.subhead || offer.description || 'Desbloquea el curso completo para continuar.'
+  const benefits = (copy?.benefits && copy.benefits.length > 0)
+    ? copy.benefits
+    : (offer.benefits ? offer.benefits.split('\n').filter(Boolean) : [])
+  const priceLabel = copy?.price_label || formatPrice(offer.amount, offer.currency)
+  const priceSub = copy?.price_sub || 'pago único · acceso de por vida'
+  const ctaLabel = copy?.cta_label || 'Desbloquear ahora'
+  const secondaryLabel = copy?.secondary_label || 'Volver al curso'
+
+  return (
+    <div className="max-w-3xl mx-auto my-10 rounded-2xl border border-indigo-100/70 bg-gradient-to-br from-indigo-50 via-white to-rose-50 shadow-sm overflow-hidden">
+      <div className="p-6 md:p-10">
+        <div className="inline-flex items-center gap-1.5 mb-4 px-3 py-1 rounded-full bg-white/80 text-xs font-semibold text-indigo-700 border border-indigo-100">
+          <Lock size={12} /> Capítulo premium
+        </div>
+
+        <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-2">{headline}</h1>
+        <p className="text-gray-600 text-sm md:text-base mb-6 leading-relaxed">{subhead}</p>
+
+        {benefits.length > 0 && (
+          <ul className="space-y-2 mb-6">
+            {benefits.map((b, i) => (
+              <li key={i} className="flex items-start gap-2 text-sm text-gray-800">
+                <Check size={16} className="text-emerald-500 mt-0.5 flex-shrink-0" />
+                <span>{b}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="bg-white rounded-xl border border-gray-200 p-5 mb-5">
+          <div className="flex items-end gap-2 mb-1">
+            <span className="text-3xl md:text-4xl font-extrabold text-gray-900">{priceLabel}</span>
+            <span className="text-xs text-gray-500 pb-1">{priceSub}</span>
+          </div>
+          {copy?.urgency && (
+            <div className="mt-2 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-amber-50 text-amber-700 text-xs font-semibold border border-amber-100">
+              <Sparkles size={12} /> {copy.urgency}
+            </div>
+          )}
+        </div>
+
+        {error && (
+          <div className="mb-4 text-sm text-red-700 bg-red-50 border border-red-100 rounded-lg p-3">{error}</div>
+        )}
+
+        <div className="flex flex-col sm:flex-row gap-3">
+          {accessToken ? (
+            <button
+              type="button"
+              onClick={handleCheckout}
+              disabled={checkoutLoading}
+              className="inline-flex items-center justify-center gap-2 px-5 py-3 rounded-full bg-black text-white text-sm font-semibold hover:bg-gray-800 transition disabled:opacity-60"
+            >
+              {checkoutLoading ? 'Abriendo checkout…' : (<>{ctaLabel} <ArrowRight size={16} /></>)}
+            </button>
+          ) : (
+            <Link
+              href={getUriWithOrg(orgslug, `/login?next=${encodeURIComponent(redirectBackPath || `/course/${courseUuid}`)}`)}
+              className="inline-flex items-center justify-center gap-2 px-5 py-3 rounded-full bg-black text-white text-sm font-semibold hover:bg-gray-800 transition"
+            >
+              Inicia sesión para desbloquear <ArrowRight size={16} />
+            </Link>
+          )}
+          <Link
+            href={getUriWithOrg(orgslug, `/course/${courseUuid}`)}
+            className="inline-flex items-center justify-center gap-2 px-5 py-3 rounded-full bg-white border border-gray-200 text-gray-700 text-sm font-semibold hover:bg-gray-50 transition"
+          >
+            {secondaryLabel}
+          </Link>
+        </div>
+
+        {copy?.guarantee && (
+          <div className="mt-5 flex items-start gap-2 text-xs text-gray-500">
+            <ShieldCheck size={14} className="text-emerald-500 mt-0.5" />
+            <span>{copy.guarantee}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default PaywallGate

--- a/apps/web/components/Pages/Courses/ThanksModal.tsx
+++ b/apps/web/components/Pages/Courses/ThanksModal.tsx
@@ -1,0 +1,80 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { Dialog, DialogContent, DialogTitle } from '@components/ui/dialog'
+import { ArrowRight, PartyPopper } from 'lucide-react'
+import 'github-markdown-css/github-markdown-light.css'
+
+interface ThanksConfig {
+  markdown?: string
+  next_chapter_cta?: string
+}
+
+interface ThanksModalProps {
+  config?: ThanksConfig
+  nextHref?: string
+  queryParam?: string
+}
+
+const ThanksModal: React.FC<ThanksModalProps> = ({ config, nextHref, queryParam = 'paid' }) => {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    if (!config?.markdown) return
+    if (searchParams?.get(queryParam) === '1') setOpen(true)
+  }, [config?.markdown, searchParams, queryParam])
+
+  const handleClose = () => {
+    setOpen(false)
+    // Strip the ?paid=1 so the modal doesn't re-open on refresh
+    if (pathname && searchParams) {
+      const params = new URLSearchParams(searchParams.toString())
+      params.delete(queryParam)
+      const query = params.toString()
+      router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false })
+    }
+  }
+
+  if (!config?.markdown) return null
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) handleClose() }}>
+      <DialogContent className="flex flex-col w-[95vw] max-w-[95vw] sm:max-w-lg bg-white border border-gray-200 shadow-xl p-0 overflow-hidden rounded-2xl">
+        <DialogTitle className="sr-only">Bienvenido al curso premium</DialogTitle>
+        <div className="bg-gradient-to-br from-emerald-50 via-white to-indigo-50 p-6 md:p-8">
+          <div className="inline-flex items-center gap-1.5 mb-4 px-3 py-1 rounded-full bg-white/80 text-xs font-semibold text-emerald-700 border border-emerald-100">
+            <PartyPopper size={12} /> ¡Pago confirmado!
+          </div>
+          <div className="markdown-body max-w-none" style={{ backgroundColor: 'transparent' }}>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{config.markdown}</ReactMarkdown>
+          </div>
+        </div>
+        <div className="flex items-center justify-end gap-2 px-6 py-4 bg-white border-t border-gray-100">
+          <button
+            type="button"
+            onClick={handleClose}
+            className="text-xs text-gray-500 hover:text-gray-900 px-3 py-2"
+          >
+            Cerrar
+          </button>
+          {nextHref && (
+            <button
+              type="button"
+              onClick={() => { handleClose(); router.push(nextHref) }}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-black text-white text-sm font-semibold hover:bg-gray-800 transition"
+            >
+              {config.next_chapter_cta || 'Continuar'} <ArrowRight size={14} />
+            </button>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default ThanksModal

--- a/apps/web/components/Pages/Courses/WelcomeModal.tsx
+++ b/apps/web/components/Pages/Courses/WelcomeModal.tsx
@@ -1,0 +1,180 @@
+'use client'
+import React, { useEffect, useMemo, useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { Dialog, DialogContent, DialogTitle } from '@components/ui/dialog'
+import { ArrowRight, Check, Sparkles } from 'lucide-react'
+import { getAPIUrl } from '@services/config/config'
+import 'github-markdown-css/github-markdown-light.css'
+
+interface WelcomeStep {
+  title: string
+  body: string
+}
+
+interface WelcomeConfig {
+  markdown?: string
+  steps?: WelcomeStep[]
+}
+
+interface WelcomeModalProps {
+  config?: WelcomeConfig
+  courseUuid: string
+  user: any
+  accessToken?: string
+  onFinished?: () => void
+}
+
+const LOCAL_SKIP_KEY = (courseUuid: string, userId: number | string) =>
+  `lh_welcome_skipped_${courseUuid}_${userId}`
+
+const WelcomeModal: React.FC<WelcomeModalProps> = ({
+  config,
+  courseUuid,
+  user,
+  accessToken,
+  onFinished,
+}) => {
+  const [open, setOpen] = useState(false)
+  const [stepIdx, setStepIdx] = useState(0)
+  const [saving, setSaving] = useState(false)
+
+  const steps = useMemo(() => config?.steps || [], [config])
+  const hasMarkdown = !!config?.markdown
+  const totalSlides = (hasMarkdown ? 1 : 0) + steps.length
+
+  useEffect(() => {
+    if (!config || (!hasMarkdown && steps.length === 0)) return
+    if (!user?.id) return
+    const alreadyOnboarded = user?.details?.onboarded === true
+    if (alreadyOnboarded) return
+    const skipKey = LOCAL_SKIP_KEY(courseUuid, user.id)
+    if (typeof window !== 'undefined' && window.localStorage?.getItem(skipKey)) return
+    setOpen(true)
+  }, [config, hasMarkdown, steps.length, user?.id, user?.details?.onboarded, courseUuid])
+
+  const markOnboarded = async () => {
+    if (!user?.id || !accessToken) return
+    setSaving(true)
+    try {
+      const currentDetails = (user?.details && typeof user.details === 'object') ? user.details : {}
+      const newDetails = { ...currentDetails, onboarded: true, onboarded_course_uuid: courseUuid }
+      const body = {
+        username: user.username,
+        first_name: user.first_name || '',
+        last_name: user.last_name || '',
+        email: user.email,
+        avatar_image: user.avatar_image || '',
+        bio: user.bio || '',
+        details: newDetails,
+        profile: user.profile || {},
+      }
+      await fetch(`${getAPIUrl()}users/${user.id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify(body),
+      })
+      if (typeof window !== 'undefined') {
+        window.localStorage?.setItem(LOCAL_SKIP_KEY(courseUuid, user.id), '1')
+      }
+    } catch {
+      // fail silently — the local skip key below still prevents a loop
+      if (typeof window !== 'undefined') {
+        window.localStorage?.setItem(LOCAL_SKIP_KEY(courseUuid, user.id), '1')
+      }
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleClose = async () => {
+    await markOnboarded()
+    setOpen(false)
+    onFinished?.()
+  }
+
+  const handleNext = () => {
+    if (stepIdx < totalSlides - 1) {
+      setStepIdx(stepIdx + 1)
+    } else {
+      handleClose()
+    }
+  }
+
+  if (!config || (!hasMarkdown && steps.length === 0)) return null
+
+  const onIntro = hasMarkdown && stepIdx === 0
+  const currentStep = hasMarkdown ? steps[stepIdx - 1] : steps[stepIdx]
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) handleClose() }}>
+      <DialogContent className="flex flex-col w-[95vw] max-w-[95vw] sm:max-w-lg bg-white border border-gray-200 shadow-xl p-0 overflow-hidden rounded-2xl">
+        <DialogTitle className="sr-only">Bienvenida al curso</DialogTitle>
+        <div className="bg-gradient-to-br from-indigo-50 via-white to-rose-50 p-6 md:p-8">
+          <div className="inline-flex items-center gap-1.5 mb-4 px-3 py-1 rounded-full bg-white/80 text-xs font-semibold text-indigo-700 border border-indigo-100">
+            <Sparkles size={12} /> Paso {stepIdx + 1} de {totalSlides}
+          </div>
+
+          {onIntro ? (
+            <div className="markdown-body max-w-none" style={{ backgroundColor: 'transparent' }}>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                {config.markdown || ''}
+              </ReactMarkdown>
+            </div>
+          ) : currentStep ? (
+            <div>
+              <h2 className="text-xl font-bold text-gray-900 mb-2">{currentStep.title}</h2>
+              <p className="text-gray-700 text-sm leading-relaxed">{currentStep.body}</p>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="flex items-center justify-between px-6 py-4 bg-white border-t border-gray-100">
+          <div className="flex gap-1.5">
+            {Array.from({ length: totalSlides }).map((_, i) => (
+              <span
+                key={i}
+                className={`h-1.5 rounded-full transition-all ${i === stepIdx ? 'w-6 bg-black' : 'w-1.5 bg-gray-200'}`}
+              />
+            ))}
+          </div>
+          <div className="flex items-center gap-2">
+            {stepIdx < totalSlides - 1 ? (
+              <>
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  className="text-xs text-gray-500 hover:text-gray-900 px-2"
+                  disabled={saving}
+                >
+                  Saltar
+                </button>
+                <button
+                  type="button"
+                  onClick={handleNext}
+                  className="inline-flex items-center gap-1.5 px-4 py-2 rounded-full bg-black text-white text-sm font-semibold hover:bg-gray-800 transition"
+                >
+                  Siguiente <ArrowRight size={14} />
+                </button>
+              </>
+            ) : (
+              <button
+                type="button"
+                onClick={handleClose}
+                disabled={saving}
+                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-full bg-black text-white text-sm font-semibold hover:bg-gray-800 transition disabled:opacity-60"
+              >
+                {saving ? 'Guardando…' : (<>Empezar <Check size={14} /></>)}
+              </button>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default WelcomeModal

--- a/apps/web/services/auth/auth.ts
+++ b/apps/web/services/auth/auth.ts
@@ -210,6 +210,11 @@ interface NewAccountBody {
   password: string
   org_slug: string
   org_id: string
+  first_name?: string
+  last_name?: string
+  bio?: string
+  details?: Record<string, any>
+  profile?: Record<string, any>
 }
 
 export async function signup(body: NewAccountBody): Promise<any> {


### PR DESCRIPTION
## Summary

Adds a full student-onboarding flow to any course via a new editable `courses.onboarding_config` JSONB, without hardcoding copy:

- **Landing**: markdown-rendered hero + email-capture CTA (prefills signup email).
- **Signup**: 3 optional fields (role / business / goal) stored in `User.details`, activated when the signup link carries `course_uuid`.
- **Welcome**: first-visit modal driven by `details.onboarded`, dismissable — PATCH flips the flag so it never re-shows.
- **Paywall**: branded offer card replacing the generic RESTRICTED lock on chapters. Resolves offer via new public `GET /chapters/{uuid}/paywall_offer` that walks `UserGroupResource → PaymentsGroupSync → PaymentsOffer`. Falls back to the existing locked card when no offer is configured.
- **Thanks**: `?paid=1` modal after Stripe success, plus `send_purchase_welcome_email()` triggered from `update_enrollment_status` on first activation (failures are swallowed so webhooks keep succeeding).

Includes a new Alembic migration `n4a5b6c7d8e9_add_course_onboarding_config` adding the JSONB column.

Also lands `CLAUDE.md` / `AGENTS.md` documenting the GitHub → infra-repo → Jenkins deploy flow (no Jenkinsfile in this repo).

## Test plan

- [ ] `alembic upgrade head` runs cleanly
- [ ] `GET /courses/{uuid}` returns `onboarding_config` (null when unset)
- [ ] `PUT /courses/{uuid}` with `onboarding_config={...}` persists and round-trips
- [ ] `GET /chapters/{uuid}/paywall_offer` returns 404 when no offer is synced, returns `{offer_uuid,name,amount,currency,...}` when synced
- [ ] Anonymous visitor sees landing hero + email capture when `onboarding_config.landing` is set
- [ ] Signup prefills email from `?email=` and stores extra fields in `User.details`
- [ ] First-visit welcome modal shows, dismiss sets `details.onboarded=true`, does not re-show on reload
- [ ] RESTRICTED chapter with a synced offer renders branded paywall and starts Stripe checkout on CTA
- [ ] After Stripe success, `?paid=1` shows the thanks modal and a purchase-welcome email arrives
- [ ] Courses without `onboarding_config` render exactly as before (no regression on current landing / lock UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)