### PR TITLE
fix(web): extract PermissionSection to a shared module-level component

### DIFF
--- a/apps/web/components/Objects/Modals/Dash/OrgRoles/AddRole.tsx
+++ b/apps/web/components/Objects/Modals/Dash/OrgRoles/AddRole.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 import FormLayout, {
     FormField,
     FormLabelAndMessage,
@@ -14,8 +14,9 @@ import { queryKeys } from '@/lib/query/keys'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
 import { useFormik } from 'formik'
 import toast from 'react-hot-toast'
-import { Shield, BookOpen, Users, UserCheck, FolderOpen, Building, FileText, Activity, Monitor, CheckSquare, Square } from 'lucide-react'
+import { Shield, BookOpen, Users, UserCheck, FolderOpen, Building, FileText, Activity, Monitor } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import PermissionSection from './PermissionSection'
 
 type AddRoleProps = {
     setCreateRoleModal: any
@@ -417,45 +418,12 @@ function AddRole(props: AddRoleProps) {
         }
     }
 
-    const PermissionSection = ({ title, icon: Icon, section, permissions }: { title: string, icon: any, section: keyof Rights, permissions: string[] }) => {
-        const sectionRights = rights[section] as any
-        const allSelected = permissions.every(perm => sectionRights[perm])
-        const someSelected = permissions.some(perm => sectionRights[perm]) && !allSelected
-
-        return (
-            <div className="border border-gray-200 rounded-lg p-4 mb-4 bg-white shadow-sm">
-                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-3 gap-2">
-                    <div className="flex items-center space-x-2">
-                        <Icon className="w-4 h-4 text-gray-500" />
-                        <h3 className="font-semibold text-gray-800 text-sm sm:text-base">{title}</h3>
-                    </div>
-                    <button
-                        type="button"
-                        onClick={() => handleSelectAll(section, !allSelected)}
-                        className="flex items-center space-x-2 text-sm text-blue-600 hover:text-blue-700 font-medium self-start sm:self-auto transition-colors"
-                    >
-                        {allSelected ? <CheckSquare className="w-4 h-4" /> : someSelected ? <Square className="w-4 h-4" /> : <Square className="w-4 h-4" />}
-                        <span className="hidden sm:inline">{allSelected ? t('dashboard.users.roles.modals.create.permissions.deselect_all') : t('dashboard.users.roles.modals.create.permissions.select_all')}</span>
-                        <span className="sm:hidden">{allSelected ? t('dashboard.users.roles.modals.create.permissions.deselect') : t('dashboard.users.roles.modals.create.permissions.select')}</span>
-                    </button>
-                </div>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                    {permissions.map((permission) => (
-                        <label key={permission} className="flex items-center space-x-2 cursor-pointer p-2 rounded-md hover:bg-gray-50 transition-colors">
-                            <input
-                                type="checkbox"
-                                checked={rights[section]?.[permission as keyof typeof rights[typeof section]] || false}
-                                onChange={(e) => handleRightChange(section, permission, e.target.checked)}
-                                className="rounded border-gray-300 text-blue-600 focus:ring-blue-500 focus:ring-2"
-                            />
-                            <span className="text-sm text-gray-700 capitalize">
-                                {t(`dashboard.users.roles.modals.create.permissions.actions.${permission.replace('action_', '').replace(/_/g, '_')}`)}
-                            </span>
-                        </label>
-                    ))}
-                </div>
-            </div>
-        )
+    const permissionSectionProps = {
+        rights,
+        i18nPrefix: 'dashboard.users.roles.modals.create.permissions',
+        t,
+        onSelectAll: handleSelectAll,
+        onRightChange: handleRightChange,
     }
 
     return (
@@ -512,6 +480,7 @@ function AddRole(props: AddRoleProps) {
                         <h3 className="text-lg font-semibold text-gray-800 mb-4">{t('dashboard.users.roles.modals.create.permissions.title')}</h3>
                         
                         <PermissionSection
+                            {...permissionSectionProps}
                             title={t('dashboard.users.roles.modals.create.permissions.sections.courses')}
                             icon={BookOpen}
                             section="courses"
@@ -519,6 +488,7 @@ function AddRole(props: AddRoleProps) {
                         />
                         
                         <PermissionSection
+                            {...permissionSectionProps}
                             title={t('dashboard.users.roles.modals.create.permissions.sections.users')}
                             icon={Users}
                             section="users"
@@ -526,6 +496,7 @@ function AddRole(props: AddRoleProps) {
                         />
                         
                         <PermissionSection
+                            {...permissionSectionProps}
                             title={t('dashboard.users.roles.modals.create.permissions.sections.usergroups')}
                             icon={UserCheck}
                             section="usergroups"
@@ -533,6 +504,7 @@ function AddRole(props: AddRoleProps) {
                         />
                         
                         <PermissionSection
+                            {...permissionSectionProps}
                             title={t('dashboard.users.roles.modals.create.permissions.sections.collections')}
                             icon={FolderOpen}
                             section="collections"
@@ -540,6 +512,7 @@ function AddRole(props: AddRoleProps) {
                         />
                         
                         <PermissionSection
+                            {...permissionSectionProps}
                             title={t('dashboard.users.roles.modals.create.permissions.sections.organizations')}
                             icon={Building}
                             section="organizations"
@@ -547,6 +520,7 @@ function AddRole(props: AddRoleProps) {
                         />
                         
                         <PermissionSection
+                            {...permissionSectionProps}
                             title={t('dashboard.users.roles.modals.create.permissions.sections.coursechapters')}
                             icon={FileText}
                             section="coursechapters"
@@ -554,6 +528,7 @@ function AddRole(props: AddRoleProps) {
                         />
                         
                         <PermissionSection
+                            {...permissionSectionProps}
                             title={t('dashboard.users.roles.modals.create.permissions.sections.activities')}
                             icon={Activity}
                             section="activities"
@@ -561,6 +536,7 @@ function AddRole(props: AddRoleProps) {
                         />
                         
                         <PermissionSection
+                            {...permissionSectionProps}
                             title={t('dashboard.users.roles.modals.create.permissions.sections.roles')}
                             icon={Shield}
                             section="roles"
@@ -568,6 +544,7 @@ function AddRole(props: AddRoleProps) {
                         />
                         
                         <PermissionSection
+                            {...permissionSectionProps}
                             title={t('dashboard.users.roles.modals.create.permissions.sections.dashboard')}
                             icon={Monitor}
                             section="dashboard"

--- a/apps/web/components/Objects/Modals/Dash/OrgRoles/EditRole.tsx
+++ b/apps/web/components/Objects/Modals/Dash/OrgRoles/EditRole.tsx
@@ -1,4 +1,4 @@
-'use client'
+﻿'use client'
 import FormLayout, {
     FormField,
     FormLabelAndMessage,
@@ -14,8 +14,9 @@ import { queryKeys } from '@/lib/query/keys'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
 import { useFormik } from 'formik'
 import toast from 'react-hot-toast'
-import { Shield, BookOpen, Users, UserCheck, FolderOpen, Building, FileText, Activity, Monitor, CheckSquare, Square } from 'lucide-react'
+import { Shield, BookOpen, Users, UserCheck, FolderOpen, Building, FileText, Activity, Monitor } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import PermissionSection from './PermissionSection'
 
 type EditRoleProps = {
     role: {
@@ -366,45 +367,12 @@ function EditRole(props: EditRoleProps) {
         }
     }
 
-    const PermissionSection = ({ title, icon: Icon, section, permissions }: { title: string, icon: any, section: keyof Rights, permissions: string[] }) => {
-        const sectionRights = rights[section] as any
-        const allSelected = permissions.every(perm => sectionRights[perm])
-        const someSelected = permissions.some(perm => sectionRights[perm]) && !allSelected
-
-        return (
-            <div className="border border-gray-200 rounded-lg p-4 mb-4 bg-white shadow-sm">
-                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-3 gap-2">
-                    <div className="flex items-center space-x-2">
-                        <Icon className="w-4 h-4 text-gray-500" />
-                        <h3 className="font-semibold text-gray-800 text-sm sm:text-base">{title}</h3>
-                    </div>
-                    <button
-                        type="button"
-                        onClick={() => handleSelectAll(section, !allSelected)}
-                        className="flex items-center space-x-2 text-sm text-blue-600 hover:text-blue-700 font-medium self-start sm:self-auto transition-colors"
-                    >
-                        {allSelected ? <CheckSquare className="w-4 h-4" /> : someSelected ? <Square className="w-4 h-4" /> : <Square className="w-4 h-4" />}
-                        <span className="hidden sm:inline">{allSelected ? t('dashboard.users.roles.modals.edit.permissions.deselect_all') : t('dashboard.users.roles.modals.edit.permissions.select_all')}</span>
-                        <span className="sm:hidden">{allSelected ? t('dashboard.users.roles.modals.edit.permissions.deselect') : t('dashboard.users.roles.modals.edit.permissions.select')}</span>
-                    </button>
-                </div>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                    {permissions.map((permission) => (
-                        <label key={permission} className="flex items-center space-x-2 cursor-pointer p-2 rounded-md hover:bg-gray-50 transition-colors">
-                            <input
-                                type="checkbox"
-                                checked={rights[section]?.[permission as keyof typeof rights[typeof section]] || false}
-                                onChange={(e) => handleRightChange(section, permission, e.target.checked)}
-                                className="rounded border-gray-300 text-blue-600 focus:ring-blue-500 focus:ring-2"
-                            />
-                            <span className="text-sm text-gray-700 capitalize">
-                                {t(`dashboard.users.roles.modals.edit.permissions.actions.${permission.replace('action_', '').replace(/_/g, '_')}`)}
-                            </span>
-                        </label>
-                    ))}
-                </div>
-            </div>
-        )
+    const permissionSectionProps = {
+        rights,
+        i18nPrefix: 'dashboard.users.roles.modals.edit.permissions',
+        t,
+        onSelectAll: handleSelectAll,
+        onRightChange: handleRightChange,
     }
 
     return (
@@ -461,6 +429,7 @@ function EditRole(props: EditRoleProps) {
                         <h3 className="text-lg font-semibold text-gray-800 mb-4">{t('dashboard.users.roles.modals.edit.permissions.title')}</h3>
                         
                         <PermissionSection
+                            {...permissionSectionProps}
                             title={t('dashboard.users.roles.modals.edit.permissions.sections.courses')}
                             icon={BookOpen}
                             section="courses"
@@ -468,6 +437,7 @@ function EditRole(props: EditRoleProps) {
                         />
                         
                         <PermissionSection
+                            {...permissionSectionProps}
                             title={t('dashboard.users.roles.modals.edit.permissions.sections.users')}
                             icon={Users}
                             section="users"
@@ -475,6 +445,7 @@ function EditRole(props: EditRoleProps) {
                         />
                         
                         <PermissionSection
+                            {...permissionSectionProps}
                             title={t('dashboard.users.roles.modals.edit.permissions.sections.usergroups')}
                             icon={UserCheck}
                             section="usergroups"
@@ -482,6 +453,7 @@ function EditRole(props: EditRoleProps) {
                         />
                         
                         <PermissionSection
+                            {...permissionSectionProps}
                             title={t('dashboard.users.roles.modals.edit.permissions.sections.collections')}
                             icon={FolderOpen}
                             section="collections"
@@ -489,6 +461,7 @@ function EditRole(props: EditRoleProps) {
                         />
                         
                         <PermissionSection
+                            {...permissionSectionProps}
                             title={t('dashboard.users.roles.modals.edit.permissions.sections.organizations')}
                             icon={Building}
                             section="organizations"
@@ -496,6 +469,7 @@ function EditRole(props: EditRoleProps) {
                         />
                         
                         <PermissionSection
+                            {...permissionSectionProps}
                             title={t('dashboard.users.roles.modals.edit.permissions.sections.coursechapters')}
                             icon={FileText}
                             section="coursechapters"
@@ -503,6 +477,7 @@ function EditRole(props: EditRoleProps) {
                         />
                         
                         <PermissionSection
+                            {...permissionSectionProps}
                             title={t('dashboard.users.roles.modals.edit.permissions.sections.activities')}
                             icon={Activity}
                             section="activities"
@@ -510,6 +485,7 @@ function EditRole(props: EditRoleProps) {
                         />
                         
                         <PermissionSection
+                            {...permissionSectionProps}
                             title={t('dashboard.users.roles.modals.edit.permissions.sections.roles')}
                             icon={Shield}
                             section="roles"
@@ -517,6 +493,7 @@ function EditRole(props: EditRoleProps) {
                         />
                         
                         <PermissionSection
+                            {...permissionSectionProps}
                             title={t('dashboard.users.roles.modals.edit.permissions.sections.dashboard')}
                             icon={Monitor}
                             section="dashboard"

--- a/apps/web/components/Objects/Modals/Dash/OrgRoles/PermissionSection.tsx
+++ b/apps/web/components/Objects/Modals/Dash/OrgRoles/PermissionSection.tsx
@@ -1,0 +1,76 @@
+/* eslint-disable no-unused-vars --
+   The core no-unused-vars rule false-positives on parameter names inside
+   TS type signatures (e.g. `t: (key: string) => string`); switching the
+   project to @typescript-eslint/no-unused-vars is tracked in #800. */
+'use client'
+import React from 'react'
+import { CheckSquare, Square } from 'lucide-react'
+
+// Shared between AddRole and EditRole. Defined at module level so React
+// keeps a stable component identity — when this was declared inside the
+// modal components, every rights change remounted the whole section and
+// checkbox interactions lost focus/scroll state.
+type PermissionSectionProps = {
+    title: string
+    icon: any
+    section: string
+    permissions: string[]
+    rights: Record<string, any>
+    i18nPrefix: string
+    t: (key: string) => string
+    onSelectAll: (section: any, value: boolean) => void
+    onRightChange: (section: any, action: string, value: boolean) => void
+}
+
+const PermissionSection = ({
+    title,
+    icon: Icon,
+    section,
+    permissions,
+    rights,
+    i18nPrefix,
+    t,
+    onSelectAll,
+    onRightChange,
+}: PermissionSectionProps) => {
+    const sectionRights = (rights[section] || {}) as Record<string, boolean>
+    const allSelected = permissions.every(perm => sectionRights[perm])
+    const someSelected = permissions.some(perm => sectionRights[perm]) && !allSelected
+
+    return (
+        <div className="border border-gray-200 rounded-lg p-4 mb-4 bg-white shadow-sm">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-3 gap-2">
+                <div className="flex items-center space-x-2">
+                    <Icon className="w-4 h-4 text-gray-500" />
+                    <h3 className="font-semibold text-gray-800 text-sm sm:text-base">{title}</h3>
+                </div>
+                <button
+                    type="button"
+                    onClick={() => onSelectAll(section, !allSelected)}
+                    className="flex items-center space-x-2 text-sm text-blue-600 hover:text-blue-700 font-medium self-start sm:self-auto transition-colors"
+                >
+                    {allSelected ? <CheckSquare className="w-4 h-4" /> : someSelected ? <Square className="w-4 h-4" /> : <Square className="w-4 h-4" />}
+                    <span className="hidden sm:inline">{allSelected ? t(`${i18nPrefix}.deselect_all`) : t(`${i18nPrefix}.select_all`)}</span>
+                    <span className="sm:hidden">{allSelected ? t(`${i18nPrefix}.deselect`) : t(`${i18nPrefix}.select`)}</span>
+                </button>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                {permissions.map((permission) => (
+                    <label key={permission} className="flex items-center space-x-2 cursor-pointer p-2 rounded-md hover:bg-gray-50 transition-colors">
+                        <input
+                            type="checkbox"
+                            checked={sectionRights[permission] || false}
+                            onChange={(e) => onRightChange(section, permission, e.target.checked)}
+                            className="rounded border-gray-300 text-blue-600 focus:ring-blue-500 focus:ring-2"
+                        />
+                        <span className="text-sm text-gray-700 capitalize">
+                            {t(`${i18nPrefix}.actions.${permission.replace('action_', '').replace(/_/g, '_')}`)}
+                        </span>
+                    </label>
+                ))}
+            </div>
+        </div>
+    )
+}
+
+export default PermissionSection


### PR DESCRIPTION
## Summary
The follow-up promised in #810 — fixes the remaining 18 `react-hooks/static-components` errors by extracting the `PermissionSection` that `AddRole` and `EditRole` each declared inside their component bodies.

## Why it matters
A component type declared during render is a *new* type on every render, so React unmounts and remounts the entire subtree each time. Here that subtree is the permissions checkbox grid: every checkbox click triggers a rights-state update → parent re-render → full grid remount, dropping focus/hover state and redoing DOM work on each interaction.

## Changes
- New `OrgRoles/PermissionSection.tsx` — the two inline declarations were identical except for the i18n key prefix (`…modals.create.permissions` vs `…modals.edit.permissions`), so this also removes ~40 duplicated lines. Former closure dependencies (`rights`, the two handlers, `t`, the prefix) are now props.
- Call sites spread a shared `permissionSectionProps` object, so the 9 usages per file stay as readable as before.
- A file-level `eslint-disable no-unused-vars` with justification: the **core** rule false-positives on parameter names inside TS type signatures (e.g. `t: (key: string) => string`); moving the project to `@typescript-eslint/no-unused-vars` is part of the #800 cleanup.

## Verification
- `eslint components/Objects/Modals/Dash/OrgRoles/` → clean (was 18 static-components errors + 1 unused import)
- `tsc --noEmit` error set identical to base (the 22 pre-existing `public/*.png` module errors, unrelated)
- Behavior preserved: same markup, same i18n keys, same handler wiring
