### PR TITLE
Fix/verification mail on invites

### DIFF
--- a/apps/api/src/db/tinybird/datasources/events.datasource
+++ b/apps/api/src/db/tinybird/datasources/events.datasource
@@ -15,3 +15,4 @@ ENGINE "MergeTree"
 ENGINE_PARTITION_KEY "toYYYYMM(timestamp)"
 ENGINE_SORTING_KEY "org_id, event_name, timestamp"
 ENGINE_TTL "timestamp + toIntervalDay(365)"
+ 

--- a/apps/api/src/services/users/users.py
+++ b/apps/api/src/services/users/users.py
@@ -183,7 +183,7 @@ async def create_user(
             email=user_read.email,
             lang=get_org_default_language(org_config),
         )
-    else:
+    elif get_deployment_mode() == 'saas':
         # Import here to avoid circular imports
         from src.services.users.email_verification import send_verification_email
         await send_verification_email(request, db_session, user, org_id)

--- a/apps/web/app/auth/signup/InviteOnlySignUp.tsx
+++ b/apps/web/app/auth/signup/InviteOnlySignUp.tsx
@@ -57,7 +57,7 @@ function InviteOnlySignUpComponent(props: InviteOnlySignUpProps) {
   const org = useOrg() as any
   const router = useRouter()
   const [error, setError] = React.useState('')
-  const [message, setMessage] = React.useState('')
+  const [message, setMessage] = React.useState<{ email_verified: boolean } | null>(null)
   const formik = useFormik({
     initialValues: {
       org_slug: org?.slug,
@@ -73,12 +73,12 @@ function InviteOnlySignUpComponent(props: InviteOnlySignUpProps) {
     enableReinitialize: true,
     onSubmit: async (values) => {
       setError('')
-      setMessage('')
+      setMessage(null)
       setIsSubmitting(true)
       let res = await signUpWithInviteCode(values, props.inviteCode)
       let message = await res.json()
       if (res.status == 200) {
-        setMessage(t('auth.account_created_success'))
+        setMessage(message)
         setIsSubmitting(false)
       } else if (
         res.status == 401 ||
@@ -127,7 +127,9 @@ function InviteOnlySignUpComponent(props: InviteOnlySignUpProps) {
           <div className="font-bold text-sm">{error}</div>
         </div>
       )}
-      {message && (
+
+
+      {message && message.email_verified === false && (
         <div className="flex flex-col gap-4 bg-green-100 rounded-xl text-green-900 p-4 mb-6 nice-shadow">
           <div className="flex items-center gap-2">
             <Mail size={18} />
@@ -139,7 +141,21 @@ function InviteOnlySignUpComponent(props: InviteOnlySignUpProps) {
           <hr className="border-green-200" />
           <Link className="flex items-center gap-2 text-sm font-medium hover:underline" href="/login">
             <User size={14} />
-            <span>{t('auth.login_to_your_account')}</span>
+            <span>{t('auth.login')}</span>
+          </Link>
+        </div>
+      )}
+
+      {message && message.email_verified && (
+        <div className="flex flex-col gap-4 bg-green-100 rounded-xl text-green-900 p-4 mb-6 nice-shadow">
+          <div className="flex items-center gap-2">
+            <Mail size={18} />
+            <div className="font-bold text-sm">{t('auth.account_created_success')}</div>
+          </div>
+          <hr className="border-green-200" />
+          <Link className="flex items-center gap-2 text-sm font-medium hover:underline" href="/login">
+            <User size={14} />
+            <span>{t('auth.login')}</span>
           </Link>
         </div>
       )}

--- a/apps/web/app/auth/signup/OpenSignup.tsx
+++ b/apps/web/app/auth/signup/OpenSignup.tsx
@@ -53,7 +53,7 @@ function OpenSignUpComponent() {
   const org = useOrg() as any
   const router = useRouter()
   const [error, setError] = React.useState('')
-  const [message, setMessage] = React.useState('')
+  const [message, setMessage] = React.useState<{ email_verified: boolean } | null>(null)
   const formik = useFormik({
     initialValues: {
       org_slug: org?.slug,
@@ -69,12 +69,12 @@ function OpenSignUpComponent() {
     enableReinitialize: true,
     onSubmit: async (values) => {
       setError('')
-      setMessage('')
+      setMessage(null)
       setIsSubmitting(true)
       let res = await signup(values)
       let message = await res.json()
       if (res.status == 200) {
-        setMessage(t('auth.account_created_success'))
+        setMessage(message)
         setIsSubmitting(false)
       } else if (
         res.status == 401 ||
@@ -123,7 +123,9 @@ function OpenSignUpComponent() {
           <div className="font-bold text-sm">{error}</div>
         </div>
       )}
-      {message && (
+
+
+      {message && message.email_verified === false && (
         <div className="flex flex-col gap-4 bg-green-100 rounded-xl text-green-900 p-4 mb-6 nice-shadow">
           <div className="flex items-center gap-2">
             <Mail size={18} />
@@ -132,6 +134,20 @@ function OpenSignUpComponent() {
           <p className="text-xs text-green-800">
             {t('auth.verification_email_sent_message')}
           </p>
+          <hr className="border-green-200" />
+          <Link className="flex items-center gap-2 text-sm font-medium hover:underline" href="/login">
+            <User size={14} />
+            <span>{t('auth.login')}</span>
+          </Link>
+        </div>
+      )}
+
+      {message && message.email_verified && (
+        <div className="flex flex-col gap-4 bg-green-100 rounded-xl text-green-900 p-4 mb-6 nice-shadow">
+          <div className="flex items-center gap-2">
+            <Mail size={18} />
+            <div className="font-bold text-sm">{t('auth.account_created_success')}</div>
+          </div>
           <hr className="border-green-200" />
           <Link className="flex items-center gap-2 text-sm font-medium hover:underline" href="/login">
             <User size={14} />


### PR DESCRIPTION
## Fix: Email verification banner based on `email_verified` field

### Problem
Two related issues were found in the signup flow:

1. The email verification banner was always shown after signup, regardless of whether the user actually needed to verify their email.
2. In OSS/self-hosted mode, the backend was attempting to send a verification email even though users are automatically verified.

### Solution

**Frontend:** Instead of relying on a static success string, the `message` state now stores the full `UserRead` object returned by the API after a successful signup. The banner is then conditionally rendered based on the `email_verified` field.

**Backend:** The verification email is now only sent in SaaS mode. In OSS/self-hosted mode, no email is sent since users are automatically verified.

### Changes
- `InviteOnlySignUp.tsx` | updated `message` state type from `string` to `{ email_verified: boolean } | null`
- `OpenSignup.tsx` | same changes as above
- `users.py` | replaced `else` with `elif get_deployment_mode() == 'saas'` to skip verification email in OSS/self-hosted mode