### PR TITLE
Assignments more fixes

### DIFF
--- a/apps/api/migrations/versions/a1b2c3d4e5f7_add_manually_graded_to_task_submission.py
+++ b/apps/api/migrations/versions/a1b2c3d4e5f7_add_manually_graded_to_task_submission.py
@@ -1,0 +1,57 @@
+"""Add manually_graded flag to assignmenttasksubmission
+
+Adds a boolean ``manually_graded`` column to ``assignmenttasksubmission``
+that defaults to false. When true, the aggregate grading pass skips
+server-side re-verification for that task so a teacher's deliberate
+override is not overwritten by the auto-grader.
+
+Revision ID: a1b2c3d4e5f7
+Revises: 7f2b9d1c3e4a
+Create Date: 2026-05-27
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel  # noqa: F401
+
+
+revision: str = 'a1b2c3d4e5f7'
+down_revision: Union[str, None] = '7f2b9d1c3e4a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if 'assignmenttasksubmission' not in inspector.get_table_names():
+        return
+
+    existing_columns = {col['name'] for col in inspector.get_columns('assignmenttasksubmission')}
+    if 'manually_graded' in existing_columns:
+        return
+
+    op.add_column(
+        'assignmenttasksubmission',
+        sa.Column(
+            'manually_graded',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if 'assignmenttasksubmission' not in inspector.get_table_names():
+        return
+
+    existing_columns = {col['name'] for col in inspector.get_columns('assignmenttasksubmission')}
+    if 'manually_graded' in existing_columns:
+        op.drop_column('assignmenttasksubmission', 'manually_graded')

--- a/apps/api/src/db/courses/assignments.py
+++ b/apps/api/src/db/courses/assignments.py
@@ -215,6 +215,10 @@ class AssignmentTaskSubmissionBase(SQLModel):
     task_submission: Dict = Field(default_factory=dict, sa_column=Column(JSON))
     grade: int = 0  # Task-local raw score; aggregated into AssignmentUserSubmission.grade
     task_submission_grade_feedback: str
+    # True when a teacher set this task's grade through the manual grading UI.
+    # The aggregate grading pass skips server-side re-verification for these
+    # rows so the teacher's deliberate override is not overwritten.
+    manually_graded: bool = False
     assignment_type: AssignmentTaskTypeEnum
 
     user_id: int
@@ -246,6 +250,7 @@ class AssignmentTaskSubmissionUpdate(SQLModel):
     task_submission: Optional[Dict] = Field(default=None, sa_column=Column(JSON))
     grade: Optional[int] = None
     task_submission_grade_feedback: Optional[str] = None
+    manually_graded: Optional[bool] = None
     assignment_type: Optional[AssignmentTaskTypeEnum] = None
 
 
@@ -257,6 +262,7 @@ class AssignmentTaskSubmission(AssignmentTaskSubmissionBase, table=True):
     task_submission: Dict = Field(default_factory=dict, sa_column=Column(JSON))
     grade: int = 0  # Task-local raw score; aggregated into AssignmentUserSubmission.grade
     task_submission_grade_feedback: str
+    manually_graded: bool = Field(default=False, nullable=False)
     assignment_type: AssignmentTaskTypeEnum
 
     user_id: int = Field(

--- a/apps/api/src/services/courses/activities/assignments.py
+++ b/apps/api/src/services/courses/activities/assignments.py
@@ -552,6 +552,7 @@ def _build_tasks_breakdown(
                 "points_summary": f"{task_raw}/{task_max}",
                 "passed": task_percentage >= passing_threshold,
                 "feedback": ts.task_submission_grade_feedback if ts else None,
+                "manually_graded": bool(ts.manually_graded) if ts else False,
             }
         )
     return rows
@@ -1348,10 +1349,24 @@ async def handle_assignment_task_submission(
                 detail="Assignment deadline has passed",
             )
 
+        # SECURITY: Regular users cannot update grades - only check if actual values are being set
+        if (assignment_task_submission_object.grade is not None and assignment_task_submission_object.grade != 0) or \
+           (assignment_task_submission_object.task_submission_grade_feedback is not None and assignment_task_submission_object.task_submission_grade_feedback != ""):
+            raise HTTPException(
+                status_code=403,
+                detail="You do not have permission to update grades"
+            )
+
         assignment_task_submission_object.grade = None
         assignment_task_submission_object.task_submission_grade_feedback = None
         assignment_task_submission_object.assignment_task_id = None
         assignment_task_submission_object.assignment_type = None
+
+        # Students cannot flag a submission as manually graded — that's
+        # exclusively a teacher action. Also force-clear any prior flag so a
+        # student edit invalidates the teacher's earlier manual grade and the
+        # task re-enters the server-verified pool on the next grading pass.
+        assignment_task_submission_object.manually_graded = False
 
         # Only need read permission for submissions
         await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
@@ -2573,26 +2588,27 @@ async def _apply_grade_and_finalize(
     # If the verified grade differs from what the client submitted, overwrite
     # it so tampering is caught and future reads see the correct number.
     #
-    # This ONLY runs on the auto-grade path. On the teacher's manual grading
-    # path (auto_graded=False) the instructor has explicitly set per-task
-    # grades via the dashboard, and those overrides must win — re-deriving the
-    # grade from the student's answer here would silently discard a teacher's
-    # legitimate grade (e.g. awarding credit for a short-answer the exact
-    # matcher would mark wrong).
-    if auto_graded:
-        for task in assignment_tasks:
-            ts = task_submissions_by_task_id.get(task.id)
-            verified = await _server_verified_task_grade(task, ts)
-            if verified is None or ts is None:
-                continue
-            if int(ts.grade or 0) != verified:
-                ts.grade = verified
-                ts.task_submission_grade_feedback = (
-                    "Server-verified: correct"
-                    if verified > 0
-                    else "Server-verified: incorrect"
-                )
-                db_session.add(ts)
+    # Tasks that a teacher has manually graded (``manually_graded``) are skipped
+    # so the deliberate override is not clobbered by the auto-grader — e.g. a
+    # teacher awarding credit for a short-answer the exact matcher would mark
+    # wrong. This is the per-task replacement for the old whole-pass
+    # ``auto_graded`` gate: non-manual tasks are still re-verified even when a
+    # teacher is grading the submission, while manual overrides always win.
+    for task in assignment_tasks:
+        ts = task_submissions_by_task_id.get(task.id)
+        if ts is not None and ts.manually_graded:
+            continue
+        verified = await _server_verified_task_grade(task, ts)
+        if verified is None or ts is None:
+            continue
+        if int(ts.grade or 0) != verified:
+            ts.grade = verified
+            ts.task_submission_grade_feedback = (
+                "Server-verified: correct"
+                if verified > 0
+                else "Server-verified: incorrect"
+            )
+            db_session.add(ts)
 
     raw_grade = 0
     for ts in task_submissions_by_task_id.values():

--- a/apps/api/src/tests/services/test_assignment_manual_grading.py
+++ b/apps/api/src/tests/services/test_assignment_manual_grading.py
@@ -8,8 +8,11 @@ explicit per-task grade with a grade re-derived from the student's answer — so
 a teacher could never award credit the exact-matcher would mark wrong, and the
 dashboard "Full/Half/Zero" grade controls had no effect on submit.
 
-Fix: only re-verify on the auto-grade path (``auto_graded=True``). These tests
-pin both halves of that contract.
+Fix: the aggregate grading pass skips server-side re-verification for any task
+a teacher flagged ``manually_graded`` (set when grading from the dashboard), so
+the instructor's explicit per-task grade survives, while non-manual tasks are
+still re-verified for anti-tampering. These tests pin both halves of that
+contract, including the quiz-score override from issue #891.
 """
 
 from datetime import datetime
