### PR TITLE
fix(web): resolve rules-of-hooks violations and hoist render-defined components

### DIFF
--- a/apps/web/components/Dashboard/Pages/Course/EditCourseSEO/EditCourseSEO.tsx
+++ b/apps/web/components/Dashboard/Pages/Course/EditCourseSEO/EditCourseSEO.tsx
@@ -87,6 +87,14 @@ const isValidUrl = (url: string) => {
   }
 };
 
+// Module-level so React keeps a stable component identity — defining this
+// inside EditCourseSEO would remount the counter on every keystroke.
+const CharacterCounter = ({ current, max }: { current: number, max: number }) => (
+  <span className={`text-xs ${current > max ? 'text-red-500' : 'text-gray-400'}`}>
+    {current}/{max}
+  </span>
+);
+
 function EditCourseSEO(props: EditCourseSEOProps) {
   const { t } = useTranslation()
   const [error, setError] = React.useState('');
@@ -215,12 +223,6 @@ function EditCourseSEO(props: EditCourseSEOProps) {
       </div>
     );
   }
-
-  const CharacterCounter = ({ current, max }: { current: number, max: number }) => (
-    <span className={`text-xs ${current > max ? 'text-red-500' : 'text-gray-400'}`}>
-      {current}/{max}
-    </span>
-  );
 
   return (
     <div>

--- a/apps/web/components/Objects/Activities/AI/AIActivityAsk.tsx
+++ b/apps/web/components/Objects/Activities/AI/AIActivityAsk.tsx
@@ -605,9 +605,9 @@ const AIMessagePlaceHolder = (props: {
 }) => {
   const session = useLHSession() as any
   const aiChatBotState = useAIChatBot() as AIChatBotStateTypes
+  const { t } = useTranslation()
 
   if (!aiChatBotState.error.isError) {
-    const { t } = useTranslation()
     return (
       <div className={`w-full ${props.isFullscreen ? 'flex-1 flex items-center justify-center' : 'h-[237px]'}`}>
         <div className="flex flex-col text-center justify-center pt-6">

--- a/apps/web/components/Objects/Activities/DynamicCanva/AI/AICanvaToolkit.tsx
+++ b/apps/web/components/Objects/Activities/DynamicCanva/AI/AICanvaToolkit.tsx
@@ -27,8 +27,9 @@ function AICanvaToolkit(props: AICanvaToolkitProps) {
   const pathname = usePathname()
   const is_ai_feature_enabled = useGetAIFeatures({ feature: 'activity_ask' })
 
-  // Never show the AI bubble in embedded views
-  if (pathname?.startsWith('/embed/')) return null
+  // Never show the AI bubble in embedded views. Checked after the hooks
+  // below so the hook order stays stable when navigating in/out of /embed/.
+  const isEmbedView = pathname?.startsWith('/embed/') ?? false
   const [bubbleState, setBubbleState] = useState({
     visible: false,
     top: 0,
@@ -87,7 +88,7 @@ function AICanvaToolkit(props: AICanvaToolkitProps) {
   }, [props.editor])
 
   useEffect(() => {
-    if (!props.editor || !is_ai_feature_enabled) return
+    if (!props.editor || !is_ai_feature_enabled || isEmbedView) return
 
     const handleSelectionUpdate = () => {
       // Small delay to ensure DOM is updated
@@ -125,9 +126,9 @@ function AICanvaToolkit(props: AICanvaToolkitProps) {
       window.removeEventListener('scroll', handleScroll, true)
       document.removeEventListener('mousedown', handleClickOutside)
     }
-  }, [props.editor, is_ai_feature_enabled, updateBubblePosition])
+  }, [props.editor, is_ai_feature_enabled, isEmbedView, updateBubblePosition])
 
-  if (!is_ai_feature_enabled || !bubbleState.visible) {
+  if (isEmbedView || !is_ai_feature_enabled || !bubbleState.visible) {
     return null
   }
 

--- a/apps/web/components/Objects/Communities/DiscussionEditor.tsx
+++ b/apps/web/components/Objects/Communities/DiscussionEditor.tsx
@@ -14,6 +14,34 @@ interface DiscussionEditorProps {
   minHeight?: string
 }
 
+// Defined at module level so React keeps the same component identity across
+// renders — defining it inside DiscussionEditor would remount every button
+// (and drop hover/focus state) on each keystroke.
+const ToolbarButton = ({
+  onClick,
+  isActive,
+  children,
+  title,
+}: {
+  onClick: () => void
+  isActive?: boolean
+  children: React.ReactNode
+  title: string
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    title={title}
+    className={`p-1.5 rounded transition-colors ${
+      isActive
+        ? 'bg-gray-200 text-gray-900'
+        : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700'
+    }`}
+  >
+    {children}
+  </button>
+)
+
 export function DiscussionEditor({
   content,
   onChange,
@@ -88,31 +116,6 @@ export function DiscussionEditor({
 
     editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run()
   }
-
-  const ToolbarButton = ({
-    onClick,
-    isActive,
-    children,
-    title,
-  }: {
-    onClick: () => void
-    isActive?: boolean
-    children: React.ReactNode
-    title: string
-  }) => (
-    <button
-      type="button"
-      onClick={onClick}
-      title={title}
-      className={`p-1.5 rounded transition-colors ${
-        isActive
-          ? 'bg-gray-200 text-gray-900'
-          : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700'
-      }`}
-    >
-      {children}
-    </button>
-  )
 
   return (
     <div className="discussion-editor">


### PR DESCRIPTION
﻿## Summary
Fixes the two crash-grade `react-hooks/rules-of-hooks` violations in the web app 鈥?hooks called conditionally, which corrupts React's hook ordering at runtime ("Rendered fewer hooks than expected").

These surfaced while working through the lint backlog from #800 (124 of the 824 lint errors are `react-hooks/*`; these 4 are the only `rules-of-hooks` ones and the most severe class, so they get their own focused PR).

## The two bugs

**1. `AICanvaToolkit.tsx`** 鈥?the embed-view guard ran *before* three hooks:

```tsx
if (pathname?.startsWith('/embed/')) return null   // 鈫?early return
const [bubbleState, setBubbleState] = useState(...) // 鈫?hooks after it
const updateBubblePosition = useCallback(...)
useEffect(...)
```

Navigating between an embed view and a regular activity changes how many hooks run, which is exactly the case React's rule exists to prevent. Fix: compute `isEmbedView` up front, run all hooks unconditionally, and guard the effect body and the render output instead. Behavior is unchanged 鈥?embed views still render nothing and the listeners are still not attached there.

**2. `AIActivityAsk.tsx` (`AIMessagePlaceHolder`)** 鈥?`useTranslation()` was called inside the `if (!aiChatBotState.error.isError)` branch, so the first time the chat errors, the hook disappears from the render and ordering breaks. Fix: hoist it above the conditional.

## Verification
- `eslint --rule` check: `react-hooks/rules-of-hooks` reports 0 problems on both files (was 4)
- 7 insertions / 6 deletions; no behavioral change intended


## Follow-up commit in this PR
`7d07037` also hoists two render-defined components flagged by `react-hooks/static-components` (the remount-on-every-render class):
- `DiscussionEditor.ToolbarButton` (9 errors) — toolbar remounted on every keystroke
- `EditCourseSEO.CharacterCounter` (6 errors) — counter remounted on every keystroke

Both are dependency-free, so they move to module scope verbatim. The remaining `static-components` errors (`AddRole`/`EditRole` `PermissionSection`) need props-threading and are left for a follow-up PR.
