### PR TITLE
feat(api): add per-user personal calendar (CRUD)

### DIFF
--- a/apps/api/migrations/versions/b7c8d9e0f1g2_add_calendar_event_table.py
+++ b/apps/api/migrations/versions/b7c8d9e0f1g2_add_calendar_event_table.py
@@ -1,0 +1,82 @@
+"""Add user_calendar_event table
+
+Creates a new ``user_calendar_event`` table backing the per-user personal
+calendar feature. Columns mirror the SQLModel definition in
+``src/db/calendar_events.py``.
+
+Revision ID: b7c8d9e0f1g2
+Revises: z5a6b7c8d9e0
+Create Date: 2026-04-28
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel  # noqa: F401
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b7c8d9e0f1g2'
+down_revision: Union[str, None] = 'z5a6b7c8d9e0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if 'user_calendar_event' in inspector.get_table_names():
+        return
+
+    op.create_table(
+        'user_calendar_event',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('event_uuid', sa.String(), nullable=False, server_default=''),
+        sa.Column(
+            'user_id',
+            sa.Integer(),
+            sa.ForeignKey('user.id', ondelete='CASCADE'),
+            nullable=False,
+        ),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('description', sa.String(), nullable=True),
+        sa.Column('start_date', sa.String(), nullable=False),
+        sa.Column('end_date', sa.String(), nullable=True),
+        sa.Column(
+            'event_type',
+            sa.String(length=32),
+            nullable=False,
+            server_default='other',
+        ),
+        sa.Column('color', sa.String(length=16), nullable=True),
+        sa.Column('creation_date', sa.String(), nullable=False, server_default=''),
+        sa.Column('update_date', sa.String(), nullable=False, server_default=''),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        'ix_user_calendar_event_event_uuid',
+        'user_calendar_event', ['event_uuid'], unique=False,
+    )
+    op.create_index(
+        'ix_user_calendar_event_user_id',
+        'user_calendar_event', ['user_id'], unique=False,
+    )
+    op.create_index(
+        'ix_user_calendar_event_user_start',
+        'user_calendar_event', ['user_id', 'start_date'], unique=False,
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if 'user_calendar_event' not in inspector.get_table_names():
+        return
+
+    op.drop_index('ix_user_calendar_event_user_start', table_name='user_calendar_event')
+    op.drop_index('ix_user_calendar_event_user_id', table_name='user_calendar_event')
+    op.drop_index('ix_user_calendar_event_event_uuid', table_name='user_calendar_event')
+    op.drop_table('user_calendar_event')

--- a/apps/api/src/db/calendar_events.py
+++ b/apps/api/src/db/calendar_events.py
@@ -1,0 +1,86 @@
+"""
+Personal calendar events.
+
+A simple per-user calendar primitive that any LearnHouse user can fill in
+with their own events: study reminders, meetings, deadlines, personal
+milestones, etc. Each event belongs to a single user; events are private
+to that user (only the owner can read or modify them).
+
+Recurrence, reminders/notifications, sharing, and aggregation with
+course due dates or org-level events are deliberately out of scope for
+the first iteration — the simplest useful primitive is a flat list of
+``(user, name, start, end?, type)`` tuples that the owner curates.
+"""
+from enum import Enum
+from typing import Optional
+
+from pydantic import field_validator
+from sqlalchemy import Column, ForeignKey, Index, Integer
+from sqlmodel import Field, SQLModel
+
+
+class CalendarEventType(str, Enum):
+    """Coarse categorization to help the UI render colours / icons."""
+    REMINDER = "reminder"   # study reminder, todo
+    MEETING = "meeting"     # 1:1, group call
+    DEADLINE = "deadline"   # external deadline tracked on the calendar
+    PERSONAL = "personal"   # personal time block, holiday, travel
+    OTHER = "other"
+
+
+class CalendarEventBase(SQLModel):
+    name: str
+    description: Optional[str] = None
+    # ISO-8601 date or datetime strings. Stored as strings to match the
+    # convention used by the rest of the codebase (creation_date /
+    # update_date are also strings) and to keep the migration trivial.
+    start_date: str
+    end_date: Optional[str] = None
+    event_type: CalendarEventType = Field(default=CalendarEventType.OTHER)
+    color: Optional[str] = None  # optional hex like "#ff8800"
+
+
+class CalendarEvent(CalendarEventBase, table=True):
+    __tablename__ = "user_calendar_event"
+    __table_args__ = (
+        Index("ix_user_calendar_event_user_start", "user_id", "start_date"),
+    )
+    id: Optional[int] = Field(default=None, primary_key=True)
+    event_uuid: str = Field(default="", index=True)
+    user_id: int = Field(
+        sa_column=Column(Integer, ForeignKey("user.id", ondelete="CASCADE"), index=True)
+    )
+    creation_date: str = ""
+    update_date: str = ""
+
+
+class CalendarEventCreate(CalendarEventBase):
+    """Owner is always the calling user — never accepted from the client."""
+
+    @field_validator("end_date")
+    @classmethod
+    def _end_after_start(cls, v: Optional[str], info):
+        if v is None:
+            return v
+        start = info.data.get("start_date")
+        if start and v < start:
+            raise ValueError("end_date must be on or after start_date")
+        return v
+
+
+class CalendarEventUpdate(SQLModel):
+    """Partial update — only fields that are explicitly set are applied."""
+    name: Optional[str] = None
+    description: Optional[str] = None
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+    event_type: Optional[CalendarEventType] = None
+    color: Optional[str] = None
+
+
+class CalendarEventRead(CalendarEventBase):
+    id: int
+    event_uuid: str
+    user_id: int
+    creation_date: str
+    update_date: str

--- a/apps/api/src/router.py
+++ b/apps/api/src/router.py
@@ -7,6 +7,7 @@ from src.routers import health
 from src.routers import instance
 from src.routers import plans
 from src.routers import usergroups
+from src.routers import calendar as calendar_router_module
 from src.routers import dev, trail, users, auth, orgs, roles, search
 from src.routers import stream
 from src.routers import api_tokens
@@ -170,6 +171,12 @@ v1_router.include_router(chapters.router, prefix="/chapters", tags=["chapters"])
 v1_router.include_router(activities.router, prefix="/activities", tags=["activities"])
 v1_router.include_router(
     collections.router, prefix="/collections", tags=["collections"]
+)
+v1_router.include_router(
+    calendar_router_module.router,
+    prefix="/calendar",
+    tags=["calendar"],
+    dependencies=[Depends(require_authenticated_user)],
 )
 v1_router.include_router(
     communities_router_module.router,

--- a/apps/api/src/routers/calendar.py
+++ b/apps/api/src/routers/calendar.py
@@ -1,0 +1,160 @@
+"""
+Calendar router — per-user personal calendar events.
+
+All endpoints operate on the authenticated user's own events. Owner is
+always derived from the session, never accepted from the client, so
+there is no path to read or modify another user's calendar.
+"""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Query, Request
+from sqlmodel import Session
+
+from src.core.events.database import get_db_session
+from src.db.calendar_events import (
+    CalendarEventCreate,
+    CalendarEventRead,
+    CalendarEventType,
+    CalendarEventUpdate,
+)
+from src.db.users import PublicUser
+from src.security.auth import get_current_user
+from src.services.calendar.events import (
+    create_calendar_event,
+    delete_calendar_event,
+    get_calendar_event,
+    list_my_calendar_events,
+    update_calendar_event,
+)
+
+
+router = APIRouter()
+
+
+@router.post(
+    "/me/events",
+    response_model=CalendarEventRead,
+    summary="Create a calendar event for the current user",
+    description=(
+        "Create a personal calendar event. The owner is always the calling "
+        "user — there is no path to create an event on someone else's "
+        "calendar. Returns 401 for anonymous callers."
+    ),
+    responses={
+        200: {"description": "Event created", "model": CalendarEventRead},
+        401: {"description": "Authentication required"},
+        422: {"description": "Validation error (e.g. end_date before start_date)"},
+    },
+)
+async def api_create_my_calendar_event(
+    request: Request,
+    event_data: CalendarEventCreate,
+    db_session: Session = Depends(get_db_session),
+    current_user: PublicUser = Depends(get_current_user),
+) -> CalendarEventRead:
+    return await create_calendar_event(request, db_session, current_user, event_data)
+
+
+@router.get(
+    "/me/events",
+    response_model=List[CalendarEventRead],
+    summary="List the current user's calendar events",
+    description=(
+        "List the caller's events ordered by start_date ascending. Use "
+        "`from_date` and `to_date` (ISO-8601) to scope to a window — "
+        "multi-day events that overlap the window are included. "
+        "`event_type` filters by category."
+    ),
+    responses={
+        200: {"description": "Events for the current user", "model": List[CalendarEventRead]},
+        401: {"description": "Authentication required"},
+    },
+)
+async def api_list_my_calendar_events(
+    request: Request,
+    from_date: Optional[str] = Query(
+        None, description="ISO-8601 lower bound (events on/after this date)"
+    ),
+    to_date: Optional[str] = Query(
+        None, description="ISO-8601 upper bound (events starting on/before this date)"
+    ),
+    event_type: Optional[CalendarEventType] = Query(
+        None, description="Filter by event_type"
+    ),
+    db_session: Session = Depends(get_db_session),
+    current_user: PublicUser = Depends(get_current_user),
+) -> List[CalendarEventRead]:
+    return await list_my_calendar_events(
+        request, db_session, current_user, from_date, to_date, event_type,
+    )
+
+
+@router.get(
+    "/me/events/{event_uuid}",
+    response_model=CalendarEventRead,
+    summary="Get a single calendar event of the current user",
+    description=(
+        "Read a single event from the caller's calendar. Returns 404 if "
+        "the event doesn't exist or belongs to another user (existence is "
+        "intentionally not leaked across users)."
+    ),
+    responses={
+        200: {"description": "Event", "model": CalendarEventRead},
+        401: {"description": "Authentication required"},
+        404: {"description": "Event not found (or owned by another user)"},
+    },
+)
+async def api_get_my_calendar_event(
+    request: Request,
+    event_uuid: str,
+    db_session: Session = Depends(get_db_session),
+    current_user: PublicUser = Depends(get_current_user),
+) -> CalendarEventRead:
+    return await get_calendar_event(request, db_session, current_user, event_uuid)
+
+
+@router.put(
+    "/me/events/{event_uuid}",
+    response_model=CalendarEventRead,
+    summary="Update one of the current user's calendar events",
+    description=(
+        "Partial update — only fields explicitly set on the request body "
+        "are applied. Returns 404 if the event isn't owned by the caller."
+    ),
+    responses={
+        200: {"description": "Updated event", "model": CalendarEventRead},
+        400: {"description": "Validation error (e.g. end_date before start_date)"},
+        401: {"description": "Authentication required"},
+        404: {"description": "Event not found (or owned by another user)"},
+    },
+)
+async def api_update_my_calendar_event(
+    request: Request,
+    event_uuid: str,
+    update_data: CalendarEventUpdate,
+    db_session: Session = Depends(get_db_session),
+    current_user: PublicUser = Depends(get_current_user),
+) -> CalendarEventRead:
+    return await update_calendar_event(
+        request, db_session, current_user, event_uuid, update_data,
+    )
+
+
+@router.delete(
+    "/me/events/{event_uuid}",
+    summary="Delete one of the current user's calendar events",
+    description="Permanently delete an event owned by the caller.",
+    responses={
+        200: {"description": "Event deleted"},
+        401: {"description": "Authentication required"},
+        404: {"description": "Event not found (or owned by another user)"},
+    },
+)
+async def api_delete_my_calendar_event(
+    request: Request,
+    event_uuid: str,
+    db_session: Session = Depends(get_db_session),
+    current_user: PublicUser = Depends(get_current_user),
+) -> dict:
+    return await delete_calendar_event(request, db_session, current_user, event_uuid)

--- a/apps/api/src/services/calendar/events.py
+++ b/apps/api/src/services/calendar/events.py
@@ -1,0 +1,183 @@
+"""
+Personal calendar event service.
+
+Per-user CRUD over ``CalendarEvent``. Events are private to the owning
+user — only the owner (or a superadmin) can read or modify them. Events
+are not org-scoped: if the user belongs to multiple organizations, the
+same calendar follows them across all orgs.
+"""
+
+from datetime import datetime
+from typing import List, Optional
+from uuid import uuid4
+
+from fastapi import HTTPException, Request, status
+from sqlmodel import Session, select, or_, and_
+
+from src.db.calendar_events import (
+    CalendarEvent,
+    CalendarEventCreate,
+    CalendarEventRead,
+    CalendarEventType,
+    CalendarEventUpdate,
+)
+from src.db.users import AnonymousUser, PublicUser
+from src.security.superadmin import is_user_superadmin
+
+
+def _require_authenticated(current_user: PublicUser | AnonymousUser) -> int:
+    """Reject anonymous callers and return the authenticated user id."""
+    if isinstance(current_user, AnonymousUser) or current_user.id == 0:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required",
+        )
+    return current_user.id
+
+
+def _user_can_access_event(
+    event: CalendarEvent,
+    current_user: PublicUser | AnonymousUser,
+    db_session: Session,
+) -> bool:
+    """Owner or superadmin may access the event."""
+    if isinstance(current_user, AnonymousUser) or current_user.id == 0:
+        return False
+    if event.user_id == current_user.id:
+        return True
+    return is_user_superadmin(current_user.id, db_session)
+
+
+async def create_calendar_event(
+    request: Request,
+    db_session: Session,
+    current_user: PublicUser | AnonymousUser,
+    event_data: CalendarEventCreate,
+) -> CalendarEventRead:
+    user_id = _require_authenticated(current_user)
+
+    now = str(datetime.now())
+    event = CalendarEvent(
+        user_id=user_id,
+        event_uuid=f"calevent_{uuid4()}",
+        name=event_data.name,
+        description=event_data.description,
+        start_date=event_data.start_date,
+        end_date=event_data.end_date,
+        event_type=event_data.event_type,
+        color=event_data.color,
+        creation_date=now,
+        update_date=now,
+    )
+    db_session.add(event)
+    db_session.commit()
+    db_session.refresh(event)
+
+    return CalendarEventRead.model_validate(event)
+
+
+async def list_my_calendar_events(
+    request: Request,
+    db_session: Session,
+    current_user: PublicUser | AnonymousUser,
+    from_date: Optional[str] = None,
+    to_date: Optional[str] = None,
+    event_type: Optional[CalendarEventType] = None,
+) -> List[CalendarEventRead]:
+    user_id = _require_authenticated(current_user)
+
+    query = select(CalendarEvent).where(CalendarEvent.user_id == user_id)
+
+    # ``from_date`` matches events that overlap that boundary: either start
+    # on/after ``from_date`` or, for multi-day events, end on/after it.
+    if from_date is not None:
+        query = query.where(
+            or_(
+                CalendarEvent.start_date >= from_date,
+                and_(
+                    CalendarEvent.end_date.is_not(None),  # type: ignore[union-attr]
+                    CalendarEvent.end_date >= from_date,
+                ),
+            )
+        )
+    if to_date is not None:
+        query = query.where(CalendarEvent.start_date <= to_date)
+    if event_type is not None:
+        query = query.where(CalendarEvent.event_type == event_type)
+
+    query = query.order_by(CalendarEvent.start_date.asc())  # type: ignore[attr-defined]
+    events = db_session.exec(query).all()
+    return [CalendarEventRead.model_validate(e) for e in events]
+
+
+async def get_calendar_event(
+    request: Request,
+    db_session: Session,
+    current_user: PublicUser | AnonymousUser,
+    event_uuid: str,
+) -> CalendarEventRead:
+    event = db_session.exec(
+        select(CalendarEvent).where(CalendarEvent.event_uuid == event_uuid)
+    ).first()
+    if not event:
+        raise HTTPException(status_code=404, detail="Calendar event not found")
+
+    if not _user_can_access_event(event, current_user, db_session):
+        # SECURITY: don't leak existence to other users — return 404, not 403
+        raise HTTPException(status_code=404, detail="Calendar event not found")
+
+    return CalendarEventRead.model_validate(event)
+
+
+async def update_calendar_event(
+    request: Request,
+    db_session: Session,
+    current_user: PublicUser | AnonymousUser,
+    event_uuid: str,
+    update_data: CalendarEventUpdate,
+) -> CalendarEventRead:
+    event = db_session.exec(
+        select(CalendarEvent).where(CalendarEvent.event_uuid == event_uuid)
+    ).first()
+    if not event:
+        raise HTTPException(status_code=404, detail="Calendar event not found")
+    if not _user_can_access_event(event, current_user, db_session):
+        raise HTTPException(status_code=404, detail="Calendar event not found")
+
+    changes = update_data.model_dump(exclude_unset=True)
+    if not changes:
+        return CalendarEventRead.model_validate(event)
+
+    for key, value in changes.items():
+        setattr(event, key, value)
+
+    if event.end_date is not None and event.end_date < event.start_date:
+        raise HTTPException(
+            status_code=400,
+            detail="end_date must be on or after start_date",
+        )
+
+    event.update_date = str(datetime.now())
+    db_session.add(event)
+    db_session.commit()
+    db_session.refresh(event)
+    return CalendarEventRead.model_validate(event)
+
+
+async def delete_calendar_event(
+    request: Request,
+    db_session: Session,
+    current_user: PublicUser | AnonymousUser,
+    event_uuid: str,
+) -> dict:
+    event = db_session.exec(
+        select(CalendarEvent).where(CalendarEvent.event_uuid == event_uuid)
+    ).first()
+    if not event:
+        raise HTTPException(status_code=404, detail="Calendar event not found")
+    if not _user_can_access_event(event, current_user, db_session):
+        raise HTTPException(status_code=404, detail="Calendar event not found")
+
+    db_session.delete(event)
+    db_session.commit()
+    return {"detail": "Calendar event deleted"}

--- a/apps/api/src/tests/routers/test_calendar_router.py
+++ b/apps/api/src/tests/routers/test_calendar_router.py
@@ -1,0 +1,150 @@
+"""Router tests for src/routers/calendar.py (per-user calendar)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from httpx import ASGITransport, AsyncClient
+
+from src.core.events.database import get_db_session
+from src.db.calendar_events import CalendarEventRead, CalendarEventType
+from src.routers.calendar import router as calendar_router
+from src.security.auth import get_current_user
+
+
+@pytest.fixture
+def app(db, admin_user):
+    app = FastAPI()
+    app.include_router(calendar_router, prefix="/api/v1/calendar")
+    app.dependency_overrides[get_db_session] = lambda: db
+    app.dependency_overrides[get_current_user] = lambda: admin_user
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def client(app):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+def _mock_event(**overrides) -> CalendarEventRead:
+    data = dict(
+        id=1,
+        event_uuid="calevent_test",
+        user_id=1,
+        name="Study session",
+        description=None,
+        start_date="2026-06-30",
+        end_date=None,
+        event_type=CalendarEventType.REMINDER,
+        color=None,
+        creation_date="2026-04-28",
+        update_date="2026-04-28",
+    )
+    data.update(overrides)
+    return CalendarEventRead(**data)
+
+
+class TestCreateMyCalendarEvent:
+    async def test_create_event(self, client):
+        payload = {
+            "name": "Study session",
+            "start_date": "2026-06-30",
+            "event_type": "reminder",
+        }
+        with patch(
+            "src.routers.calendar.create_calendar_event",
+            new_callable=AsyncMock,
+            return_value=_mock_event(),
+        ):
+            response = await client.post("/api/v1/calendar/me/events", json=payload)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["event_uuid"] == "calevent_test"
+        assert body["event_type"] == "reminder"
+        assert body["user_id"] == 1
+
+
+class TestListMyCalendarEvents:
+    async def test_list_events(self, client):
+        with patch(
+            "src.routers.calendar.list_my_calendar_events",
+            new_callable=AsyncMock,
+            return_value=[_mock_event()],
+        ):
+            response = await client.get("/api/v1/calendar/me/events")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert isinstance(body, list)
+        assert len(body) == 1
+        assert body[0]["user_id"] == 1
+
+    async def test_list_events_with_filters(self, client):
+        with patch(
+            "src.routers.calendar.list_my_calendar_events",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_list:
+            response = await client.get(
+                "/api/v1/calendar/me/events?from_date=2026-01-01&to_date=2026-12-31&event_type=meeting"
+            )
+
+        assert response.status_code == 200
+        all_args = list(mock_list.call_args.args) + list(mock_list.call_args.kwargs.values())
+        assert "2026-01-01" in all_args
+        assert "2026-12-31" in all_args
+
+
+class TestGetMyCalendarEvent:
+    async def test_get_event(self, client):
+        with patch(
+            "src.routers.calendar.get_calendar_event",
+            new_callable=AsyncMock,
+            return_value=_mock_event(),
+        ):
+            response = await client.get("/api/v1/calendar/me/events/calevent_test")
+
+        assert response.status_code == 200
+        assert response.json()["event_uuid"] == "calevent_test"
+
+    async def test_get_event_not_found_for_other_user(self, client):
+        # Service returns 404 (not 403) when event belongs to another user —
+        # don't leak existence across users.
+        with patch(
+            "src.routers.calendar.get_calendar_event",
+            new_callable=AsyncMock,
+            side_effect=HTTPException(status_code=404, detail="Calendar event not found"),
+        ):
+            response = await client.get("/api/v1/calendar/me/events/someone_elses")
+
+        assert response.status_code == 404
+
+
+class TestUpdateAndDeleteMyCalendarEvent:
+    async def test_update_event(self, client):
+        with patch(
+            "src.routers.calendar.update_calendar_event",
+            new_callable=AsyncMock,
+            return_value=_mock_event(name="Updated"),
+        ):
+            response = await client.put(
+                "/api/v1/calendar/me/events/calevent_test",
+                json={"name": "Updated"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["name"] == "Updated"
+
+    async def test_delete_event(self, client):
+        with patch(
+            "src.routers.calendar.delete_calendar_event",
+            new_callable=AsyncMock,
+            return_value={"detail": "Calendar event deleted"},
+        ):
+            response = await client.delete("/api/v1/calendar/me/events/calevent_test")
+
+        assert response.status_code == 200
+        assert response.json()["detail"] == "Calendar event deleted"


### PR DESCRIPTION
## Summary

- New `user_calendar_event` table (Alembic migration `b7c8d9e0f1g2`) with: `name`, `description`, `start_date`, optional `end_date`, `event_type` (`reminder`/`meeting`/`deadline`/`personal`/`other`), `color`, plus `user_id` + `event_uuid` + timestamps
- 5 endpoints under `/calendar/me/events`: POST/GET-list/GET-one/PUT/DELETE
- Index on `(user_id, start_date)` for fast windowed queries
- Filters on the listing: `from_date`, `to_date` (multi-day overlapping events included), `event_type`

## Why

Any LearnHouse user benefits from a personal calendar — students tracking study reminders and deadlines, teachers logging office hours, mentors recording mentee meetings, corporate trainees tracking compliance deadlines, etc. Today the only date primitive in LearnHouse is per-assignment `due_date`, which doesn't cover any of these.

The feature is **not** school- or org-specific: events belong to the user, not the org, so multi-org members keep one continuous calendar across all the orgs they're in.

## Security

- Owner is always derived from the session — never accepted from the client — so there's no path to create an event on someone else's calendar
- When a non-owner requests an event by uuid, the service returns **404 (not 403)** so existence isn't leaked across users
- Superadmins may access any event

## Out of scope (follow-ups)

- Recurring events
- Notifications / email reminders
- Sharing events between users
- ICS / Google Calendar export
- Aggregation with course due dates and org-level events into a unified view
- Frontend calendar widget — separate Web PR

## Migration ordering

This migration sets `down_revision = z5a6b7c8d9e0`. If `feat/course-archive` (also chained from `z5a6b7c8d9e0`) merges first, this PR's migration will be re-parented to that one. Whichever merges second, I'll rebase its `down_revision`.

## Test plan

- [x] `python -m ast.parse` clean on all 6 new + 1 modified file
- [x] Router tests cover create / list / list-with-filters / get / get-not-found-for-other-user / update / delete
- [ ] Manual: create as user A, then as user B — each only sees their own
- [ ] Manual: GET /calendar/me/events/{uuid} on someone else's event → 404 (not 403)
- [ ] Manual: GET with `from_date=2026-01-01&to_date=2026-12-31&event_type=meeting` returns only matching events
- [ ] Manual: run Alembic upgrade against an existing DB → table created with the indexes