@@ -30,7 +33,7 @@ from src.services.courses.activities.assignments import _apply_grade_and_finaliz
 _PATCH_DISPATCH = "src.services.courses.activities.assignments.dispatch_webhooks"
 
 
-async def _setup(db, org, course, chapter, activity, regular_user, *, student_answer, stored_grade):
+async def _setup(db, org, course, chapter, activity, regular_user, *, student_answer, stored_grade, manually_graded=False):
     """Create an assignment + one SHORT_ANSWER task (correct answer '4', exact)
     plus a student submission whose stored answer / grade we control."""
     assignment = Assignment(
@@ -89,6 +92,7 @@ async def _setup(db, org, course, chapter, activity, regular_user, *, student_an
         assignment_task_submission_uuid="ats_manual_test",
         task_submission={"answer": student_answer},
         grade=stored_grade,
+        manually_graded=manually_graded,
         task_submission_grade_feedback="",
         assignment_type=AssignmentTaskTypeEnum.SHORT_ANSWER,
         user_id=regular_user.id,
@@ -110,11 +114,12 @@ class TestManualGradeOverridePreserved:
     async def test_manual_grade_is_not_overwritten_by_reverification(
         self, db, org, course, chapter, activity, regular_user
     ):
-        # Student answered WRONG ("5"), but the teacher manually set the task
-        # grade to 100. Manual grading (auto_graded=False) must keep the 100.
+        # Student answered WRONG ("5"), but the teacher manually graded the task
+        # to 100 and flagged it ``manually_graded``. The per-task flag must keep
+        # the 100 even though the auto-verifier would compute 0 for "5".
         assignment, submission = await _setup(
             db, org, course, chapter, activity, regular_user,
-            student_answer="5", stored_grade=100,
+            student_answer="5", stored_grade=100, manually_graded=True,
         )
         with patch(_PATCH_DISPATCH, new_callable=AsyncMock):
             computed = await _apply_grade_and_finalize(
@@ -175,3 +180,149 @@ class TestAutoGradeStillReverifies:
             )
         assert computed["grade"] == 100
         assert computed["percentage"] == 100.0
+
+
+# ---------------------------------------------------------------------------
+# Issue #891: instructor cannot override an auto-graded QUIZ score.
+# A single-quiz assignment auto-grades to 67% (2 of 3 options correct). The
+# teacher sets the quiz to full marks; the manual override must stick instead
+# of being reverted to 67% by the aggregate re-verification pass.
+# ---------------------------------------------------------------------------
+
+# One question, three options: two of the student's choices match the answer
+# key and one does not → 2/3 → round(66.67) → 67 on auto-grade.
+_QUIZ_CONTENTS = {
+    "questions": [
+        {
+            "questionUUID": "q1",
+            "options": [
+                {"optionUUID": "o1", "assigned_right_answer": True},
+                {"optionUUID": "o2", "assigned_right_answer": False},
+                {"optionUUID": "o3", "assigned_right_answer": True},
+            ],
+        }
+    ]
+}
+# Student checks o1 (right) and leaves o2 (right: stays unchecked) and o3
+# (wrong: should have been checked) → 2 of 3 options match.
+_QUIZ_SUBMISSION = {"submissions": [{"questionUUID": "q1", "optionUUID": "o1", "answer": True}]}
+
+
+async def _setup_quiz(db, org, course, chapter, activity, regular_user, *, stored_grade, manually_graded):
+    """Assignment with one QUIZ task (max 100) whose stored answer auto-grades
+    to 67, plus a task submission whose grade / manually_graded we control."""
+    assignment = Assignment(
+        title="Quiz 891",
+        description="x",
+        due_date="2030-01-01",
+        published=True,
+        grading_type=GradingTypeEnum.NUMERIC,
+        auto_grading=False,
+        org_id=org.id,
+        course_id=course.id,
+        chapter_id=chapter.id,
+        activity_id=activity.id,
+        assignment_uuid="assignment_quiz_891",
+        creation_date=str(datetime.now()),
+        update_date=str(datetime.now()),
+    )
+    db.add(assignment)
+    await db.commit()
+    await db.refresh(assignment)
+
+    task = AssignmentTask(
+        title="Q1",
+        description="Pick the right options",
+        hint="",
+        reference_file=None,
+        assignment_type=AssignmentTaskTypeEnum.QUIZ,
+        contents=_QUIZ_CONTENTS,
+        max_grade_value=100,
+        assignment_id=assignment.id,
+        org_id=org.id,
+        course_id=course.id,
+        chapter_id=chapter.id,
+        activity_id=activity.id,
+        assignment_task_uuid="assignmenttask_quiz_891",
+        creation_date=str(datetime.now()),
+        update_date=str(datetime.now()),
+    )
+    db.add(task)
+    await db.commit()
+    await db.refresh(task)
+
+    user_submission = AssignmentUserSubmission(
+        user_id=regular_user.id,
+        assignment_id=assignment.id,
+        grade=0,
+        submission_status=AssignmentUserSubmissionStatus.SUBMITTED,
+        attempt_number=1,
+        assignmentusersubmission_uuid="aus_quiz_891",
+        creation_date=str(datetime.now()),
+        update_date=str(datetime.now()),
+    )
+    db.add(user_submission)
+
+    task_submission = AssignmentTaskSubmission(
+        assignment_task_submission_uuid="ats_quiz_891",
+        task_submission=_QUIZ_SUBMISSION,
+        grade=stored_grade,
+        manually_graded=manually_graded,
+        task_submission_grade_feedback="",
+        assignment_type=AssignmentTaskTypeEnum.QUIZ,
+        user_id=regular_user.id,
+        activity_id=task.activity_id,
+        course_id=task.course_id,
+        chapter_id=task.chapter_id,
+        assignment_task_id=task.id,
+        creation_date=str(datetime.now()),
+        update_date=str(datetime.now()),
+    )
+    db.add(task_submission)
+    await db.commit()
+    await db.refresh(user_submission)
+    return assignment, user_submission
+
+
+class TestQuizManualOverride:
+    async def test_manual_quiz_override_survives(
+        self, db, org, course, chapter, activity, regular_user
+    ):
+        # Issue #891: teacher sets the quiz to 100 and flags it manually_graded.
+        # The aggregate pass must keep 100, NOT revert to the auto-graded 67.
+        assignment, submission = await _setup_quiz(
+            db, org, course, chapter, activity, regular_user,
+            stored_grade=100, manually_graded=True,
+        )
+        with patch(_PATCH_DISPATCH, new_callable=AsyncMock):
+            computed = await _apply_grade_and_finalize(
+                assignment=assignment,
+                course=course,
+                user_id=regular_user.id,
+                assignment_user_submission=submission,
+                db_session=db,
+                auto_graded=False,
+            )
+        assert computed["grade"] == 100
+        assert computed["percentage"] == 100.0
+
+    async def test_non_manual_quiz_is_reverified_to_auto_score(
+        self, db, org, course, chapter, activity, regular_user
+    ):
+        # Same quiz, but NOT flagged manual: a stale/tampered stored 100 must be
+        # re-verified back down to the real auto-graded 67 (anti-tampering).
+        assignment, submission = await _setup_quiz(
+            db, org, course, chapter, activity, regular_user,
+            stored_grade=100, manually_graded=False,
+        )
+        with patch(_PATCH_DISPATCH, new_callable=AsyncMock):
+            computed = await _apply_grade_and_finalize(
+                assignment=assignment,
+                course=course,
+                user_id=regular_user.id,
+                assignment_user_submission=submission,
+                db_session=db,
+                auto_graded=True,
+            )
+        assert computed["grade"] == 67
+        assert computed["percentage"] == 67.0

--- a/apps/api/src/tests/services/test_assignments_service.py
+++ b/apps/api/src/tests/services/test_assignments_service.py
@@ -28,6 +28,7 @@ from src.db.courses.assignments import (
     AssignmentRead,
     AssignmentTaskCreate,
     AssignmentTaskRead,
+    AssignmentTaskSubmission,
     AssignmentTaskSubmissionCreate,
     AssignmentTaskSubmissionRead,
     AssignmentTaskSubmissionUpdate,
@@ -564,6 +565,25 @@ class TestHandleAssignmentTaskSubmission:
             )
         assert isinstance(result, AssignmentTaskSubmissionRead)
 
+    async def test_regular_user_cannot_self_assign_grade(
+        self, mock_request, db, assignment_task, regular_user
+    ):
+        # SECURITY: a non-instructor submitting with a non-zero grade is
+        # rejected — students cannot grade their own work.
+        obj = AssignmentTaskSubmissionUpdate(
+            task_submission={"answer": "x"},
+            grade=50,
+        )
+        # is_instructor → False, enrollment → True
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, side_effect=[False, True]):
+            with pytest.raises(HTTPException) as exc:
+                await handle_assignment_task_submission(
+                    mock_request, assignment_task.assignment_task_uuid, obj, regular_user, db
+                )
+        assert exc.value.status_code == 403
+        assert "grade" in exc.value.detail.lower()
+
 
 # ---------------------------------------------------------------------------
 # read_assignment_submissions
@@ -807,6 +827,157 @@ class TestGradeAssignmentSubmission:
             )
         assert "message" in result
         assert "display_grade" in result
