### PR TITLE
feat(api): add archive/unarchive for courses

### DIFF
--- a/apps/api/migrations/versions/a6b7c8d9e0f1_add_is_archived_to_course.py
+++ b/apps/api/migrations/versions/a6b7c8d9e0f1_add_is_archived_to_course.py
@@ -1,0 +1,61 @@
+"""Add is_archived flag to course
+
+Adds a non-nullable boolean ``is_archived`` column to ``course`` that
+defaults to false. When true, the course rejects new enrollments and is
+hidden from default course listings (visible to admins via the
+``include_archived=true`` query parameter).
+
+Existing courses are migrated to ``is_archived=false`` via the server
+default, so the change is backwards-compatible.
+
+Revision ID: a6b7c8d9e0f1
+Revises: z5a6b7c8d9e0
+Create Date: 2026-04-28
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel  # noqa: F401
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a6b7c8d9e0f1'
+down_revision: Union[str, None] = 'z5a6b7c8d9e0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if 'course' not in inspector.get_table_names():
+        return
+
+    existing_columns = {col['name'] for col in inspector.get_columns('course')}
+    if 'is_archived' in existing_columns:
+        return
+
+    op.add_column(
+        'course',
+        sa.Column(
+            'is_archived',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if 'course' not in inspector.get_table_names():
+        return
+
+    existing_columns = {col['name'] for col in inspector.get_columns('course')}
+    if 'is_archived' in existing_columns:
+        op.drop_column('course', 'is_archived')

--- a/apps/api/src/db/courses/courses.py
+++ b/apps/api/src/db/courses/courses.py
@@ -57,6 +57,10 @@ class CourseBase(SQLModel):
     public: bool
     published: bool = Field(default=False)
     open_to_contributors: bool
+    # Archived courses are read-only: visible to enrolled users and listed
+    # to admins (when include_archived=True) but reject new enrollments and
+    # are hidden from default course listings.
+    is_archived: bool = Field(default=False)
 
 
 class Course(CourseBase, table=True):

--- a/apps/api/src/routers/courses/courses.py
+++ b/apps/api/src/routers/courses/courses.py
@@ -33,6 +33,8 @@ from src.services.courses.courses import (
     search_courses,
     get_course_user_rights,
     clone_course,
+    archive_course,
+    unarchive_course,
 )
 from src.services.courses.updates import (
     create_update,
@@ -442,6 +444,7 @@ async def api_get_course_by_orgslug(
     limit: int,
     org_slug: str,
     include_unpublished: bool = False,
+    include_archived: bool = False,
     db_session: Session = Depends(get_db_session),
     current_user: PublicUser = Depends(get_current_user),
 ) -> List[CourseRead]:
@@ -449,7 +452,9 @@ async def api_get_course_by_orgslug(
     Get courses by page and limit
     """
     return await get_courses_orgslug(
-        request, current_user, org_slug, db_session, page, limit, include_unpublished
+        request, current_user, org_slug, db_session, page, limit,
+        include_unpublished=include_unpublished,
+        include_archived=include_archived,
     )
 
 
