### PR TITLE
feat(cli): add Wasabi preset to S3 storage setup wizard

### DIFF
--- a/apps/cli/src/prompts/features.ts
+++ b/apps/cli/src/prompts/features.ts
@@ -128,6 +128,18 @@ export async function promptFeatures(): Promise<FeaturesConfig> {
 
   if (config.s3Enabled) {
     p.log.info('Configure S3 Storage')
+
+    const provider = await p.select({
+      message: 'S3 provider?',
+      options: [
+        { value: 'aws', label: 'AWS S3', hint: 'Default — no endpoint URL needed' },
+        { value: 'wasabi', label: 'Wasabi', hint: 'S3-compatible' },
+        { value: 'custom', label: 'Other (S3-compatible)', hint: 'MinIO, Cloudflare R2, Backblaze B2, etc.' },
+      ],
+      initialValue: 'aws',
+    })
+    if (p.isCancel(provider)) { p.cancel(); process.exit(0) }
+
     const bucket = await p.text({
       message: 'S3 bucket name?',
       validate: validateRequired,
@@ -135,12 +147,43 @@ export async function promptFeatures(): Promise<FeaturesConfig> {
     if (p.isCancel(bucket)) { p.cancel(); process.exit(0) }
     config.s3BucketName = bucket as string
 
-    const endpoint = await p.text({
-      message: 'S3 endpoint URL? (leave empty for AWS S3)',
-      placeholder: 'https://s3.amazonaws.com',
-    })
-    if (p.isCancel(endpoint)) { p.cancel(); process.exit(0) }
-    if (endpoint) config.s3EndpointUrl = endpoint as string
+    if (provider === 'wasabi') {
+      p.log.info('Region URLs: https://docs.wasabi.com/docs/what-are-the-service-urls-for-wasabi-s-different-storage-regions')
+      const region = await p.select({
+        message: 'Wasabi region?',
+        options: [
+          { value: 'us-east-1', label: 'US East 1 (N. Virginia)' },
+          { value: 'us-east-2', label: 'US East 2 (N. Virginia)' },
+          { value: 'us-central-1', label: 'US Central 1 (Texas)' },
+          { value: 'us-west-1', label: 'US West 1 (Oregon)' },
+          { value: 'us-west-2', label: 'US West 2 (San Jose)' },
+          { value: 'ca-central-1', label: 'CA Central 1 (Toronto)' },
+          { value: 'eu-central-1', label: 'EU Central 1 (Amsterdam)' },
+          { value: 'eu-central-2', label: 'EU Central 2 (Frankfurt)' },
+          { value: 'eu-west-1', label: 'EU West 1 (United Kingdom)' },
+          { value: 'eu-west-2', label: 'EU West 2 (Paris)' },
+          { value: 'eu-west-3', label: 'EU West 3 (United Kingdom)' },
+          { value: 'eu-south-1', label: 'EU South 1 (Milan)' },
+          { value: 'ap-northeast-1', label: 'AP Northeast 1 (Tokyo)' },
+          { value: 'ap-northeast-2', label: 'AP Northeast 2 (Osaka)' },
+          { value: 'ap-southeast-1', label: 'AP Southeast 1 (Singapore)' },
+          { value: 'ap-southeast-2', label: 'AP Southeast 2 (Sydney)' },
+        ],
+        initialValue: 'us-east-1',
+      })
+      if (p.isCancel(region)) { p.cancel(); process.exit(0) }
+      config.s3EndpointUrl = `https://s3.${region}.wasabisys.com`
+    } else if (provider === 'custom') {
+      const endpoint = await p.text({
+        message: 'S3 endpoint URL?',
+        placeholder: 'https://s3.example.com',
+        validate: validateRequired,
+      })
+      if (p.isCancel(endpoint)) { p.cancel(); process.exit(0) }
+      config.s3EndpointUrl = endpoint as string
+    }
+
+    p.log.info('Tip: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set in your environment for S3 to work (skip if using AWS IAM roles).')
   }
 
   if (config.googleOAuthEnabled) {


### PR DESCRIPTION
## Summary

- Adds a "S3 provider" selector to the setup wizard with three options: **AWS S3**, **Wasabi**, **Other (S3-compatible)**
- For Wasabi: lists all 16 official regions ([reference](https://docs.wasabi.com/docs/what-are-the-service-urls-for-wasabi-s-different-storage-regions)) and auto-fills the endpoint URL as `https://s3.{region}.wasabisys.com`
- For AWS S3: no endpoint URL is set (boto3 uses regional defaults)
- For Other: free-form endpoint URL input — covers MinIO, Cloudflare R2, Backblaze B2, etc. (preserves the previous behavior)
- Adds a closing tip reminding users that `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` must be set in their environment (skippable when running on AWS with IAM roles)

## Why

Self-hosters frequently use Wasabi as a cheaper S3 alternative, but the existing wizard treats S3 setup as a binary "AWS or paste-a-URL" choice. Without knowing the exact Wasabi regional URL format, users have to leave the wizard, look up the docs, copy/paste back. A guided preset removes this friction for the most common alternative provider while keeping the freeform path intact for everything else.

The API storage layer already supports any S3-compatible service via `LEARNHOUSE_S3_API_ENDPOINT_URL` — `apps/api/src/services/courses/transfer/storage_utils.py` funnels every S3 call through a config-aware boto3 client and `apps/api/config/config.py` exposes a configurable `endpoint_url` field. So this is purely a wizard UX improvement: no API/server-side code changes, no new env vars, no schema changes.

## Notes

- Single file: `apps/cli/src/prompts/features.ts` (+49 / −6 lines)
- `apps/cli/src/types.ts`, `apps/cli/src/templates/env.ts`, and existing tests are unchanged
- Fully backwards-compatible — running `learnhouse setup` without enabling S3 sees no difference
- The reference link is rendered as plain text in the prompt; modern terminals (Windows Terminal, iTerm2, GNOME Terminal, VS Code integrated terminal) make it Ctrl/Cmd-clickable
- Adding more presets later (e.g., explicit Cloudflare R2 with account-ID prompt) is straightforward — the same `provider` switch can grow

## Test plan

- [ ] `npx learnhouse setup` → enable S3 → pick **AWS S3** → verify no `LEARNHOUSE_S3_API_ENDPOINT_URL` is written to `.env`
- [ ] Re-run → pick **Wasabi** → choose `eu-central-1` → verify `.env` contains `LEARNHOUSE_S3_API_ENDPOINT_URL=https://s3.eu-central-1.wasabisys.com`
- [ ] Re-run → pick **Wasabi** → choose any other region → verify the URL pattern matches `https://s3.{region}.wasabisys.com`
- [ ] Re-run → pick **Other** → enter `http://minio:9000` → verify `.env` contains the custom URL
- [ ] Existing unit tests still pass (`bun test` in `apps/cli`)
- [ ] Confirm the Wasabi docs link is rendered (and Ctrl-clickable in a modern terminal) before the region selector appears