### PR TITLE
fix(web): derived-state effects and HeaderProfileBox memoization (incl. i18n bug)

### DIFF
--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskNumberAnswerObject.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskNumberAnswerObject.tsx
@@ -79,7 +79,9 @@ function TaskNumberAnswerObject({
   const [contents, setContents] = useState<NumberAnswerContents>(DEFAULT_CONTENTS)
   const [studentAnswer, setStudentAnswer] = useState<string>('')
   const [initialAnswer, setInitialAnswer] = useState<string>('')
-  const [showSavingDisclaimer, setShowSavingDisclaimer] = useState(false)
+  // Derived: the disclaimer shows exactly while the draft differs from the
+  // last saved answer (submitFC syncs initialAnswer on success).
+  const showSavingDisclaimer = view === 'student' && studentAnswer !== initialAnswer
 
   const [userSubmissions, setUserSubmissions] = useState<any>(null)
   const [userSubmissionObject, setUserSubmissionObject] = useState<any>(null)
@@ -150,12 +152,6 @@ function TaskNumberAnswerObject({
     }
   }, [view, assignmentTaskUUID, assignment, access_token])
 
-  useEffect(() => {
-    if (view === 'student') {
-      setShowSavingDisclaimer(studentAnswer !== initialAnswer)
-    }
-  }, [studentAnswer, initialAnswer, view])
-
   // --- SAVE (teacher) ---
   async function saveFC() {
     if (!assignmentTaskState?.assignmentTask?.assignment_task_uuid) return
@@ -199,7 +195,6 @@ function TaskNumberAnswerObject({
     if (res.success) {
       setUserSubmissions(res.data)
       setInitialAnswer(studentAnswer)
-      setShowSavingDisclaimer(false)
       toast.success(t('dashboard.assignments.editor.toasts.task_saved'))
     } else {
       toast.error(t('dashboard.assignments.editor.toasts.task_save_error'))

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskShortAnswerObject.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskShortAnswerObject.tsx
@@ -83,7 +83,9 @@ function TaskShortAnswerObject({
   const [contents, setContents] = useState<ShortAnswerContents>(DEFAULT_CONTENTS)
   const [studentAnswer, setStudentAnswer] = useState<string>('')
   const [initialAnswer, setInitialAnswer] = useState<string>('')
-  const [showSavingDisclaimer, setShowSavingDisclaimer] = useState(false)
+  // Derived: the disclaimer shows exactly while the draft differs from the
+  // last saved answer (submitFC syncs initialAnswer on success).
+  const showSavingDisclaimer = view === 'student' && studentAnswer !== initialAnswer
 
   const [userSubmissions, setUserSubmissions] = useState<any>(null)
   const [userSubmissionObject, setUserSubmissionObject] = useState<any>(null)
@@ -154,12 +156,6 @@ function TaskShortAnswerObject({
     }
   }, [view, assignmentTaskUUID, assignment, access_token])
 
-  useEffect(() => {
-    if (view === 'student') {
-      setShowSavingDisclaimer(studentAnswer !== initialAnswer)
-    }
-  }, [studentAnswer, initialAnswer, view])
-
   // --- SAVE (teacher) ---
   async function saveFC() {
     if (!assignmentTaskState?.assignmentTask?.assignment_task_uuid) return
@@ -219,7 +215,6 @@ function TaskShortAnswerObject({
     if (res.success) {
       setUserSubmissions(res.data)
       setInitialAnswer(studentAnswer)
-      setShowSavingDisclaimer(false)
       toast.success(t('dashboard.assignments.editor.toasts.task_saved'))
     } else {
       toast.error(t('dashboard.assignments.editor.toasts.task_save_error'))

--- a/apps/web/components/Hooks/useFeatureFlag.tsx
+++ b/apps/web/components/Hooks/useFeatureFlag.tsx
@@ -1,5 +1,5 @@
 import { useOrg } from '@components/Contexts/OrgContext'
-import { useEffect, useState } from 'react'
+import { useMemo } from 'react'
 
 type FeatureType = {
   path: string[]
@@ -8,12 +8,13 @@ type FeatureType = {
 
 function useFeatureFlag(feature: FeatureType) {
   const org = useOrg() as any
-  const [isEnabled, setIsEnabled] = useState<boolean>(!!feature.defaultValue)
 
-  useEffect(() => {
+  // Derived directly from org config — computing during render avoids the
+  // extra "stale then corrected" render cycle the old effect+setState caused.
+  return useMemo(() => {
     if (org?.config?.config) {
       let currentValue = org.config.config
-      
+
       // Traverse the path to get the feature flag value
       for (const key of feature.path) {
         if (currentValue && typeof currentValue === 'object') {
@@ -24,13 +25,10 @@ function useFeatureFlag(feature: FeatureType) {
         }
       }
 
-      setIsEnabled(!!currentValue)
-    } else {
-      setIsEnabled(!!feature.defaultValue)
+      return !!currentValue
     }
+    return !!feature.defaultValue
   }, [org, feature])
-
-  return isEnabled
 }
 
 export default useFeatureFlag

--- a/apps/web/components/Security/HeaderProfileBox.tsx
+++ b/apps/web/components/Security/HeaderProfileBox.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useEffect, useMemo } from 'react'
+import React, { useMemo } from 'react'
 
 import Link from 'next/link'
 import { Package, Crown, Shield, User, Users, SignOut, CaretDown, Globe, Check, ShoppingBag } from '@phosphor-icons/react'
@@ -49,19 +49,16 @@ export const HeaderProfileBox = ({ primaryColor = '' }: { primaryColor?: string 
   const colors = getMenuColorClasses(primaryColor)
 
 
-  useEffect(() => { }
-    , [session])
-
   const userRoleInfo = useMemo((): RoleInfo | null => {
     if (!userRoles || userRoles.length === 0) return null;
 
     // Find the highest priority role for the current organization
     const orgRoles = userRoles.filter((role: any) => role.org.id === org?.id);
-    
+
     if (orgRoles.length === 0) return null;
 
     // Sort by role priority (admin > maintainer > instructor > user)
-    const sortedRoles = orgRoles.sort((a: any, b: any) => {
+    const sortedRoles = [...orgRoles].sort((a: any, b: any) => {
       const getRolePriority = (role: any) => {
         if (role.role.role_uuid === 'role_global_admin' || role.role.id === 1) return 4;
         if (role.role.role_uuid === 'role_global_maintainer' || role.role.id === 2) return 3;
@@ -118,7 +115,8 @@ export const HeaderProfileBox = ({ primaryColor = '' }: { primaryColor?: string 
     }
 
     return roleConfigs[roleKey] || roleConfigs['role_global_user'];
-  }, [userRoles, org?.id]);
+    // t is a real dependency: the labels must recompute on language change
+  }, [userRoles, org?.id, t]);
 
   const customRoles = useMemo((): CustomRoleInfo[] => {
     if (!userRoles || userRoles.length === 0) return [];
@@ -143,7 +141,8 @@ export const HeaderProfileBox = ({ primaryColor = '' }: { primaryColor?: string 
       name: role.role.name || t('roles.custom_role'),
       description: role.role.description
     }));
-  }, [userRoles, org?.id]);
+    // t is a real dependency: the fallback label must recompute on language change
+  }, [userRoles, org?.id, t]);
 
   return (
     <div className="flex items-stretch items-center">


### PR DESCRIPTION
## Summary
The "bucket A" PR offered in the #800 triage — fixes the derived-state-in-effect cases plus the memoization bugs in `HeaderProfileBox`. All are behavior-preserving except one which fixes a visible i18n bug.

## Changes

**1. Derived state computed during render** (`react-hooks/set-state-in-effect`, −5 errors)
- `useFeatureFlag`: `isEnabled` is a pure function of org config + feature path; the effect+setState version rendered every consumer twice (stale, then corrected) on each org/feature change. Now a `useMemo` over the same traversal.
- `TaskNumberAnswerObject` / `TaskShortAnswerObject`: `showSavingDisclaimer` is exactly `studentAnswer !== initialAnswer` in student view — now computed inline. The post-submit `setShowSavingDisclaimer(false)` was already redundant because `submitFC` syncs `initialAnswer` on the same success path, flipping the comparison by itself.
- The remaining errors in the Task files are the teacher-view context sync and fetch effects (buckets B/C from the triage) — intentionally untouched.

**2. `HeaderProfileBox` memoization repairs** (`react-hooks/preserve-manual-memoization`, −10 errors)
- Both `useMemo` blocks call `t()` but omitted it from deps, so **role badge labels didn't recompute on language change** — a real i18n bug, and the reason React Compiler refused to preserve the memoization here.
- `orgRoles.sort()` mutated in place; now sorts a copy.
- Removed an empty `useEffect(() => {}, [session])` left from an earlier refactor (and the now-unused `useEffect` import).

## Verification
- `react-hooks/set-state-in-effect` −5, `react-hooks/preserve-manual-memoization` −10; no new lint findings
- `tsc --noEmit` error set identical to base (the 22 pre-existing `public/*.png` module errors)
- Net diff: −13 lines
