### PR TITLE
fix(api): always open text files as UTF-8 (locale-dependent crashes on CJK Windows)

### DIFF
--- a/apps/api/config/config.py
+++ b/apps/api/config/config.py
@@ -120,7 +120,7 @@ def get_learnhouse_config() -> LearnHouseConfig:
     yaml_path = os.path.join(os.path.dirname(__file__), "config.yaml")
 
     # Load the YAML file
-    with open(yaml_path, "r") as f:
+    with open(yaml_path, "r", encoding="utf-8") as f:
         yaml_config = yaml.safe_load(f)
     
     # Ensure yaml_config is not None (defensive programming)

--- a/apps/api/src/services/courses/migration/migration_service.py
+++ b/apps/api/src/services/courses/migration/migration_service.py
@@ -161,7 +161,7 @@ async def _upload_migration_files_inner(
         if not manifest_real.startswith(temp_real + os.sep):
             raise ValueError("Invalid path")
         if os.path.exists(manifest_real):
-            with open(manifest_real, "r") as f:
+            with open(manifest_real, "r", encoding="utf-8") as f:
                 existing_manifest = json.load(f)
             existing_files = existing_manifest.get("files", [])
     else:
@@ -240,7 +240,7 @@ async def _upload_migration_files_inner(
         "files": all_files,
     }
     manifest_real = _resolve_within(temp_real, "manifest.json")
-    with open(manifest_real, "w") as f:
+    with open(manifest_real, "w", encoding="utf-8") as f:
         json.dump(manifest, f)
 
     return MigrationUploadResponse(
@@ -266,7 +266,7 @@ async def suggest_structure(
     if not os.path.exists(manifest_real):
         raise ValueError(f"Migration package not found: {temp_id}")
 
-    with open(manifest_real, "r") as f:
+    with open(manifest_real, "r", encoding="utf-8") as f:
         manifest = json.load(f)
 
     files = manifest["files"]
@@ -391,7 +391,7 @@ async def create_course_from_migration(
     if not os.path.exists(manifest_real):
         raise ValueError(f"Migration package not found: {temp_id}")
 
-    with open(manifest_real, "r") as f:
+    with open(manifest_real, "r", encoding="utf-8") as f:
         manifest = json.load(f)
 
     file_lookup = {fi["file_id"]: fi for fi in manifest["files"]}

--- a/apps/api/src/services/courses/transfer/import_service.py
+++ b/apps/api/src/services/courses/transfer/import_service.py
@@ -232,7 +232,7 @@ async def analyze_import_package(
                 detail="Invalid package: manifest.json not found"
             )
 
-        with open(manifest_path, 'r') as f:
+        with open(manifest_path, 'r', encoding="utf-8") as f:
             manifest = json.load(f)
 
         # Validate manifest format
@@ -253,7 +253,7 @@ async def analyze_import_package(
             if not os.path.exists(course_json_path):
                 continue
 
-            with open(course_json_path, 'r') as f:
+            with open(course_json_path, 'r', encoding="utf-8") as f:
                 course_data = json.load(f)
 
             # Count chapters and activities
@@ -363,7 +363,7 @@ async def import_courses(
     extract_dir = os.path.join(work_dir, "extracted")
     manifest_path = os.path.join(extract_dir, "manifest.json")
 
-    with open(manifest_path, 'r') as f:
+    with open(manifest_path, 'r', encoding="utf-8") as f:
         manifest = json.load(f)
 
     # Build a map of course_uuid to path
@@ -468,7 +468,7 @@ async def _import_single_course(
     Import a single course from the extracted package.
     """
     # Load course data
-    with open(os.path.join(course_path, "course.json"), 'r') as f:
+    with open(os.path.join(course_path, "course.json"), 'r', encoding="utf-8") as f:
         course_data = json.load(f)
 
     # Apply name prefix if specified
@@ -565,7 +565,7 @@ async def _import_single_course(
             chapter_dir_path = os.path.join(chapters_dir, chapter_uuid_dir)
             chapter_json_path = os.path.join(chapter_dir_path, "chapter.json")
             if os.path.isdir(chapter_dir_path) and os.path.exists(chapter_json_path):
-                with open(chapter_json_path, 'r') as f:
+                with open(chapter_json_path, 'r', encoding="utf-8") as f:
                     chapter_data = json.load(f)
                 chapter_items.append((chapter_uuid_dir, chapter_data))
 
@@ -633,7 +633,7 @@ async def _import_chapter(
             activity_dir_path = os.path.join(activities_dir, activity_uuid_dir)
             activity_json_path = os.path.join(activity_dir_path, "activity.json")
             if os.path.isdir(activity_dir_path) and os.path.exists(activity_json_path):
-                with open(activity_json_path, 'r') as f:
+                with open(activity_json_path, 'r', encoding="utf-8") as f:
                     activity_data = json.load(f)
                 activity_items.append((activity_uuid_dir, activity_data))
 
@@ -743,7 +743,7 @@ async def _import_activity(
             block_json_path = os.path.join(block_dir_path, "block.json")
 
             if os.path.isdir(block_dir_path) and os.path.exists(block_json_path):
-                with open(block_json_path, 'r') as f:
+                with open(block_json_path, 'r', encoding="utf-8") as f:
                     block_data = json.load(f)
 
                 new_block_uuid, content_updates = await _import_block(

--- a/apps/api/src/tests/security/test_scorm_security.py
+++ b/apps/api/src/tests/security/test_scorm_security.py
@@ -77,7 +77,7 @@ class TestDefusedXml:
         )
         if not os.path.exists(scorm_path):
             pytest.skip("EE not present (OSS build) — SCORM source check not applicable")
-        with open(scorm_path) as f:
+        with open(scorm_path, encoding='utf-8') as f:
             source = f.read()
 
         # Should use defusedxml for parsing


### PR DESCRIPTION
## Summary
13 call sites open text files without an explicit `encoding`, so Python falls back to the OS locale codec. On Windows machines with a CJK locale (cp936/GBK, Shift-JIS, …) this breaks the API in two distinct ways — found while trying to run the test suite on a zh-CN Windows machine.

## The two failure modes

**1. The entire test suite cannot even collect.** `config/config.py:123` reads `config.yaml` with the locale codec; the moment the YAML contains a non-ASCII byte:

```
UnicodeDecodeError: 'gbk' codec can't decode byte 0x94 in position 1955: illegal multibyte sequence
```

Every test file that imports app code dies at collection. CJK-locale contributors can't run tests at all.

**2. Course import/migration breaks at runtime, not just in tests.** `migration_service.py` and `import_service.py` read **and write** JSON manifests with the locale codec — so on those systems, importing or migrating any course whose content contains non-ASCII characters (i.e. any non-English course on an education platform) fails or produces mojibake manifests.

## Fix
`encoding="utf-8"` on all 13 text-mode `open()` calls (flagged via `ruff check --select PLW1514`). JSON and YAML are UTF-8 by spec, so this is the correct behavior on every platform — not just a Windows accommodation.

## Verification (Windows, zh-CN locale, Python 3.14.3)
- Before: test collection aborts with the UnicodeDecodeError above
- After: **2519 passed, 3 skipped** — the suite runs
- The 9 remaining failures are a *separate pre-existing* Windows issue (path-separator assumptions in `walk_directory`/migration paths producing `\` where tests — and possibly S3 keys — expect `/`). Filing that separately with details, since it may affect S3 key generation on Windows self-hosts and deserves its own discussion.