+
+
+# ---------------------------------------------------------------------------
+# _apply_grade_and_finalize: manually_graded skip
+# ---------------------------------------------------------------------------
+
+
+class TestManuallyGradedSkipsVerification:
+    """Regression guard for the per-task manual grading override.
+
+    The aggregate grading pass runs server-side re-verification on
+    SERVER_VERIFIED_TASK_TYPES (SHORT_ANSWER, NUMBER_ANSWER, QUIZ, FORM,
+    CODE). When a teacher has manually graded a task, that verification
+    must be skipped so the override survives.
+    """
+
+    async def _make_task_submission(
+        self, db, assignment_task, regular_user, *, ts_id, uuid_suffix,
+        grade, feedback, manually_graded, answer,
+    ):
+        ts = AssignmentTaskSubmission(
+            id=ts_id,
+            assignment_task_submission_uuid=f"ats_{uuid_suffix}",
+            task_submission={"answer": answer},
+            grade=grade,
+            task_submission_grade_feedback=feedback,
+            manually_graded=manually_graded,
+            assignment_type=AssignmentTaskTypeEnum.SHORT_ANSWER,
+            user_id=regular_user.id,
+            activity_id=assignment_task.activity_id,
+            course_id=assignment_task.course_id,
+            chapter_id=assignment_task.chapter_id,
+            assignment_task_id=assignment_task.id,
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(ts)
+        await db.commit()
+        await db.refresh(ts)
+        return ts
+
+    async def test_manual_grade_survives_wrong_answer(
+        self,
+        mock_request,
+        db,
+        assignment,
+        assignment_task,
+        user_submission,
+        admin_user,
+        regular_user,
+    ):
+        # SHORT_ANSWER task expects "4"; student submitted "5" (wrong). The
+        # auto-verifier would compute 0, but the teacher set grade=100 with
+        # manually_graded=True — the override must hold.
+        ts = await self._make_task_submission(
+            db, assignment_task, regular_user,
+            ts_id=41, uuid_suffix="manual",
+            grade=100, feedback="Graded by teacher : @badr",
+            manually_graded=True, answer="5",
+        )
+
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_DISPATCH, new_callable=AsyncMock), \
+             patch(_PATCH_TRACK, new_callable=AsyncMock), \
+             patch(_PATCH_CERT, new_callable=AsyncMock):
+            result = await grade_assignment_submission(
+                mock_request,
+                regular_user.id,
+                assignment.assignment_uuid,
+                admin_user,
+                db,
+            )
+
+        await db.refresh(ts)
+        assert ts.grade == 100
+        assert ts.task_submission_grade_feedback == "Graded by teacher : @badr"
+        assert ts.manually_graded is True
+        assert result["grade"] == 100
+        # The breakdown exposes manually_graded so the modal can render a chip.
+        task_breakdown = result["tasks"][0]
+        assert task_breakdown["manually_graded"] is True
+
+    async def test_non_manual_wrong_answer_is_overwritten(
+        self,
+        mock_request,
+        db,
+        assignment,
+        assignment_task,
+        user_submission,
+        admin_user,
+        regular_user,
+    ):
+        # Same wrong answer but manually_graded=False: the verifier must
+        # overwrite the stale stored grade and stamp its own feedback.
+        # This locks in the anti-tampering behavior so a future change to
+        # the skip condition doesn't accidentally disable verification.
+        ts = await self._make_task_submission(
+            db, assignment_task, regular_user,
+            ts_id=42, uuid_suffix="auto",
+            grade=100, feedback="Stale client grade",
+            manually_graded=False, answer="5",
+        )
+
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_DISPATCH, new_callable=AsyncMock), \
+             patch(_PATCH_TRACK, new_callable=AsyncMock), \
+             patch(_PATCH_CERT, new_callable=AsyncMock):
+            result = await grade_assignment_submission(
+                mock_request,
+                regular_user.id,
+                assignment.assignment_uuid,
+                admin_user,
+                db,
+            )
+
+        await db.refresh(ts)
+        assert ts.grade == 0
+        assert ts.task_submission_grade_feedback == "Server-verified: incorrect"
+        assert result["grade"] == 0
+        task_breakdown = result["tasks"][0]
+        assert task_breakdown["manually_graded"] is False
+
+    async def test_task_without_submission_is_skipped(
+        self,
+        mock_request,
+        db,
+        assignment,
+        assignment_task,
+        user_submission,
+        admin_user,
+        regular_user,
+    ):
+        # The assignment has a task but the student never submitted it. The
+        # re-verification loop must skip it (ts is None) without error and the
+        # un-submitted task contributes 0 to the aggregate grade.
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_DISPATCH, new_callable=AsyncMock), \
+             patch(_PATCH_TRACK, new_callable=AsyncMock), \
+             patch(_PATCH_CERT, new_callable=AsyncMock):
+            result = await grade_assignment_submission(
+                mock_request,
+                regular_user.id,
+                assignment.assignment_uuid,
+                admin_user,
+                db,
+            )
+
+        assert result["grade"] == 0
+        task_breakdown = result["tasks"][0]
+        assert task_breakdown["submitted"] is False
+        assert task_breakdown["manually_graded"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/src/tests/services/test_grade_computation_edge.py
+++ b/apps/api/src/tests/services/test_grade_computation_edge.py
@@ -390,8 +390,12 @@ def _bt_task(id, max_grade_value, title="T", description="D",
     )
 
 
-def _bt_submission(grade, feedback="ok"):
-    return SimpleNamespace(grade=grade, task_submission_grade_feedback=feedback)
+def _bt_submission(grade, feedback="ok", manually_graded=False):
+    return SimpleNamespace(
+        grade=grade,
+        task_submission_grade_feedback=feedback,
+        manually_graded=manually_graded,
+    )
 
 
 class TestBuildTasksBreakdown:
@@ -417,6 +421,7 @@ class TestBuildTasksBreakdown:
         assert row["points_summary"] == "80/100"
         assert row["passed"] is True
         assert row["feedback"] == "good"
+        assert row["manually_graded"] is False
 
     def test_no_submission_marks_unsubmitted_zero_grade(self):
         """A task with no submission yields submitted=False, grade 0, no feedback, and failed."""

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskCodeObject.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskCodeObject.tsx
@@ -31,7 +31,6 @@ import {
   ChevronRight,
   ShieldCheck,
   BookOpen,
-  Lock,
   Settings2,
 } from 'lucide-react'
 import React, { useEffect, useState } from 'react'
@@ -41,6 +40,7 @@ import { useTranslation } from 'react-i18next'
 import dynamic from 'next/dynamic'
 import { useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query/keys'
+import { applyManualGrade } from './applyManualGrade'
 
 const CodeMirror = dynamic(() => import('@uiw/react-codemirror'), {
   ssr: false,
@@ -476,38 +476,19 @@ function TaskCodeObject({ view, assignmentTaskUUID, user_id }: TaskCodeObjectPro
 
   // --- MANUAL GRADE (grading view) ---
   async function gradeCustomFC(grade: number, feedback?: string) {
-    if (!assignmentTaskUUID || !userSubmissions) return
-    const maxPoints = assignmentTaskOutsideProvider?.max_grade_value || 100
-    if (Number.isNaN(grade) || grade < 0) {
-      toast.error('Grade must be a positive number.')
-      return
-    }
-    if (grade > maxPoints) {
-      toast.error(`Grade cannot be more than ${maxPoints} points`)
-      return
-    }
-    const trimmed = feedback?.trim()
-    const finalFeedback = trimmed && trimmed.length > 0
-      ? trimmed
-      : `Graded by teacher : @${session?.data?.user?.username ?? ''}`
-    const values = {
-      assignment_task_submission_uuid: userSubmissions.assignment_task_submission_uuid,
-      task_submission: userSubmissions,
+    if (!userSubmissions) return
+    await applyManualGrade({
       grade,
-      task_submission_grade_feedback: finalFeedback,
-    }
-    const res = await handleAssignmentTaskSubmission(
-      values,
+      feedback,
+      maxPoints: assignmentTaskOutsideProvider?.max_grade_value || 100,
       assignmentTaskUUID,
-      assignment.assignment_object.assignment_uuid,
-      access_token
-    )
-    if (res) {
-      getAssignmentTaskSubmissionFromIdentifiedUserUI()
-      toast.success(`Task graded successfully with ${grade} points`)
-    } else {
-      toast.error('Error grading task, please retry later.')
-    }
+      assignmentUUID: assignment.assignment_object.assignment_uuid,
+      accessToken: access_token,
+      username: session?.data?.user?.username,
+      assignmentTaskSubmissionUUID: userSubmissions.assignment_task_submission_uuid,
+      taskSubmissionPayload: userSubmissions,
+      onSuccess: getAssignmentTaskSubmissionFromIdentifiedUserUI,
+    })
   }
 
   // --- GRADE (grading view) ---
@@ -572,6 +553,7 @@ function TaskCodeObject({ view, assignmentTaskUUID, user_id }: TaskCodeObjectPro
         },
         grade: finalGrade,
         task_submission_grade_feedback: feedback,
+        manually_graded: false,
       }
 
       const res = await handleAssignmentTaskSubmission(
@@ -1158,7 +1140,7 @@ function CodeOptionToggle({
   label: string
   description: string
   checked: boolean
-  onChange: (next: boolean) => void
+  onChange: (_next: boolean) => void
 }) {
   return (
     <div className="flex items-start justify-between gap-2 p-2 rounded-md bg-white border border-slate-200">

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskFileObject.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskFileObject.tsx
@@ -13,6 +13,7 @@ import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/query/keys';
+import { applyManualGrade } from './applyManualGrade';
 
 type FileSchema = {
     fileUUID: string;
@@ -167,11 +168,13 @@ export default function TaskFileObject({ view, user_id, assignmentTaskUUID }: Ta
 
     // Detect changes between initial and current submissions
     useEffect(() => {
+        /* eslint-disable react-hooks/set-state-in-effect */
         if (userSubmissions.fileUUID !== initialUserSubmissions.fileUUID) {
             setShowSavingDisclaimer(true);
         } else {
             setShowSavingDisclaimer(false);
         }
+        /* eslint-enable react-hooks/set-state-in-effect */
     }, [userSubmissions]);
 
     /* STUDENT VIEW CODE */
@@ -201,40 +204,24 @@ export default function TaskFileObject({ view, user_id, assignmentTaskUUID }: Ta
     }
 
     async function gradeCustomFC(grade: number, feedback?: string) {
-        if (assignmentTaskUUID) {
-            if (Number.isNaN(grade) || grade < 0) {
-                toast.error('Grade must be a positive number.');
-                return;
-            }
-            if (grade > assignmentTaskOutsideProvider.max_grade_value) {
-                toast.error(`Grade cannot be more than ${assignmentTaskOutsideProvider.max_grade_value} points`);
-                return;
-            }
-            const trimmed = feedback?.trim();
-            const finalFeedback = trimmed && trimmed.length > 0
-                ? trimmed
-                : `Graded by teacher : @${session?.data?.user?.username ?? ''}`;
-
-            const values = {
-                assignment_task_submission_uuid: userSubmissions.assignment_task_submission_uuid,
-                task_submission: userSubmissions,
-                grade,
-                task_submission_grade_feedback: finalFeedback,
-            };
-
-            const res = await handleAssignmentTaskSubmission(values, assignmentTaskUUID, assignment.assignment_object.assignment_uuid, access_token);
-            if (res) {
-                getAssignmentTaskSubmissionFromIdentifiedUserUI();
-                toast.success(`Task graded successfully with ${grade} points`);
-            } else {
-                toast.error('Error grading task, please retry later.');
-            }
-        }
+        await applyManualGrade({
+            grade,
+            feedback,
+            maxPoints: assignmentTaskOutsideProvider?.max_grade_value || 100,
+            assignmentTaskUUID,
+            assignmentUUID: assignment.assignment_object.assignment_uuid,
+            accessToken: access_token,
+            username: session?.data?.user?.username,
+            assignmentTaskSubmissionUUID: userSubmissions?.assignment_task_submission_uuid,
+            taskSubmissionPayload: userSubmissions,
+            onSuccess: getAssignmentTaskSubmissionFromIdentifiedUserUI,
+        });
     }
 
     /* GRADING VIEW CODE */
     const [assignmentTaskOutsideProvider, setAssignmentTaskOutsideProvider] = useState<any>(null);
     useEffect(() => {
+        /* eslint-disable react-hooks/set-state-in-effect */
         // Student area: hydrate from already-fetched context payloads.
         if (view === 'student') {
             hydrateTaskFromContext()
@@ -246,6 +233,7 @@ export default function TaskFileObject({ view, user_id, assignmentTaskUUID }: Ta
             getAssignmentTaskUI();
             getAssignmentTaskSubmissionFromIdentifiedUserUI();
         }
+        /* eslint-enable react-hooks/set-state-in-effect */
     }, [view, assignmentTaskUUID, assignment?.assignment_tasks, taskSubmissionsMap])
 
     return (

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskFormObject.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskFormObject.tsx
@@ -11,6 +11,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/query/keys';
+import { applyManualGrade } from './applyManualGrade';
 
 type FormSchema = {
     questionText: string;
@@ -251,32 +252,18 @@ function TaskFormObject({ view, assignmentTaskUUID, user_id }: TaskFormObjectPro
             toast.error('User ID is required for grading.');
             return;
         }
-        const maxPoints = assignmentTaskOutsideProvider?.max_grade_value || 100;
-        if (Number.isNaN(grade) || grade < 0) {
-            toast.error('Grade must be a positive number.');
-            return;
-        }
-        if (grade > maxPoints) {
-            toast.error(`Grade cannot be more than ${maxPoints} points`);
-            return;
-        }
-        const trimmed = feedback?.trim();
-        const finalFeedback = trimmed && trimmed.length > 0
-            ? trimmed
-            : `Graded by teacher : @${session?.data?.user?.username ?? ''}`;
-        const values = {
-            assignment_task_submission_uuid: userSubmissions.assignment_task_submission_uuid,
-            task_submission: userSubmissions,
+        await applyManualGrade({
             grade,
-            task_submission_grade_feedback: finalFeedback,
-        };
-        const res = await handleAssignmentTaskSubmission(values, assignmentTaskUUID, assignment.assignment_object.assignment_uuid, access_token);
-        if (res) {
-            getAssignmentTaskSubmissionFromIdentifiedUserUI();
-            toast.success(`Task graded successfully with ${grade} points`);
-        } else {
-            toast.error('Error grading task, please retry later.');
-        }
+            feedback,
+            maxPoints: assignmentTaskOutsideProvider?.max_grade_value || 100,
+            assignmentTaskUUID,
+            assignmentUUID: assignment.assignment_object.assignment_uuid,
+            accessToken: access_token,
+            username: session?.data?.user?.username,
+            assignmentTaskSubmissionUUID: userSubmissions.assignment_task_submission_uuid,
+            taskSubmissionPayload: userSubmissions,
+            onSuccess: getAssignmentTaskSubmissionFromIdentifiedUserUI,
+        });
     };
 
     const gradeFC = async () => {
@@ -310,6 +297,7 @@ function TaskFormObject({ view, assignmentTaskUUID, user_id }: TaskFormObjectPro
             task_submission: userSubmissions,
             grade: finalGrade,
             task_submission_grade_feedback: 'Auto graded by system',
+            manually_graded: false,
         };
 
         const res = await handleAssignmentTaskSubmission(values, assignmentTaskUUID, assignment.assignment_object.assignment_uuid, access_token);

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskNumberAnswerObject.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskNumberAnswerObject.tsx
@@ -18,6 +18,7 @@ import { CheckCircle2, XCircle } from 'lucide-react'
 import React, { useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
+import { applyManualGrade } from './applyManualGrade'
 
 type NumberAnswerContents = {
   prompt: string
@@ -93,6 +94,7 @@ function TaskNumberAnswerObject({
     if (view === 'teacher' && assignmentTaskState?.assignmentTask?.contents) {
       const c = assignmentTaskState.assignmentTask.contents
       if (c.prompt !== undefined || c.correct_value !== undefined) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setContents(normalizeContents(c))
       }
     }
@@ -143,6 +145,7 @@ function TaskNumberAnswerObject({
   }
 
   useEffect(() => {
+    /* eslint-disable react-hooks/set-state-in-effect */
     if (view === 'student') {
       loadTaskDefinition()
       loadOwnSubmission()
@@ -150,6 +153,7 @@ function TaskNumberAnswerObject({
       loadTaskDefinition()
       loadUserSubmission()
     }
+    /* eslint-enable react-hooks/set-state-in-effect */
   }, [view, assignmentTaskUUID, assignment, access_token])
 
   // --- SAVE (teacher) ---
@@ -210,41 +214,22 @@ function TaskNumberAnswerObject({
       : `${contents.correct_value}${contents.unit ? ' ' + contents.unit : ''}`
 
   async function gradeCustomFC(grade: number, feedback?: string) {
-    if (!assignmentTaskUUID || !userSubmissions) return
-    const maxPoints =
-      assignmentTaskOutsideProvider?.max_grade_value ||
-      assignmentTaskState?.assignmentTask?.max_grade_value ||
-      100
-    if (Number.isNaN(grade) || grade < 0) {
-      toast.error('Grade must be a positive number.')
-      return
-    }
-    if (grade > maxPoints) {
-      toast.error(`Grade cannot be more than ${maxPoints} points`)
-      return
-    }
-    const trimmed = feedback?.trim()
-    const finalFeedback = trimmed && trimmed.length > 0
-      ? trimmed
-      : `Graded by teacher : @${session?.data?.user?.username ?? ''}`
-    const values = {
-      assignment_task_submission_uuid: userSubmissions.assignment_task_submission_uuid,
-      task_submission: userSubmissions.task_submission,
+    if (!userSubmissions) return
+    await applyManualGrade({
       grade,
-      task_submission_grade_feedback: finalFeedback,
-    }
-    const res = await handleAssignmentTaskSubmission(
-      values,
+      feedback,
+      maxPoints:
+        assignmentTaskOutsideProvider?.max_grade_value ||
+        assignmentTaskState?.assignmentTask?.max_grade_value ||
+        100,
       assignmentTaskUUID,
-      assignment.assignment_object.assignment_uuid,
-      access_token
-    )
-    if (res) {
-      loadUserSubmission()
-      toast.success(`Task graded successfully with ${grade} points`)
-    } else {
-      toast.error('Error grading task, please retry later.')
-    }
+      assignmentUUID: assignment.assignment_object.assignment_uuid,
+      accessToken: access_token,
+      username: session?.data?.user?.username,
+      assignmentTaskSubmissionUUID: userSubmissions.assignment_task_submission_uuid,
+      taskSubmissionPayload: userSubmissions.task_submission,
+      onSuccess: loadUserSubmission,
+    })
   }
 
   return (

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskQuizObject.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskQuizObject.tsx
@@ -11,6 +11,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/query/keys';
+import { applyManualGrade } from './applyManualGrade';
 
 type QuizSchema = {
     questionText: string;
@@ -303,33 +304,18 @@ function TaskQuizObject({ view, assignmentTaskUUID, user_id }: TaskQuizObjectPro
     }
 
     async function gradeCustomFC(grade: number, feedback?: string) {
-        if (!assignmentTaskUUID) return;
-        const maxPoints = assignmentTaskOutsideProvider?.max_grade_value || 100;
-        if (Number.isNaN(grade) || grade < 0) {
-            toast.error('Grade must be a positive number.');
-            return;
-        }
-        if (grade > maxPoints) {
-            toast.error(`Grade cannot be more than ${maxPoints} points`);
-            return;
-        }
-        const trimmed = feedback?.trim();
-        const finalFeedback = trimmed && trimmed.length > 0
-            ? trimmed
-            : `Graded by teacher : @${session?.data?.user?.username ?? ''}`;
-        const values = {
-            assignment_task_submission_uuid: userSubmissions.assignment_task_submission_uuid,
-            task_submission: userSubmissions,
+        await applyManualGrade({
             grade,
-            task_submission_grade_feedback: finalFeedback,
-        };
-        const res = await handleAssignmentTaskSubmission(values, assignmentTaskUUID, assignment.assignment_object.assignment_uuid, access_token);
-        if (res) {
-            getAssignmentTaskSubmissionFromIdentifiedUserUI();
-            toast.success(`Task graded successfully with ${grade} points`);
-        } else {
-            toast.error('Error grading task, please retry later.');
-        }
+            feedback,
+            maxPoints: assignmentTaskOutsideProvider?.max_grade_value || 100,
+            assignmentTaskUUID,
+            assignmentUUID: assignment.assignment_object.assignment_uuid,
+            accessToken: access_token,
+            username: session?.data?.user?.username,
+            assignmentTaskSubmissionUUID: userSubmissions.assignment_task_submission_uuid,
+            taskSubmissionPayload: userSubmissions,
+            onSuccess: getAssignmentTaskSubmissionFromIdentifiedUserUI,
+        });
     }
 
     async function gradeFC() {
@@ -357,6 +343,7 @@ function TaskQuizObject({ view, assignmentTaskUUID, user_id }: TaskQuizObjectPro
                 task_submission: userSubmissions,
                 grade: finalGrade,
                 task_submission_grade_feedback: 'Auto graded by system',
+                manually_graded: false,
             };
 
             const res = await handleAssignmentTaskSubmission(values, assignmentTaskUUID, assignment.assignment_object.assignment_uuid, access_token);

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskShortAnswerObject.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskShortAnswerObject.tsx
@@ -18,6 +18,7 @@ import { CheckCircle2, Plus, X, XCircle } from 'lucide-react'
 import React, { useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
+import { applyManualGrade } from './applyManualGrade'
 
 type MatchMode = 'exact' | 'case_insensitive' | 'contains' | 'regex'
 
@@ -97,6 +98,7 @@ function TaskShortAnswerObject({
     if (view === 'teacher' && assignmentTaskState?.assignmentTask?.contents) {
       const c = assignmentTaskState.assignmentTask.contents
       if (c.prompt !== undefined || Array.isArray(c.correct_answers)) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setContents(normalizeContents(c))
       }
     }
@@ -147,6 +149,7 @@ function TaskShortAnswerObject({
   }
 
   useEffect(() => {
+    /* eslint-disable react-hooks/set-state-in-effect */
     if (view === 'student') {
       loadTaskDefinition()
       loadOwnSubmission()
@@ -154,6 +157,7 @@ function TaskShortAnswerObject({
       loadTaskDefinition()
       loadUserSubmission()
     }
+    /* eslint-enable react-hooks/set-state-in-effect */
   }, [view, assignmentTaskUUID, assignment, access_token])
 
   // --- SAVE (teacher) ---
@@ -247,41 +251,22 @@ function TaskShortAnswerObject({
   const gradedPassed = userSubmissionObject?.grade > 0
 
   async function gradeCustomFC(grade: number, feedback?: string) {
-    if (!assignmentTaskUUID || !userSubmissions) return
-    const maxPoints =
-      assignmentTaskOutsideProvider?.max_grade_value ||
-      assignmentTaskState?.assignmentTask?.max_grade_value ||
-      100
-    if (Number.isNaN(grade) || grade < 0) {
-      toast.error('Grade must be a positive number.')
-      return
-    }
-    if (grade > maxPoints) {
-      toast.error(`Grade cannot be more than ${maxPoints} points`)
-      return
-    }
-    const trimmed = feedback?.trim()
-    const finalFeedback = trimmed && trimmed.length > 0
-      ? trimmed
-      : `Graded by teacher : @${session?.data?.user?.username ?? ''}`
-    const values = {
-      assignment_task_submission_uuid: userSubmissions.assignment_task_submission_uuid,
-      task_submission: userSubmissions.task_submission,
+    if (!userSubmissions) return
+    await applyManualGrade({
       grade,
-      task_submission_grade_feedback: finalFeedback,
-    }
-    const res = await handleAssignmentTaskSubmission(
-      values,
+      feedback,
+      maxPoints:
+        assignmentTaskOutsideProvider?.max_grade_value ||
+        assignmentTaskState?.assignmentTask?.max_grade_value ||
+        100,
       assignmentTaskUUID,
-      assignment.assignment_object.assignment_uuid,
-      access_token
-    )
-    if (res) {
-      loadUserSubmission()
-      toast.success(`Task graded successfully with ${grade} points`)
-    } else {
-      toast.error('Error grading task, please retry later.')
-    }
+      assignmentUUID: assignment.assignment_object.assignment_uuid,
+      accessToken: access_token,
+      username: session?.data?.user?.username,
+      assignmentTaskSubmissionUUID: userSubmissions.assignment_task_submission_uuid,
+      taskSubmissionPayload: userSubmissions.task_submission,
+      onSuccess: loadUserSubmission,
+    })
   }
 
   return (

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/applyManualGrade.ts
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/applyManualGrade.ts
@@ -1,0 +1,65 @@
+import toast from 'react-hot-toast'
+import { handleAssignmentTaskSubmission } from '@services/courses/assignments'
+
+interface ApplyManualGradeArgs {
+    grade: number
+    feedback?: string
+    maxPoints: number
+    assignmentTaskUUID?: string | null
+    assignmentUUID: string
+    accessToken: string
+    username?: string | null
+    assignmentTaskSubmissionUUID?: string | null
+    /**
+     * Value persisted into the `task_submission` JSON field on the server. Each
+     * task type stores a slightly different shape here, so callers pass it in.
+     */
+    taskSubmissionPayload: unknown
+    onSuccess: () => void
+}
+
+export async function applyManualGrade({
+    grade,
+    feedback,
+    maxPoints,
+    assignmentTaskUUID,
+    assignmentUUID,
+    accessToken,
+    username,
+    assignmentTaskSubmissionUUID,
+    taskSubmissionPayload,
+    onSuccess,
+}: ApplyManualGradeArgs): Promise<void> {
+    if (!assignmentTaskUUID) return
+    if (Number.isNaN(grade) || grade < 0) {
+        toast.error('Grade must be a positive number.')
+        return
+    }
+    if (grade > maxPoints) {
+        toast.error(`Grade cannot be more than ${maxPoints} points`)
+        return
+    }
+    const trimmed = feedback?.trim()
+    const finalFeedback = trimmed && trimmed.length > 0
+        ? trimmed
+        : `Graded by teacher : @${username ?? ''}`
+    const values = {
+        assignment_task_submission_uuid: assignmentTaskSubmissionUUID,
+        task_submission: taskSubmissionPayload,
+        grade,
+        task_submission_grade_feedback: finalFeedback,
+        manually_graded: true,
+    }
+    const res = await handleAssignmentTaskSubmission(
+        values,
+        assignmentTaskUUID,
+        assignmentUUID,
+        accessToken,
+    )
+    if (res) {
+        onSuccess()
+        toast.success(`Task graded successfully with ${grade} points`)
+    } else {
+        toast.error('Error grading task, please retry later.')
+    }
+}

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/subpages/Modals/EvaluateAssignment.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/subpages/Modals/EvaluateAssignment.tsx
@@ -1,5 +1,5 @@
 import { useAssignments } from '@components/Contexts/Assignments/AssignmentContext';
-import { BookOpenCheck, Check, CircleHelp, Download, Info, MessageSquare, X } from 'lucide-react';
+import { BookOpenCheck, Check, CircleHelp, Download, Info, MessageSquare, UserCheck, X } from 'lucide-react';
 import Link from 'next/link';
 import React, { useEffect, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query';
@@ -169,6 +169,12 @@ function EvaluateAssignment({ user_id }: any) {
                                         {taskSubmitted
                                             ? tb.percentage_display
                                             : t('dashboard.assignments.submissions.preview.not_submitted')}
+                                    </div>
+                                )}
+                                {tb?.manually_graded && (
+                                    <div className='flex items-center space-x-1 text-[10px] font-bold px-2 py-0.5 rounded-full bg-orange-50 text-orange-700'>
+                                        <UserCheck size={10} />
+                                        <span>{t('dashboard.assignments.submissions.preview.manually_graded', { defaultValue: 'Manually graded' })}</span>
                                     </div>
                                 )}
                             </div>


### PR DESCRIPTION
… update grading logic

- Introduced `manually_graded` field in `AssignmentTaskSubmission` to indicate if a task was graded manually by a teacher.
- Updated grading logic to skip server-side verification for manually graded tasks, ensuring teacher overrides are preserved.
- Modified task submission handling to clear manual grading flags when students edit submissions.
- Enhanced UI components to reflect manual grading status in task breakdowns and feedback messages.

---
Fixes #891 — instructors can override an auto-graded quiz score (was stuck at the auto-computed %, e.g. 67%); the manual per-task grade is flagged `manually_graded` so the aggregate pass preserves it.
