### PR TITLE
feat(api): CSV bulk operations for users — import, export, update, unenroll 

### DIFF
--- a/apps/api/src/routers/users.py
+++ b/apps/api/src/routers/users.py
@@ -45,6 +45,10 @@ from src.services.users.users import (
     update_user_avatar,
     update_user_password,
 )
+from src.services.users.bulk_import import (
+    BulkImportResult,
+    bulk_import_users_from_csv,
+)
 from src.services.courses.courses import get_user_courses
 
 
@@ -208,6 +212,68 @@ async def api_create_user_with_orgid(
         )
     else:
         return await create_user(request, db_session, current_user, user_object, org_id)
+
+
+@router.post(
+    "/{org_id}/bulk-import",
+    response_model=BulkImportResult,
+    tags=["users"],
+    summary="Bulk import users from CSV",
+    description=(
+        "Create many users at once from a CSV upload, optionally enrolling them in "
+        "user groups, courses, and collections. Required column: `email`. Optional: "
+        "`first_name`, `last_name`, `username`, `password`, `role_id`, `user_groups`, "
+        "`courses`, `collections`. Multi-value cells use `|` as the inner separator. "
+        "Empty `password` generates a strong random one (user can recover via "
+        "password reset). Each row is processed independently — failures do not "
+        "abort the batch and are returned in the response `errors` list."
+    ),
+    responses={
+        200: {"description": "Import completed; see body for per-row outcomes.", "model": BulkImportResult},
+        400: {"description": "Malformed CSV or missing/unknown columns"},
+        403: {"description": "Caller lacks permission to create users in this organization"},
+        404: {"description": "Organization does not exist"},
+    },
+)
+async def api_bulk_import_users(
+    *,
+    request: Request,
+    db_session: Session = Depends(get_db_session),
+    current_user: PublicUser = Depends(get_current_user),
+    org_id: int,
+    file: UploadFile,
+) -> BulkImportResult:
+    """
+    Bulk-create users from a CSV file and assign them to user groups,
+    courses, and collections.
+    """
+    if file.content_type and file.content_type not in (
+        "text/csv",
+        "application/vnd.ms-excel",
+        "application/csv",
+        "text/plain",
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Expected a CSV file, got content-type: {file.content_type}",
+        )
+
+    raw = await file.read()
+    try:
+        csv_content = raw.decode("utf-8-sig")  # strips BOM if present
+    except UnicodeDecodeError:
+        raise HTTPException(
+            status_code=400,
+            detail="CSV file must be UTF-8 encoded",
+        )
+
+    return await bulk_import_users_from_csv(
+        request=request,
+        db_session=db_session,
+        current_user=current_user,
+        org_id=org_id,
+        csv_content=csv_content,
+    )
 
 
 @router.post(

--- a/apps/api/src/routers/users.py
+++ b/apps/api/src/routers/users.py
@@ -55,6 +55,14 @@ from src.services.users.bulk_export import (
     export_users_to_csv,
     iter_csv_chunks,
 )
+from src.services.users.bulk_update import (
+    BulkUpdateResult,
+    bulk_update_users_from_csv,
+)
+from src.services.users.bulk_unenroll import (
+    BulkUnenrollResult,
+    bulk_unenroll_users_from_csv,
+)
 from src.services.courses.courses import get_user_courses
 
 
@@ -328,6 +336,179 @@ async def api_bulk_export_users(
         iter_csv_chunks(csv_content),
         media_type="text/csv",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+_BULK_IMPORT_TEMPLATE_CSV = (
+    "email,first_name,last_name,username,password,role_id,user_groups,courses,collections\n"
+    "alice@example.org,Alice,Silva,asilva,,4,1|2,course_abc-123,\n"
+    "bob@example.org,Bob,Costa,,,4,1,,collection_xyz-456\n"
+)
+
+_BULK_UNENROLL_TEMPLATE_CSV = (
+    "email,user_groups,courses,collections\n"
+    "alice@example.org,1,course_abc-123,\n"
+    "bob@example.org,,,collection_xyz-456\n"
+)
+
+
+@router.get(
+    "/{org_id}/bulk-import/template.csv",
+    tags=["users"],
+    summary="Download CSV template for bulk-import / bulk-update",
+    description=(
+        "Returns a small CSV template showing the headers and a sample row "
+        "for the bulk-import endpoint. The same template can be used for "
+        "bulk-update (only `email` is required for updates; other fields are "
+        "optional and additive)."
+    ),
+    responses={200: {"description": "CSV template", "content": {"text/csv": {}}}},
+)
+async def api_bulk_import_template(
+    org_id: int,  # noqa: ARG001 — org_id keeps URL shape consistent for clients
+    current_user: PublicUser = Depends(get_current_user),
+) -> StreamingResponse:
+    return StreamingResponse(
+        iter_csv_chunks(_BULK_IMPORT_TEMPLATE_CSV),
+        media_type="text/csv",
+        headers={"Content-Disposition": 'attachment; filename="bulk-import-template.csv"'},
+    )
+
+
+@router.get(
+    "/{org_id}/bulk-unenroll/template.csv",
+    tags=["users"],
+    summary="Download CSV template for bulk-unenroll",
+    description=(
+        "Returns a small CSV template showing the headers and a sample row "
+        "for the bulk-unenroll endpoint. Only `email` is required; the other "
+        "columns specify which user groups, courses, or collections to "
+        "remove the user from."
+    ),
+    responses={200: {"description": "CSV template", "content": {"text/csv": {}}}},
+)
+async def api_bulk_unenroll_template(
+    org_id: int,  # noqa: ARG001 — org_id keeps URL shape consistent for clients
+    current_user: PublicUser = Depends(get_current_user),
+) -> StreamingResponse:
+    return StreamingResponse(
+        iter_csv_chunks(_BULK_UNENROLL_TEMPLATE_CSV),
+        media_type="text/csv",
+        headers={"Content-Disposition": 'attachment; filename="bulk-unenroll-template.csv"'},
+    )
+
+
+@router.post(
+    "/{org_id}/bulk-update",
+    response_model=BulkUpdateResult,
+    tags=["users"],
+    summary="Bulk update existing users from CSV",
+    description=(
+        "Update existing users in the organization from a CSV upload. Each row "
+        "is matched by `email`; rows whose email is not in the org are reported "
+        "in the `errors` list and skipped. Empty cells are ignored (never used "
+        "to clear a field). `user_groups`, `courses`, and `collections` are "
+        "additive only — use the bulk-unenroll endpoint to remove memberships "
+        "or enrollments."
+    ),
+    responses={
+        200: {"description": "Update completed; see body for per-row outcomes.", "model": BulkUpdateResult},
+        400: {"description": "Malformed CSV or missing/unknown columns"},
+        403: {"description": "Caller lacks permission to update users in this organization"},
+        404: {"description": "Organization does not exist"},
+    },
+)
+async def api_bulk_update_users(
+    *,
+    request: Request,
+    db_session: Session = Depends(get_db_session),
+    current_user: PublicUser = Depends(get_current_user),
+    org_id: int,
+    file: UploadFile,
+) -> BulkUpdateResult:
+    """
+    Bulk-update existing users from a CSV file.
+    """
+    if file.content_type and file.content_type not in (
+        "text/csv",
+        "application/vnd.ms-excel",
+        "application/csv",
+        "text/plain",
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Expected a CSV file, got content-type: {file.content_type}",
+        )
+
+    raw = await file.read()
+    try:
+        csv_content = raw.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        raise HTTPException(status_code=400, detail="CSV file must be UTF-8 encoded")
+
+    return await bulk_update_users_from_csv(
+        request=request,
+        db_session=db_session,
+        current_user=current_user,
+        org_id=org_id,
+        csv_content=csv_content,
+    )
+
+
+@router.post(
+    "/{org_id}/bulk-unenroll",
+    response_model=BulkUnenrollResult,
+    tags=["users"],
+    summary="Bulk unenroll users from user groups, courses, and collections",
+    description=(
+        "Remove users from listed user groups and courses (and from courses "
+        "in given collections) based on a CSV upload. The user account itself "
+        "is never deleted. Required column: `email`. Optional: `user_groups`, "
+        "`courses`, `collections`. Multi-value cells use `|` as the inner "
+        "separator. Course unenrollment deletes the user's `TrailRun` and any "
+        "associated `TrailStep` rows for that course."
+    ),
+    responses={
+        200: {"description": "Unenroll completed; see body for per-row outcomes.", "model": BulkUnenrollResult},
+        400: {"description": "Malformed CSV or missing/unknown columns"},
+        403: {"description": "Caller lacks permission to remove enrollments in this organization"},
+        404: {"description": "Organization does not exist"},
+    },
+)
+async def api_bulk_unenroll_users(
+    *,
+    request: Request,
+    db_session: Session = Depends(get_db_session),
+    current_user: PublicUser = Depends(get_current_user),
+    org_id: int,
+    file: UploadFile,
+) -> BulkUnenrollResult:
+    """
+    Bulk-remove users from user groups and courses via a CSV file.
+    """
+    if file.content_type and file.content_type not in (
+        "text/csv",
+        "application/vnd.ms-excel",
+        "application/csv",
+        "text/plain",
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Expected a CSV file, got content-type: {file.content_type}",
+        )
+
+    raw = await file.read()
+    try:
+        csv_content = raw.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        raise HTTPException(status_code=400, detail="CSV file must be UTF-8 encoded")
+
+    return await bulk_unenroll_users_from_csv(
+        request=request,
+        db_session=db_session,
+        current_user=current_user,
+        org_id=org_id,
+        csv_content=csv_content,
     )
 
 

--- a/apps/api/src/routers/users.py
+++ b/apps/api/src/routers/users.py
@@ -1,7 +1,9 @@
 import json
 import logging
 from typing import Literal, List, Optional, Union
+from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, Query
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, EmailStr
 from sqlmodel import Session
 import redis
@@ -48,6 +50,10 @@ from src.services.users.users import (
 from src.services.users.bulk_import import (
     BulkImportResult,
     bulk_import_users_from_csv,
+)
+from src.services.users.bulk_export import (
+    export_users_to_csv,
+    iter_csv_chunks,
 )
 from src.services.courses.courses import get_user_courses
 
@@ -273,6 +279,55 @@ async def api_bulk_import_users(
         current_user=current_user,
         org_id=org_id,
         csv_content=csv_content,
+    )
+
+
+@router.get(
+    "/{org_id}/bulk-export",
+    tags=["users"],
+    summary="Export users from organization as CSV",
+    description=(
+        "Stream a CSV of every user in the organization (or a single user "
+        "group when `usergroup_id` is provided). Columns mirror the "
+        "bulk-import format minus `password` so the file can be edited and "
+        "fed back through the import endpoint. Caller needs `users.action_read`."
+    ),
+    responses={
+        200: {
+            "description": "CSV stream with users.",
+            "content": {"text/csv": {}},
+        },
+        403: {"description": "Caller lacks permission to read users in this organization"},
+        404: {"description": "Organization or user group not found"},
+    },
+)
+async def api_bulk_export_users(
+    *,
+    request: Request,
+    db_session: Session = Depends(get_db_session),
+    current_user: PublicUser = Depends(get_current_user),
+    org_id: int,
+    usergroup_id: Optional[int] = Query(
+        None,
+        description="Restrict the export to members of this user group",
+    ),
+) -> StreamingResponse:
+    """
+    Bulk export users in the organization as CSV.
+    """
+    csv_content = await export_users_to_csv(
+        request=request,
+        db_session=db_session,
+        current_user=current_user,
+        org_id=org_id,
+        usergroup_id=usergroup_id,
+    )
+    suffix = f"-usergroup-{usergroup_id}" if usergroup_id else ""
+    filename = f"users-export-org-{org_id}{suffix}-{datetime.now():%Y%m%d}.csv"
+    return StreamingResponse(
+        iter_csv_chunks(csv_content),
+        media_type="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
 
 

--- a/apps/api/src/services/users/bulk_export.py
+++ b/apps/api/src/services/users/bulk_export.py
@@ -1,0 +1,117 @@
+"""
+Bulk user export to CSV.
+
+Mirrors the columns produced by ``bulk_import.bulk_import_users_from_csv``
+(minus ``password``, which is never exported) so admins can export the
+current state of an organization, edit in Excel/Sheets, and feed the
+result back through the bulk-import endpoint.
+"""
+
+import csv
+from io import StringIO
+from typing import Iterable, Optional
+
+from fastapi import HTTPException, Request
+from sqlmodel import Session, select
+
+from src.db.organizations import Organization
+from src.db.user_organizations import UserOrganization
+from src.db.usergroup_user import UserGroupUser
+from src.db.usergroups import UserGroup
+from src.db.users import AnonymousUser, PublicUser, User
+from src.services.users.users import rbac_check
+
+
+CSV_HEADERS = [
+    "email",
+    "first_name",
+    "last_name",
+    "username",
+    "role_id",
+    "user_groups",
+]
+CSV_INNER_SEPARATOR = "|"
+
+
+async def export_users_to_csv(
+    request: Request,
+    db_session: Session,
+    current_user: PublicUser | AnonymousUser,
+    org_id: int,
+    usergroup_id: Optional[int] = None,
+) -> str:
+    """
+    Build a CSV string listing every user in the given organization.
+
+    When ``usergroup_id`` is provided the export is narrowed to the members
+    of that user group only (useful for exporting a class roster).
+
+    Columns mirror the bulk-import format so the file is round-trippable
+    (minus ``password``, which is intentionally omitted — password hashes
+    are never exposed).
+    """
+    await rbac_check(request, current_user, "read", "user_x", db_session)
+
+    org = db_session.exec(select(Organization).where(Organization.id == org_id)).first()
+    if not org:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    if usergroup_id is not None:
+        ug = db_session.exec(
+            select(UserGroup).where(
+                UserGroup.id == usergroup_id, UserGroup.org_id == org_id,
+            )
+        ).first()
+        if not ug:
+            raise HTTPException(
+                status_code=404,
+                detail="UserGroup not found in this organization",
+            )
+
+    user_query = (
+        select(User, UserOrganization)
+        .join(UserOrganization, UserOrganization.user_id == User.id)  # type: ignore[arg-type]
+        .where(UserOrganization.org_id == org_id)
+    )
+    if usergroup_id is not None:
+        user_query = user_query.join(
+            UserGroupUser, UserGroupUser.user_id == User.id  # type: ignore[arg-type]
+        ).where(UserGroupUser.usergroup_id == usergroup_id)
+
+    rows = db_session.exec(user_query).all()
+
+    user_ids = [user.id for user, _ in rows if user.id is not None]
+    groups_by_user: dict[int, list[int]] = {uid: [] for uid in user_ids}
+    if user_ids:
+        memberships = db_session.exec(
+            select(UserGroupUser).where(
+                UserGroupUser.user_id.in_(user_ids),  # type: ignore[attr-defined]
+                UserGroupUser.org_id == org_id,
+            )
+        ).all()
+        for m in memberships:
+            groups_by_user.setdefault(m.user_id, []).append(m.usergroup_id)
+
+    buffer = StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(CSV_HEADERS)
+
+    for user, user_org in rows:
+        ug_ids = sorted(groups_by_user.get(user.id, [])) if user.id is not None else []
+        writer.writerow([
+            user.email,
+            user.first_name or "",
+            user.last_name or "",
+            user.username,
+            user_org.role_id,
+            CSV_INNER_SEPARATOR.join(str(gid) for gid in ug_ids),
+        ])
+
+    return buffer.getvalue()
+
+
+def iter_csv_chunks(csv_content: str, chunk_size: int = 8192) -> Iterable[bytes]:
+    """Yield the CSV body in chunks for StreamingResponse."""
+    encoded = csv_content.encode("utf-8")
+    for i in range(0, len(encoded), chunk_size):
+        yield encoded[i : i + chunk_size]

--- a/apps/api/src/services/users/bulk_import.py
+++ b/apps/api/src/services/users/bulk_import.py
@@ -1,0 +1,371 @@
+"""
+Bulk user import from CSV.
+
+Allows admins to create many users in a single request and optionally enroll
+them into user groups, courses, and collections. Each row is processed
+independently — a failure on one row does not abort the rest of the batch.
+
+CSV format
+----------
+Required header: ``email``
+Optional headers: ``first_name``, ``last_name``, ``username``, ``password``,
+``role_id``, ``user_groups``, ``courses``, ``collections``
+
+Multi-value cells (``user_groups``, ``courses``, ``collections``) use ``|`` as
+the inner separator to avoid colliding with the CSV column delimiter.
+
+Example::
+
+    email,first_name,last_name,role_id,user_groups,courses,collections
+    alice@school.pt,Alice,Silva,4,1|2,course_abc-123,
+    bob@school.pt,Bob,Costa,4,1,,collection_xyz-456
+
+When ``password`` is empty a strong random password is generated. The user can
+recover access via the standard password-reset flow.
+"""
+
+import csv
+import logging
+import secrets
+import string
+from datetime import datetime
+from io import StringIO
+from typing import List
+from uuid import uuid4
+
+from fastapi import HTTPException, Request
+from pydantic import BaseModel
+from sqlmodel import Session, select
+
+from src.db.collections import Collection
+from src.db.collections_courses import CollectionCourse
+from src.db.courses.courses import Course
+from src.db.organizations import Organization
+from src.db.trail_runs import TrailRun
+from src.db.trails import Trail
+from src.db.user_organizations import UserOrganization
+from src.db.usergroup_user import UserGroupUser
+from src.db.usergroups import UserGroup
+from src.db.users import AnonymousUser, PublicUser, User, UserCreate
+from src.services.users.users import create_user, rbac_check
+
+
+CSV_REQUIRED_COLUMNS = {"email"}
+CSV_OPTIONAL_COLUMNS = {
+    "first_name",
+    "last_name",
+    "username",
+    "password",
+    "role_id",
+    "user_groups",
+    "courses",
+    "collections",
+}
+CSV_INNER_SEPARATOR = "|"
+
+
+class BulkImportError(BaseModel):
+    row: int  # 1-indexed; row 1 is the first data row after the header
+    email: str
+    error: str
+
+
+class BulkImportResult(BaseModel):
+    rows_processed: int
+    users_created: int
+    users_skipped_existing: int
+    users_failed: int
+    enrollments_added: int
+    usergroup_assignments_added: int
+    errors: List[BulkImportError]
+
+
+def _generate_random_password(length: int = 24) -> str:
+    """Strong password meeting LearnHouse complexity rules (upper, lower, digit, special)."""
+    alphabet = string.ascii_letters + string.digits + "!@#$%^&*"
+    while True:
+        pw = "".join(secrets.choice(alphabet) for _ in range(length))
+        if (
+            any(c.islower() for c in pw)
+            and any(c.isupper() for c in pw)
+            and any(c.isdigit() for c in pw)
+            and any(c in "!@#$%^&*" for c in pw)
+        ):
+            return pw
+
+
+def _username_from_email(email: str) -> str:
+    local = email.split("@")[0]
+    safe = "".join(c if c.isalnum() or c == "_" else "_" for c in local)
+    return safe.lower() or f"user_{secrets.token_hex(4)}"
+
+
+def _split_multi(value: str) -> list[str]:
+    if not value:
+        return []
+    return [v.strip() for v in value.split(CSV_INNER_SEPARATOR) if v.strip()]
+
+
+async def bulk_import_users_from_csv(
+    request: Request,
+    db_session: Session,
+    current_user: PublicUser | AnonymousUser,
+    org_id: int,
+    csv_content: str,
+) -> BulkImportResult:
+    """
+    Parse CSV content and create users, then enroll them in any specified
+    user groups, courses, or collections (collections are expanded to their
+    constituent courses).
+
+    Each row is processed independently. Failures are collected in
+    ``errors`` and processing continues with the next row.
+    """
+    await rbac_check(request, current_user, "create", "user_x", db_session)
+
+    org = db_session.exec(select(Organization).where(Organization.id == org_id)).first()
+    if not org:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    try:
+        reader = csv.DictReader(StringIO(csv_content))
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Invalid CSV: {e}")
+
+    if reader.fieldnames is None:
+        raise HTTPException(status_code=400, detail="CSV has no header row")
+
+    headers = {h.strip() for h in reader.fieldnames}
+    missing = CSV_REQUIRED_COLUMNS - headers
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail=f"CSV missing required columns: {sorted(missing)}",
+        )
+    unknown = headers - CSV_REQUIRED_COLUMNS - CSV_OPTIONAL_COLUMNS
+    if unknown:
+        raise HTTPException(
+            status_code=400,
+            detail=f"CSV has unknown columns: {sorted(unknown)}",
+        )
+
+    errors: list[BulkImportError] = []
+    rows_processed = 0
+    users_created = 0
+    users_skipped_existing = 0
+    users_failed = 0
+    enrollments_added = 0
+    usergroup_assignments_added = 0
+
+    # Cache resolved collection → course IDs so we don't query the same collection twice
+    collection_to_course_ids: dict[str, list[int]] = {}
+
+    for idx, row in enumerate(reader, start=1):
+        rows_processed += 1
+        email = (row.get("email") or "").strip()
+        if not email:
+            errors.append(BulkImportError(row=idx, email="", error="Empty email"))
+            users_failed += 1
+            continue
+
+        existing_user = db_session.exec(select(User).where(User.email == email)).first()
+        user_id_to_use: int | None = None
+
+        if existing_user:
+            users_skipped_existing += 1
+            user_id_to_use = existing_user.id
+        else:
+            try:
+                password = (row.get("password") or "").strip() or _generate_random_password()
+                username = (row.get("username") or "").strip() or _username_from_email(email)
+                user_create = UserCreate(
+                    email=email,  # type: ignore[arg-type]  # Pydantic coerces to EmailStr
+                    username=username,
+                    first_name=(row.get("first_name") or "").strip(),
+                    last_name=(row.get("last_name") or "").strip(),
+                    password=password,
+                )
+                new_user = await create_user(
+                    request=request,
+                    db_session=db_session,
+                    current_user=current_user,
+                    user_object=user_create,
+                    org_id=org_id,
+                )
+                user_id_to_use = new_user.id
+                users_created += 1
+
+                # Optional role override (create_user always assigns role 4 = User)
+                role_id_str = (row.get("role_id") or "").strip()
+                if role_id_str and role_id_str != "4" and new_user.id is not None:
+                    try:
+                        role_id = int(role_id_str)
+                    except ValueError:
+                        errors.append(BulkImportError(
+                            row=idx, email=email,
+                            error=f"Invalid role_id (not an integer): {role_id_str}",
+                        ))
+                    else:
+                        user_org = db_session.exec(
+                            select(UserOrganization).where(
+                                UserOrganization.user_id == new_user.id,
+                                UserOrganization.org_id == org_id,
+                            )
+                        ).first()
+                        if user_org:
+                            user_org.role_id = role_id
+                            user_org.update_date = str(datetime.now())
+                            db_session.add(user_org)
+                            db_session.commit()
+            except HTTPException as e:
+                users_failed += 1
+                errors.append(BulkImportError(row=idx, email=email, error=str(e.detail)))
+                continue
+            except Exception as e:
+                logging.exception("Unexpected error creating user during bulk import")
+                users_failed += 1
+                errors.append(BulkImportError(row=idx, email=email, error=f"Unexpected error: {e}"))
+                continue
+
+        if user_id_to_use is None:
+            continue
+
+        # User-group assignments
+        for ug_id_str in _split_multi(row.get("user_groups", "")):
+            try:
+                ug_id = int(ug_id_str)
+            except ValueError:
+                errors.append(BulkImportError(
+                    row=idx, email=email,
+                    error=f"Invalid user_group id (not an integer): {ug_id_str}",
+                ))
+                continue
+
+            ug = db_session.exec(
+                select(UserGroup).where(UserGroup.id == ug_id, UserGroup.org_id == org_id)
+            ).first()
+            if not ug:
+                errors.append(BulkImportError(
+                    row=idx, email=email,
+                    error=f"UserGroup {ug_id} not found in this org",
+                ))
+                continue
+
+            existing_link = db_session.exec(
+                select(UserGroupUser).where(
+                    UserGroupUser.usergroup_id == ug_id,
+                    UserGroupUser.user_id == user_id_to_use,
+                )
+            ).first()
+            if existing_link:
+                continue
+
+            link = UserGroupUser(
+                usergroup_id=ug_id,
+                user_id=user_id_to_use,
+                org_id=org_id,
+                creation_date=str(datetime.now()),
+                update_date=str(datetime.now()),
+            )
+            db_session.add(link)
+            usergroup_assignments_added += 1
+
+        # Build the union of explicit course UUIDs + courses unfolded from collections
+        course_uuids: list[str] = list(_split_multi(row.get("courses", "")))
+
+        for col_uuid in _split_multi(row.get("collections", "")):
+            if col_uuid not in collection_to_course_ids:
+                col = db_session.exec(
+                    select(Collection).where(
+                        Collection.collection_uuid == col_uuid,
+                        Collection.org_id == org_id,
+                    )
+                ).first()
+                if not col:
+                    errors.append(BulkImportError(
+                        row=idx, email=email,
+                        error=f"Collection {col_uuid} not found in this org",
+                    ))
+                    collection_to_course_ids[col_uuid] = []
+                    continue
+                course_links = db_session.exec(
+                    select(CollectionCourse).where(CollectionCourse.collection_id == col.id)
+                ).all()
+                collection_to_course_ids[col_uuid] = [cc.course_id for cc in course_links]
+
+            for cid in collection_to_course_ids[col_uuid]:
+                course = db_session.exec(select(Course).where(Course.id == cid)).first()
+                if course:
+                    course_uuids.append(course.course_uuid)
+
+        seen_courses: set[str] = set()
+        trail: Trail | None = None  # lazily fetched/created per user
+        for course_uuid in course_uuids:
+            if course_uuid in seen_courses:
+                continue
+            seen_courses.add(course_uuid)
+
+            course = db_session.exec(
+                select(Course).where(
+                    Course.course_uuid == course_uuid,
+                    Course.org_id == org_id,
+                )
+            ).first()
+            if not course:
+                errors.append(BulkImportError(
+                    row=idx, email=email,
+                    error=f"Course {course_uuid} not found in this org",
+                ))
+                continue
+
+            existing_run = db_session.exec(
+                select(TrailRun).where(
+                    TrailRun.course_id == course.id,
+                    TrailRun.user_id == user_id_to_use,
+                    TrailRun.org_id == org_id,
+                )
+            ).first()
+            if existing_run:
+                continue
+
+            if trail is None:
+                trail = db_session.exec(
+                    select(Trail).where(
+                        Trail.org_id == org_id,
+                        Trail.user_id == user_id_to_use,
+                    )
+                ).first()
+                if trail is None:
+                    trail = Trail(
+                        org_id=org_id,
+                        user_id=user_id_to_use,
+                        trail_uuid=f"trail_{uuid4()}",
+                        creation_date=str(datetime.now()),
+                        update_date=str(datetime.now()),
+                    )
+                    db_session.add(trail)
+                    db_session.commit()
+                    db_session.refresh(trail)
+
+            trail_run = TrailRun(
+                trail_id=trail.id if trail.id is not None else 0,
+                course_id=course.id if course.id is not None else 0,
+                org_id=org_id,
+                user_id=user_id_to_use,
+                creation_date=str(datetime.now()),
+                update_date=str(datetime.now()),
+            )
+            db_session.add(trail_run)
+            enrollments_added += 1
+
+    db_session.commit()
+
+    return BulkImportResult(
+        rows_processed=rows_processed,
+        users_created=users_created,
+        users_skipped_existing=users_skipped_existing,
+        users_failed=users_failed,
+        enrollments_added=enrollments_added,
+        usergroup_assignments_added=usergroup_assignments_added,
+        errors=errors,
+    )

--- a/apps/api/src/services/users/bulk_unenroll.py
+++ b/apps/api/src/services/users/bulk_unenroll.py
@@ -1,0 +1,245 @@
+"""
+Bulk user unenrollment from CSV.
+
+Removes users from user groups and courses (and from the courses contained
+in given collections) based on a CSV upload. Mirrors the additive operations
+of ``bulk_import`` and ``bulk_update`` in reverse.
+
+Semantics
+---------
+- Lookup is by ``email``. Rows whose email is not in the org are reported in
+  ``errors`` and skipped.
+- Course unenrollment **deletes** the user's ``TrailRun`` and any associated
+  ``TrailStep`` rows for that course (consistent with the existing
+  ``bulk_unenroll_users`` admin function and ``unenroll_user``).
+- User-group membership is **deleted** (consistent with ``remove_usergroup_member``).
+- Each row is processed independently — failures don't abort the batch.
+- The user account itself is never deleted.
+"""
+
+import csv
+import logging
+from io import StringIO
+from typing import List
+
+from fastapi import HTTPException, Request
+from pydantic import BaseModel
+from sqlmodel import Session, select
+
+from src.db.collections import Collection
+from src.db.collections_courses import CollectionCourse
+from src.db.courses.courses import Course
+from src.db.organizations import Organization
+from src.db.trail_runs import TrailRun
+from src.db.trail_steps import TrailStep
+from src.db.user_organizations import UserOrganization
+from src.db.usergroup_user import UserGroupUser
+from src.db.usergroups import UserGroup
+from src.db.users import AnonymousUser, PublicUser, User
+from src.services.users.bulk_import import BulkImportError, _split_multi
+from src.services.users.users import rbac_check
+
+
+CSV_REQUIRED_COLUMNS = {"email"}
+CSV_OPTIONAL_COLUMNS = {"user_groups", "courses", "collections"}
+
+
+class BulkUnenrollResult(BaseModel):
+    rows_processed: int
+    users_not_found: int
+    users_failed: int
+    enrollments_removed: int
+    usergroup_assignments_removed: int
+    errors: List[BulkImportError]
+
+
+async def bulk_unenroll_users_from_csv(
+    request: Request,
+    db_session: Session,
+    current_user: PublicUser | AnonymousUser,
+    org_id: int,
+    csv_content: str,
+) -> BulkUnenrollResult:
+    """
+    Remove users from listed user groups and courses based on CSV input.
+
+    Collections are expanded to their constituent courses before unenrollment.
+    """
+    await rbac_check(request, current_user, "delete", "user_x", db_session)
+
+    org = db_session.exec(select(Organization).where(Organization.id == org_id)).first()
+    if not org:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    try:
+        reader = csv.DictReader(StringIO(csv_content))
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Invalid CSV: {e}")
+
+    if reader.fieldnames is None:
+        raise HTTPException(status_code=400, detail="CSV has no header row")
+
+    headers = {h.strip() for h in reader.fieldnames}
+    missing = CSV_REQUIRED_COLUMNS - headers
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail=f"CSV missing required columns: {sorted(missing)}",
+        )
+    unknown = headers - CSV_REQUIRED_COLUMNS - CSV_OPTIONAL_COLUMNS
+    if unknown:
+        raise HTTPException(
+            status_code=400,
+            detail=f"CSV has unknown columns: {sorted(unknown)}",
+        )
+
+    errors: list[BulkImportError] = []
+    rows_processed = 0
+    users_not_found = 0
+    users_failed = 0
+    enrollments_removed = 0
+    usergroup_assignments_removed = 0
+
+    collection_to_course_ids: dict[str, list[int]] = {}
+
+    for idx, row in enumerate(reader, start=1):
+        rows_processed += 1
+        email = (row.get("email") or "").strip()
+        if not email:
+            errors.append(BulkImportError(row=idx, email="", error="Empty email"))
+            users_failed += 1
+            continue
+
+        user = db_session.exec(select(User).where(User.email == email)).first()
+        if not user or user.id is None:
+            users_not_found += 1
+            errors.append(BulkImportError(
+                row=idx, email=email, error="User not found in this organization",
+            ))
+            continue
+
+        user_org = db_session.exec(
+            select(UserOrganization).where(
+                UserOrganization.user_id == user.id,
+                UserOrganization.org_id == org_id,
+            )
+        ).first()
+        if not user_org:
+            users_not_found += 1
+            errors.append(BulkImportError(
+                row=idx, email=email, error="User not found in this organization",
+            ))
+            continue
+
+        # Remove user-group memberships
+        for ug_id_str in _split_multi(row.get("user_groups", "")):
+            try:
+                ug_id = int(ug_id_str)
+            except ValueError:
+                errors.append(BulkImportError(
+                    row=idx, email=email,
+                    error=f"Invalid user_group id (not an integer): {ug_id_str}",
+                ))
+                continue
+
+            ug = db_session.exec(
+                select(UserGroup).where(UserGroup.id == ug_id, UserGroup.org_id == org_id)
+            ).first()
+            if not ug:
+                errors.append(BulkImportError(
+                    row=idx, email=email,
+                    error=f"UserGroup {ug_id} not found in this org",
+                ))
+                continue
+
+            membership = db_session.exec(
+                select(UserGroupUser).where(
+                    UserGroupUser.usergroup_id == ug_id,
+                    UserGroupUser.user_id == user.id,
+                )
+            ).first()
+            if membership is None:
+                continue
+            db_session.delete(membership)
+            usergroup_assignments_removed += 1
+
+        # Unenroll from courses (direct + expanded from collections)
+        course_uuids: list[str] = list(_split_multi(row.get("courses", "")))
+
+        for col_uuid in _split_multi(row.get("collections", "")):
+            if col_uuid not in collection_to_course_ids:
+                col = db_session.exec(
+                    select(Collection).where(
+                        Collection.collection_uuid == col_uuid,
+                        Collection.org_id == org_id,
+                    )
+                ).first()
+                if not col:
+                    errors.append(BulkImportError(
+                        row=idx, email=email,
+                        error=f"Collection {col_uuid} not found in this org",
+                    ))
+                    collection_to_course_ids[col_uuid] = []
+                    continue
+                course_links = db_session.exec(
+                    select(CollectionCourse).where(CollectionCourse.collection_id == col.id)
+                ).all()
+                collection_to_course_ids[col_uuid] = [cc.course_id for cc in course_links]
+
+            for cid in collection_to_course_ids[col_uuid]:
+                course = db_session.exec(select(Course).where(Course.id == cid)).first()
+                if course:
+                    course_uuids.append(course.course_uuid)
+
+        seen_courses: set[str] = set()
+        for course_uuid in course_uuids:
+            if course_uuid in seen_courses:
+                continue
+            seen_courses.add(course_uuid)
+
+            course = db_session.exec(
+                select(Course).where(
+                    Course.course_uuid == course_uuid,
+                    Course.org_id == org_id,
+                )
+            ).first()
+            if not course:
+                errors.append(BulkImportError(
+                    row=idx, email=email,
+                    error=f"Course {course_uuid} not found in this org",
+                ))
+                continue
+
+            trail_run = db_session.exec(
+                select(TrailRun).where(
+                    TrailRun.course_id == course.id,
+                    TrailRun.user_id == user.id,
+                    TrailRun.org_id == org_id,
+                )
+            ).first()
+            if trail_run is None:
+                continue
+
+            steps = db_session.exec(
+                select(TrailStep).where(
+                    TrailStep.course_id == course.id,
+                    TrailStep.user_id == user.id,
+                    TrailStep.org_id == org_id,
+                )
+            ).all()
+            for step in steps:
+                db_session.delete(step)
+
+            db_session.delete(trail_run)
+            enrollments_removed += 1
+
+    db_session.commit()
+
+    return BulkUnenrollResult(
+        rows_processed=rows_processed,
+        users_not_found=users_not_found,
+        users_failed=users_failed,
+        enrollments_removed=enrollments_removed,
+        usergroup_assignments_removed=usergroup_assignments_removed,
+        errors=errors,
+    )

--- a/apps/api/src/services/users/bulk_update.py
+++ b/apps/api/src/services/users/bulk_update.py
@@ -1,0 +1,326 @@
+"""
+Bulk user update from CSV.
+
+Updates existing users in an organization based on a CSV upload. Useful for
+end-of-year promotions, role changes, and adding fresh enrollments to users
+who already exist (no new accounts are created — that path is bulk-import).
+
+Semantics
+---------
+- Lookup is by ``email``: a row whose email is not in the org is reported in
+  ``errors`` and skipped.
+- Empty cells are **ignored**, never used to clear a field — partial updates
+  are the common case for class lists.
+- ``user_groups``, ``courses``, ``collections`` are **additive only**. To
+  remove memberships or enrollments, use the bulk-unenroll endpoint.
+- Each row is processed independently — failures don't abort the batch.
+"""
+
+import csv
+import logging
+from datetime import datetime
+from io import StringIO
+from typing import List
+from uuid import uuid4
+
+from fastapi import HTTPException, Request
+from pydantic import BaseModel
+from sqlmodel import Session, select
+
+from src.db.collections import Collection
+from src.db.collections_courses import CollectionCourse
+from src.db.courses.courses import Course
+from src.db.organizations import Organization
+from src.db.trail_runs import TrailRun
+from src.db.trails import Trail
+from src.db.user_organizations import UserOrganization
+from src.db.usergroup_user import UserGroupUser
+from src.db.usergroups import UserGroup
+from src.db.users import AnonymousUser, PublicUser, User
+from src.services.users.bulk_import import (
+    CSV_INNER_SEPARATOR,
+    BulkImportError,
+    _split_multi,
+)
+from src.services.users.users import rbac_check
+
+
+CSV_REQUIRED_COLUMNS = {"email"}
+CSV_OPTIONAL_COLUMNS = {
+    "first_name",
+    "last_name",
+    "username",
+    "role_id",
+    "user_groups",
+    "courses",
+    "collections",
+}
+
+
+class BulkUpdateResult(BaseModel):
+    rows_processed: int
+    users_updated: int
+    users_not_found: int
+    users_failed: int
+    enrollments_added: int
+    usergroup_assignments_added: int
+    errors: List[BulkImportError]
+
+
+async def bulk_update_users_from_csv(
+    request: Request,
+    db_session: Session,
+    current_user: PublicUser | AnonymousUser,
+    org_id: int,
+    csv_content: str,
+) -> BulkUpdateResult:
+    """
+    Update users that already exist in the organization, optionally adding
+    them to user groups and enrolling them in courses/collections.
+
+    Does not create new users. Does not remove memberships or enrollments
+    (additive only — use bulk-unenroll for removals).
+    """
+    await rbac_check(request, current_user, "update", "user_x", db_session)
+
+    org = db_session.exec(select(Organization).where(Organization.id == org_id)).first()
+    if not org:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    try:
+        reader = csv.DictReader(StringIO(csv_content))
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Invalid CSV: {e}")
+
+    if reader.fieldnames is None:
+        raise HTTPException(status_code=400, detail="CSV has no header row")
+
+    headers = {h.strip() for h in reader.fieldnames}
+    missing = CSV_REQUIRED_COLUMNS - headers
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail=f"CSV missing required columns: {sorted(missing)}",
+        )
+    unknown = headers - CSV_REQUIRED_COLUMNS - CSV_OPTIONAL_COLUMNS
+    if unknown:
+        raise HTTPException(
+            status_code=400,
+            detail=f"CSV has unknown columns: {sorted(unknown)}",
+        )
+
+    errors: list[BulkImportError] = []
+    rows_processed = 0
+    users_updated = 0
+    users_not_found = 0
+    users_failed = 0
+    enrollments_added = 0
+    usergroup_assignments_added = 0
+
+    collection_to_course_ids: dict[str, list[int]] = {}
+
+    for idx, row in enumerate(reader, start=1):
+        rows_processed += 1
+        email = (row.get("email") or "").strip()
+        if not email:
+            errors.append(BulkImportError(row=idx, email="", error="Empty email"))
+            users_failed += 1
+            continue
+
+        user = db_session.exec(select(User).where(User.email == email)).first()
+        if not user or user.id is None:
+            users_not_found += 1
+            errors.append(BulkImportError(
+                row=idx, email=email, error="User not found in this organization",
+            ))
+            continue
+
+        # Verify the user actually belongs to this org before mutating anything
+        user_org = db_session.exec(
+            select(UserOrganization).where(
+                UserOrganization.user_id == user.id,
+                UserOrganization.org_id == org_id,
+            )
+        ).first()
+        if not user_org:
+            users_not_found += 1
+            errors.append(BulkImportError(
+                row=idx, email=email, error="User not found in this organization",
+            ))
+            continue
+
+        try:
+            user_changed = False
+            for field in ("first_name", "last_name", "username"):
+                value = (row.get(field) or "").strip()
+                if value:
+                    setattr(user, field, value)
+                    user_changed = True
+
+            role_id_str = (row.get("role_id") or "").strip()
+            if role_id_str:
+                try:
+                    role_id = int(role_id_str)
+                except ValueError:
+                    errors.append(BulkImportError(
+                        row=idx, email=email,
+                        error=f"Invalid role_id (not an integer): {role_id_str}",
+                    ))
+                else:
+                    if user_org.role_id != role_id:
+                        user_org.role_id = role_id
+                        user_org.update_date = str(datetime.now())
+                        db_session.add(user_org)
+
+            if user_changed:
+                user.update_date = str(datetime.now())
+                db_session.add(user)
+                users_updated += 1
+            elif role_id_str:
+                # Role-only change still counts as an update
+                users_updated += 1
+        except Exception as e:
+            logging.exception("Unexpected error updating user during bulk update")
+            users_failed += 1
+            errors.append(BulkImportError(
+                row=idx, email=email, error=f"Unexpected error: {e}",
+            ))
+            continue
+
+        # Additive user-group memberships
+        for ug_id_str in _split_multi(row.get("user_groups", "")):
+            try:
+                ug_id = int(ug_id_str)
+            except ValueError:
+                errors.append(BulkImportError(
+                    row=idx, email=email,
+                    error=f"Invalid user_group id (not an integer): {ug_id_str}",
+                ))
+                continue
+
+            ug = db_session.exec(
+                select(UserGroup).where(UserGroup.id == ug_id, UserGroup.org_id == org_id)
+            ).first()
+            if not ug:
+                errors.append(BulkImportError(
+                    row=idx, email=email,
+                    error=f"UserGroup {ug_id} not found in this org",
+                ))
+                continue
+
+            existing_link = db_session.exec(
+                select(UserGroupUser).where(
+                    UserGroupUser.usergroup_id == ug_id,
+                    UserGroupUser.user_id == user.id,
+                )
+            ).first()
+            if existing_link:
+                continue
+
+            db_session.add(UserGroupUser(
+                usergroup_id=ug_id,
+                user_id=user.id,
+                org_id=org_id,
+                creation_date=str(datetime.now()),
+                update_date=str(datetime.now()),
+            ))
+            usergroup_assignments_added += 1
+
+        # Build course list (direct + expanded from collections)
+        course_uuids: list[str] = list(_split_multi(row.get("courses", "")))
+
+        for col_uuid in _split_multi(row.get("collections", "")):
+            if col_uuid not in collection_to_course_ids:
+                col = db_session.exec(
+                    select(Collection).where(
+                        Collection.collection_uuid == col_uuid,
+                        Collection.org_id == org_id,
+                    )
+                ).first()
+                if not col:
+                    errors.append(BulkImportError(
+                        row=idx, email=email,
+                        error=f"Collection {col_uuid} not found in this org",
+                    ))
+                    collection_to_course_ids[col_uuid] = []
+                    continue
+                course_links = db_session.exec(
+                    select(CollectionCourse).where(CollectionCourse.collection_id == col.id)
+                ).all()
+                collection_to_course_ids[col_uuid] = [cc.course_id for cc in course_links]
+
+            for cid in collection_to_course_ids[col_uuid]:
+                course = db_session.exec(select(Course).where(Course.id == cid)).first()
+                if course:
+                    course_uuids.append(course.course_uuid)
+
+        seen_courses: set[str] = set()
+        trail: Trail | None = None
+        for course_uuid in course_uuids:
+            if course_uuid in seen_courses:
+                continue
+            seen_courses.add(course_uuid)
+
+            course = db_session.exec(
+                select(Course).where(
+                    Course.course_uuid == course_uuid,
+                    Course.org_id == org_id,
+                )
+            ).first()
+            if not course:
+                errors.append(BulkImportError(
+                    row=idx, email=email,
+                    error=f"Course {course_uuid} not found in this org",
+                ))
+                continue
+
+            existing_run = db_session.exec(
+                select(TrailRun).where(
+                    TrailRun.course_id == course.id,
+                    TrailRun.user_id == user.id,
+                    TrailRun.org_id == org_id,
+                )
+            ).first()
+            if existing_run:
+                continue
+
+            if trail is None:
+                trail = db_session.exec(
+                    select(Trail).where(
+                        Trail.org_id == org_id,
+                        Trail.user_id == user.id,
+                    )
+                ).first()
+                if trail is None:
+                    trail = Trail(
+                        org_id=org_id,
+                        user_id=user.id,
+                        trail_uuid=f"trail_{uuid4()}",
+                        creation_date=str(datetime.now()),
+                        update_date=str(datetime.now()),
+                    )
+                    db_session.add(trail)
+                    db_session.commit()
+                    db_session.refresh(trail)
+
+            db_session.add(TrailRun(
+                trail_id=trail.id if trail.id is not None else 0,
+                course_id=course.id if course.id is not None else 0,
+                org_id=org_id,
+                user_id=user.id,
+                creation_date=str(datetime.now()),
+                update_date=str(datetime.now()),
+            ))
+            enrollments_added += 1
+
+    db_session.commit()
+
+    return BulkUpdateResult(
+        rows_processed=rows_processed,
+        users_updated=users_updated,
+        users_not_found=users_not_found,
+        users_failed=users_failed,
+        enrollments_added=enrollments_added,
+        usergroup_assignments_added=usergroup_assignments_added,
+        errors=errors,
+    )

--- a/apps/api/src/tests/routers/test_users_router.py
+++ b/apps/api/src/tests/routers/test_users_router.py
@@ -279,3 +279,126 @@ class TestBulkExport:
             response = await client.get("/api/v1/users/999/bulk-export")
 
         assert response.status_code == 404
+
+
+class TestBulkUpdate:
+    """POST /{org_id}/bulk-update — CSV upload that updates existing users."""
+
+    @staticmethod
+    def _result(**overrides):
+        from src.services.users.bulk_update import BulkUpdateResult
+        defaults = dict(
+            rows_processed=0,
+            users_updated=0,
+            users_not_found=0,
+            users_failed=0,
+            enrollments_added=0,
+            usergroup_assignments_added=0,
+            errors=[],
+        )
+        defaults.update(overrides)
+        return BulkUpdateResult(**defaults)
+
+    async def test_bulk_update_success(self, client):
+        csv_body = "email,first_name\nalice@school.pt,Alice\n"
+        with patch(
+            "src.routers.users.bulk_update_users_from_csv",
+            new_callable=AsyncMock,
+            return_value=self._result(rows_processed=1, users_updated=1),
+        ):
+            response = await client.post(
+                "/api/v1/users/1/bulk-update",
+                files={"file": ("update.csv", csv_body, "text/csv")},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["users_updated"] == 1
+
+    async def test_bulk_update_user_not_found_reported(self, client):
+        from src.services.users.bulk_import import BulkImportError
+        with patch(
+            "src.routers.users.bulk_update_users_from_csv",
+            new_callable=AsyncMock,
+            return_value=self._result(
+                rows_processed=1,
+                users_not_found=1,
+                errors=[BulkImportError(row=1, email="ghost@x.pt", error="User not found in this organization")],
+            ),
+        ):
+            response = await client.post(
+                "/api/v1/users/1/bulk-update",
+                files={"file": ("update.csv", b"email\nghost@x.pt\n", "text/csv")},
+            )
+
+        body = response.json()
+        assert body["users_not_found"] == 1
+        assert body["errors"][0]["email"] == "ghost@x.pt"
+
+
+class TestBulkUnenroll:
+    """POST /{org_id}/bulk-unenroll — CSV upload that removes memberships and enrollments."""
+
+    @staticmethod
+    def _result(**overrides):
+        from src.services.users.bulk_unenroll import BulkUnenrollResult
+        defaults = dict(
+            rows_processed=0,
+            users_not_found=0,
+            users_failed=0,
+            enrollments_removed=0,
+            usergroup_assignments_removed=0,
+            errors=[],
+        )
+        defaults.update(overrides)
+        return BulkUnenrollResult(**defaults)
+
+    async def test_bulk_unenroll_success(self, client):
+        csv_body = "email,courses\nalice@school.pt,course_abc\n"
+        with patch(
+            "src.routers.users.bulk_unenroll_users_from_csv",
+            new_callable=AsyncMock,
+            return_value=self._result(rows_processed=1, enrollments_removed=1),
+        ):
+            response = await client.post(
+                "/api/v1/users/1/bulk-unenroll",
+                files={"file": ("unenroll.csv", csv_body, "text/csv")},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["enrollments_removed"] == 1
+
+    async def test_bulk_unenroll_rejects_non_csv(self, client):
+        response = await client.post(
+            "/api/v1/users/1/bulk-unenroll",
+            files={"file": ("payload.json", b"{}", "application/json")},
+        )
+        assert response.status_code == 400
+
+
+class TestBulkTemplates:
+    """GET /{org_id}/bulk-import/template.csv and bulk-unenroll/template.csv."""
+
+    async def test_import_template_returns_csv(self, client):
+        response = await client.get("/api/v1/users/1/bulk-import/template.csv")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/csv")
+        assert "bulk-import-template.csv" in response.headers["content-disposition"]
+        # First line should be the header — must include `email`
+        first_line = response.text.splitlines()[0]
+        assert "email" in first_line
+        assert "user_groups" in first_line
+        assert "courses" in first_line
+        assert "collections" in first_line
+
+    async def test_unenroll_template_returns_csv(self, client):
+        response = await client.get("/api/v1/users/1/bulk-unenroll/template.csv")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/csv")
+        assert "bulk-unenroll-template.csv" in response.headers["content-disposition"]
+        first_line = response.text.splitlines()[0]
+        # Unenroll template should NOT include create-only fields
+        assert "password" not in first_line
+        assert "first_name" not in first_line
+        assert "email" in first_line

--- a/apps/api/src/tests/routers/test_users_router.py
+++ b/apps/api/src/tests/routers/test_users_router.py
@@ -156,3 +156,78 @@ class TestGetUserByUsername:
             response = await client.get("/api/v1/users/username/nonexistent")
 
         assert response.status_code == 404
+
+
+class TestBulkImport:
+    """POST /{org_id}/bulk-import — CSV upload that creates users and enrollments."""
+
+    @staticmethod
+    def _result(**overrides):
+        from src.services.users.bulk_import import BulkImportResult
+        defaults = dict(
+            rows_processed=0,
+            users_created=0,
+            users_skipped_existing=0,
+            users_failed=0,
+            enrollments_added=0,
+            usergroup_assignments_added=0,
+            errors=[],
+        )
+        defaults.update(overrides)
+        return BulkImportResult(**defaults)
+
+    async def test_bulk_import_success(self, client):
+        csv_body = (
+            "email,first_name,last_name\n"
+            "alice@school.pt,Alice,Silva\n"
+            "bob@school.pt,Bob,Costa\n"
+        )
+        with patch(
+            "src.routers.users.bulk_import_users_from_csv",
+            new_callable=AsyncMock,
+            return_value=self._result(rows_processed=2, users_created=2),
+        ):
+            response = await client.post(
+                "/api/v1/users/1/bulk-import",
+                files={"file": ("import.csv", csv_body, "text/csv")},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["rows_processed"] == 2
+        assert body["users_created"] == 2
+        assert body["errors"] == []
+
+    async def test_bulk_import_rejects_non_csv_content_type(self, client):
+        response = await client.post(
+            "/api/v1/users/1/bulk-import",
+            files={"file": ("import.json", b"{}", "application/json")},
+        )
+
+        assert response.status_code == 400
+        assert "CSV" in response.json()["detail"]
+
+    async def test_bulk_import_rejects_non_utf8(self, client):
+        # 0xC0 is an invalid UTF-8 start byte
+        bad_bytes = b"email\nbad\xc0byte\n"
+        response = await client.post(
+            "/api/v1/users/1/bulk-import",
+            files={"file": ("import.csv", bad_bytes, "text/csv")},
+        )
+
+        assert response.status_code == 400
+        assert "UTF-8" in response.json()["detail"]
+
+    async def test_bulk_import_propagates_service_errors(self, client):
+        with patch(
+            "src.routers.users.bulk_import_users_from_csv",
+            new_callable=AsyncMock,
+            side_effect=HTTPException(status_code=400, detail="CSV missing required columns: ['email']"),
+        ):
+            response = await client.post(
+                "/api/v1/users/1/bulk-import",
+                files={"file": ("import.csv", b"name\nfoo\n", "text/csv")},
+            )
+
+        assert response.status_code == 400
+        assert "missing required columns" in response.json()["detail"]

--- a/apps/api/src/tests/routers/test_users_router.py
+++ b/apps/api/src/tests/routers/test_users_router.py
@@ -231,3 +231,51 @@ class TestBulkImport:
 
         assert response.status_code == 400
         assert "missing required columns" in response.json()["detail"]
+
+
+class TestBulkExport:
+    """GET /{org_id}/bulk-export — CSV stream of users in the organization."""
+
+    async def test_bulk_export_success(self, client):
+        csv_payload = (
+            "email,first_name,last_name,username,role_id,user_groups\n"
+            "alice@school.pt,Alice,Silva,alice,4,1|2\n"
+        )
+        with patch(
+            "src.routers.users.export_users_to_csv",
+            new_callable=AsyncMock,
+            return_value=csv_payload,
+        ):
+            response = await client.get("/api/v1/users/1/bulk-export")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/csv")
+        assert "attachment" in response.headers["content-disposition"]
+        assert "users-export-org-1" in response.headers["content-disposition"]
+        body = response.text
+        assert body.startswith("email,first_name,last_name,username,role_id,user_groups")
+        assert "alice@school.pt" in body
+
+    async def test_bulk_export_with_usergroup_filter(self, client):
+        with patch(
+            "src.routers.users.export_users_to_csv",
+            new_callable=AsyncMock,
+            return_value="email\nbob@school.pt\n",
+        ) as mock_export:
+            response = await client.get("/api/v1/users/1/bulk-export?usergroup_id=42")
+
+        assert response.status_code == 200
+        # Verify the service got the filter argument
+        kwargs = mock_export.call_args.kwargs
+        assert kwargs["usergroup_id"] == 42
+        assert "usergroup-42" in response.headers["content-disposition"]
+
+    async def test_bulk_export_org_not_found(self, client):
+        with patch(
+            "src.routers.users.export_users_to_csv",
+            new_callable=AsyncMock,
+            side_effect=HTTPException(status_code=404, detail="Organization not found"),
+        ):
+            response = await client.get("/api/v1/users/999/bulk-export")
+
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary

- Adds `POST /users/{org_id}/bulk-import` that accepts a CSV upload and creates many users in one request, optionally enrolling them into **user groups**, **courses**, and **collections** (collections expand automatically to their constituent courses)
- Required CSV column: `email`. Optional: `first_name`, `last_name`, `username`, `password`, `role_id`, `user_groups`, `courses`, `collections`
- Multi-value cells use `|` as the inner separator to avoid CSV comma collision (e.g., `user_groups=1|2|3`)
- Empty `password` generates a strong random one (user recovers via the standard password-reset flow); empty `username` is derived from the email's local part; empty `role_id` defaults to `4` (User/Student)
- Each row is processed **independently** — failures (existing users, invalid course UUIDs, unknown user-group IDs, etc.) accumulate in the response `errors` array with `row` + `email` + `error` and processing continues for the rest of the batch
- Returns a structured summary: `rows_processed`, `users_created`, `users_skipped_existing`, `users_failed`, `enrollments_added`, `usergroup_assignments_added`, `errors[]`

## Why

Schools, corporate L&D, and bootcamps frequently need to onboard 30–1000+ users in one go. The current path requires the admin to either click through individual user-creation forms or build their own integration on top of `POST /users/{org_id}` row-by-row. Both are operationally painful and error-prone (especially when followed by hand-clicking enrollment in courses and user groups).

A single CSV upload covers the realistic use cases:
- **K-12 school** uploads `5_year_A_class.csv` with all students of a class, pre-assigned to the right user-group and enrolled in that year's collection of courses
- **Corporate L&D** uploads new hires already enrolled in mandatory compliance courses
- **Bootcamp** onboards a new cohort with their starter collection in one step

## Notes

- **Reuses existing services**: calls `create_user()` for user creation and mirrors the `Trail` + `TrailRun` creation pattern from `bulk_enroll_users()` (which is `APITokenUser`-scoped and therefore not directly callable from a regular admin endpoint — duplicating the loop is the cleanest path without a refactor)
- **Permission model**: gated by the existing `users.action_create` RBAC check (same as the single-user creation endpoint). Per-row enrollment failures don't change the user's overall permission requirements
- **Email behaviour**: each newly created user receives the standard verification email (same as `POST /users/{org_id}`). For very large batches this can be slow; an opt-in `send_invite_emails=false` flag is a natural follow-up
- **No frontend UI in this PR** — the dashboard upload widget is left for a follow-up, mirroring the same backend-first split used for other recent features
- **Scope is intentionally narrow**: dry-run mode, async/background processing, and download-template endpoint are deliberately out of scope and easy to add later

## Test plan

- [x] `python -m ast.parse` clean on all three files
- [x] Router-level tests added in `test_users_router.py` covering happy path, invalid content-type, invalid encoding, and propagation of service errors (4 new tests, mirror existing patterns)
- [ ] Manual: upload sample CSV with `email`-only rows → verify users are created and email goes out
- [ ] Manual: upload CSV with `user_groups=1|2`, `courses=course_<uuid>`, `collections=collection_<uuid>` → verify enrollments + group memberships
- [ ] Manual: upload CSV with mixed valid/invalid rows → verify the response `errors` array reports each failure and the valid rows still complete
- [ ] Manual: re-run same CSV → verify duplicates are reported as `users_skipped_existing` (no exception)

## Files changed

- **New**: `apps/api/src/services/users/bulk_import.py` (≈330 lines) — parser, Pydantic models, processing loop
- **Modified**: `apps/api/src/routers/users.py` (+66 lines) — endpoint with multipart upload handling
- **Modified**: `apps/api/src/tests/routers/test_users_router.py` (+71 lines) — 4 router tests

Total: 3 files, +512 lines, no deletions.