@@ -465,6 +470,7 @@ async def api_get_course_by_orgslug(
 async def api_get_courses_count(
     request: Request,
     org_slug: str,
+    include_archived: bool = False,
     db_session: Session = Depends(get_db_session),
     current_user: PublicUser = Depends(get_current_user),
 ) -> int:
@@ -472,7 +478,8 @@ async def api_get_courses_count(
     Get total count of courses for an organization
     """
     return await get_courses_count_orgslug(
-        request, current_user, org_slug, db_session
+        request, current_user, org_slug, db_session,
+        include_archived=include_archived,
     )
 
 
@@ -605,6 +612,55 @@ async def api_clone_course(
     - Create permission for courses in the organization
     """
     return await clone_course(request, course_uuid, current_user, db_session)
+
+
+@router.post(
+    "/{course_uuid}/archive",
+    response_model=CourseRead,
+    summary="Archive a course",
+    description=(
+        "Mark a course as archived (read-only). Archived courses reject new "
+        "enrollments and are hidden from default course listings (visible "
+        "with `?include_archived=true`). Existing enrollments and progress "
+        "are preserved. Idempotent: archiving an already-archived course is "
+        "a no-op."
+    ),
+    responses={
+        200: {"description": "Course is now archived", "model": CourseRead},
+        403: {"description": "Caller lacks update permission on this course"},
+        404: {"description": "Course not found"},
+    },
+)
+async def api_archive_course(
+    request: Request,
+    course_uuid: str,
+    db_session: Session = Depends(get_db_session),
+    current_user: PublicUser = Depends(get_current_user),
+) -> CourseRead:
+    return await archive_course(request, course_uuid, current_user, db_session)
+
+
+@router.post(
+    "/{course_uuid}/unarchive",
+    response_model=CourseRead,
+    summary="Unarchive a course",
+    description=(
+        "Restore an archived course to the active state. Idempotent: "
+        "unarchiving an active course is a no-op."
+    ),
+    responses={
+        200: {"description": "Course is now active", "model": CourseRead},
+        403: {"description": "Caller lacks update permission on this course"},
+        404: {"description": "Course not found"},
+    },
+)
+async def api_unarchive_course(
+    request: Request,
+    course_uuid: str,
+    db_session: Session = Depends(get_db_session),
+    current_user: PublicUser = Depends(get_current_user),
+) -> CourseRead:
+    return await unarchive_course(request, course_uuid, current_user, db_session)
 
 
 @router.get(

--- a/apps/api/src/services/courses/courses.py
+++ b/apps/api/src/services/courses/courses.py
@@ -245,6 +245,7 @@ async def get_courses_orgslug(
     page: int = 1,
     limit: int = 10,
     include_unpublished: bool = False,
+    include_archived: bool = False,
 ) -> List[CourseRead]:
     # Cap limit to prevent excessive DB reads
     limit = min(limit, 100)
@@ -335,6 +336,11 @@ async def get_courses_orgslug(
                 ))
             )
 
+    # Archived courses are hidden by default; only org admins / maintainers
+    # may opt in via include_archived=True.
+    if not (include_archived and can_view_unpublished):
+        query = query.where(Course.is_archived == False)  # noqa: E712
+
     # Apply ordering and pagination — only use DISTINCT when outerjoins may produce duplicates
     query = query.order_by(Course.creation_date.desc()).offset(offset).limit(limit)
     if needs_distinct:
@@ -390,6 +396,7 @@ async def get_courses_orgslug(
             "public": course.public,
             "published": course.published,
             "open_to_contributors": course.open_to_contributors,
+            "is_archived": course.is_archived,
             "course_uuid": course.course_uuid,
             "creation_date": course.creation_date,
             "update_date": course.update_date,
@@ -397,8 +404,8 @@ async def get_courses_orgslug(
         })
         course_reads.append(course_read)
 
-    # Cache the result for anonymous public views
-    if is_anon and not include_unpublished and course_reads:
+    # Cache the result for anonymous public views (archived stays excluded by default)
+    if is_anon and not include_unpublished and not include_archived and course_reads:
         from src.services.courses.cache import set_cached_courses_list
         set_cached_courses_list(
             org_slug, page, limit,
@@ -413,6 +420,7 @@ async def get_courses_count_orgslug(
     current_user: PublicUser | AnonymousUser | APITokenUser,
     org_slug: str,
     db_session: Session,
+    include_archived: bool = False,
 ) -> int:
     """
     Get total count of courses for an organization (respecting visibility rules)
@@ -457,6 +465,9 @@ async def get_courses_count_orgslug(
                 ResourceAuthor.user_id.isnot(None)  # Courses where user is an ACTIVE resource author
             ))
         )
+
+    if not include_archived:
+        query = query.where(Course.is_archived == False)  # noqa: E712
 
     count = db_session.exec(query).one()
     return count
@@ -585,6 +596,7 @@ async def search_courses(
             "public": course.public,
             "published": course.published,
             "open_to_contributors": course.open_to_contributors,
+            "is_archived": course.is_archived,
             "course_uuid": course.course_uuid,
             "creation_date": course.creation_date,
             "update_date": course.update_date,
@@ -925,6 +937,95 @@ async def update_course(
     return course
 
 
+def assert_course_not_archived(course: Course) -> None:
+    """Raise 403 if the course is archived. Use to gate write paths."""
+    if course.is_archived:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Course is archived (read-only); unarchive it first to allow this operation",
+        )
+
+
+async def _set_course_archive_state(
+    request: Request,
+    course_uuid: str,
+    current_user: PublicUser | AnonymousUser | APITokenUser,
+    db_session: Session,
+    archived: bool,
+) -> CourseRead:
+    """Shared archive/unarchive implementation (idempotent)."""
+    statement = select(Course).where(Course.course_uuid == course_uuid)
+    course = db_session.exec(statement).first()
+
+    if not course:
+        raise HTTPException(status_code=404, detail="Course not found")
+
+    await check_resource_access(
+        request, db_session, current_user, course.course_uuid, AccessAction.UPDATE,
+    )
+
+    if course.is_archived != archived:
+        course.is_archived = archived
+        course.update_date = str(datetime.now())
+        db_session.add(course)
+        db_session.commit()
+        db_session.refresh(course)
+
+        await dispatch_webhooks(
+            event_name="course_archived" if archived else "course_unarchived",
+            org_id=course.org_id,
+            data={
+                "course_uuid": course.course_uuid,
+                "name": course.name,
+                "is_archived": course.is_archived,
+            },
+        )
+
+    authors_statement = (
+        select(ResourceAuthor, User)
+        .join(User, ResourceAuthor.user_id == User.id)  # type: ignore
+        .where(ResourceAuthor.resource_uuid == course.course_uuid)
+        .order_by(ResourceAuthor.id.asc())  # type: ignore
+    )
+    author_results = db_session.exec(authors_statement).all()
+    authors = [
+        AuthorWithRole(
+            user=UserRead.model_validate(user),
+            authorship=resource_author.authorship,
+            authorship_status=resource_author.authorship_status,
+            creation_date=resource_author.creation_date,
+            update_date=resource_author.update_date,
+        )
+        for resource_author, user in author_results
+    ]
+
+    return CourseRead(**course.model_dump(), authors=authors)
+
+
+async def archive_course(
+    request: Request,
+    course_uuid: str,
+    current_user: PublicUser | AnonymousUser | APITokenUser,
+    db_session: Session,
+) -> CourseRead:
+    """Mark a course as archived (read-only). Idempotent."""
+    return await _set_course_archive_state(
+        request, course_uuid, current_user, db_session, archived=True,
+    )
+
+
+async def unarchive_course(
+    request: Request,
+    course_uuid: str,
+    current_user: PublicUser | AnonymousUser | APITokenUser,
+    db_session: Session,
+) -> CourseRead:
+    """Restore an archived course to the active state. Idempotent."""
+    return await _set_course_archive_state(
+        request, course_uuid, current_user, db_session, archived=False,
+    )
+
+
 async def delete_course(
     request: Request,
     course_uuid: str,
@@ -1038,6 +1139,7 @@ async def get_user_courses(
             "public": course.public,
             "published": course.published,
             "open_to_contributors": course.open_to_contributors,
+            "is_archived": course.is_archived,
             "course_uuid": course.course_uuid,
             "creation_date": course.creation_date,
             "update_date": course.update_date,

--- a/apps/api/src/services/trail/trail.py
+++ b/apps/api/src/services/trail/trail.py
@@ -404,6 +404,12 @@ async def add_course_to_trail(
             status_code=status.HTTP_404_NOT_FOUND, detail="Course not found"
         )
 
+    if course.is_archived:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Course is archived; new enrollments are not allowed",
+        )
+
     # check if run already exists
     statement = select(TrailRun).where(
         TrailRun.course_id == course.id, TrailRun.user_id == user.id

--- a/apps/api/src/tests/routers/test_courses_router.py
+++ b/apps/api/src/tests/routers/test_courses_router.py
@@ -396,6 +396,40 @@ class TestDeleteCourse:
         assert response.json()["course_uuid"] == "course_clone"
 
 
+class TestArchiveCourse:
+    async def test_archive_course_returns_archived_state(self, client):
+        with patch(
+            "src.routers.courses.courses.archive_course",
+            new_callable=AsyncMock,
+            return_value=_mock_course_read(course_uuid="course_test", is_archived=True),
+        ):
+            response = await client.post("/api/v1/courses/course_test/archive")
+
+        assert response.status_code == 200
+        assert response.json()["is_archived"] is True
+
+    async def test_archive_course_not_found(self, client):
+        with patch(
+            "src.routers.courses.courses.archive_course",
+            new_callable=AsyncMock,
+            side_effect=HTTPException(status_code=404, detail="Course not found"),
+        ):
+            response = await client.post("/api/v1/courses/missing/archive")
+
+        assert response.status_code == 404
+
+    async def test_unarchive_course_returns_active_state(self, client):
+        with patch(
+            "src.routers.courses.courses.unarchive_course",
+            new_callable=AsyncMock,
+            return_value=_mock_course_read(course_uuid="course_test", is_archived=False),
+        ):
+            response = await client.post("/api/v1/courses/course_test/unarchive")
+
+        assert response.status_code == 200
+        assert response.json()["is_archived"] is False
+
+
 class TestContributorEndpoints:
     async def test_apply_course_contributor(self, client):
         with patch(


### PR DESCRIPTION
## Summary

- Adds `is_archived` to the `Course` table (Alembic migration `a6b7c8d9e0f1`, server-default `false` so existing rows are preserved)
- `POST /courses/{course_uuid}/archive` and `POST /courses/{course_uuid}/unarchive` — both idempotent, dispatch `course_archived` / `course_unarchived` webhooks
- New enrollments rejected on archived courses (`add_course_to_trail` returns 403)
- Listings hide archived courses by default; admins/maintainers can opt in via `?include_archived=true` on `/courses/org_slug/{slug}/page/{p}/limit/{l}` and `/courses/org_slug/{slug}/count`
- 3 router tests covering archive/unarchive happy path and 404
- RBAC reuses the existing `check_resource_access(... AccessAction.UPDATE)` — same gate as `update_course`

## Why

Schools recycling curriculum at end of school year need to freeze the previous year's courses (no new enrollments, hidden from default listings) while keeping enrolled users' historical progress and certificates intact. The same primitive serves any "course is finished — preserve, don't delete" use case in corporate training.

Without this, admins either delete courses (losing data) or leave them active (cluttering listings and exposing them to new students).

## Notes

- **Idempotent**: archiving an already-archived course is a no-op (no webhook fired); same for unarchive
- **Filter is admin-gated**: `include_archived=true` is only honoured for users who can already view unpublished courses; anonymous users and regular users always see the filtered set
- **Cache**: anonymous public listings are cached, but only when `include_archived=false` (the default), so archived state changes don't pollute the cached payload

## Out of scope (follow-up)

These were intentionally **not** blocked while archived to keep the PR focused on the most impactful gate (new enrollments) — happy to add in a follow-up if reviewers want them in scope:

- Course content mutations (`update_course`, chapter create/update, activity create/update) — typical workflow archives *after* content is finalized
- `TrailStep` mutations (existing students continuing progress) — admins should ideally archive at term end after notifying students
- Frontend UI (archive button, archived-courses tab in dashboard) — separate Web PR

## Test plan

- [x] `python -m ast.parse` clean on all 5 modified + 1 new file
- [x] Router tests cover archive happy path, unarchive happy path, 404
- [ ] Manual: archive a course, hit `POST /trail/add_course/{uuid}` → expect 403
- [ ] Manual: archive a course, list courses without `include_archived` → not present; with `include_archived=true` (as admin) → present
- [ ] Manual: archive then unarchive → course is selectable again, new enrollment works
- [ ] Manual: run Alembic upgrade against an existing DB → `is_archived` column exists with default false on all existing rows

## Files

- **New**: `apps/api/migrations/versions/a6b7c8d9e0f1_add_is_archived_to_course.py`
- **Modified**: `apps/api/src/db/courses/courses.py` (+4 lines), `apps/api/src/services/courses/courses.py` (+106), `apps/api/src/services/trail/trail.py` (+6), `apps/api/src/routers/courses/courses.py` (+60), `apps/api/src/tests/routers/test_courses_router.py` (+33)
