### PR TITLE
fix: high-severity bug fixes + backend security hardening

### DIFF
--- a/apps/api/src/core/middleware/cors.py
+++ b/apps/api/src/core/middleware/cors.py
@@ -1,16 +1,53 @@
 """Tenancy-aware CORS configuration."""
 
+import re
+from urllib.parse import urlparse
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from config.config import get_learnhouse_config
 
 
-# Permissive regex used in `single` tenancy: matches any well-formed http(s)
-# origin. The operator's host is the only valid origin in single mode, and
-# auth cookies are host-only — cross-origin attackers cannot read them or
-# forge authenticated requests, so echoing the request Origin back is safe.
-_SINGLE_TENANCY_ORIGIN_REGEX = r"^https?://[^/\s]+$"
+_SINGLE_TENANCY_LOCALHOST_REGEX = r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$"
+
+
+def _host_from(value: str) -> str:
+    """Extract a bare hostname from a config value that may be a host or URL."""
+    value = (value or "").strip().rstrip("/")
+    if not value:
+        return ""
+    host = urlparse(value).hostname if "://" in value else value
+    return (host or "").removeprefix("www.").lower()
+
+
+def _single_tenancy_origin_regex(config) -> str:
+    """Build a CORS origin regex pinned to the configured host(s).
+
+    Reflecting any origin back with ``allow_credentials=True`` lets a malicious
+    site make authenticated cross-origin requests (S25). In single mode we
+    therefore only allow the operator's configured frontend/domain host(s)
+    (with or without a ``www.`` prefix, any scheme/port), plus localhost as a
+    fallback so local/dev flows keep working.
+    """
+    hosts = set()
+    for cfg_value in (
+        config.hosting_config.frontend_domain,
+        config.hosting_config.domain,
+    ):
+        host = _host_from(cfg_value)
+        if host and "localhost" not in host:
+            hosts.add(host)
+
+    if not hosts:
+        return _SINGLE_TENANCY_LOCALHOST_REGEX
+
+    host_alternation = "|".join(
+        rf"(?:www\.)?{re.escape(h)}" for h in sorted(hosts)
+    )
+    return (
+        rf"^https?://(?:{host_alternation}|localhost|127\.0\.0\.1)(:\d+)?$"
+    )
 
 
 def get_cors_origin_regex() -> str:
@@ -18,7 +55,8 @@ def get_cors_origin_regex() -> str:
     Compute the regex for ``CORSMiddleware``'s ``allow_origin_regex`` based on
     the active tenancy mode.
 
-    - ``single`` → accept any well-formed http(s) origin (see comment above).
+    - ``single`` → pin to the configured frontend/domain host(s) only (S25),
+      since credentials are allowed and reflecting any origin would be unsafe.
     - ``multi``  → use the configured ``LEARNHOUSE_ALLOWED_REGEXP`` (matches
       the configured domain and its subdomains). Verified per-org custom
       domains are a known gap; they require backend restart or per-request
@@ -26,7 +64,7 @@ def get_cors_origin_regex() -> str:
     """
     config = get_learnhouse_config()
     if config.hosting_config.tenancy == "single":
-        return _SINGLE_TENANCY_ORIGIN_REGEX
+        return _single_tenancy_origin_regex(config)
     return config.hosting_config.allowed_regexp
 
 

--- a/apps/api/src/db/courses/chapters.py
+++ b/apps/api/src/db/courses/chapters.py
@@ -46,8 +46,6 @@ class ChapterUpdate(SQLModel):
     description: Optional[str] = None
     thumbnail_image: Optional[str] = None
     lock_type: Optional[LockType] = None
-    course_id: Optional[int] = None
-    org_id: Optional[int] = None
     extra_metadata: Optional[dict] = None
 
 

--- a/apps/api/src/db/organizations.py
+++ b/apps/api/src/db/organizations.py
@@ -54,7 +54,6 @@ class OrganizationUpdate(SQLModel):
     label: Optional[str] = None
     slug: Optional[str] = None
     email: Optional[str] = None
-    explore: Optional[bool] = None
 
 class OrganizationCreate(OrganizationBase):
     pass

--- a/apps/api/src/routers/ai/ai.py
+++ b/apps/api/src/routers/ai/ai.py
@@ -132,9 +132,11 @@ async def activity_chat_event_generator(
             yield f"data: {json.dumps({'type': 'follow_ups', 'follow_up_suggestions': follow_ups})}\n\n"
 
     except asyncio.CancelledError:
-        stream_failed = True
-        # Client disconnect / server shutdown. Re-raise so Starlette observes
-        # the cancellation, but let the finally refund first.
+        # Client disconnect / server shutdown. Do NOT force a refund here: if
+        # the model already produced output the credit was legitimately spent.
+        # The finally block still refunds when nothing was produced
+        # (full_response empty), so a disconnect *after* a full response can't
+        # be abused to get free AI. Re-raise so Starlette observes the cancel.
         raise
     except Exception:
         stream_failed = True
@@ -405,9 +407,11 @@ async def editor_chat_event_generator(
             yield f"data: {json.dumps({'type': 'follow_ups', 'follow_up_suggestions': follow_ups})}\n\n"
 
     except asyncio.CancelledError:
-        stream_failed = True
-        # Client disconnect / cancellation — let Starlette observe it after
-        # we refund credits in the finally block.
+        # Client disconnect / cancellation. Do NOT force a refund here: if the
+        # model already produced output the credit was legitimately spent. The
+        # finally block still refunds when nothing was produced (full_response
+        # empty), so a disconnect *after* a full response can't be abused to
+        # get free AI. Re-raise so Starlette observes the cancel.
         raise
     except Exception:
         stream_failed = True

--- a/apps/api/src/routers/ai/ai.py
+++ b/apps/api/src/routers/ai/ai.py
@@ -55,7 +55,7 @@ async def api_ai_start_activity_chat_session(
     """
     Start a new AI Chat session with a Course Activity
     """
-    return ai_start_activity_chat_session(
+    return await ai_start_activity_chat_session(
         request, chat_session_object, current_user, db_session
     )
 
@@ -80,7 +80,7 @@ async def api_ai_send_activity_chat_message(
     """
     Send a message to an AI Chat session with a Course Activity
     """
-    return ai_send_activity_chat_message(
+    return await ai_send_activity_chat_message(
         request, chat_session_object, current_user, db_session
     )
 
@@ -300,6 +300,7 @@ async def editor_chat_event_generator(
     buffer = ""
     in_content_block = False
     content_buffer = ""
+    stream_failed = False
 
     try:
         # Send start event immediately
@@ -404,18 +405,16 @@ async def editor_chat_event_generator(
             yield f"data: {json.dumps({'type': 'follow_ups', 'follow_up_suggestions': follow_ups})}\n\n"
 
     except asyncio.CancelledError:
+        stream_failed = True
         # Client disconnect / cancellation — let Starlette observe it after
         # we refund credits in the finally block.
-        if org_id is not None and not full_response:
-            try:
-                refund_ai_credit(org_id, 1)
-            except Exception:
-                logger.debug("AI credit refund failed", exc_info=True)
         raise
     except Exception:
+        stream_failed = True
         logger.exception("Error in editor_chat_event_generator")
         yield f"data: {json.dumps({'type': 'error', 'message': 'An internal error occurred while processing the AI request.'})}\n\n"
-        if org_id is not None and not full_response:
+    finally:
+        if org_id is not None and (stream_failed or not full_response):
             try:
                 refund_ai_credit(org_id, 1)
             except Exception:

--- a/apps/api/src/routers/ai/magicblocks.py
+++ b/apps/api/src/routers/ai/magicblocks.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from sqlmodel import select
 import json
+import logging
 
 from src.db.organizations import Organization
 from src.db.courses.courses import Course
@@ -10,8 +11,10 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from src.core.events.database import get_db_session
 from src.db.users import PublicUser, AnonymousUser, APITokenUser
 from src.security.auth import get_current_user, get_authenticated_user, resolve_acting_user_id
+from src.security.org_auth import is_org_member
 from src.security.features_utils.usage import (
     reserve_ai_credit,
+    refund_ai_credit,
 )
 from src.security.features_utils.plan_check import get_org_plan
 from src.security.features_utils.plans import plan_meets_requirement
@@ -31,18 +34,47 @@ from src.services.ai.schemas.magicblocks import (
 
 router = APIRouter()
 
+logger = logging.getLogger(__name__)
 
-async def event_generator(generator, session_uuid: str):
-    """Convert async generator to SSE format"""
+
+async def event_generator(
+    generator,
+    session_uuid: str,
+    org_id: int | None = None,
+    reserved_credits: int = 0,
+):
+    """Convert async generator to SSE format.
+
+    Credits are reserved by the caller before the stream is created. If the
+    stream dies before producing any model output (upstream error, client
+    disconnect, cancellation) we refund the reserved credits so a flaky
+    connection doesn't silently drain the org's quota.
+    """
+    import asyncio
+
+    produced_content = False
+    stream_failed = False
     try:
         async for chunk in generator:
+            if chunk:
+                produced_content = True
             # Send each chunk as an SSE data event
             yield f"data: {json.dumps({'type': 'chunk', 'content': chunk})}\n\n"
 
         # Send completion event
         yield f"data: {json.dumps({'type': 'done', 'session_uuid': session_uuid})}\n\n"
+    except asyncio.CancelledError:
+        stream_failed = True
+        raise
     except Exception as e:
+        stream_failed = True
         yield f"data: {json.dumps({'type': 'error', 'message': str(e)})}\n\n"
+    finally:
+        if org_id is not None and reserved_credits > 0 and (stream_failed or not produced_content):
+            try:
+                refund_ai_credit(org_id, reserved_credits)
+            except Exception:
+                logger.debug("MagicBlock AI credit refund failed", exc_info=True)
 
 
 async def get_org_ai_model(org_id: int, db_session: AsyncSession) -> str:
@@ -117,9 +149,16 @@ async def start_magicblock_session(
     if not org or org.id is None:
         raise HTTPException(status_code=404, detail="Organization not found")
 
+    acting_user_id = resolve_acting_user_id(current_user)
+    if not await is_org_member(acting_user_id, org.id, db_session):
+        raise HTTPException(
+            status_code=403,
+            detail="You are not a member of this organization",
+        )
+
     # F-9: per-user + per-org rate limit before any compute / credit spend.
     from src.services.security.rate_limiting import enforce_ai_rate_limit
-    enforce_ai_rate_limit(resolve_acting_user_id(current_user), org.id)
+    enforce_ai_rate_limit(acting_user_id, org.id)
 
     # Atomically check + deduct AI credits to prevent concurrent-request overdraw.
     await reserve_ai_credit(org.id, db_session, amount=3)
@@ -131,7 +170,8 @@ async def start_magicblock_session(
     session = create_magicblock_session(
         block_uuid=session_request.block_uuid,
         activity_uuid=session_request.activity_uuid,
-        context=session_request.context
+        context=session_request.context,
+        user_id=acting_user_id,
     )
 
     # Generate with streaming
@@ -142,7 +182,7 @@ async def start_magicblock_session(
     )
 
     return StreamingResponse(
-        event_generator(stream, session.session_uuid),
+        event_generator(stream, session.session_uuid, org_id=org.id, reserved_credits=3),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",
@@ -183,6 +223,10 @@ async def iterate_magicblock_session(
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
 
+    acting_user_id = resolve_acting_user_id(current_user)
+    if session.user_id is not None and session.user_id != acting_user_id:
+        raise HTTPException(status_code=404, detail="Session not found")
+
     # Check iteration limit
     if session.iteration_count >= session.max_iterations:
         raise HTTPException(
@@ -216,9 +260,15 @@ async def iterate_magicblock_session(
     if not org or org.id is None:
         raise HTTPException(status_code=404, detail="Organization not found")
 
+    if not await is_org_member(acting_user_id, org.id, db_session):
+        raise HTTPException(
+            status_code=403,
+            detail="You are not a member of this organization",
+        )
+
     # F-9: per-user + per-org rate limit before any compute / credit spend.
     from src.services.security.rate_limiting import enforce_ai_rate_limit
-    enforce_ai_rate_limit(resolve_acting_user_id(current_user), org.id)
+    enforce_ai_rate_limit(acting_user_id, org.id)
 
     # Atomically check + deduct AI credits to prevent concurrent-request overdraw.
     await reserve_ai_credit(org.id, db_session, amount=3)
@@ -238,7 +288,7 @@ async def iterate_magicblock_session(
     )
 
     return StreamingResponse(
-        event_generator(stream, session.session_uuid),
+        event_generator(stream, session.session_uuid, org_id=org.id, reserved_credits=3),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",
@@ -270,6 +320,9 @@ async def get_session_state(
     session = get_magicblock_session(session_uuid)
 
     if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    if session.user_id is not None and session.user_id != resolve_acting_user_id(current_user):
         raise HTTPException(status_code=404, detail="Session not found")
 
     return MagicBlockSessionResponse(

--- a/apps/api/src/routers/ai/magicblocks.py
+++ b/apps/api/src/routers/ai/magicblocks.py
@@ -66,9 +66,12 @@ async def event_generator(
     except asyncio.CancelledError:
         stream_failed = True
         raise
-    except Exception as e:
+    except Exception:
         stream_failed = True
-        yield f"data: {json.dumps({'type': 'error', 'message': str(e)})}\n\n"
+        # Log the full exception server-side; never leak exception/stack-trace
+        # detail to the external client (CodeQL py/stack-trace-exposure).
+        logger.exception("MagicBlock stream failed for session %s", session_uuid)
+        yield f"data: {json.dumps({'type': 'error', 'message': 'Generation failed. Please try again.'})}\n\n"
     finally:
         if org_id is not None and reserved_credits > 0 and (stream_failed or not produced_content):
             try:

--- a/apps/api/src/routers/ai/rag.py
+++ b/apps/api/src/routers/ai/rag.py
@@ -31,6 +31,7 @@ from src.services.ai.base import (
     get_chat_messages,
     delete_chat_session,
     update_chat_session_meta,
+    chat_session_belongs_to_user,
 )
 from src.services.ai.rag.embedding_service import embed_course_content
 from src.services.ai.rag.query_service import query_course_rag_stream
@@ -223,6 +224,10 @@ async def api_rag_chat(
 
     # Get or create chat session
     is_new_session = chat_request.aichat_uuid is None
+    if not is_new_session and not chat_session_belongs_to_user(
+        chat_request.aichat_uuid, chat_acting_user_id
+    ):
+        raise HTTPException(status_code=404, detail="Chat session not found")
     chat_session = get_chat_session_history(chat_request.aichat_uuid)
 
     # Perform RAG query with streaming

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -24,6 +24,7 @@ import httpx
 from src.services.analytics.analytics import track
 from src.services.analytics.cache import get_cached_result, set_cached_result
 from src.services.analytics.events import ALLOWED_FRONTEND_EVENTS
+from src.services.orgs.users import _csv_safe
 from src.services.analytics.queries import (
     ALL_QUERIES,
     ADVANCED_QUERIES,
@@ -859,7 +860,9 @@ async def export_analytics(
         if rows:
             writer = csv.DictWriter(output, fieldnames=rows[0].keys())
             writer.writeheader()
-            writer.writerows(rows)
+            writer.writerows(
+                {k: _csv_safe(v) for k, v in row.items()} for row in rows
+            )
         output.write("\n")
 
     filename = f"analytics_export_{safe_org_id}_{safe_days}d.csv"

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -157,7 +157,7 @@ def set_auth_cookies(response: Response, access_token: str, refresh_token: str, 
         secure=is_secure,
         samesite="lax",
         domain=cookie_domain,
-        expires=int(timedelta(hours=8).total_seconds()),
+        max_age=int(timedelta(hours=8).total_seconds()),
     )
     response.set_cookie(
         key=JWT_REFRESH_COOKIE_NAME,
@@ -166,7 +166,7 @@ def set_auth_cookies(response: Response, access_token: str, refresh_token: str, 
         secure=is_secure,
         samesite="lax",
         domain=cookie_domain,
-        expires=int(timedelta(days=30).total_seconds()),
+        max_age=int(timedelta(days=30).total_seconds()),
     )
 
 
@@ -273,7 +273,7 @@ async def refresh(
         secure=is_secure,
         samesite="lax",
         domain=cookie_domain,
-        expires=int(timedelta(hours=8).total_seconds()),
+        max_age=int(timedelta(hours=8).total_seconds()),
     )
     response.set_cookie(
         key=JWT_REFRESH_COOKIE_NAME,
@@ -282,7 +282,7 @@ async def refresh(
         secure=is_secure,
         samesite="lax",
         domain=cookie_domain,
-        expires=int(JWT_REFRESH_TOKEN_EXPIRES.total_seconds()),
+        max_age=int(JWT_REFRESH_TOKEN_EXPIRES.total_seconds()),
     )
     # Return the rotated refresh token in the body so a Next.js route handler
     # acting as a proxy can mirror the rotation onto its own cookies. Without
@@ -485,11 +485,18 @@ async def third_party_login(
             )
             org_id = None
 
+    user = None
+
     # Google
     if body.provider == "google":
 
         user = await signWithGoogle(
             request, body.access_token, body.email, org_id, current_user, db_session
+        )
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unsupported provider",
         )
 
     if not user:

--- a/apps/api/src/routers/code_execution.py
+++ b/apps/api/src/routers/code_execution.py
@@ -3,6 +3,7 @@ import base64
 import io
 import logging
 import os
+import re
 import zipfile
 
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, Form
@@ -403,7 +404,32 @@ async def upload_sqlite_db(
     if not course_uuid.startswith("course_"):
         raise HTTPException(status_code=400, detail="Invalid course_uuid")
 
+    _SAFE_SEGMENT = re.compile(r"^[A-Za-z0-9_-]+$")
+    for _label, _value in (
+        ("org_uuid", org_uuid),
+        ("activity_uuid", activity_uuid),
+        ("block_id", block_id),
+    ):
+        if not _value or not _SAFE_SEGMENT.match(_value):
+            raise HTTPException(status_code=400, detail=f"Invalid {_label}")
+
     await _require_course_access(request, current_user, course_uuid, "update", db_session)
+
+    from sqlmodel import select
+    from src.db.courses.courses import Course
+    from src.db.organizations import Organization
+
+    course_org_uuid = (
+        await db_session.execute(
+            select(Organization.org_uuid)
+            .join(Course, Course.org_id == Organization.id)
+            .where(Course.course_uuid == course_uuid)
+        )
+    ).scalars().first()
+    if course_org_uuid is None:
+        raise HTTPException(status_code=404, detail="Course not found")
+    if course_org_uuid != org_uuid:
+        raise HTTPException(status_code=400, detail="org_uuid does not match course organization")
 
     directory = f"courses/{course_uuid}/activities/{activity_uuid}/dynamic/blocks/codePlayground/{block_id}"
 

--- a/apps/api/src/routers/code_execution.py
+++ b/apps/api/src/routers/code_execution.py
@@ -120,7 +120,10 @@ def _validate_storage_path(file_path: str) -> str:
     # Resolve to absolute and verify containment within content/
     base_real = os.path.realpath("content")
     full_real = os.path.realpath(full_path)
-    if not full_real.startswith(base_real + os.sep) and full_real != base_real:
+    try:
+        if os.path.commonpath([base_real, full_real]) != base_real:
+            raise HTTPException(status_code=400, detail="Invalid file path")
+    except ValueError:
         raise HTTPException(status_code=400, detail="Invalid file path")
     return full_path
 
@@ -178,7 +181,10 @@ def _read_storage_file(file_path: str) -> bytes:
         # the realpath check to be visible immediately before the file operation).
         base_real = os.path.realpath("content")
         resolved = os.path.realpath(safe_path)  # noqa: S108
-        if not resolved.startswith(base_real + os.sep):
+        try:
+            if os.path.commonpath([base_real, resolved]) != base_real:
+                raise HTTPException(status_code=400, detail="Invalid file path")
+        except ValueError:
             raise HTTPException(status_code=400, detail="Invalid file path")
         if not os.path.isfile(resolved):
             raise HTTPException(status_code=404, detail="SQLite database file not found")

--- a/apps/api/src/routers/content_files.py
+++ b/apps/api/src/routers/content_files.py
@@ -187,9 +187,9 @@ async def _check_content_access(
     if len(parts) >= 2 and parts[0] == 'users':
         return
 
-    # Unknown path pattern — require auth as a safe default
     if isinstance(current_user, AnonymousUser):
         raise HTTPException(status_code=401, detail="Authentication required")
+    raise HTTPException(status_code=403, detail="Access denied")
 
 
 @router.get(

--- a/apps/api/src/routers/local_content.py
+++ b/apps/api/src/routers/local_content.py
@@ -43,15 +43,12 @@ def _validate_content_path(file_path: str) -> Path | None:
     if '..' in normalized:  # pragma: no cover
         return None
 
-    # Canonicalize via os.path.realpath (resolves symlinks, normalizes) and verify containment.
-    # realpath is used deliberately: it is a recognized path-injection sanitizer.
     try:
         base_real = os.path.realpath(str(CONTENT_DIR))
         full_real = os.path.realpath(os.path.join(base_real, normalized))
+        if os.path.commonpath([base_real, full_real]) != base_real:
+            return None
     except (OSError, ValueError):
-        return None
-
-    if not full_real.startswith(base_real + os.sep) and full_real != base_real:
         return None
 
     return Path(full_real)

--- a/apps/api/src/security/auth.py
+++ b/apps/api/src/security/auth.py
@@ -398,13 +398,17 @@ async def get_current_user(
             # are only valid at their specific consume endpoint — allowing them as
             # session tokens would let an intercepted single-use token act as a
             # full session for its entire TTL.
-            # A token with no "purpose" key (purpose is None via .get) is treated
-            # as a normal session token and is allowed through. A token that
-            # explicitly carries purpose="session" is also allowed. Any other
-            # purpose value — including "password_reset" and "email_verification"
-            # — is rejected.
             token_purpose = payload.get("purpose")
-            if token_purpose is not None and token_purpose != "session":
+            SINGLE_USE_PURPOSES = {
+                "reset",
+                "verify",
+                "email_verification",
+                "magic_link",
+                "password_reset",
+            }
+            if token_purpose in SINGLE_USE_PURPOSES or (
+                token_purpose is not None and token_purpose != "session"
+            ):
                 raise credentials_exception
             username = payload.get("sub")
 

--- a/apps/api/src/security/csrf.py
+++ b/apps/api/src/security/csrf.py
@@ -63,7 +63,7 @@ class CSRFProtectionMiddleware(BaseHTTPMiddleware):
         if origin in self.allowed_origins:
             return True
 
-        if self.compiled_regexp and self.compiled_regexp.match(origin):
+        if self.compiled_regexp and self.compiled_regexp.fullmatch(origin):
             return True
 
         if self.development_mode:
@@ -86,11 +86,6 @@ class CSRFProtectionMiddleware(BaseHTTPMiddleware):
             referer_origin = self._extract_origin_from_url(referer)
             if referer_origin:
                 return self._is_origin_allowed(referer_origin)
-
-        # No Origin and no Referer — in development mode, allow these
-        # (server-side proxies like Next.js strip the Origin header)
-        if self.development_mode:
-            return True
 
         return False
 

--- a/apps/api/src/security/features_utils/usage.py
+++ b/apps/api/src/security/features_utils/usage.py
@@ -989,6 +989,11 @@ async def get_ai_credits_summary(org_id: int, db_session: AsyncSession) -> dict:
 
     base_credits = get_ai_credit_limit(org_plan)
 
+    config = org_config.config or {}
+    extra = 0
+    if config.get("config_version", "1.0").startswith("2"):
+        extra = config.get("overrides", {}).get("ai", {}).get("extra_limit", 0) or 0
+
     # Batch-fetch both keys in a single round-trip
     purchased_raw, used_raw = r.mget(
         f"ai_credits_purchased:{org_id}",
@@ -1007,7 +1012,7 @@ async def get_ai_credits_summary(org_id: int, db_session: AsyncSession) -> dict:
             "remaining_credits": "unlimited",
         }
 
-    total_credits = base_credits + purchased_credits_count
+    total_credits = base_credits + extra + purchased_credits_count
     remaining_credits = max(0, total_credits - used_credits_count)
 
     return {

--- a/apps/api/src/security/file_validation.py
+++ b/apps/api/src/security/file_validation.py
@@ -161,6 +161,50 @@ FILE_TYPES = {
 }
 
 
+EXT_TO_CANONICAL_MIME = {
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.png': 'image/png',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp',
+    '.mp4': 'video/mp4',
+    '.webm': 'video/webm',
+    '.pdf': 'application/pdf',
+    '.mp3': 'audio/mpeg',
+    '.wav': 'audio/wav',
+    '.ogg': 'audio/ogg',
+    '.m4a': 'audio/mp4',
+    '.zip': 'application/zip',
+    '.sqlite': 'application/vnd.sqlite3',
+    '.db': 'application/vnd.sqlite3',
+    '.sqlite3': 'application/vnd.sqlite3',
+    '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+}
+
+
+MIME_TO_SAFE_EXT = {
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+    'image/gif': 'gif',
+    'image/webp': 'webp',
+    'video/mp4': 'mp4',
+    'video/webm': 'webm',
+    'application/pdf': 'pdf',
+    'audio/mpeg': 'mp3',
+    'audio/wav': 'wav',
+    'audio/ogg': 'ogg',
+    'audio/mp4': 'm4a',
+    'application/zip': 'zip',
+    'application/x-zip-compressed': 'zip',
+    'application/vnd.sqlite3': 'sqlite3',
+    'application/x-sqlite3': 'sqlite3',
+    'application/octet-stream': 'bin',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'pptx',
+}
+
+
 def validate_upload(
     file: UploadFile,
     allowed_types: List[str],
@@ -214,18 +258,38 @@ def validate_upload(
     # Validate file content
     if not config['validator'](content):
         raise HTTPException(status_code=415, detail="File appears to be corrupted or invalid")
-    
-    return file.content_type, content
+
+    canonical_type = EXT_TO_CANONICAL_MIME.get(ext, file.content_type)
+    return canonical_type, content
 
 
-def get_safe_filename(original_filename: str, prefix: str = "") -> str:
-    """Generate a safe filename with UUID and validated extension."""
+def get_safe_filename(
+    original_filename: str,
+    prefix: str = "",
+    content_type: Optional[str] = None,
+) -> str:
+    """Generate a safe filename with a UUID prefix and a safe extension.
+
+    When ``content_type`` is provided (the validated, server-determined MIME
+    type from ``validate_upload``), the stored extension is derived from that
+    type via ``MIME_TO_SAFE_EXT`` — NOT from the client-supplied filename.
+    This prevents a client from controlling the stored file's extension (e.g.
+    uploading image bytes under a ".html" name). When no content_type is
+    given, fall back to the (sanitized) client extension for backward
+    compatibility.
+    """
+    if content_type is not None:
+        safe_ext = MIME_TO_SAFE_EXT.get(content_type)
+        if safe_ext:
+            return f"{prefix}.{safe_ext}"
+        return f"{prefix}.bin"
+
     if not original_filename:
         return f"{prefix}.bin"
-    
+
     ext = original_filename.split('.')[-1].lower()
     # Only allow safe alphanumeric extensions
     if re.match(r'^[a-zA-Z0-9]+$', ext):
         return f"{prefix}.{ext}"
-    
+
     return f"{prefix}.bin"

--- a/apps/api/src/security/rbac/utils.py
+++ b/apps/api/src/security/rbac/utils.py
@@ -195,4 +195,8 @@ async def get_element_organization_id(
         from src.db.boards import Board
         return (await db_session.execute(select(Board.org_id).where(Board.board_uuid == element_uuid))).scalars().first()
 
+    elif element_type == "playgrounds":
+        from src.db.playgrounds import Playground
+        return (await db_session.execute(select(Playground.org_id).where(Playground.playground_uuid == element_uuid))).scalars().first()
+
     return None

--- a/apps/api/src/services/admin/admin.py
+++ b/apps/api/src/services/admin/admin.py
@@ -1216,7 +1216,7 @@ def _validate_magic_link_redirect(redirect_to: Optional[str]) -> Optional[str]:
         raise HTTPException(status_code=400, detail=detail)
 
     parts = urlsplit(value.replace("\\", "/"))
-    if parts.scheme or parts.netloc:
+    if parts.scheme or parts.netloc:  # pragma: no cover
         raise HTTPException(status_code=400, detail=detail)
 
     return value

--- a/apps/api/src/services/admin/admin.py
+++ b/apps/api/src/services/admin/admin.py
@@ -1205,18 +1205,19 @@ def _validate_magic_link_redirect(redirect_to: Optional[str]) -> Optional[str]:
     if not value:
         return None
 
-    lowered = value.lower()
-    if "://" in lowered or lowered.startswith("//") or lowered.startswith("\\\\"):
-        raise HTTPException(
-            status_code=400,
-            detail="redirect_to must be a same-origin path starting with '/'",
-        )
+    from urllib.parse import urlsplit
+
+    detail = "redirect_to must be a same-origin path starting with '/'"
 
     if not value.startswith("/"):
-        raise HTTPException(
-            status_code=400,
-            detail="redirect_to must be a same-origin path starting with '/'",
-        )
+        raise HTTPException(status_code=400, detail=detail)
+
+    if len(value) >= 2 and value[1] in ("/", "\\"):
+        raise HTTPException(status_code=400, detail=detail)
+
+    parts = urlsplit(value.replace("\\", "/"))
+    if parts.scheme or parts.netloc:
+        raise HTTPException(status_code=400, detail=detail)
 
     return value
 

--- a/apps/api/src/services/ai/ai.py
+++ b/apps/api/src/services/ai/ai.py
@@ -442,16 +442,20 @@ async def ai_start_activity_chat_session_stream(
     # Atomic credit reservation to prevent concurrent over-use.
     await reserve_ai_credit(org.id, db_session)
 
-    chat_session = get_chat_session_history()
+    try:
+        chat_session = get_chat_session_history()
 
-    message = "You are a helpful Education Assistant, and you are helping a student with the associated Course. "
-    message += "Use the course content provided to answer questions about the course material."
-    message += "For context, this is the Course name: "
-    message += course.name
-    message += " and this is the Lecture name: "
-    message += activity.name
-    message += "."
-    message += "Use your knowledge to help the student if the context is not enough."
+        message = "You are a helpful Education Assistant, and you are helping a student with the associated Course. "
+        message += "Use the course content provided to answer questions about the course material."
+        message += "For context, this is the Course name: "
+        message += course.name
+        message += " and this is the Lecture name: "
+        message += activity.name
+        message += "."
+        message += "Use your knowledge to help the student if the context is not enough."
+    except Exception:
+        refund_ai_credit(org.id)
+        raise
 
     return {
         "chat_session": chat_session,
@@ -487,16 +491,20 @@ async def ai_send_activity_chat_message_stream(
     # Atomic credit reservation to prevent concurrent over-use.
     await reserve_ai_credit(org.id, db_session)
 
-    chat_session = get_chat_session_history(chat_session_object.aichat_uuid)
+    try:
+        chat_session = get_chat_session_history(chat_session_object.aichat_uuid)
 
-    message = "You are a helpful Education Assistant, and you are helping a student with the associated Course. "
-    message += "Use the course content provided to answer questions about the course material."
-    message += "For context, this is the Course name: "
-    message += course.name
-    message += " and this is the Lecture name: "
-    message += activity.name
-    message += "."
-    message += "Use your knowledge to help the student if the context is not enough."
+        message = "You are a helpful Education Assistant, and you are helping a student with the associated Course. "
+        message += "Use the course content provided to answer questions about the course material."
+        message += "For context, this is the Course name: "
+        message += course.name
+        message += " and this is the Lecture name: "
+        message += activity.name
+        message += "."
+        message += "Use your knowledge to help the student if the context is not enough."
+    except Exception:
+        refund_ai_credit(org.id)
+        raise
 
     return {
         "chat_session": chat_session,

--- a/apps/api/src/services/ai/base.py
+++ b/apps/api/src/services/ai/base.py
@@ -234,6 +234,30 @@ def update_chat_session_meta(aichat_uuid: str, user_id: int, title: Optional[str
         return None
 
 
+def chat_session_belongs_to_user(aichat_uuid: str, user_id: int) -> bool:
+    """Return True if the chat session is owned by ``user_id``.
+
+    Ownership is recorded in the ``chat_meta:<uuid>`` Redis key (see
+    :func:`save_chat_session_meta`). A session with no metadata (brand-new or
+    expired) is treated as ownable by the caller — the IDOR risk we guard
+    against is reusing *another* user's existing session, which always has a
+    populated ``user_id``. This mirrors the ownership check in
+    :func:`get_chat_messages` / :func:`delete_chat_session`.
+    """
+    r = _get_redis()
+    if not r:
+        return True
+    try:
+        meta_data = r.get(f"chat_meta:{aichat_uuid}")
+        if not meta_data:
+            return True
+        meta = json.loads(meta_data.decode("utf-8") if isinstance(meta_data, bytes) else meta_data)
+        return meta.get("user_id") == user_id
+    except Exception as e:
+        logger.error("Failed to verify chat session ownership: %s", e, exc_info=True)
+        return False
+
+
 def get_user_chat_sessions(user_id: int, org_id: Optional[int] = None) -> list[dict]:
     """Return all chat sessions for a user, newest first. Optionally filter by org_id."""
     r = _get_redis()

--- a/apps/api/src/services/ai/magicblocks.py
+++ b/apps/api/src/services/ai/magicblocks.py
@@ -60,7 +60,8 @@ def get_magicblock_session(session_uuid: str) -> Optional[MagicBlockSessionData]
 def create_magicblock_session(
     block_uuid: str,
     activity_uuid: str,
-    context: MagicBlockContext
+    context: MagicBlockContext,
+    user_id: Optional[int] = None,
 ) -> MagicBlockSessionData:
     """Create a new MagicBlock session"""
     session_uuid = f"mb_{uuid4()}"
@@ -73,7 +74,8 @@ def create_magicblock_session(
         max_iterations=MAX_ITERATIONS,
         message_history=[],
         current_html=None,
-        context=context
+        context=context,
+        user_id=user_id,
     )
 
     save_magicblock_session(session)

--- a/apps/api/src/services/ai/magicblocks.py
+++ b/apps/api/src/services/ai/magicblocks.py
@@ -298,8 +298,14 @@ Please modify the HTML code above according to the user's request. Output ONLY t
 
         save_magicblock_session(session)
 
-    except Exception as e:
-        yield f"Error: {str(e)}"
+    except Exception:
+        # Re-raise instead of yielding the error as a content chunk. Yielding
+        # "Error: {e}" both leaked exception detail to the client and defeated
+        # the caller's credit-refund logic (a non-empty chunk read as success).
+        # event_generator's handler emits a sanitized SSE error event and
+        # refunds the reserved credits.
+        logger.exception("MagicBlock generation failed")
+        raise
 
 
 def extract_html_from_response(response: str) -> str:

--- a/apps/api/src/services/ai/rag/content_extraction.py
+++ b/apps/api/src/services/ai/rag/content_extraction.py
@@ -11,6 +11,7 @@ Extracts text from all course content types:
 """
 
 import logging
+import os
 from typing import Optional
 
 from sqlmodel import select
@@ -26,6 +27,24 @@ from src.services.courses.transfer.storage_utils import read_file_content
 logger = logging.getLogger(__name__)
 
 MAX_PDF_CHARS = 100_000
+
+
+def _is_safe_content_path(file_path: str) -> bool:
+    """Reject obviously unsafe stored-file paths before reading them.
+
+    Block values (file_id/uri/file_path) are persisted from user input, so
+    guard against traversal here in addition to the containment check in
+    read_file_content (S8). Rejects empty paths, NUL bytes, absolute paths and
+    any ``..`` component.
+    """
+    if not file_path or not isinstance(file_path, str) or "\x00" in file_path:
+        return False
+    normalized = file_path.replace("\\", "/")
+    if normalized.startswith("/") or os.path.isabs(file_path):
+        return False
+    if ".." in normalized.split("/"):
+        return False
+    return True
 
 
 def extract_text_from_prosemirror(content: dict) -> str:
@@ -181,7 +200,7 @@ def _extract_block_content(block: Block, activity_name: str) -> Optional[dict]:
     if block_type == BlockTypeEnum.BLOCK_DOCUMENT_PDF:
         # Read PDF file and extract text
         file_path = content.get("file_id") or content.get("uri") or content.get("file_path", "")
-        if not file_path:
+        if not file_path or not _is_safe_content_path(file_path):
             return None
         pdf_bytes = read_file_content(file_path)
         if not pdf_bytes:
@@ -332,7 +351,7 @@ async def extract_all_course_content(
             content = activity.content
             if content and isinstance(content, dict):
                 file_path = content.get("file_id") or content.get("uri") or content.get("file_path", "")
-                if file_path:
+                if file_path and _is_safe_content_path(file_path):
                     pdf_bytes = read_file_content(file_path)
                     if pdf_bytes:
                         text = extract_text_from_pdf(pdf_bytes)

--- a/apps/api/src/services/ai/schemas/magicblocks.py
+++ b/apps/api/src/services/ai/schemas/magicblocks.py
@@ -46,3 +46,4 @@ class MagicBlockSessionData(BaseModel):
     message_history: List[MagicBlockMessage]
     current_html: Optional[str]
     context: MagicBlockContext
+    user_id: Optional[int] = None

--- a/apps/api/src/services/boards/boards.py
+++ b/apps/api/src/services/boards/boards.py
@@ -34,6 +34,8 @@ async def create_board(
 ) -> BoardRead:
     await check_resource_access(request, db_session, current_user, "board_x", AccessAction.CREATE)
 
+    await require_org_membership(resolve_acting_user_id(current_user), org_id, db_session)
+
     board = Board(
         **board_object.model_dump(),
         org_id=org_id,
@@ -157,6 +159,8 @@ async def duplicate_board(
     await check_resource_access(request, db_session, current_user, source.board_uuid, AccessAction.READ)
     # Also need create permission
     await check_resource_access(request, db_session, current_user, "board_x", AccessAction.CREATE)
+
+    await require_org_membership(resolve_acting_user_id(current_user), source.org_id, db_session)
 
     board = Board(
         org_id=source.org_id,

--- a/apps/api/src/services/communities/votes.py
+++ b/apps/api/src/services/communities/votes.py
@@ -3,6 +3,8 @@ from uuid import uuid4
 from datetime import datetime
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlalchemy import update as sql_update
+from sqlalchemy.exc import IntegrityError
 from fastapi import HTTPException, Request
 
 from src.db.users import PublicUser, AnonymousUser, APITokenUser
@@ -50,35 +52,41 @@ async def upvote_discussion(
         request, db_session, current_user, community.community_uuid, AccessAction.READ
     )
 
-    # Check if user has already voted
-    existing_vote_statement = select(DiscussionVote).where(
-        DiscussionVote.discussion_id == discussion.id,
-        DiscussionVote.user_id == current_user.id,
-    )
-    existing_vote = (await db_session.execute(existing_vote_statement)).scalars().first()
-
+    existing_vote = (await db_session.execute(
+        select(DiscussionVote).where(
+            DiscussionVote.discussion_id == discussion.id,
+            DiscussionVote.user_id == current_user.id,
+        )
+    )).scalars().first()
     if existing_vote:
         raise HTTPException(
             status_code=400,
             detail="You have already upvoted this discussion",
         )
 
-    # Create vote
     vote = DiscussionVote(
         discussion_id=discussion.id,
         user_id=current_user.id,
         vote_uuid=f"vote_{uuid4()}",
         creation_date=str(datetime.now()),
     )
+    try:
+        db_session.add(vote)
+        await db_session.execute(
+            sql_update(Discussion)
+            .where(Discussion.id == discussion.id)
+            .values(upvote_count=Discussion.upvote_count + 1)
+        )
+        await db_session.commit()
+    except IntegrityError:
+        await db_session.rollback()
+        raise HTTPException(
+            status_code=400,
+            detail="You have already upvoted this discussion",
+        )
 
-    db_session.add(vote)
-
-    # Increment upvote count
-    discussion.upvote_count += 1
-    db_session.add(discussion)
-
-    await db_session.commit()
     await db_session.refresh(vote)
+    await db_session.refresh(discussion)
 
     await dispatch_webhooks(
         event_name="discussion_vote_cast",

--- a/apps/api/src/services/courses/activities/assignments.py
+++ b/apps/api/src/services/courses/activities/assignments.py
@@ -72,6 +72,27 @@ def _block_api_tokens(current_user: PublicUser | AnonymousUser | APITokenUser) -
         )
 
 
+def _is_assignment_past_due(assignment: Assignment) -> bool:
+    """Return True if the assignment has a due_date set and it is in the past.
+
+    due_date is stored as a free-form string. We parse it defensively: if it
+    is empty or unparseable, we treat the deadline as NOT set (return False)
+    so a malformed value never locks students out. Comparison is done with a
+    naive ``datetime.now()`` to match the rest of this module (all timestamps
+    here are naive local-time strings produced by ``datetime.now()``).
+    """
+    raw = getattr(assignment, "due_date", None)
+    if not raw or not str(raw).strip():
+        return False
+    try:
+        parsed = datetime.fromisoformat(str(raw).strip())
+    except (ValueError, TypeError):
+        return False
+    if parsed.tzinfo is not None:
+        parsed = parsed.replace(tzinfo=None)
+    return parsed < datetime.now()
+
+
 ## > Grade computation
 
 # Default passing threshold as a percentage (0-100). Used for PASS_FAIL,
@@ -1313,14 +1334,17 @@ async def handle_assignment_task_submission(
                 status_code=403,
                 detail="You must be enrolled in this course to submit assignments"
             )
-        
-        # SECURITY: Regular users cannot update grades - only check if actual values are being set
-        if (assignment_task_submission_object.grade is not None and assignment_task_submission_object.grade != 0) or \
-           (assignment_task_submission_object.task_submission_grade_feedback is not None and assignment_task_submission_object.task_submission_grade_feedback != ""):
+
+        if _is_assignment_past_due(assignment):
             raise HTTPException(
                 status_code=403,
-                detail="You do not have permission to update grades"
+                detail="Assignment deadline has passed",
             )
+
+        assignment_task_submission_object.grade = None
+        assignment_task_submission_object.task_submission_grade_feedback = None
+        assignment_task_submission_object.assignment_task_id = None
+        assignment_task_submission_object.assignment_type = None
 
         # Only need read permission for submissions
         await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
@@ -1675,8 +1699,23 @@ async def update_assignment_task_submission(
             detail="Course not found",
         )
 
-    # RBAC check
-    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
+    is_instructor = await authorization_verify_based_on_roles(
+        request, current_user.id, "update", course.course_uuid, db_session
+    )
+
+    if is_instructor:
+        await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
+    else:
+        await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
+        if assignment_task_submission.user_id != current_user.id:
+            raise HTTPException(
+                status_code=403,
+                detail="You can only update your own submissions",
+            )
+        assignment_task_submission_object.grade = None
+        assignment_task_submission_object.task_submission_grade_feedback = None
+        assignment_task_submission_object.assignment_task_id = None
+        assignment_task_submission_object.assignment_type = None
 
     # Update only the fields that were passed in
     for var, value in vars(assignment_task_submission_object).items():
@@ -1811,6 +1850,15 @@ async def create_assignment_submission(
 
     # RBAC check
     await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
+
+    is_instructor = await authorization_verify_based_on_roles(
+        request, current_user.id, "update", course.course_uuid, db_session
+    )
+    if not is_instructor and _is_assignment_past_due(assignment):
+        raise HTTPException(
+            status_code=403,
+            detail="Assignment deadline has passed",
+        )
 
     # Either reuse the existing PENDING row (retry path) or create a fresh
     # submission. On the retry path we keep the original
@@ -2201,6 +2249,9 @@ async def update_assignment_submission(
                 status_code=403,
                 detail="You can only update your own submissions",
             )
+        for protected_field in ("grade", "submission_status", "user_id", "assignment_id"):
+            if hasattr(assignment_user_submission_object, protected_field):
+                setattr(assignment_user_submission_object, protected_field, None)
 
     # Update only the fields that were passed in
     for var, value in vars(assignment_user_submission_object).items():

--- a/apps/api/src/services/courses/activities/assignments.py
+++ b/apps/api/src/services/courses/activities/assignments.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import math
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
 from uuid import uuid4
 from fastapi import HTTPException, Request, UploadFile
 from sqlmodel import select
@@ -84,12 +84,19 @@ def _is_assignment_past_due(assignment: Assignment) -> bool:
     raw = getattr(assignment, "due_date", None)
     if not raw or not str(raw).strip():
         return False
+    raw_str = str(raw).strip()
     try:
-        parsed = datetime.fromisoformat(str(raw).strip())
+        parsed = datetime.fromisoformat(raw_str)
     except (ValueError, TypeError):
         return False
     if parsed.tzinfo is not None:
         parsed = parsed.replace(tzinfo=None)
+    # A date-only deadline (e.g. "2026-06-12", produced by an HTML
+    # <input type="date">) parses to midnight. The whole due day should still
+    # count as on time, so treat a value with no time component as end-of-day
+    # by shifting the cutoff to the following midnight.
+    if "T" not in raw_str and ":" not in raw_str:
+        parsed = parsed + timedelta(days=1)
     return parsed < datetime.now()
 
 

--- a/apps/api/src/services/courses/certifications.py
+++ b/apps/api/src/services/courses/certifications.py
@@ -427,7 +427,13 @@ async def is_course_fully_completed(
         return False
 
     completed_activities = (await db_session.execute(
-        select(func.count(TrailStep.id)).where(
+        select(func.count(func.distinct(TrailStep.activity_id)))
+        .join(
+            ChapterActivity,
+            (ChapterActivity.activity_id == TrailStep.activity_id)
+            & (ChapterActivity.course_id == TrailStep.course_id),
+        )
+        .where(
             TrailStep.user_id == user_id,
             TrailStep.course_id == course_id,
             TrailStep.complete == True,
@@ -466,7 +472,13 @@ async def check_course_completion_and_create_certificate(
         return False  # No activities in course
 
     completed_count = (await db_session.execute(
-        select(func.count(TrailStep.id)).where(
+        select(func.count(func.distinct(TrailStep.activity_id)))
+        .join(
+            ChapterActivity,
+            (ChapterActivity.activity_id == TrailStep.activity_id)
+            & (ChapterActivity.course_id == TrailStep.course_id),
+        )
+        .where(
             TrailStep.user_id == user_id,
             TrailStep.course_id == course_id,
             TrailStep.complete == True,

--- a/apps/api/src/services/courses/chapters.py
+++ b/apps/api/src/services/courses/chapters.py
@@ -169,6 +169,8 @@ async def update_chapter(
 
     # Update only the fields that were passed in
     for var, value in vars(chapter_object).items():
+        if var in ("org_id", "course_id"):
+            continue
         if value is not None:
             setattr(chapter, var, value)
 
@@ -560,6 +562,18 @@ async def reorder_chapters_and_activities(
     # Create a map of existing chapters for faster lookup
     existing_chapter_map = {cc.chapter_id: cc for cc in existing_course_chapters}
 
+    unlinked_chapter_ids = [
+        co.chapter_id
+        for co in chapters_order.chapter_order_by_ids
+        if co.chapter_id not in existing_chapter_map
+    ]
+    chapter_owner_map = {}
+    if unlinked_chapter_ids:
+        rows = (await db_session.execute(
+            select(Chapter).where(Chapter.id.in_(unlinked_chapter_ids))  # type: ignore
+        )).scalars().all()
+        chapter_owner_map = {c.id: c for c in rows}
+
     # Update or create course chapters based on new order
     for index, chapter_order in enumerate(chapters_order.chapter_order_by_ids):
         if chapter_order.chapter_id in existing_chapter_map:
@@ -568,6 +582,12 @@ async def reorder_chapters_and_activities(
             course_chapter.order = index
             db_session.add(course_chapter)
         else:
+            owner = chapter_owner_map.get(chapter_order.chapter_id)
+            if owner is None or owner.course_id != course.id or owner.org_id != course.org_id:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Chapter {chapter_order.chapter_id} is not part of this course",
+                )
             # Create new course chapter
             course_chapter = CourseChapter(
                 chapter_id=chapter_order.chapter_id,
@@ -599,9 +619,22 @@ async def reorder_chapters_and_activities(
 
     # Create a map for faster lookup
     existing_activity_map = {
-        (ca.chapter_id, ca.activity_id): ca 
+        (ca.chapter_id, ca.activity_id): ca
         for ca in existing_chapter_activities
     }
+
+    valid_chapter_ids = {co.chapter_id for co in chapters_order.chapter_order_by_ids}
+    requested_activity_ids = {
+        ao.activity_id
+        for co in chapters_order.chapter_order_by_ids
+        for ao in co.activities_order_by_ids
+    }
+    activity_owner_map = {}
+    if requested_activity_ids:
+        rows = (await db_session.execute(
+            select(Activity).where(Activity.id.in_(requested_activity_ids))  # type: ignore
+        )).scalars().all()
+        activity_owner_map = {a.id: a for a in rows}
 
     # Track which activities we want to keep
     activities_to_keep = set()
@@ -610,14 +643,29 @@ async def reorder_chapters_and_activities(
     for chapter_order in chapters_order.chapter_order_by_ids:
         for index, activity_order in enumerate(chapter_order.activities_order_by_ids):
             activity_key = (chapter_order.chapter_id, activity_order.activity_id)
-            activities_to_keep.add(activity_key)
 
             if activity_key in existing_activity_map:
+                activities_to_keep.add(activity_key)
                 # Update existing activity order
                 chapter_activity = existing_activity_map[activity_key]
                 chapter_activity.order = index
                 db_session.add(chapter_activity)
             else:
+                owner = activity_owner_map.get(activity_order.activity_id)
+                if (
+                    chapter_order.chapter_id not in valid_chapter_ids
+                    or owner is None
+                    or owner.course_id != course.id
+                    or owner.org_id != course.org_id
+                ):
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=(
+                            f"Activity {activity_order.activity_id} or chapter "
+                            f"{chapter_order.chapter_id} is not part of this course"
+                        ),
+                    )
+                activities_to_keep.add(activity_key)
                 # Create new chapter activity
                 chapter_activity = ChapterActivity(
                     chapter_id=chapter_order.chapter_id,

--- a/apps/api/src/services/courses/collections.py
+++ b/apps/api/src/services/courses/collections.py
@@ -107,6 +107,11 @@ async def create_collection(
             course = (await db_session.execute(statement)).scalars().first()
             
             if course:
+                if course.org_id != collection.org_id:
+                    raise HTTPException(
+                        status_code=403,
+                        detail=f"Course {course.name} does not belong to this organization",
+                    )
                 # Verify user has read access to the course before adding it to collection
                 try:
                     await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
@@ -194,6 +199,11 @@ async def update_collection(
 
     # Add new collection_courses
     for course in courses or []:
+        course_statement = select(Course).where(Course.id == int(course))
+        course_obj = (await db_session.execute(course_statement)).scalars().first()
+        if not course_obj or course_obj.org_id != collection.org_id:
+            continue
+
         collection_course = CollectionCourse(
             collection_id=int(collection.id),  # type: ignore
             course_id=int(course),

--- a/apps/api/src/services/courses/courses.py
+++ b/apps/api/src/services/courses/courses.py
@@ -25,6 +25,7 @@ from src.db.courses.courses import (
     ThumbnailType,
 )
 from src.security.auth import resolve_acting_user_id
+from src.security.org_auth import require_org_membership
 from src.security.rbac.rbac import (
     authorization_verify_if_user_is_anon,
     authorization_verify_based_on_org_admin_status,
@@ -594,11 +595,15 @@ async def create_course(
     # For now, we'll use the existing RBAC check but with proper organization context
     await check_resource_access(request, db_session, current_user, "course_x", AccessAction.CREATE)
 
+    await require_org_membership(
+        resolve_acting_user_id(current_user), org_id, db_session
+    )
+
     # Usage check
     await check_limits_with_usage("courses", org_id, db_session)
 
     # Complete course object
-    course.org_id = course.org_id
+    course.org_id = org_id
 
     # Get org uuid
     org_statement = select(Organization).where(Organization.id == org_id)

--- a/apps/api/src/services/courses/transfer/import_service.py
+++ b/apps/api/src/services/courses/transfer/import_service.py
@@ -107,7 +107,10 @@ def _safe_manifest_join(extract_dir: str, manifest_path: Optional[str]) -> Optio
     target = os.path.join(extract_dir, safe)
     base_real = os.path.realpath(extract_dir)
     target_real = os.path.realpath(target)
-    if target_real != base_real and not target_real.startswith(base_real + os.sep):
+    try:
+        if os.path.commonpath([base_real, target_real]) != base_real:
+            return None
+    except ValueError:
         return None
     return target
 
@@ -232,7 +235,11 @@ async def analyze_import_package(
                 # extract_dir (shouldn't happen with a fresh uuid4 tempdir but
                 # defense in depth) cannot redirect the write.
                 resolved = os.path.realpath(target_path)
-                if not (resolved == abs_extract or resolved.startswith(abs_extract + os.sep)):
+                try:
+                    contained = os.path.commonpath([abs_extract, resolved]) == abs_extract
+                except ValueError:
+                    contained = False
+                if not contained:
                     continue
 
                 if info.is_dir():

--- a/apps/api/src/services/courses/transfer/import_service.py
+++ b/apps/api/src/services/courses/transfer/import_service.py
@@ -91,6 +91,27 @@ def sanitize_path(path: str) -> str:
     return sanitized
 
 
+def _safe_manifest_join(extract_dir: str, manifest_path: Optional[str]) -> Optional[str]:
+    """Safely resolve a manifest-supplied relative path under extract_dir.
+
+    manifest.json ``path`` values are attacker-controlled (they come from the
+    uploaded package), so they must be sanitized exactly like zip entry names
+    and re-verified to stay inside extract_dir (S13). Returns the joined path
+    on success, or None if the path is empty, missing, or escapes extract_dir.
+    """
+    if not manifest_path or not isinstance(manifest_path, str):
+        return None
+    safe = sanitize_path(manifest_path)
+    if not safe:
+        return None
+    target = os.path.join(extract_dir, safe)
+    base_real = os.path.realpath(extract_dir)
+    target_real = os.path.realpath(target)
+    if target_real != base_real and not target_real.startswith(base_real + os.sep):
+        return None
+    return target
+
+
 async def analyze_import_package(
     request: Request,
     zip_file: UploadFile,
@@ -247,7 +268,9 @@ async def analyze_import_package(
         # Analyze courses in the package
         courses_info = []
         for course_entry in manifest.get("courses", []):
-            course_path = os.path.join(extract_dir, course_entry.get("path", ""))
+            course_path = _safe_manifest_join(extract_dir, course_entry.get("path", ""))
+            if not course_path:
+                continue
             course_json_path = os.path.join(course_path, "course.json")
 
             if not os.path.exists(course_json_path):
@@ -372,7 +395,9 @@ async def import_courses(
         cid = entry.get("course_uuid")
         cpath = entry.get("path")
         if cid and cpath:
-            course_paths[cid] = os.path.join(extract_dir, cpath)
+            safe_course_path = _safe_manifest_join(extract_dir, cpath)
+            if safe_course_path:
+                course_paths[cid] = safe_course_path
 
     results = []
     successful = 0
@@ -467,6 +492,9 @@ async def _import_single_course(
     """
     Import a single course from the extracted package.
     """
+    if not course_path or ".." in str(course_path).replace("\\", "/").split("/"):
+        raise HTTPException(status_code=400, detail="Invalid course path in package")
+
     # Load course data
     with open(os.path.join(course_path, "course.json"), 'r') as f:
         course_data = json.load(f)

--- a/apps/api/src/services/courses/transfer/storage_utils.py
+++ b/apps/api/src/services/courses/transfer/storage_utils.py
@@ -46,7 +46,10 @@ def _validate_local_path(file_path: str) -> Optional[str]:
 
     base_real = os.path.realpath(_CONTENT_ROOT)
     full_real = os.path.realpath(file_path)
-    if full_real != base_real and not full_real.startswith(base_real + os.sep):
+    try:
+        if os.path.commonpath([base_real, full_real]) != base_real:
+            return None
+    except ValueError:
         return None
 
     return file_path

--- a/apps/api/src/services/courses/transfer/storage_utils.py
+++ b/apps/api/src/services/courses/transfer/storage_utils.py
@@ -23,6 +23,34 @@ logger = logging.getLogger(__name__)
 _s3_client = None
 _s3_client_lock = threading.Lock()
 
+_CONTENT_ROOT = "content"
+
+
+def _validate_local_path(file_path: str) -> Optional[str]:
+    """Validate a local filesystem path for reading.
+
+    Rejects NUL bytes, ``..`` traversal components and absolute paths, then
+    verifies the resolved real path stays within the content root. Returns the
+    path to open on success, or None if the path is unsafe / out of bounds
+    (callers treat None as "not found").
+    """
+    if not file_path or "\x00" in file_path:
+        return None
+
+    normalized = file_path.replace("\\", "/")
+
+    if normalized.startswith("/") or os.path.isabs(file_path):
+        return None
+    if ".." in normalized.split("/"):
+        return None
+
+    base_real = os.path.realpath(_CONTENT_ROOT)
+    full_real = os.path.realpath(file_path)
+    if full_real != base_real and not full_real.startswith(base_real + os.sep):
+        return None
+
+    return file_path
+
 
 @functools.cache
 def get_content_delivery_type() -> str:
@@ -107,9 +135,12 @@ def read_file_content(file_path: str) -> Optional[bytes]:
                 return None
         return None
     else:
-        # Read from local filesystem
-        if os.path.exists(file_path):
-            with open(file_path, 'rb') as f:
+        safe_path = _validate_local_path(file_path)
+        if safe_path is None:
+            logger.warning("Rejected unsafe local file path: %s", file_path)
+            return None
+        if os.path.isfile(safe_path):
+            with open(safe_path, 'rb') as f:
                 return f.read()
         return None
 

--- a/apps/api/src/services/email/utils.py
+++ b/apps/api/src/services/email/utils.py
@@ -19,18 +19,32 @@ def _is_allowed_base_url(url: str) -> bool:
     config = get_learnhouse_config()
     url_stripped = url.rstrip("/")
 
-    # In single tenancy, the operator's host is authoritative — accept any
-    # http(s) URL with a non-empty hostname. The VPS may be reachable on a
-    # domain the operator hasn't enumerated in `allowed_origins`, and that's
-    # the entire point of the single mode.
     if config.hosting_config.tenancy == "single":
         parsed = urlparse(url_stripped)
-        if (
-            parsed.scheme in ("http", "https")
-            and parsed.hostname
-            and not parsed.hostname.startswith(".")
+        if parsed.scheme not in ("http", "https") or not parsed.hostname:
+            return False
+
+        req_host = parsed.hostname.removeprefix("www.").lower()
+
+        configured_hosts = set()
+        for cfg_value in (
+            config.hosting_config.frontend_domain,
+            config.hosting_config.domain,
         ):
+            cfg_value = (cfg_value or "").strip().rstrip("/")
+            if not cfg_value:
+                continue
+            cfg_host = urlparse(cfg_value).hostname or cfg_value
+            cfg_host = cfg_host.removeprefix("www.").lower()
+            if cfg_host:
+                configured_hosts.add(cfg_host)
+
+        if req_host in configured_hosts:
             return True
+
+        if config.general_config.development_mode and req_host in ("localhost", "127.0.0.1"):
+            return True
+
         return False
 
     allowed_origins = config.hosting_config.allowed_origins

--- a/apps/api/src/services/email/utils.py
+++ b/apps/api/src/services/email/utils.py
@@ -34,7 +34,13 @@ def _is_allowed_base_url(url: str) -> bool:
             cfg_value = (cfg_value or "").strip().rstrip("/")
             if not cfg_value:
                 continue
-            cfg_host = urlparse(cfg_value).hostname or cfg_value
+            # frontend_domain/domain may be a bare host or "host:port" with no
+            # scheme (the shipped default is "localhost:3000"). urlparse only
+            # populates .hostname when a scheme or leading "//" is present, so
+            # prefix "//" for schemeless values; otherwise the port would leak
+            # into the host and never match req_host (which is always port-less).
+            cfg_parsed = urlparse(cfg_value if "://" in cfg_value else f"//{cfg_value}")
+            cfg_host = cfg_parsed.hostname or cfg_value
             cfg_host = cfg_host.removeprefix("www.").lower()
             if cfg_host:
                 configured_hosts.add(cfg_host)

--- a/apps/api/src/services/orgs/join.py
+++ b/apps/api/src/services/orgs/join.py
@@ -108,6 +108,8 @@ async def join_org(
             db_session.add(user_organization)
             await db_session.commit()
 
+            await increase_feature_usage("members", org.id, db_session)
+
             from src.routers.users import _invalidate_session_cache
             _invalidate_session_cache(user.id)
 
@@ -120,8 +122,6 @@ async def join_org(
                     int(inviteCode.get("usergroup_id")),
                     str(user.id),
                 )
-
-            await increase_feature_usage("members", org.id, db_session)
 
             return "Great, You're part of the Organization"
 

--- a/apps/api/src/services/orgs/usage.py
+++ b/apps/api/src/services/orgs/usage.py
@@ -108,12 +108,14 @@ async def get_org_usage_and_limits(
     # Get limits via resolve_feature (handles mode, overrides, packs)
     courses_resolved = resolve_feature("courses", config, org_id)
     members_resolved = resolve_feature("members", config, org_id)
-    admin_seats_resolved = resolve_feature("admin_seats", config, org_id)
     courses_limit = courses_resolved["limit"]
     members_limit = members_resolved["limit"]
     members_plan_limit = 0 if mode != 'saas' else get_plan_limit(org_plan, "members")
     members_purchased = 0 if mode != 'saas' else get_purchased_member_seats(org_id)
-    admin_seats_limit = admin_seats_resolved["limit"]
+    # admin_seats is not a resolvable feature in resolve_feature() (it has no
+    # plan feature config), so resolve_feature would return limit=0 -> wrongly
+    # reported as "unlimited". Read the real per-plan limit directly.
+    admin_seats_limit = 0 if mode != 'saas' else get_plan_limit(org_plan, "admin_seats")
 
     def calc_remaining(usage: int, limit: int) -> int | str:
         if limit == 0:

--- a/apps/api/src/services/orgs/usage.py
+++ b/apps/api/src/services/orgs/usage.py
@@ -108,11 +108,12 @@ async def get_org_usage_and_limits(
     # Get limits via resolve_feature (handles mode, overrides, packs)
     courses_resolved = resolve_feature("courses", config, org_id)
     members_resolved = resolve_feature("members", config, org_id)
+    admin_seats_resolved = resolve_feature("admin_seats", config, org_id)
     courses_limit = courses_resolved["limit"]
     members_limit = members_resolved["limit"]
     members_plan_limit = 0 if mode != 'saas' else get_plan_limit(org_plan, "members")
     members_purchased = 0 if mode != 'saas' else get_purchased_member_seats(org_id)
-    admin_seats_limit = 0 if mode != 'saas' else get_plan_limit(org_plan, "admin_seats")
+    admin_seats_limit = admin_seats_resolved["limit"]
 
     def calc_remaining(usage: int, limit: int) -> int | str:
         if limit == 0:

--- a/apps/api/src/services/orgs/users.py
+++ b/apps/api/src/services/orgs/users.py
@@ -33,6 +33,19 @@ from src.services.webhooks.dispatch import dispatch_webhooks
 logger = logging.getLogger(__name__)
 
 
+def _csv_safe(value):
+    """Neutralize CSV formula injection (S12).
+
+    Spreadsheet apps interpret a cell whose first character is one of = + - @
+    (or a leading tab / carriage return) as a formula. Prefix any such string
+    with a single quote so it is rendered as literal text. Non-string values
+    are returned unchanged.
+    """
+    if isinstance(value, str) and value and value[0] in ("=", "+", "-", "@", "\t", "\r"):
+        return "'" + value
+    return value
+
+
 async def get_organization_users(
     request: Request,
     org_id: int,
@@ -390,14 +403,14 @@ async def export_organization_users_csv(
             groups = "; ".join(user_usergroups_map.get(user.id, []))
 
             writer.writerow([
-                f"{user.first_name or ''} {user.last_name or ''}".strip(),
-                user.username or "",
-                user.email or "",
-                groups,
-                role.name if role else "",
+                _csv_safe(f"{user.first_name or ''} {user.last_name or ''}".strip()),
+                _csv_safe(user.username or ""),
+                _csv_safe(user.email or ""),
+                _csv_safe(groups),
+                _csv_safe(role.name if role else ""),
                 fmt_date(user_org.creation_date),
                 "Yes" if user.email_verified else "No",
-                user.signup_method or "",
+                _csv_safe(user.signup_method or ""),
                 fmt_date(user.last_login_at) if hasattr(user, "last_login_at") else "",
             ])
 

--- a/apps/api/src/services/podcasts/podcasts.py
+++ b/apps/api/src/services/podcasts/podcasts.py
@@ -16,6 +16,7 @@ from src.security.features_utils.usage import (
 from src.db.resource_authors import ResourceAuthor, ResourceAuthorshipEnum, ResourceAuthorshipStatusEnum
 from src.db.users import PublicUser, AnonymousUser, User, UserRead, APITokenUser
 from src.security.auth import resolve_acting_user_id
+from src.security.org_auth import require_org_membership
 from src.db.podcasts.podcasts import (
     Podcast,
     PodcastCreate,
@@ -468,6 +469,10 @@ async def create_podcast(
 
     # SECURITY: Check if user has permission to create podcasts
     await check_resource_access(request, db_session, current_user, "podcast_x", AccessAction.CREATE)
+
+    await require_org_membership(
+        resolve_acting_user_id(current_user), org_id, db_session
+    )
 
     # Check plan access (podcasts require standard+ plan)
     await check_feature_access("podcasts", org_id, db_session)

--- a/apps/api/src/services/trail/trail.py
+++ b/apps/api/src/services/trail/trail.py
@@ -18,6 +18,7 @@ from src.services.courses.certifications import (
 from src.services.analytics.analytics import track
 from src.services.analytics import events as analytics_events
 from src.services.webhooks.dispatch import dispatch_webhooks
+from src.security.rbac import check_resource_access, AccessAction
 
 
 async def _build_trail_read(
@@ -89,7 +90,7 @@ async def _build_trail_read(
         for step in steps_by_run.get(tr.id, []):
             db_session.expunge(step)
             step_course = course_map.get(step.course_id)
-            step.data = dict(course=step_course)
+            step.data = {"course": step_course.model_dump() if step_course else None}
             run.steps.append(step)
 
         trail_runs.append(run)
@@ -219,6 +220,10 @@ async def add_activity_to_trail(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Course not found"
         )
+
+    await check_resource_access(
+        request, db_session, user, course.course_uuid, AccessAction.READ
+    )
 
     trail = await check_trail_presence(
         org_id=course.org_id,
@@ -404,6 +409,10 @@ async def add_course_to_trail(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Course not found"
         )
+
+    await check_resource_access(
+        request, db_session, user, course.course_uuid, AccessAction.READ
+    )
 
     # check if run already exists
     statement = select(TrailRun).where(

--- a/apps/api/src/services/users/usergroups.py
+++ b/apps/api/src/services/users/usergroups.py
@@ -14,10 +14,11 @@ from src.security.rbac.rbac import (
     authorization_verify_based_on_roles_and_authorship_or_api_token,
     authorization_verify_if_user_is_anon,
 )
-from src.security.org_auth import require_org_role_permission
+from src.security.org_auth import require_org_role_permission, require_org_membership
 from src.security.rbac.config import get_resource_config
 from src.db.usergroup_resources import UserGroupResource
 from src.db.usergroup_user import UserGroupUser
+from src.db.user_organizations import UserOrganization
 from src.db.organizations import Organization
 from src.db.usergroups import UserGroup, UserGroupCreate, UserGroupRead, UserGroupUpdate
 from src.db.users import AnonymousUser, APITokenUser, InternalUser, PublicUser, User, UserRead
@@ -109,7 +110,13 @@ async def create_usergroup(
     usergroup_create: UserGroupCreate,
 ) -> UserGroupRead:
 
+    from src.security.auth import resolve_acting_user_id
+
     usergroup = UserGroup.model_validate(usergroup_create)
+
+    await require_org_membership(
+        resolve_acting_user_id(current_user), usergroup_create.org_id, db_session
+    )
 
     # RBAC check
     await rbac_check(
@@ -235,6 +242,12 @@ async def read_usergroups_by_org_id(
     org_id: int,
 ) -> list[UserGroupRead]:
 
+    from src.security.auth import resolve_acting_user_id
+
+    await require_org_membership(
+        resolve_acting_user_id(current_user), org_id, db_session
+    )
+
     statement = select(UserGroup).where(UserGroup.org_id == org_id).order_by(UserGroup.creation_date.desc())
     usergroups = (await db_session.execute(statement)).scalars().all()
 
@@ -263,6 +276,16 @@ async def get_usergroups_by_resource(
         UserGroupResource.resource_uuid == resource_uuid
     )
     usergroup_resources = (await db_session.execute(statement)).scalars().all()
+
+    if not usergroup_resources:
+        return []
+
+    from src.security.auth import resolve_acting_user_id
+
+    target_org_id = usergroup_resources[0].org_id
+    await require_org_membership(
+        resolve_acting_user_id(current_user), target_org_id, db_session
+    )
 
     # RBAC check
     await rbac_check(
@@ -450,6 +473,20 @@ async def add_users_to_usergroup(
 
         if usergroup_user:
             logging.error(f"User with id {user_id} already exists in UserGroup")
+            continue
+
+        membership_statement = select(UserOrganization).where(
+            UserOrganization.user_id == user_id,
+            UserOrganization.org_id == usergroup.org_id,
+        )
+        user_org_membership = (
+            await db_session.execute(membership_statement)
+        ).scalars().first()
+
+        if not user_org_membership:
+            logging.error(
+                f"User with id {user_id} is not a member of org {usergroup.org_id}; skipping"
+            )
             continue
 
         if user:

--- a/apps/api/src/services/users/usergroups.py
+++ b/apps/api/src/services/users/usergroups.py
@@ -277,6 +277,17 @@ async def get_usergroups_by_resource(
     )
     usergroup_resources = (await db_session.execute(statement)).scalars().all()
 
+    # Authorize unconditionally, before the empty-result shortcut below, so an
+    # absent/unlinked resource cannot be used as an unauthenticated existence
+    # oracle (an anonymous caller must get 403, not an empty 200).
+    await rbac_check(
+        request,
+        usergroup_uuid="usergroup_X",
+        current_user=current_user,
+        action="read",
+        db_session=db_session,
+    )
+
     if not usergroup_resources:
         return []
 
@@ -285,15 +296,6 @@ async def get_usergroups_by_resource(
     target_org_id = usergroup_resources[0].org_id
     await require_org_membership(
         resolve_acting_user_id(current_user), target_org_id, db_session
-    )
-
-    # RBAC check
-    await rbac_check(
-        request,
-        usergroup_uuid="usergroup_X",
-        current_user=current_user,
-        action="read",
-        db_session=db_session,
     )
 
     # Batch fetch all usergroups in a single query

--- a/apps/api/src/services/utils/upload_content.py
+++ b/apps/api/src/services/utils/upload_content.py
@@ -44,10 +44,11 @@ async def upload_file(
     from src.security.file_validation import get_safe_filename
     
     # Validate the file
-    _, content = validate_upload(file, allowed_types, max_size)
-    
-    # Generate safe filename
-    filename = get_safe_filename(file.filename, f"{uuid4()}_{filename_prefix}")
+    content_type, content = validate_upload(file, allowed_types, max_size)
+
+    filename = get_safe_filename(
+        file.filename, f"{uuid4()}_{filename_prefix}", content_type=content_type
+    )
     
     # Save the file
     await upload_content(

--- a/apps/api/src/services/webhooks/dispatch.py
+++ b/apps/api/src/services/webhooks/dispatch.py
@@ -244,22 +244,19 @@ async def _prune_delivery_logs(webhook_id: int) -> None:
     """Keep only the most recent LOG_RETENTION_PER_ENDPOINT logs per endpoint."""
     try:
         async with _async_session_factory() as db_session:
-            ordered_ids = (await db_session.execute(
+            keep_ids = (
                 select(WebhookDeliveryLog.id)
                 .where(WebhookDeliveryLog.webhook_id == webhook_id)
                 .order_by(col(WebhookDeliveryLog.id).desc())
-            )).scalars().all()
-            stale_ids = [
-                row if isinstance(row, int) else row[0]
-                for row in ordered_ids[LOG_RETENTION_PER_ENDPOINT:]
-            ]
-            if stale_ids:
-                await db_session.execute(
-                    delete(WebhookDeliveryLog).where(
-                        WebhookDeliveryLog.webhook_id == webhook_id,
-                        WebhookDeliveryLog.id.in_(stale_ids),
-                    )
+                .limit(LOG_RETENTION_PER_ENDPOINT)
+                .scalar_subquery()
+            )
+            await db_session.execute(
+                delete(WebhookDeliveryLog).where(
+                    WebhookDeliveryLog.webhook_id == webhook_id,
+                    col(WebhookDeliveryLog.id).not_in(keep_ids),
                 )
-                await db_session.commit()
+            )
+            await db_session.commit()
     except Exception:
         logger.warning("Failed to prune webhook delivery logs for endpoint %s", webhook_id)

--- a/apps/api/src/tests/core/test_middleware_cors.py
+++ b/apps/api/src/tests/core/test_middleware_cors.py
@@ -8,28 +8,50 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from src.core.middleware.cors import (
-    _SINGLE_TENANCY_ORIGIN_REGEX,
+    _SINGLE_TENANCY_LOCALHOST_REGEX,
     configure_cors,
     get_cors_origin_regex,
 )
 
 
-def _config(tenancy: str, allowed_regexp: str = r"^https?://acme\.test$"):
+def _config(
+    tenancy: str,
+    allowed_regexp: str = r"^https?://acme\.test$",
+    frontend_domain: str = "app.example.com",
+    domain: str = "example.com",
+):
     return SimpleNamespace(
         hosting_config=SimpleNamespace(
             tenancy=tenancy,
             allowed_regexp=allowed_regexp,
+            frontend_domain=frontend_domain,
+            domain=domain,
         )
     )
 
 
 class TestGetCorsOriginRegex:
-    def test_single_tenancy_returns_permissive_regex(self):
+    def test_single_tenancy_pins_to_configured_hosts(self):
         with patch(
             "src.core.middleware.cors.get_learnhouse_config",
             return_value=_config("single"),
         ):
-            assert get_cors_origin_regex() == _SINGLE_TENANCY_ORIGIN_REGEX
+            regex = get_cors_origin_regex()
+            assert re.fullmatch(regex, "https://app.example.com")
+            assert re.fullmatch(regex, "https://example.com")
+            assert re.fullmatch(regex, "https://www.app.example.com")
+            assert re.fullmatch(regex, "http://localhost:3000")
+            assert not re.fullmatch(regex, "https://evil.example.org")
+
+    def test_single_tenancy_falls_back_to_localhost_when_unconfigured(self):
+        with patch(
+            "src.core.middleware.cors.get_learnhouse_config",
+            return_value=_config("single", frontend_domain="", domain=""),
+        ):
+            regex = get_cors_origin_regex()
+            assert regex == _SINGLE_TENANCY_LOCALHOST_REGEX
+            assert re.fullmatch(regex, "http://localhost:3000")
+            assert not re.fullmatch(regex, "https://evil.example.org")
 
     def test_multi_tenancy_returns_configured_regex(self):
         configured = r"^https?://(.*\.)?learnhouse\.io$"
@@ -41,32 +63,38 @@ class TestGetCorsOriginRegex:
 
 
 class TestSingleTenancyRegex:
-    """The permissive regex used in single mode must accept legitimate
-    operator origins and reject obvious garbage."""
+    """The single-mode regex must accept the configured operator origin(s)
+    and reject everything else while credentials are allowed."""
 
     @staticmethod
-    def _matches(origin: str) -> bool:
-        return re.fullmatch(_SINGLE_TENANCY_ORIGIN_REGEX, origin) is not None
+    def _regex() -> str:
+        with patch(
+            "src.core.middleware.cors.get_learnhouse_config",
+            return_value=_config("single"),
+        ):
+            return get_cors_origin_regex()
 
-    def test_accepts_https_domain(self):
-        assert self._matches("https://learn.example.org")
+    def _matches(self, origin: str) -> bool:
+        return re.fullmatch(self._regex(), origin) is not None
+
+    def test_accepts_configured_https_domain(self):
+        assert self._matches("https://app.example.com")
 
     def test_accepts_http_localhost_with_port(self):
         assert self._matches("http://localhost:3000")
 
-    def test_accepts_https_with_port(self):
+    def test_accepts_configured_host_with_port(self):
         assert self._matches("https://app.example.com:8443")
 
-    def test_accepts_ip_origin(self):
-        # Internal pod-to-pod or dev IP origins must work in single mode.
-        assert self._matches("http://10.0.0.5:3000")
+    def test_rejects_unconfigured_domain(self):
+        assert not self._matches("https://learn.example.org")
 
     def test_rejects_origin_with_path(self):
         # CORS Origin header should never include a path; reject if present.
-        assert not self._matches("https://learn.example.org/login")
+        assert not self._matches("https://app.example.com/login")
 
     def test_rejects_origin_with_whitespace(self):
-        assert not self._matches("https://learn.example.org foo")
+        assert not self._matches("https://app.example.com foo")
 
     def test_rejects_non_http_scheme(self):
         assert not self._matches("javascript:alert(1)")

--- a/apps/api/src/tests/routers/test_ai_chat_router.py
+++ b/apps/api/src/tests/routers/test_ai_chat_router.py
@@ -1,0 +1,279 @@
+"""Behavioral tests for src/routers/ai/ai.py.
+
+Covers:
+- The two non-streaming endpoints that `return await <service>(...)` (lines 58, 83).
+- The editor_chat_event_generator refund-in-finally path (lines 303, 408-421).
+
+External I/O is fully mocked. Handler functions are called directly with an
+AsyncMock db_session and a fake current_user. No network, no app spin-up.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.routers.ai import ai as ai_router
+from src.services.ai.schemas.ai import (
+    SendActivityAIChatMessage,
+    StartActivityAIChatSession,
+)
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming endpoints: return await <service>(...)  (lines 58, 83)
+# ---------------------------------------------------------------------------
+
+
+class TestNonStreamingEndpoints:
+    async def test_start_activity_chat_session_returns_awaited_result(self):
+        request = MagicMock()
+        db_session = AsyncMock()
+        current_user = MagicMock()
+        chat_obj = StartActivityAIChatSession(activity_uuid="act_1", message="hi")
+
+        sentinel = object()
+        with patch.object(
+            ai_router,
+            "ai_start_activity_chat_session",
+            new_callable=AsyncMock,
+            return_value=sentinel,
+        ) as svc:
+            result = await ai_router.api_ai_start_activity_chat_session(
+                request, chat_obj, current_user, db_session
+            )
+
+        assert result is sentinel
+        svc.assert_awaited_once_with(request, chat_obj, current_user, db_session)
+
+    async def test_send_activity_chat_message_returns_awaited_result(self):
+        request = MagicMock()
+        db_session = AsyncMock()
+        current_user = MagicMock()
+        chat_obj = SendActivityAIChatMessage(
+            aichat_uuid="chat_1", activity_uuid="act_1", message="hi"
+        )
+
+        sentinel = object()
+        with patch.object(
+            ai_router,
+            "ai_send_activity_chat_message",
+            new_callable=AsyncMock,
+            return_value=sentinel,
+        ) as svc:
+            result = await ai_router.api_ai_send_activity_chat_message(
+                request, chat_obj, current_user, db_session
+            )
+
+        assert result is sentinel
+        svc.assert_awaited_once_with(request, chat_obj, current_user, db_session)
+
+
+# ---------------------------------------------------------------------------
+# editor_chat_event_generator refund-in-finally  (lines 303, 408-421)
+# ---------------------------------------------------------------------------
+
+
+async def _drain(gen):
+    return [chunk async for chunk in gen]
+
+
+class TestEditorChatEventGeneratorRefund:
+    async def test_refund_called_when_stream_raises(self):
+        """Upstream stream raises -> error event emitted and refund issued."""
+
+        async def failing_stream():
+            if False:
+                yield ""  # pragma: no cover - make this an async generator
+            raise RuntimeError("model exploded")
+
+        with patch.object(
+            ai_router, "refund_ai_credit"
+        ) as refund, patch.object(
+            ai_router, "save_message_to_history"
+        ), patch.object(
+            ai_router,
+            "generate_follow_up_suggestions",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            events = await _drain(
+                ai_router.editor_chat_event_generator(
+                    failing_stream(),
+                    aichat_uuid="chat_1",
+                    activity_uuid="act_1",
+                    user_message="hi",
+                    ai_friendly_text="ctx",
+                    ai_model="gemini-2.5-flash",
+                    org_id=42,
+                )
+            )
+
+        # error event emitted (lines 412-415)
+        assert any('"type": "error"' in e for e in events)
+        # refund issued in finally (line 417-419)
+        refund.assert_called_once_with(42, 1)
+
+    async def test_refund_called_on_empty_response(self):
+        """Stream produces nothing -> refund because full_response is empty."""
+
+        async def empty_stream():
+            if False:
+                yield ""  # pragma: no cover
+            return
+
+        with patch.object(
+            ai_router, "refund_ai_credit"
+        ) as refund, patch.object(
+            ai_router, "save_message_to_history"
+        ), patch.object(
+            ai_router,
+            "generate_follow_up_suggestions",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            await _drain(
+                ai_router.editor_chat_event_generator(
+                    empty_stream(),
+                    aichat_uuid="chat_1",
+                    activity_uuid="act_1",
+                    user_message="hi",
+                    ai_friendly_text="ctx",
+                    ai_model="gemini-2.5-flash",
+                    org_id=7,
+                )
+            )
+
+        refund.assert_called_once_with(7, 1)
+
+    async def test_no_refund_on_successful_nonempty_stream(self):
+        """Stream produced content and succeeded -> no refund."""
+
+        async def good_stream():
+            yield "Hello "
+            yield "world"
+
+        with patch.object(
+            ai_router, "refund_ai_credit"
+        ) as refund, patch.object(
+            ai_router, "save_message_to_history"
+        ), patch.object(
+            ai_router,
+            "generate_follow_up_suggestions",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            events = await _drain(
+                ai_router.editor_chat_event_generator(
+                    good_stream(),
+                    aichat_uuid="chat_1",
+                    activity_uuid="act_1",
+                    user_message="hi",
+                    ai_friendly_text="ctx",
+                    ai_model="gemini-2.5-flash",
+                    org_id=99,
+                )
+            )
+
+        refund.assert_not_called()
+        assert any('"type": "done"' in e for e in events)
+
+    async def test_cancelled_error_refunds_and_reraises(self):
+        """CancelledError path (lines 407-411) refunds then re-raises."""
+        import asyncio
+
+        async def cancelling_stream():
+            if False:
+                yield ""  # pragma: no cover
+            raise asyncio.CancelledError()
+
+        with patch.object(
+            ai_router, "refund_ai_credit"
+        ) as refund, patch.object(
+            ai_router, "save_message_to_history"
+        ), patch.object(
+            ai_router,
+            "generate_follow_up_suggestions",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await _drain(
+                    ai_router.editor_chat_event_generator(
+                        cancelling_stream(),
+                        aichat_uuid="chat_1",
+                        activity_uuid="act_1",
+                        user_message="hi",
+                        ai_friendly_text="ctx",
+                        ai_model="gemini-2.5-flash",
+                        org_id=5,
+                    )
+                )
+
+        refund.assert_called_once_with(5, 1)
+
+    async def test_no_refund_when_org_id_none(self):
+        """org_id None -> finally block must not attempt refund (line 417 guard)."""
+
+        async def failing_stream():
+            if False:
+                yield ""  # pragma: no cover
+            raise RuntimeError("boom")
+
+        with patch.object(
+            ai_router, "refund_ai_credit"
+        ) as refund, patch.object(
+            ai_router, "save_message_to_history"
+        ), patch.object(
+            ai_router,
+            "generate_follow_up_suggestions",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            await _drain(
+                ai_router.editor_chat_event_generator(
+                    failing_stream(),
+                    aichat_uuid="chat_1",
+                    activity_uuid="act_1",
+                    user_message="hi",
+                    ai_friendly_text="ctx",
+                    ai_model="gemini-2.5-flash",
+                    org_id=None,
+                )
+            )
+
+        refund.assert_not_called()
+
+    async def test_refund_failure_swallowed(self):
+        """A failing refund (lines 420-421) must not break the generator."""
+
+        async def failing_stream():
+            if False:
+                yield ""  # pragma: no cover
+            raise RuntimeError("boom")
+
+        with patch.object(
+            ai_router,
+            "refund_ai_credit",
+            side_effect=RuntimeError("refund down"),
+        ), patch.object(
+            ai_router, "save_message_to_history"
+        ), patch.object(
+            ai_router,
+            "generate_follow_up_suggestions",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            # should not raise despite refund failing
+            events = await _drain(
+                ai_router.editor_chat_event_generator(
+                    failing_stream(),
+                    aichat_uuid="chat_1",
+                    activity_uuid="act_1",
+                    user_message="hi",
+                    ai_friendly_text="ctx",
+                    ai_model="gemini-2.5-flash",
+                    org_id=11,
+                )
+            )
+
+        assert any('"type": "error"' in e for e in events)

--- a/apps/api/src/tests/routers/test_auth_third_party.py
+++ b/apps/api/src/tests/routers/test_auth_third_party.py
@@ -1,0 +1,38 @@
+"""Tests for the third_party_login OAuth handler in src/routers/auth.py.
+
+Targets the `else: raise HTTPException(...)` branch (line ~497) that rejects any
+provider other than the supported ones (currently only "google").
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException, Response, status
+
+from src.db.users import AnonymousUser
+from src.routers.auth import third_party_login
+
+
+@pytest.mark.asyncio
+async def test_third_party_login_rejects_unsupported_provider():
+    # provider != "google" with org_id=None skips the org-validation block and
+    # falls straight through to the unsupported-provider `else: raise`.
+    body = SimpleNamespace(
+        email="user@example.com",
+        provider="facebook",
+        access_token="tok",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await third_party_login(
+            request=SimpleNamespace(),
+            response=Response(),
+            body=body,
+            org_id=None,
+            current_user=AnonymousUser(),
+            db_session=AsyncMock(),
+        )
+
+    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert exc_info.value.detail == "Unsupported provider"

--- a/apps/api/src/tests/routers/test_code_execution_upload.py
+++ b/apps/api/src/tests/routers/test_code_execution_upload.py
@@ -1,0 +1,212 @@
+"""Behavioral tests for the new validation in upload_sqlite_db.
+
+Targets the newly-added validation logic in
+``src/routers/code_execution.py`` (the ``upload_sqlite_db`` handler):
+
+- strict ``^[A-Za-z0-9_-]+$`` regex on org_uuid / activity_uuid / block_id
+- the DB check that org_uuid matches the course's actual organization
+
+We call ``upload_sqlite_db`` directly (it is an async function) with a real
+in-memory DB session (so the org-match query actually runs against a seeded
+course), patching out RBAC and the storage ``upload_file`` so the tests focus
+purely on the new validation lines.
+"""
+
+from io import BytesIO
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+import src.routers.code_execution as code_execution
+from src.routers.code_execution import upload_sqlite_db
+
+
+# Minimal valid SQLite header so the file "looks like" a real SQLite db.
+SQLITE_MAGIC = b"SQLite format 3\x00" + b"\x00" * 16
+
+
+def _make_upload(filename: str = "playground.sqlite3") -> UploadFile:
+    return UploadFile(filename=filename, file=BytesIO(SQLITE_MAGIC))
+
+
+@pytest.fixture
+def patched_deps():
+    """Patch RBAC + storage upload so only the new validation runs.
+
+    Both names are imported into the code_execution module namespace, so we
+    patch them there (matching how the handler resolves them at call time):
+
+    - ``_require_course_access`` wraps the RBAC check
+      (``authorization_verify_based_on_roles_and_authorship``).
+    - ``upload_file`` is the storage write path.
+    """
+    with patch.object(
+        code_execution, "_require_course_access", new_callable=AsyncMock
+    ) as rbac, patch.object(
+        code_execution, "upload_file", new_callable=AsyncMock
+    ) as upload:
+        upload.return_value = "sqlite_db_abc123.sqlite3"
+        yield {"rbac": rbac, "upload": upload}
+
+
+async def _call(db, current_user, *, org_uuid, activity_uuid, block_id,
+                course_uuid="course_test", mock_request):
+    return await upload_sqlite_db(
+        request=mock_request,
+        file_object=_make_upload(),
+        activity_uuid=activity_uuid,
+        block_id=block_id,
+        org_uuid=org_uuid,
+        course_uuid=course_uuid,
+        current_user=current_user,
+        db_session=db,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Malformed segment validation (regex ^[A-Za-z0-9_-]+$) — one test per field
+# ---------------------------------------------------------------------------
+
+BAD_VALUES = ["../x", "a/b", "x;y", "", "a b", "a.b"]
+
+
+@pytest.mark.parametrize("bad", BAD_VALUES)
+async def test_malformed_org_uuid_raises_400(
+    bad, db, admin_user, mock_request, patched_deps
+):
+    with pytest.raises(HTTPException) as exc:
+        await _call(
+            db, admin_user,
+            org_uuid=bad, activity_uuid="activity_test", block_id="block_1",
+            mock_request=mock_request,
+        )
+    assert exc.value.status_code == 400
+    assert "org_uuid" in exc.value.detail
+    # validation happens before RBAC + storage are touched
+    patched_deps["rbac"].assert_not_awaited()
+    patched_deps["upload"].assert_not_awaited()
+
+
+@pytest.mark.parametrize("bad", BAD_VALUES)
+async def test_malformed_activity_uuid_raises_400(
+    bad, db, admin_user, mock_request, patched_deps
+):
+    with pytest.raises(HTTPException) as exc:
+        await _call(
+            db, admin_user,
+            org_uuid="org_test", activity_uuid=bad, block_id="block_1",
+            mock_request=mock_request,
+        )
+    assert exc.value.status_code == 400
+    assert "activity_uuid" in exc.value.detail
+    patched_deps["rbac"].assert_not_awaited()
+    patched_deps["upload"].assert_not_awaited()
+
+
+@pytest.mark.parametrize("bad", BAD_VALUES)
+async def test_malformed_block_id_raises_400(
+    bad, db, admin_user, mock_request, patched_deps
+):
+    with pytest.raises(HTTPException) as exc:
+        await _call(
+            db, admin_user,
+            org_uuid="org_test", activity_uuid="activity_test", block_id=bad,
+            mock_request=mock_request,
+        )
+    assert exc.value.status_code == 400
+    assert "block_id" in exc.value.detail
+    patched_deps["rbac"].assert_not_awaited()
+    patched_deps["upload"].assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# course_uuid prefix guard (pre-existing line 410-411, exercised here too)
+# ---------------------------------------------------------------------------
+
+async def test_bad_course_uuid_prefix_raises_400(
+    db, admin_user, mock_request, patched_deps
+):
+    with pytest.raises(HTTPException) as exc:
+        await _call(
+            db, admin_user,
+            org_uuid="org_test", activity_uuid="activity_test", block_id="block_1",
+            course_uuid="not_a_course_uuid",
+            mock_request=mock_request,
+        )
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid course_uuid"
+
+
+# ---------------------------------------------------------------------------
+# org-match DB logic
+# ---------------------------------------------------------------------------
+
+async def test_course_not_found_raises_404(
+    db, admin_user, mock_request, patched_deps
+):
+    """Well-formed request but the course_uuid does not exist in the DB."""
+    with pytest.raises(HTTPException) as exc:
+        await _call(
+            db, admin_user,
+            org_uuid="org_test", activity_uuid="activity_test", block_id="block_1",
+            course_uuid="course_does_not_exist",
+            mock_request=mock_request,
+        )
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Course not found"
+    # RBAC ran (it's before the query); storage did not
+    patched_deps["rbac"].assert_awaited_once()
+    patched_deps["upload"].assert_not_awaited()
+
+
+async def test_org_uuid_mismatch_raises_400(
+    db, admin_user, course, mock_request, patched_deps
+):
+    """Course exists (org 'org_test') but a different org_uuid is supplied."""
+    with pytest.raises(HTTPException) as exc:
+        await _call(
+            db, admin_user,
+            org_uuid="org_other",  # course actually belongs to org_test
+            activity_uuid="activity_test", block_id="block_1",
+            course_uuid="course_test",
+            mock_request=mock_request,
+        )
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "org_uuid does not match course organization"
+    patched_deps["rbac"].assert_awaited_once()
+    patched_deps["upload"].assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+async def test_valid_request_uploads_and_returns_path(
+    db, admin_user, course, mock_request, patched_deps
+):
+    """Well-formed UUIDs, org matches the course, RBAC allows -> upload runs."""
+    result = await _call(
+        db, admin_user,
+        org_uuid="org_test", activity_uuid="activity_test", block_id="block_1",
+        course_uuid="course_test",
+        mock_request=mock_request,
+    )
+
+    patched_deps["rbac"].assert_awaited_once()
+    patched_deps["upload"].assert_awaited_once()
+
+    # upload_file was called with the org-scoped directory layout
+    _, kwargs = patched_deps["upload"].call_args
+    assert kwargs["type_of_dir"] == "orgs"
+    assert kwargs["uuid"] == "org_test"
+    assert kwargs["allowed_types"] == ["database"]
+    assert "course_test" in kwargs["directory"]
+    assert "activity_test" in kwargs["directory"]
+    assert "block_1" in kwargs["directory"]
+
+    assert result["file_path"] == (
+        "orgs/org_test/courses/course_test/activities/activity_test/"
+        "dynamic/blocks/codePlayground/block_1/sqlite_db_abc123.sqlite3"
+    )
+    assert result["file_name"] == "playground.sqlite3"

--- a/apps/api/src/tests/routers/test_magicblocks_router.py
+++ b/apps/api/src/tests/routers/test_magicblocks_router.py
@@ -1,0 +1,386 @@
+"""Behavioral tests for src/routers/ai/magicblocks.py.
+
+Covers:
+- event_generator refund on failure / empty / CancelledError (lines 37-77).
+- start_magicblock_session org-membership 403 (lines 152-161).
+- iterate_magicblock_session ownership 404 + org-membership (lines 226-229, 263-271).
+- get_session_state ownership 404 / 200 (lines 325-327, 328-337).
+
+External I/O fully mocked. Handlers are called directly with an AsyncMock
+db_session whose .execute() returns a result supporting .scalars().first().
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.routers.ai import magicblocks as mb
+from src.services.ai.schemas.magicblocks import (
+    MagicBlockContext,
+    SendMagicBlockMessage,
+    StartMagicBlockSession,
+)
+
+
+def _result(value):
+    """Build a fake SQLAlchemy result: result.scalars().first() -> value."""
+    scalars = MagicMock()
+    scalars.first.return_value = value
+    res = MagicMock()
+    res.scalars.return_value = scalars
+    return res
+
+
+def _db_returning(*values):
+    """AsyncMock db_session whose successive execute() calls return values."""
+    db = AsyncMock()
+    db.execute.side_effect = [_result(v) for v in values]
+    return db
+
+
+def _context():
+    return MagicBlockContext(
+        course_title="C",
+        course_description="D",
+        activity_name="A",
+        activity_content_summary="S",
+    )
+
+
+def _session(user_id=1, iteration_count=0, max_iterations=5):
+    return SimpleNamespace(
+        session_uuid="sess_1",
+        block_uuid="block_1",
+        activity_uuid="act_1",
+        iteration_count=iteration_count,
+        max_iterations=max_iterations,
+        current_html="<div></div>",
+        message_history=[],
+        user_id=user_id,
+    )
+
+
+async def _drain(gen):
+    return [chunk async for chunk in gen]
+
+
+# ---------------------------------------------------------------------------
+# event_generator (lines 37-77)
+# ---------------------------------------------------------------------------
+
+
+class TestEventGeneratorRefund:
+    async def test_refund_on_stream_exception(self):
+        async def failing():
+            if False:
+                yield ""  # pragma: no cover
+            raise RuntimeError("boom")
+
+        with patch.object(mb, "refund_ai_credit") as refund:
+            events = await _drain(
+                mb.event_generator(failing(), "sess_1", org_id=3, reserved_credits=3)
+            )
+
+        assert any('"type": "error"' in e for e in events)
+        refund.assert_called_once_with(3, 3)
+
+    async def test_refund_on_empty_stream(self):
+        async def empty():
+            if False:
+                yield ""  # pragma: no cover
+            return
+
+        with patch.object(mb, "refund_ai_credit") as refund:
+            events = await _drain(
+                mb.event_generator(empty(), "sess_1", org_id=4, reserved_credits=3)
+            )
+
+        # done emitted but no content -> refund
+        assert any('"type": "done"' in e for e in events)
+        refund.assert_called_once_with(4, 3)
+
+    async def test_no_refund_when_content_produced(self):
+        async def good():
+            yield "html"
+
+        with patch.object(mb, "refund_ai_credit") as refund:
+            events = await _drain(
+                mb.event_generator(good(), "sess_1", org_id=5, reserved_credits=3)
+            )
+
+        assert any('"type": "chunk"' in e for e in events)
+        refund.assert_not_called()
+
+    async def test_refund_on_cancelled_error_and_reraise(self):
+        async def cancelling():
+            if False:
+                yield ""  # pragma: no cover
+            raise asyncio.CancelledError()
+
+        with patch.object(mb, "refund_ai_credit") as refund:
+            with pytest.raises(asyncio.CancelledError):
+                await _drain(
+                    mb.event_generator(
+                        cancelling(), "sess_1", org_id=6, reserved_credits=3
+                    )
+                )
+
+        refund.assert_called_once_with(6, 3)
+
+    async def test_no_refund_when_org_id_none(self):
+        async def failing():
+            if False:
+                yield ""  # pragma: no cover
+            raise RuntimeError("boom")
+
+        with patch.object(mb, "refund_ai_credit") as refund:
+            await _drain(
+                mb.event_generator(failing(), "sess_1", org_id=None, reserved_credits=3)
+            )
+
+        refund.assert_not_called()
+
+    async def test_refund_failure_swallowed(self):
+        """Failing refund (lines 76-77) must not break the generator."""
+
+        async def failing():
+            if False:
+                yield ""  # pragma: no cover
+            raise RuntimeError("boom")
+
+        with patch.object(
+            mb, "refund_ai_credit", side_effect=RuntimeError("refund down")
+        ):
+            events = await _drain(
+                mb.event_generator(failing(), "sess_1", org_id=8, reserved_credits=3)
+            )
+
+        assert any('"type": "error"' in e for e in events)
+
+    async def test_no_refund_when_reserved_credits_zero(self):
+        """reserved_credits=0 guard (line 73) -> no refund attempt."""
+
+        async def failing():
+            if False:
+                yield ""  # pragma: no cover
+            raise RuntimeError("boom")
+
+        with patch.object(mb, "refund_ai_credit") as refund:
+            await _drain(
+                mb.event_generator(failing(), "sess_1", org_id=8, reserved_credits=0)
+            )
+
+        refund.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# start_magicblock_session — org membership 403 (lines 152-161)
+# ---------------------------------------------------------------------------
+
+
+class TestStartMagicblockSession:
+    def _request_obj(self):
+        return StartMagicBlockSession(
+            activity_uuid="act_1",
+            block_uuid="block_1",
+            prompt="make a thing",
+            context=_context(),
+        )
+
+    async def test_non_member_raises_403(self):
+        activity = SimpleNamespace(activity_uuid="act_1")
+        course = SimpleNamespace(org_id=10)
+        org = SimpleNamespace(id=10)
+        db = _db_returning(activity, course, org)
+        current_user = MagicMock()
+
+        with patch.object(mb, "resolve_acting_user_id", return_value=1), patch.object(
+            mb, "is_org_member", new_callable=AsyncMock, return_value=False
+        ), patch.object(mb, "reserve_ai_credit", new_callable=AsyncMock) as reserve:
+            with pytest.raises(HTTPException) as exc:
+                await mb.start_magicblock_session(
+                    MagicMock(), self._request_obj(), current_user, db
+                )
+
+        assert exc.value.status_code == 403
+        # credits must not be reserved if membership failed
+        reserve.assert_not_called()
+
+    async def test_member_proceeds_and_returns_streaming_response(self):
+        activity = SimpleNamespace(activity_uuid="act_1")
+        course = SimpleNamespace(org_id=10)
+        org = SimpleNamespace(id=10)
+        db = _db_returning(activity, course, org)
+        current_user = MagicMock()
+
+        async def fake_stream():
+            yield "html"
+
+        with patch.object(mb, "resolve_acting_user_id", return_value=1), patch.object(
+            mb, "is_org_member", new_callable=AsyncMock, return_value=True
+        ), patch.object(
+            mb, "reserve_ai_credit", new_callable=AsyncMock
+        ) as reserve, patch.object(
+            mb, "get_org_ai_model", new_callable=AsyncMock, return_value="gemini-x"
+        ), patch.object(
+            mb, "create_magicblock_session", return_value=_session()
+        ), patch.object(
+            mb, "generate_magicblock_stream", return_value=fake_stream()
+        ), patch(
+            "src.services.security.rate_limiting.enforce_ai_rate_limit"
+        ):
+            resp = await mb.start_magicblock_session(
+                MagicMock(), self._request_obj(), current_user, db
+            )
+
+        assert resp.media_type == "text/event-stream"
+        reserve.assert_awaited_once()
+        # reserve called with amount=3
+        assert reserve.await_args.kwargs.get("amount") == 3
+
+    async def test_missing_activity_raises_404(self):
+        db = _db_returning(None)
+        with patch.object(mb, "resolve_acting_user_id", return_value=1):
+            with pytest.raises(HTTPException) as exc:
+                await mb.start_magicblock_session(
+                    MagicMock(), self._request_obj(), MagicMock(), db
+                )
+        assert exc.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# iterate_magicblock_session — ownership 404 + membership 403
+# ---------------------------------------------------------------------------
+
+
+class TestIterateMagicblockSession:
+    def _msg(self):
+        return SendMagicBlockMessage(
+            session_uuid="sess_1",
+            activity_uuid="act_1",
+            block_uuid="block_1",
+            message="iterate please",
+        )
+
+    async def test_session_owned_by_other_user_raises_404(self):
+        """session.user_id != acting user -> 404 (lines 226-228)."""
+        session = _session(user_id=999)
+        with patch.object(mb, "get_magicblock_session", return_value=session), patch.object(
+            mb, "resolve_acting_user_id", return_value=1
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await mb.iterate_magicblock_session(
+                    MagicMock(), self._msg(), MagicMock(), AsyncMock()
+                )
+        assert exc.value.status_code == 404
+
+    async def test_missing_session_raises_404(self):
+        with patch.object(mb, "get_magicblock_session", return_value=None):
+            with pytest.raises(HTTPException) as exc:
+                await mb.iterate_magicblock_session(
+                    MagicMock(), self._msg(), MagicMock(), AsyncMock()
+                )
+        assert exc.value.status_code == 404
+
+    async def test_non_member_raises_403(self):
+        """Owned session, valid limits, but not an org member -> 403 (263-267)."""
+        session = _session(user_id=1)
+        course = SimpleNamespace(org_id=10)
+        org = SimpleNamespace(id=10)
+        db = _db_returning(course, org)
+
+        with patch.object(mb, "get_magicblock_session", return_value=session), patch.object(
+            mb, "resolve_acting_user_id", return_value=1
+        ), patch.object(
+            mb, "is_org_member", new_callable=AsyncMock, return_value=False
+        ), patch.object(mb, "reserve_ai_credit", new_callable=AsyncMock) as reserve:
+            with pytest.raises(HTTPException) as exc:
+                await mb.iterate_magicblock_session(
+                    MagicMock(), self._msg(), MagicMock(), db
+                )
+
+        assert exc.value.status_code == 403
+        reserve.assert_not_called()
+
+    async def test_member_proceeds(self):
+        session = _session(user_id=1)
+        course = SimpleNamespace(org_id=10)
+        org = SimpleNamespace(id=10)
+        db = _db_returning(course, org)
+
+        async def fake_stream():
+            yield "html"
+
+        with patch.object(mb, "get_magicblock_session", return_value=session), patch.object(
+            mb, "resolve_acting_user_id", return_value=1
+        ), patch.object(
+            mb, "is_org_member", new_callable=AsyncMock, return_value=True
+        ), patch.object(
+            mb, "reserve_ai_credit", new_callable=AsyncMock
+        ), patch.object(
+            mb, "get_org_ai_model", new_callable=AsyncMock, return_value="gemini-x"
+        ), patch.object(
+            mb, "generate_magicblock_stream", return_value=fake_stream()
+        ), patch(
+            "src.services.security.rate_limiting.enforce_ai_rate_limit"
+        ):
+            resp = await mb.iterate_magicblock_session(
+                MagicMock(), self._msg(), MagicMock(), db
+            )
+
+        assert resp.media_type == "text/event-stream"
+
+    async def test_max_iterations_raises_400(self):
+        session = _session(user_id=1, iteration_count=5, max_iterations=5)
+        with patch.object(mb, "get_magicblock_session", return_value=session), patch.object(
+            mb, "resolve_acting_user_id", return_value=1
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await mb.iterate_magicblock_session(
+                    MagicMock(), self._msg(), MagicMock(), AsyncMock()
+                )
+        assert exc.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# get_session_state — ownership 404 / 200 (lines 320-337)
+# ---------------------------------------------------------------------------
+
+
+class TestGetSessionState:
+    async def test_missing_session_404(self):
+        with patch.object(mb, "get_magicblock_session", return_value=None):
+            with pytest.raises(HTTPException) as exc:
+                await mb.get_session_state("sess_1", MagicMock(), AsyncMock())
+        assert exc.value.status_code == 404
+
+    async def test_other_user_session_404(self):
+        session = _session(user_id=999)
+        with patch.object(mb, "get_magicblock_session", return_value=session), patch.object(
+            mb, "resolve_acting_user_id", return_value=1
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await mb.get_session_state("sess_1", MagicMock(), AsyncMock())
+        assert exc.value.status_code == 404
+
+    async def test_owned_session_returns_state(self):
+        session = _session(user_id=1)
+        with patch.object(mb, "get_magicblock_session", return_value=session), patch.object(
+            mb, "resolve_acting_user_id", return_value=1
+        ):
+            resp = await mb.get_session_state("sess_1", MagicMock(), AsyncMock())
+
+        assert resp.session_uuid == "sess_1"
+        assert resp.html_content == "<div></div>"
+
+    async def test_anonymous_session_user_id_none_allowed(self):
+        """session.user_id is None -> ownership guard skipped, returns 200."""
+        session = _session(user_id=None)
+        with patch.object(mb, "get_magicblock_session", return_value=session), patch.object(
+            mb, "resolve_acting_user_id", return_value=1
+        ):
+            resp = await mb.get_session_state("sess_1", MagicMock(), AsyncMock())
+        assert resp.session_uuid == "sess_1"

--- a/apps/api/src/tests/routers/test_rag_chat_ownership.py
+++ b/apps/api/src/tests/routers/test_rag_chat_ownership.py
@@ -1,0 +1,137 @@
+"""Behavioral tests for src/routers/ai/rag.py chat-session ownership (lines 227-230).
+
+When `aichat_uuid` is supplied and `chat_session_belongs_to_user` returns False,
+api_rag_chat raises 404. When it returns True the handler proceeds to build the
+streaming response.
+
+DB + external services are mocked; the handler is called directly.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.routers.ai import rag as rag_router
+from src.routers.ai.rag import RAGChatRequest
+
+
+def _result(value):
+    scalars = MagicMock()
+    scalars.first.return_value = value
+    res = MagicMock()
+    res.scalars.return_value = scalars
+    return res
+
+
+def _db_with_course(course, org_config=None):
+    """db.execute returns the course first, then org_config (for copilot check)."""
+    db = AsyncMock()
+    db.execute.side_effect = [_result(course), _result(org_config)]
+    return db
+
+
+class TestRagChatOwnership:
+    def _req(self, aichat_uuid):
+        return RAGChatRequest(
+            message="hello",
+            course_uuid="course_1",
+            aichat_uuid=aichat_uuid,
+            mode="course_only",
+        )
+
+    async def test_foreign_chat_session_raises_404(self):
+        course = SimpleNamespace(id=1, org_id=10)
+        db = _db_with_course(course, org_config=None)
+        current_user = MagicMock()
+
+        with patch.object(
+            rag_router, "resolve_acting_user_id", return_value=1
+        ), patch.object(
+            rag_router, "is_org_member", new_callable=AsyncMock, return_value=True
+        ), patch(
+            "src.services.security.rate_limiting.enforce_ai_rate_limit"
+        ), patch.object(
+            rag_router, "reserve_ai_credit", new_callable=AsyncMock
+        ), patch.object(
+            rag_router, "chat_session_belongs_to_user", return_value=False
+        ) as belongs:
+            with pytest.raises(HTTPException) as exc:
+                await rag_router.api_rag_chat(
+                    MagicMock(), self._req("chat_foreign"), current_user, db
+                )
+
+        assert exc.value.status_code == 404
+        belongs.assert_called_once_with("chat_foreign", 1)
+
+    async def test_owned_chat_session_proceeds(self):
+        course = SimpleNamespace(id=1, org_id=10)
+        db = _db_with_course(course, org_config=None)
+        current_user = MagicMock()
+
+        async def fake_stream():
+            yield "answer"
+
+        with patch.object(
+            rag_router, "resolve_acting_user_id", return_value=1
+        ), patch.object(
+            rag_router, "is_org_member", new_callable=AsyncMock, return_value=True
+        ), patch(
+            "src.services.security.rate_limiting.enforce_ai_rate_limit"
+        ), patch.object(
+            rag_router, "reserve_ai_credit", new_callable=AsyncMock
+        ), patch.object(
+            rag_router, "chat_session_belongs_to_user", return_value=True
+        ) as belongs, patch.object(
+            rag_router,
+            "get_chat_session_history",
+            return_value={"aichat_uuid": "chat_owned", "message_history": []},
+        ), patch.object(
+            rag_router,
+            "query_course_rag_stream",
+            new_callable=AsyncMock,
+            return_value=(fake_stream(), []),
+        ):
+            resp = await rag_router.api_rag_chat(
+                MagicMock(), self._req("chat_owned"), current_user, db
+            )
+
+        assert resp.media_type == "text/event-stream"
+        belongs.assert_called_once_with("chat_owned", 1)
+
+    async def test_new_session_skips_ownership_check(self):
+        """aichat_uuid None -> is_new_session True -> ownership check skipped."""
+        course = SimpleNamespace(id=1, org_id=10)
+        db = _db_with_course(course, org_config=None)
+        current_user = MagicMock()
+
+        async def fake_stream():
+            yield "answer"
+
+        with patch.object(
+            rag_router, "resolve_acting_user_id", return_value=1
+        ), patch.object(
+            rag_router, "is_org_member", new_callable=AsyncMock, return_value=True
+        ), patch(
+            "src.services.security.rate_limiting.enforce_ai_rate_limit"
+        ), patch.object(
+            rag_router, "reserve_ai_credit", new_callable=AsyncMock
+        ), patch.object(
+            rag_router, "chat_session_belongs_to_user", return_value=False
+        ) as belongs, patch.object(
+            rag_router,
+            "get_chat_session_history",
+            return_value={"aichat_uuid": "new_chat", "message_history": []},
+        ), patch.object(
+            rag_router,
+            "query_course_rag_stream",
+            new_callable=AsyncMock,
+            return_value=(fake_stream(), []),
+        ):
+            resp = await rag_router.api_rag_chat(
+                MagicMock(), self._req(None), current_user, db
+            )
+
+        assert resp.media_type == "text/event-stream"
+        belongs.assert_not_called()

--- a/apps/api/src/tests/security/test_content_access.py
+++ b/apps/api/src/tests/security/test_content_access.py
@@ -312,3 +312,27 @@ class TestS3ContentAccess:
             "orgs/org1/logo.png",
             self._make_anon_user(), db
         )
+
+    @pytest.mark.asyncio
+    async def test_unknown_path_anonymous_rejected_401(self):
+        from src.routers.content_files import _check_content_access
+        db = self._make_db_session()
+        with pytest.raises(HTTPException) as exc_info:
+            await _check_content_access(
+                "something/unknown/file.txt",
+                self._make_anon_user(), db
+            )
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_unknown_path_authenticated_rejected_403(self):
+        # content_files.py line 192: an authenticated (non-anon) user hitting an
+        # unrecognized path pattern is denied with 403 (deny-by-default).
+        from src.routers.content_files import _check_content_access
+        db = self._make_db_session()
+        with pytest.raises(HTTPException) as exc_info:
+            await _check_content_access(
+                "something/unknown/file.txt",
+                self._make_auth_user(), db
+            )
+        assert exc_info.value.status_code == 403

--- a/apps/api/src/tests/security/test_csrf.py
+++ b/apps/api/src/tests/security/test_csrf.py
@@ -139,7 +139,7 @@ class TestCSRFOriginValidation:
         with patch("urllib.parse.urlparse", side_effect=Exception("boom")):
             assert mw._extract_origin_from_url("not-a-url") is None
 
-    def test_development_mode_allows_missing_headers(self):
+    def test_development_mode_rejects_missing_headers(self):
         with patch("src.security.csrf.get_learnhouse_config", return_value=_make_mock_config(
             allowed_origins=[],
             development_mode=True
@@ -147,7 +147,7 @@ class TestCSRFOriginValidation:
             from src.security.csrf import CSRFProtectionMiddleware
 
             mw = CSRFProtectionMiddleware(MagicMock())
-            assert mw.is_allowed_origin(None, None) is True
+            assert mw.is_allowed_origin(None, None) is False
 
 
 class TestCSRFExemptions:

--- a/apps/api/src/tests/security/test_feature_usage.py
+++ b/apps/api/src/tests/security/test_feature_usage.py
@@ -502,9 +502,9 @@ class TestFeatureUsage:
             "plan": "standard",
             "base_credits": 5,
             "purchased_credits": 4,
-            "total_credits": 9,
+            "total_credits": 11,
             "used_credits": 6,
-            "remaining_credits": 3,
+            "remaining_credits": 5,
         }
 
 

--- a/apps/api/src/tests/security/test_file_validation_runtime.py
+++ b/apps/api/src/tests/security/test_file_validation_runtime.py
@@ -197,3 +197,44 @@ class TestSafeFilename:
 
     def test_safe_filename_rejects_unsafe_extension(self):
         assert get_safe_filename("name.bad-ext", "prefix") == "prefix.bin"
+
+    def test_safe_filename_uses_content_type_not_client_filename(self):
+        # A client-supplied dangerous name must NOT control the stored extension;
+        # the validated content_type drives the extension instead.
+        assert (
+            get_safe_filename("evil.php", "prefix", content_type="image/png")
+            == "prefix.png"
+        )
+        assert (
+            get_safe_filename("evil.html", "prefix", content_type="image/jpeg")
+            == "prefix.jpg"
+        )
+
+    @pytest.mark.parametrize(
+        ("content_type", "expected_ext"),
+        [
+            ("image/png", "png"),
+            ("image/jpeg", "jpg"),
+            ("video/mp4", "mp4"),
+            ("application/pdf", "pdf"),
+            ("application/vnd.sqlite3", "sqlite3"),
+            ("application/x-sqlite3", "sqlite3"),
+            (
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "docx",
+            ),
+        ],
+    )
+    def test_safe_filename_maps_known_content_types(self, content_type, expected_ext):
+        assert (
+            get_safe_filename("whatever.xyz", "pfx", content_type=content_type)
+            == f"pfx.{expected_ext}"
+        )
+
+    def test_safe_filename_unknown_content_type_falls_back_to_bin(self):
+        # content_type given but not in MIME_TO_SAFE_EXT -> ".bin", still ignoring
+        # the client filename's extension.
+        assert (
+            get_safe_filename("evil.png", "pfx", content_type="application/x-msdownload")
+            == "pfx.bin"
+        )

--- a/apps/api/src/tests/security/test_rbac_utils_runtime.py
+++ b/apps/api/src/tests/security/test_rbac_utils_runtime.py
@@ -98,6 +98,8 @@ class TestRBACUtilsRuntime:
             ("episode_2", [None], None),
             ("board_1", [24], 24),
             ("board_2", [None], None),
+            ("playground_1", [25], 25),
+            ("playground_2", [None], None),
         ],
     )
     async def test_get_element_organization_id_covers_remaining_branches(
@@ -109,6 +111,23 @@ class TestRBACUtilsRuntime:
         session = _session_with_results(*results)
 
         assert await get_element_organization_id(element_uuid, session) == expected
+
+    @pytest.mark.asyncio
+    async def test_get_element_organization_id_playground_returns_real_org_id(self, db, org):
+        """End-to-end: a real Playground row's org_id is resolved through the
+        new `playgrounds` branch of get_element_organization_id."""
+        from src.db.playgrounds import Playground
+
+        playground = Playground(
+            name="My Playground",
+            org_id=org.id,
+            playground_uuid="playground_runtime_1",
+        )
+        db.add(playground)
+        await db.commit()
+
+        result = await get_element_organization_id("playground_runtime_1", db)
+        assert result == org.id
 
     @pytest.mark.asyncio
     async def test_get_element_organization_id_unknown_type_returns_none(self):

--- a/apps/api/src/tests/security/test_remediation_ai_credit_refund.py
+++ b/apps/api/src/tests/security/test_remediation_ai_credit_refund.py
@@ -167,3 +167,38 @@ async def test_activity_chat_refunds_on_client_disconnect():
                 pass
 
     assert refunded == [(77, 1)]
+
+
+@pytest.mark.asyncio
+async def test_activity_chat_does_not_refund_on_disconnect_after_content():
+    """Abuse guard: a client that disconnects AFTER receiving model output must
+    NOT get its credit refunded, otherwise scripted disconnects yield free AI."""
+    from src.routers.ai.ai import activity_chat_event_generator
+
+    async def _content_then_cancel():
+        yield "hello"
+        raise asyncio.CancelledError()
+
+    refunded = []
+    with patch(
+        "src.security.features_utils.usage.refund_ai_credit",
+        side_effect=lambda org_id, amount=1: refunded.append((org_id, amount)),
+    ), patch(
+        "src.routers.ai.ai.save_message_to_history",
+    ):
+        gen = activity_chat_event_generator(
+            _content_then_cancel(),
+            "chat_uuid",
+            "activity_uuid",
+            "hello",
+            "ai text",
+            "gemini",
+            org_id=77,
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            async for _ in gen:
+                pass
+
+    # Content was produced before the disconnect → credit legitimately spent.
+    assert refunded == []

--- a/apps/api/src/tests/services/test_admin_service_extra.py
+++ b/apps/api/src/tests/services/test_admin_service_extra.py
@@ -168,6 +168,33 @@ def test_validate_magic_link_redirect_whitespace_returns_none():
     assert result is None
 
 
+def test_validate_magic_link_redirect_accepts_same_origin_path():
+    assert _validate_magic_link_redirect("/dashboard") == "/dashboard"
+    assert _validate_magic_link_redirect("/course/foo?x=1") == "/course/foo?x=1"
+
+
+def test_validate_magic_link_redirect_returns_none_for_empty_and_none():
+    assert _validate_magic_link_redirect(None) is None
+    assert _validate_magic_link_redirect("") is None
+
+
+@pytest.mark.parametrize(
+    "redirect_to",
+    [
+        "/\\evil.com",        # backslash-prefixed -> treated as protocol-relative
+        "//evil.com",          # protocol-relative
+        "https://evil.com",    # absolute external URL with scheme
+        "http://evil.com",
+        "javascript:alert(1)",  # scheme without leading slash
+        "evil.com",            # does not start with '/'
+    ],
+)
+def test_validate_magic_link_redirect_rejects_open_redirects(redirect_to):
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_magic_link_redirect(redirect_to)
+    assert exc_info.value.status_code == 400
+
+
 # ---------------------------------------------------------------------------
 # Lines 986, 995 — consume_magic_link_token
 # ---------------------------------------------------------------------------

--- a/apps/api/src/tests/services/test_ai_ai_stream_refund.py
+++ b/apps/api/src/tests/services/test_ai_ai_stream_refund.py
@@ -1,0 +1,150 @@
+"""Behavioral tests for src/services/ai/ai.py streaming refund-on-failure.
+
+Covers the try/except blocks in:
+- ai_start_activity_chat_session_stream  (lines 445-458)
+- ai_send_activity_chat_message_stream   (lines 494-507)
+
+Both reserve a credit, then build the system prompt inside a try; if anything
+inside raises, refund_ai_credit(org.id) is called and the exception re-raises.
+
+We force the failure by making get_chat_session_history raise, and mock
+_get_activity_and_course_info / reserve / rate-limit so no real I/O happens.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.ai import ai as ai_service
+from src.services.ai.schemas.ai import (
+    SendActivityAIChatMessage,
+    StartActivityAIChatSession,
+)
+
+
+def _activity_course_org(org_id=10):
+    activity = SimpleNamespace(activity_uuid="act_1", name="Lesson")
+    course = SimpleNamespace(org_id=org_id, name="Course")
+    org = SimpleNamespace(id=org_id)
+    return activity, course, org, "gemini-2.5-flash", "friendly text"
+
+
+class TestStartStreamRefund:
+    async def test_refund_on_failure_and_reraise(self):
+        chat_obj = StartActivityAIChatSession(activity_uuid="act_1", message="hi")
+        current_user = MagicMock()
+        db_session = AsyncMock()
+
+        with patch.object(
+            ai_service,
+            "_get_activity_and_course_info",
+            new_callable=AsyncMock,
+            return_value=_activity_course_org(org_id=10),
+        ), patch.object(
+            ai_service, "reserve_ai_credit", new_callable=AsyncMock
+        ), patch.object(
+            ai_service, "resolve_acting_user_id", return_value=1
+        ), patch(
+            "src.services.security.rate_limiting.enforce_ai_rate_limit"
+        ), patch.object(
+            ai_service,
+            "get_chat_session_history",
+            side_effect=RuntimeError("session store down"),
+        ), patch.object(
+            ai_service, "refund_ai_credit"
+        ) as refund:
+            with pytest.raises(RuntimeError, match="session store down"):
+                await ai_service.ai_start_activity_chat_session_stream(
+                    MagicMock(), chat_obj, current_user, db_session
+                )
+
+        refund.assert_called_once_with(10)
+
+    async def test_no_refund_on_success(self):
+        chat_obj = StartActivityAIChatSession(activity_uuid="act_1", message="hi")
+        with patch.object(
+            ai_service,
+            "_get_activity_and_course_info",
+            new_callable=AsyncMock,
+            return_value=_activity_course_org(org_id=10),
+        ), patch.object(
+            ai_service, "reserve_ai_credit", new_callable=AsyncMock
+        ), patch.object(
+            ai_service, "resolve_acting_user_id", return_value=1
+        ), patch(
+            "src.services.security.rate_limiting.enforce_ai_rate_limit"
+        ), patch.object(
+            ai_service,
+            "get_chat_session_history",
+            return_value={"aichat_uuid": "c1", "message_history": []},
+        ), patch.object(
+            ai_service, "refund_ai_credit"
+        ) as refund:
+            context = await ai_service.ai_start_activity_chat_session_stream(
+                MagicMock(), chat_obj, MagicMock(), AsyncMock()
+            )
+
+        refund.assert_not_called()
+        assert context["chat_session"]["aichat_uuid"] == "c1"
+        assert context["user_message"] == "hi"
+
+
+class TestSendStreamRefund:
+    async def test_refund_on_failure_and_reraise(self):
+        chat_obj = SendActivityAIChatMessage(
+            aichat_uuid="c1", activity_uuid="act_1", message="hi"
+        )
+        with patch.object(
+            ai_service,
+            "_get_activity_and_course_info",
+            new_callable=AsyncMock,
+            return_value=_activity_course_org(org_id=20),
+        ), patch.object(
+            ai_service, "reserve_ai_credit", new_callable=AsyncMock
+        ), patch.object(
+            ai_service, "resolve_acting_user_id", return_value=1
+        ), patch(
+            "src.services.security.rate_limiting.enforce_ai_rate_limit"
+        ), patch.object(
+            ai_service,
+            "get_chat_session_history",
+            side_effect=RuntimeError("session store down"),
+        ), patch.object(
+            ai_service, "refund_ai_credit"
+        ) as refund:
+            with pytest.raises(RuntimeError, match="session store down"):
+                await ai_service.ai_send_activity_chat_message_stream(
+                    MagicMock(), chat_obj, MagicMock(), AsyncMock()
+                )
+
+        refund.assert_called_once_with(20)
+
+    async def test_no_refund_on_success(self):
+        chat_obj = SendActivityAIChatMessage(
+            aichat_uuid="c1", activity_uuid="act_1", message="hi"
+        )
+        with patch.object(
+            ai_service,
+            "_get_activity_and_course_info",
+            new_callable=AsyncMock,
+            return_value=_activity_course_org(org_id=20),
+        ), patch.object(
+            ai_service, "reserve_ai_credit", new_callable=AsyncMock
+        ), patch.object(
+            ai_service, "resolve_acting_user_id", return_value=1
+        ), patch(
+            "src.services.security.rate_limiting.enforce_ai_rate_limit"
+        ), patch.object(
+            ai_service,
+            "get_chat_session_history",
+            return_value={"aichat_uuid": "c1", "message_history": []},
+        ), patch.object(
+            ai_service, "refund_ai_credit"
+        ) as refund:
+            context = await ai_service.ai_send_activity_chat_message_stream(
+                MagicMock(), chat_obj, MagicMock(), AsyncMock()
+            )
+
+        refund.assert_not_called()
+        assert context["chat_session"]["aichat_uuid"] == "c1"

--- a/apps/api/src/tests/services/test_ai_base_service.py
+++ b/apps/api/src/tests/services/test_ai_base_service.py
@@ -1,0 +1,62 @@
+"""Behavioral tests for chat_session_belongs_to_user (IDOR ownership guard).
+
+Covers src/services/ai/base.py lines 237-260. The function reads the
+``chat_meta:<uuid>`` Redis key and decides whether the chat session is owned
+by the requesting user. Documented behavior (read from the source):
+
+- No Redis configured -> returns True (fail-open; nothing to protect yet).
+- Meta missing/None -> returns True (brand-new/expired session is ownable).
+- Meta user_id matches -> True.
+- Meta user_id differs -> False.
+- Redis raises -> returns False (fail-closed on unexpected errors).
+"""
+import json
+
+from src.services.ai import base
+
+
+def _fake_redis_returning(meta_value):
+    class _Redis:
+        def get(self, key):
+            assert key == "chat_meta:abc-uuid"
+            return meta_value
+
+    return _Redis()
+
+
+def test_returns_true_when_no_redis(monkeypatch):
+    monkeypatch.setattr(base, "_get_redis", lambda: None)
+    assert base.chat_session_belongs_to_user("abc-uuid", 7) is True
+
+
+def test_returns_true_when_meta_missing(monkeypatch):
+    monkeypatch.setattr(base, "_get_redis", lambda: _fake_redis_returning(None))
+    assert base.chat_session_belongs_to_user("abc-uuid", 7) is True
+
+
+def test_returns_true_when_user_id_matches(monkeypatch):
+    meta = json.dumps({"aichat_uuid": "abc-uuid", "user_id": 7, "title": "x"})
+    monkeypatch.setattr(base, "_get_redis", lambda: _fake_redis_returning(meta))
+    assert base.chat_session_belongs_to_user("abc-uuid", 7) is True
+
+
+def test_returns_true_when_user_id_matches_bytes(monkeypatch):
+    """Redis often returns bytes; the code decodes them."""
+    meta = json.dumps({"aichat_uuid": "abc-uuid", "user_id": 7}).encode("utf-8")
+    monkeypatch.setattr(base, "_get_redis", lambda: _fake_redis_returning(meta))
+    assert base.chat_session_belongs_to_user("abc-uuid", 7) is True
+
+
+def test_returns_false_when_user_id_differs(monkeypatch):
+    meta = json.dumps({"aichat_uuid": "abc-uuid", "user_id": 999})
+    monkeypatch.setattr(base, "_get_redis", lambda: _fake_redis_returning(meta))
+    assert base.chat_session_belongs_to_user("abc-uuid", 7) is False
+
+
+def test_returns_false_when_redis_raises(monkeypatch):
+    class _Boom:
+        def get(self, key):
+            raise RuntimeError("redis down")
+
+    monkeypatch.setattr(base, "_get_redis", lambda: _Boom())
+    assert base.chat_session_belongs_to_user("abc-uuid", 7) is False

--- a/apps/api/src/tests/services/test_ai_magicblocks_service.py
+++ b/apps/api/src/tests/services/test_ai_magicblocks_service.py
@@ -92,3 +92,25 @@ def test_create_returns_session_even_when_no_redis(monkeypatch):
         block_uuid="b1", activity_uuid="a1", context=_context(), user_id=77
     )
     assert session.user_id == 77
+
+
+async def test_generate_stream_reraises_on_provider_error(monkeypatch):
+    """A provider failure must propagate as an exception, not be yielded as an
+    "Error: ..." content chunk. Yielding it leaked exception detail to the
+    client and defeated the router's credit-refund logic."""
+    import pytest
+
+    def _boom():
+        raise RuntimeError("upstream provider 500")
+
+    monkeypatch.setattr(mb, "get_gemini_client", _boom)
+
+    session = mb.create_magicblock_session(
+        block_uuid="b1", activity_uuid="a1", context=_context(), user_id=1
+    )
+
+    with pytest.raises(RuntimeError):
+        async for _ in mb.generate_magicblock_stream(
+            prompt="hi", session=session, gemini_model_name="gemini-x"
+        ):
+            pass

--- a/apps/api/src/tests/services/test_ai_magicblocks_service.py
+++ b/apps/api/src/tests/services/test_ai_magicblocks_service.py
@@ -1,0 +1,94 @@
+"""Behavioral tests for MagicBlock session creation/persistence.
+
+Covers src/services/ai/magicblocks.py lines 63-64 (user_id parameter on
+create_magicblock_session) and lines 77-78 (user_id stored on the session
+object), plus the Redis round-trip via save/get so user_id survives
+serialization.
+"""
+import json
+
+from src.services.ai import magicblocks as mb
+from src.services.ai.schemas.magicblocks import MagicBlockContext
+
+
+def _context():
+    return MagicBlockContext(
+        course_title="C",
+        course_description="D",
+        activity_name="A",
+        activity_content_summary="S",
+    )
+
+
+class _FakeRedis:
+    """Minimal in-memory Redis good enough for setex/get of JSON sessions."""
+
+    def __init__(self):
+        self.store = {}
+
+    def setex(self, key, ttl, value):
+        self.store[key] = value
+        return True
+
+    def get(self, key):
+        return self.store.get(key)
+
+
+def test_create_stores_user_id_on_session(monkeypatch):
+    fake = _FakeRedis()
+    monkeypatch.setattr(mb, "get_redis_connection", lambda: fake)
+
+    session = mb.create_magicblock_session(
+        block_uuid="b1",
+        activity_uuid="a1",
+        context=_context(),
+        user_id=55,
+    )
+
+    assert session.user_id == 55
+    assert session.block_uuid == "b1"
+    assert session.activity_uuid == "a1"
+    assert session.session_uuid.startswith("mb_")
+
+
+def test_create_defaults_user_id_to_none(monkeypatch):
+    monkeypatch.setattr(mb, "get_redis_connection", lambda: _FakeRedis())
+    session = mb.create_magicblock_session(
+        block_uuid="b1", activity_uuid="a1", context=_context()
+    )
+    assert session.user_id is None
+
+
+def test_create_persists_user_id_to_redis(monkeypatch):
+    fake = _FakeRedis()
+    monkeypatch.setattr(mb, "get_redis_connection", lambda: fake)
+
+    session = mb.create_magicblock_session(
+        block_uuid="b1", activity_uuid="a1", context=_context(), user_id=55
+    )
+
+    key = mb.MAGICBLOCK_SESSION_KEY.format(session_uuid=session.session_uuid)
+    stored = json.loads(fake.store[key])
+    assert stored["user_id"] == 55
+
+
+def test_user_id_round_trips_through_get(monkeypatch):
+    fake = _FakeRedis()
+    monkeypatch.setattr(mb, "get_redis_connection", lambda: fake)
+
+    created = mb.create_magicblock_session(
+        block_uuid="b1", activity_uuid="a1", context=_context(), user_id=55
+    )
+
+    loaded = mb.get_magicblock_session(created.session_uuid)
+    assert loaded is not None
+    assert loaded.user_id == 55
+    assert loaded.session_uuid == created.session_uuid
+
+
+def test_create_returns_session_even_when_no_redis(monkeypatch):
+    monkeypatch.setattr(mb, "get_redis_connection", lambda: None)
+    session = mb.create_magicblock_session(
+        block_uuid="b1", activity_uuid="a1", context=_context(), user_id=77
+    )
+    assert session.user_id == 77

--- a/apps/api/src/tests/services/test_assignments_service.py
+++ b/apps/api/src/tests/services/test_assignments_service.py
@@ -29,6 +29,7 @@ from src.db.courses.assignments import (
     AssignmentTaskCreate,
     AssignmentTaskRead,
     AssignmentTaskSubmission,
+    AssignmentTaskSubmissionCreate,
     AssignmentTaskSubmissionRead,
     AssignmentTaskSubmissionUpdate,
     AssignmentTaskTypeEnum,
@@ -46,6 +47,7 @@ from src.db.trails import Trail
 from src.db.users import APITokenUser
 from src.services.courses.activities.assignments import (
     _block_api_tokens,
+    _is_assignment_past_due,
     create_assignment,
     create_assignment_submission,
     create_assignment_task,
@@ -1307,6 +1309,73 @@ class TestUpdateAssignmentTaskSubmission:
             )
         assert result.assignment_task_submission_uuid == task_submission.assignment_task_submission_uuid
 
+    async def test_non_instructor_grade_and_feedback_stripped(
+        self, mock_request, db, regular_user, assignment_task, task_submission
+    ):
+        """Covers lines 1709-1718: a non-instructor updating their OWN task
+        submission has grade / feedback / assignment_task_id / assignment_type
+        forced to None so they cannot self-grade."""
+        original_grade = task_submission.grade  # 100
+        payload = AssignmentTaskSubmissionCreate(
+            assignment_task_submission_uuid=task_submission.assignment_task_submission_uuid,
+            user_id=regular_user.id,
+            activity_id=assignment_task.activity_id,
+            course_id=assignment_task.course_id,
+            chapter_id=assignment_task.chapter_id,
+            assignment_task_id=task_submission.assignment_task_id,
+            task_submission={"answer": "tampered"},
+            grade=5,
+            task_submission_grade_feedback="I deserve full marks",
+            assignment_type=AssignmentTaskTypeEnum.SHORT_ANSWER,
+        )
+        # is_instructor -> False; submission belongs to regular_user
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, return_value=False):
+            result = await update_assignment_task_submission(
+                mock_request,
+                task_submission.assignment_task_submission_uuid,
+                payload,
+                regular_user,
+                db,
+            )
+        # task_submission content WAS updated, but grade/feedback were NOT
+        assert result.task_submission == {"answer": "tampered"}
+        assert result.grade == original_grade
+        await db.refresh(task_submission)
+        assert task_submission.grade == original_grade
+        assert task_submission.task_submission_grade_feedback == "Correct"
+
+    async def test_non_instructor_other_users_submission_raises_403(
+        self, mock_request, db, admin_user, assignment_task, task_submission
+    ):
+        """Covers lines 1710-1714: non-instructor editing someone else's
+        submission is rejected with 403. task_submission belongs to
+        regular_user (id 2); we call as admin_user (id 1) but force
+        is_instructor -> False."""
+        payload = AssignmentTaskSubmissionCreate(
+            assignment_task_submission_uuid=task_submission.assignment_task_submission_uuid,
+            user_id=admin_user.id,
+            activity_id=assignment_task.activity_id,
+            course_id=assignment_task.course_id,
+            chapter_id=assignment_task.chapter_id,
+            assignment_task_id=task_submission.assignment_task_id,
+            task_submission={"answer": "hijack"},
+            grade=0,
+            task_submission_grade_feedback="",
+            assignment_type=AssignmentTaskTypeEnum.SHORT_ANSWER,
+        )
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, return_value=False):
+            with pytest.raises(HTTPException) as exc:
+                await update_assignment_task_submission(
+                    mock_request,
+                    task_submission.assignment_task_submission_uuid,
+                    payload,
+                    admin_user,
+                    db,
+                )
+        assert exc.value.status_code == 403
+
 
 # ---------------------------------------------------------------------------
 # delete_assignment_task_submission
@@ -1457,3 +1526,250 @@ class TestDeleteAssignmentSubmissionCertRevocation:
                 db,
             )
         assert result["message"] == "Assignment User Submission deleted"
+
+
+# ---------------------------------------------------------------------------
+# _is_assignment_past_due (lines 85-93)
+# ---------------------------------------------------------------------------
+
+
+from types import SimpleNamespace
+
+
+class TestIsAssignmentPastDue:
+    def test_past_iso_date_returns_true(self):
+        a = SimpleNamespace(due_date="2000-01-01")
+        assert _is_assignment_past_due(a) is True
+
+    def test_past_iso_datetime_returns_true(self):
+        a = SimpleNamespace(due_date="2000-01-01T12:00:00")
+        assert _is_assignment_past_due(a) is True
+
+    def test_future_iso_date_returns_false(self):
+        a = SimpleNamespace(due_date="2999-01-01")
+        assert _is_assignment_past_due(a) is False
+
+    def test_empty_string_returns_false(self):
+        assert _is_assignment_past_due(SimpleNamespace(due_date="")) is False
+
+    def test_whitespace_only_returns_false(self):
+        assert _is_assignment_past_due(SimpleNamespace(due_date="   ")) is False
+
+    def test_none_returns_false(self):
+        assert _is_assignment_past_due(SimpleNamespace(due_date=None)) is False
+
+    def test_missing_attribute_returns_false(self):
+        assert _is_assignment_past_due(SimpleNamespace()) is False
+
+    def test_garbage_string_returns_false(self):
+        assert _is_assignment_past_due(SimpleNamespace(due_date="not-a-date")) is False
+
+    def test_tz_aware_past_date_returns_true(self):
+        # tz-aware ISO string in the distant past -> stripped to naive -> past
+        a = SimpleNamespace(due_date="2000-01-01T00:00:00+00:00")
+        assert _is_assignment_past_due(a) is True
+
+
+# ---------------------------------------------------------------------------
+# Due-date enforcement (lines 1338-1342 + 1857-1861)
+# ---------------------------------------------------------------------------
+
+
+class TestDueDateEnforcement:
+    async def _set_due(self, db, assignment, due_date):
+        assignment.due_date = due_date
+        db.add(assignment)
+        await db.commit()
+        await db.refresh(assignment)
+
+    async def test_handle_task_submission_non_instructor_past_due_raises_403(
+        self, mock_request, db, assignment, assignment_task, regular_user
+    ):
+        await self._set_due(db, assignment, "2000-01-01")
+        obj = AssignmentTaskSubmissionUpdate(task_submission={"answer": "x"})
+        # is_instructor -> False, enrollment read -> True
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, side_effect=[False, True]):
+            with pytest.raises(HTTPException) as exc:
+                await handle_assignment_task_submission(
+                    mock_request, assignment_task.assignment_task_uuid, obj, regular_user, db
+                )
+        assert exc.value.status_code == 403
+        assert "deadline has passed" in exc.value.detail
+
+    async def test_handle_task_submission_instructor_past_due_allowed(
+        self, mock_request, db, assignment, assignment_task, admin_user
+    ):
+        await self._set_due(db, assignment, "2000-01-01")
+        obj = AssignmentTaskSubmissionUpdate(task_submission={"answer": "x"})
+        # is_instructor -> True bypasses the due-date check entirely
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, return_value=True):
+            result = await handle_assignment_task_submission(
+                mock_request, assignment_task.assignment_task_uuid, obj, admin_user, db
+            )
+        assert isinstance(result, AssignmentTaskSubmissionRead)
+
+    async def test_create_submission_non_instructor_past_due_raises_403(
+        self, mock_request, db, assignment, course, activity, regular_user
+    ):
+        await self._set_due(db, assignment, "2000-01-01")
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, return_value=False), \
+             patch(_PATCH_TRACK, new_callable=AsyncMock), \
+             patch(_PATCH_DISPATCH, new_callable=AsyncMock):
+            with pytest.raises(HTTPException) as exc:
+                await create_assignment_submission(
+                    mock_request, assignment.assignment_uuid, regular_user, db
+                )
+        assert exc.value.status_code == 403
+        assert "deadline has passed" in exc.value.detail
+
+    async def test_create_submission_instructor_past_due_allowed(
+        self, mock_request, db, assignment, course, activity, admin_user
+    ):
+        await self._set_due(db, assignment, "2000-01-01")
+        trail = Trail(
+            org_id=course.org_id,
+            user_id=admin_user.id,
+            trail_uuid="trail_pastdue_instructor",
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(trail)
+        await db.commit()
+        await db.refresh(trail)
+        # is_instructor -> True; due-date check skipped, submission proceeds
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_TRAIL_PRESENCE, new_callable=AsyncMock, return_value=trail), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, return_value=True), \
+             patch(_PATCH_CERT, new_callable=AsyncMock), \
+             patch(_PATCH_CERT_CHECK, new_callable=AsyncMock), \
+             patch(_PATCH_TRACK, new_callable=AsyncMock), \
+             patch(_PATCH_DISPATCH, new_callable=AsyncMock):
+            result = await create_assignment_submission(
+                mock_request, assignment.assignment_uuid, admin_user, db
+            )
+        assert result.submission_status == AssignmentUserSubmissionStatus.SUBMITTED
+
+    async def test_create_submission_non_instructor_no_due_date_allowed(
+        self, mock_request, db, assignment, course, activity, regular_user
+    ):
+        await self._set_due(db, assignment, "")
+        trail = Trail(
+            org_id=course.org_id,
+            user_id=regular_user.id,
+            trail_uuid="trail_nodue",
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(trail)
+        await db.commit()
+        await db.refresh(trail)
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_TRAIL_PRESENCE, new_callable=AsyncMock, return_value=trail), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, return_value=False), \
+             patch(_PATCH_CERT, new_callable=AsyncMock), \
+             patch(_PATCH_CERT_CHECK, new_callable=AsyncMock), \
+             patch(_PATCH_TRACK, new_callable=AsyncMock), \
+             patch(_PATCH_DISPATCH, new_callable=AsyncMock):
+            result = await create_assignment_submission(
+                mock_request, assignment.assignment_uuid, regular_user, db
+            )
+        assert result.submission_status == AssignmentUserSubmissionStatus.SUBMITTED
+
+
+# ---------------------------------------------------------------------------
+# update_assignment_submission — protected-field stripping (lines 2252-2254)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateAssignmentSubmissionProtectedFields:
+    """Covers the non-instructor protected-field stripping (lines 2252-2254).
+
+    NOTE: ``AssignmentUserSubmissionCreate`` only *declares* ``assignment_id``;
+    extra kwargs (grade/submission_status/user_id) are silently dropped by
+    pydantic, so ``assignment_id`` is the single protected field that actually
+    survives onto the payload object and exercises the ``hasattr``/``setattr``
+    stripping path. We assert via ``assignment_id`` reassignment, which is the
+    real exploit the strip guards against.
+    """
+
+    async def test_non_instructor_cannot_reassign_submission_to_another_assignment(
+        self, mock_request, db, org, course, chapter, activity, assignment,
+        user_submission, regular_user,
+    ):
+        original_assignment_id = user_submission.assignment_id  # 10
+        # A second assignment the attacker tries to move their submission onto.
+        other = Assignment(
+            id=11,
+            title="Other Assignment",
+            description="another",
+            due_date="2030-01-01",
+            published=True,
+            grading_type=GradingTypeEnum.NUMERIC,
+            auto_grading=False,
+            org_id=org.id,
+            course_id=course.id,
+            chapter_id=chapter.id,
+            activity_id=activity.id,
+            assignment_uuid="assignment_other",
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(other)
+        await db.commit()
+
+        obj = AssignmentUserSubmissionCreate(assignment_id=other.id)
+        # is_instructor -> False; submission belongs to regular_user
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, return_value=False):
+            result = await update_assignment_submission(
+                mock_request,
+                regular_user.id,
+                assignment.assignment_uuid,
+                obj,
+                regular_user,
+                db,
+            )
+        # assignment_id was stripped to None -> NOT written; stays original
+        assert result.assignment_id == original_assignment_id
+        await db.refresh(user_submission)
+        assert user_submission.assignment_id == original_assignment_id
+
+    async def test_instructor_can_reassign_assignment_id(
+        self, mock_request, db, org, course, chapter, activity, assignment,
+        user_submission, admin_user, regular_user,
+    ):
+        other = Assignment(
+            id=12,
+            title="Other Assignment 2",
+            description="another",
+            due_date="2030-01-01",
+            published=True,
+            grading_type=GradingTypeEnum.NUMERIC,
+            auto_grading=False,
+            org_id=org.id,
+            course_id=course.id,
+            chapter_id=chapter.id,
+            activity_id=activity.id,
+            assignment_uuid="assignment_other2",
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(other)
+        await db.commit()
+
+        obj = AssignmentUserSubmissionCreate(assignment_id=other.id)
+        # is_instructor -> True; assignment_id IS applied (not stripped)
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, return_value=True):
+            result = await update_assignment_submission(
+                mock_request,
+                regular_user.id,
+                assignment.assignment_uuid,
+                obj,
+                admin_user,
+                db,
+            )
+        assert result.assignment_id == other.id

--- a/apps/api/src/tests/services/test_assignments_service.py
+++ b/apps/api/src/tests/services/test_assignments_service.py
@@ -14,7 +14,7 @@ Session to AsyncSession in this PR:
   _block_api_tokens.
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -1565,6 +1565,24 @@ class TestIsAssignmentPastDue:
     def test_tz_aware_past_date_returns_true(self):
         # tz-aware ISO string in the distant past -> stripped to naive -> past
         a = SimpleNamespace(due_date="2000-01-01T00:00:00+00:00")
+        assert _is_assignment_past_due(a) is True
+
+    def test_due_today_date_only_returns_false(self):
+        # A date-only deadline of "today" must remain submittable for the whole
+        # day (date inputs have no time component) -> not past due.
+        today = datetime.now().date().isoformat()
+        a = SimpleNamespace(due_date=today)
+        assert _is_assignment_past_due(a) is False
+
+    def test_due_yesterday_date_only_returns_true(self):
+        yesterday = (datetime.now() - timedelta(days=1)).date().isoformat()
+        a = SimpleNamespace(due_date=yesterday)
+        assert _is_assignment_past_due(a) is True
+
+    def test_due_today_earlier_time_returns_true(self):
+        # When an explicit past time-of-day is given for today, it IS past due.
+        earlier = (datetime.now() - timedelta(hours=1)).replace(microsecond=0).isoformat()
+        a = SimpleNamespace(due_date=earlier)
         assert _is_assignment_past_due(a) is True
 
 

--- a/apps/api/src/tests/services/test_assignments_service.py
+++ b/apps/api/src/tests/services/test_assignments_service.py
@@ -15,6 +15,7 @@ Session to AsyncSession in this PR:
 """
 
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -1531,9 +1532,6 @@ class TestDeleteAssignmentSubmissionCertRevocation:
 # ---------------------------------------------------------------------------
 # _is_assignment_past_due (lines 85-93)
 # ---------------------------------------------------------------------------
-
-
-from types import SimpleNamespace
 
 
 class TestIsAssignmentPastDue:

--- a/apps/api/src/tests/services/test_chapters_service.py
+++ b/apps/api/src/tests/services/test_chapters_service.py
@@ -11,6 +11,7 @@ from src.db.courses.activities import Activity, ActivityLockType, ActivityRead, 
 from src.db.courses.chapter_activities import ChapterActivity
 from src.db.courses.chapters import Chapter, ChapterCreate, ChapterRead, ChapterUpdate, ChapterUpdateOrder, LockType
 from src.db.courses.course_chapters import CourseChapter
+from src.db.courses.courses import Course
 from src.services.courses.chapters import (
     DEPRECEATED_get_course_chapters,
     _apply_locks_to_chapters,
@@ -155,6 +156,44 @@ class TestUpdateChapter:
 
         assert exc_info.value.status_code == 404
         assert "Course does not exist" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_update_chapter_cannot_change_org_or_course(
+        self, db, org, course, chapter, admin_user, mock_request, activity, other_org
+    ):
+        """Covers line 172-173: update_chapter skips org_id/course_id keys, so a
+        payload carrying them can never re-home a chapter to another org/course."""
+        original_org_id = chapter.org_id
+        original_course_id = chapter.course_id
+
+        # Use a loose object so org_id/course_id survive into vars() the way a
+        # crafted/extra-bearing payload would at runtime. ChapterUpdate forbids
+        # these fields, so this is the only way to drive the guard.
+        payload = SimpleNamespace(
+            name="Renamed Chapter",
+            org_id=other_org.id,
+            course_id=99999,
+            description=None,
+            thumbnail_image=None,
+            lock_type=None,
+            extra_metadata=None,
+        )
+
+        with patch(
+            "src.services.courses.chapters.check_resource_access",
+            new_callable=AsyncMock,
+        ):
+            result = await update_chapter(
+                mock_request, payload, chapter.id, admin_user, db
+            )
+
+        # name applied, but org_id/course_id untouched
+        assert result.name == "Renamed Chapter"
+        await db.refresh(chapter)
+        assert chapter.org_id == original_org_id
+        assert chapter.course_id == original_course_id
+        assert chapter.org_id != other_org.id
+        assert chapter.course_id != 99999
 
 
 class TestDeleteChapter:
@@ -483,6 +522,145 @@ class TestReorderChaptersAndActivities:
             select(ChapterActivity).where(ChapterActivity.activity_id == third_activity.id)
         )).scalars().first()
         assert new_chapter_activity is not None
+
+    @pytest.mark.asyncio
+    async def test_reorder_rejects_chapter_from_another_course(
+        self, db, org, other_org, course, chapter, activity, admin_user, mock_request
+    ):
+        """Covers line 586-590: a chapter that has no link to this course AND is
+        owned by a different course/org must be rejected with 400."""
+        foreign_course = Course(
+            id=777,
+            name="Foreign Course",
+            description="",
+            public=True,
+            published=True,
+            open_to_contributors=False,
+            org_id=other_org.id,
+            course_uuid="course_foreign",
+            creation_date="2024-01-01",
+            update_date="2024-01-01",
+        )
+        db.add(foreign_course)
+        await db.commit()
+        await db.refresh(foreign_course)
+
+        foreign_chapter = Chapter(
+            name="Foreign Chapter",
+            description="",
+            thumbnail_image="",
+            org_id=other_org.id,
+            course_id=foreign_course.id,
+            chapter_uuid="chapter_foreign",
+            creation_date="2024-01-01",
+            update_date="2024-01-01",
+        )
+        db.add(foreign_chapter)
+        await db.commit()
+        await db.refresh(foreign_chapter)
+
+        payload = ChapterUpdateOrder.model_validate(
+            {
+                "chapter_order_by_ids": [
+                    {
+                        "chapter_id": foreign_chapter.id,
+                        "activities_order_by_ids": [],
+                    }
+                ]
+            }
+        )
+
+        with patch(
+            "src.services.courses.chapters.check_resource_access",
+            new_callable=AsyncMock,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await reorder_chapters_and_activities(
+                    mock_request, course.course_uuid, payload, admin_user, db
+                )
+
+        assert exc_info.value.status_code == 400
+        assert "not part of this course" in exc_info.value.detail
+        # No link should have been created for the foreign chapter.
+        link = (await db.execute(
+            select(CourseChapter).where(
+                CourseChapter.chapter_id == foreign_chapter.id,
+                CourseChapter.course_id == course.id,
+            )
+        )).scalars().first()
+        assert link is None
+
+    @pytest.mark.asyncio
+    async def test_reorder_rejects_activity_from_another_course(
+        self, db, org, other_org, course, chapter, activity, admin_user, mock_request
+    ):
+        """Covers line 654-667: an activity owned by a different course/org that
+        is being linked under a valid chapter must be rejected with 400."""
+        foreign_course = Course(
+            id=778,
+            name="Foreign Course 2",
+            description="",
+            public=True,
+            published=True,
+            open_to_contributors=False,
+            org_id=other_org.id,
+            course_uuid="course_foreign2",
+            creation_date="2024-01-01",
+            update_date="2024-01-01",
+        )
+        db.add(foreign_course)
+        await db.commit()
+        await db.refresh(foreign_course)
+
+        foreign_activity = Activity(
+            name="Foreign Activity",
+            activity_type=ActivityTypeEnum.TYPE_DYNAMIC,
+            activity_sub_type=ActivitySubTypeEnum.SUBTYPE_DYNAMIC_PAGE,
+            content={"type": "doc", "content": []},
+            published=True,
+            org_id=other_org.id,
+            course_id=foreign_course.id,
+            activity_uuid="activity_foreign",
+            creation_date="2024-01-01",
+            update_date="2024-01-01",
+            current_version=1,
+        )
+        db.add(foreign_activity)
+        await db.commit()
+        await db.refresh(foreign_activity)
+
+        # The chapter IS valid for this course, but the activity is foreign.
+        payload = ChapterUpdateOrder.model_validate(
+            {
+                "chapter_order_by_ids": [
+                    {
+                        "chapter_id": chapter.id,
+                        "activities_order_by_ids": [
+                            {"activity_id": foreign_activity.id},
+                        ],
+                    }
+                ]
+            }
+        )
+
+        with patch(
+            "src.services.courses.chapters.check_resource_access",
+            new_callable=AsyncMock,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await reorder_chapters_and_activities(
+                    mock_request, course.course_uuid, payload, admin_user, db
+                )
+
+        assert exc_info.value.status_code == 400
+        assert "not part of this course" in exc_info.value.detail
+        link = (await db.execute(
+            select(ChapterActivity).where(
+                ChapterActivity.activity_id == foreign_activity.id,
+                ChapterActivity.course_id == course.id,
+            )
+        )).scalars().first()
+        assert link is None
 
     @pytest.mark.asyncio
     async def test_reorder_missing_course_raises(

--- a/apps/api/src/tests/services/test_collections_service.py
+++ b/apps/api/src/tests/services/test_collections_service.py
@@ -178,6 +178,31 @@ class TestCreateCollection:
 
         assert exc_info.value.status_code == 403
 
+    @pytest.mark.asyncio
+    async def test_create_collection_rejects_course_from_other_org_403(
+        self, db, org, other_org, admin_user, mock_request, bypass_rbac,
+        bypass_webhooks,
+    ):
+        """Covers line 109-114: a course whose org_id != collection.org_id is
+        rejected with 403 (cross-org course cannot be added)."""
+        foreign_course = await _make_course(
+            db, other_org, id=900, name="Foreign Course",
+            course_uuid="course_foreign_create",
+        )
+        payload = CollectionCreate(
+            name="Cross Org Collection",
+            description="",
+            public=True,
+            courses=[foreign_course.id],
+            org_id=org.id,
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await create_collection(mock_request, payload, admin_user, db)
+
+        assert exc_info.value.status_code == 403
+        assert "does not belong to this organization" in exc_info.value.detail
+
 
 class TestUpdateCollection:
     """Tests for update_collection()."""
@@ -194,6 +219,40 @@ class TestUpdateCollection:
         )
 
         assert result.name == "Updated Name"
+
+    @pytest.mark.asyncio
+    async def test_update_collection_skips_course_from_other_org(
+        self, db, org, other_org, course, collection, admin_user, mock_request,
+        bypass_rbac,
+    ):
+        """Covers line 204-205: a course whose org_id != collection.org_id is
+        silently skipped (not linked) on update."""
+        foreign_course = await _make_course(
+            db, other_org, id=901, name="Foreign Course Update",
+            course_uuid="course_foreign_update",
+        )
+        # Ask to set the collection's courses to [same-org course, foreign course]
+        payload = CollectionUpdate(
+            name="Updated With Foreign",
+            courses=[course.id, foreign_course.id],
+        )
+
+        result = await update_collection(
+            mock_request, payload, "collection_test", admin_user, db
+        )
+
+        result_course_ids = {c.id for c in result.courses}
+        # same-org course linked, foreign one skipped
+        assert course.id in result_course_ids
+        assert foreign_course.id not in result_course_ids
+        # Confirm no join row was created for the foreign course
+        link = (await db.execute(
+            select(CollectionCourse).where(
+                CollectionCourse.collection_id == collection.id,
+                CollectionCourse.course_id == foreign_course.id,
+            )
+        )).scalars().first()
+        assert link is None
 
     @pytest.mark.asyncio
     async def test_update_collection_not_found(

--- a/apps/api/src/tests/services/test_community_comments_votes_service.py
+++ b/apps/api/src/tests/services/test_community_comments_votes_service.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
 
 from src.db.communities.communities import Community
 from src.db.communities.discussion_comments import DiscussionComment, DiscussionCommentUpdate
@@ -489,6 +490,56 @@ class TestCommunityCommentsAndVotes:
             "missing": False,
         }
         assert known_discussion_votes[discussion.discussion_uuid] is False
+
+    @pytest.mark.asyncio
+    async def test_upvote_discussion_integrity_error_race_rolls_back_and_400(
+        self, db, org, admin_user, regular_user, mock_request
+    ):
+        """Covers lines 81-86: if the INSERT+UPDATE commit hits an
+        IntegrityError (concurrent duplicate vote race), the service rolls back
+        and raises HTTPException 400 instead of leaking a 500."""
+        community = await _make_community(db, org, community_uuid="community_race")
+        discussion = await _make_discussion(
+            db,
+            community,
+            org,
+            author_id=admin_user.id,
+            discussion_uuid="discussion_race",
+        )
+
+        original_rollback = db.rollback
+        rollback_calls = []
+
+        async def failing_commit(*args, **kwargs):
+            raise IntegrityError("INSERT", {}, Exception("duplicate key"))
+
+        async def tracking_rollback(*args, **kwargs):
+            rollback_calls.append(True)
+            return await original_rollback(*args, **kwargs)
+
+        with patch(
+            "src.services.communities.votes.authorization_verify_if_user_is_anon",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.services.communities.votes.check_resource_access",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.services.communities.votes.dispatch_webhooks",
+            new_callable=AsyncMock,
+        ), patch.object(
+            db, "commit", side_effect=failing_commit
+        ), patch.object(
+            db, "rollback", side_effect=tracking_rollback
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await upvote_discussion(
+                    mock_request, discussion.discussion_uuid, regular_user, db
+                )
+
+        assert exc.value.status_code == 400
+        assert "already upvoted" in exc.value.detail
+        # safety-net rolled the failed transaction back
+        assert rollback_calls, "expected db_session.rollback() to be called"
 
     @pytest.mark.asyncio
     async def test_comment_creation_and_delete_error_branches(

--- a/apps/api/src/tests/services/test_content_extraction_service.py
+++ b/apps/api/src/tests/services/test_content_extraction_service.py
@@ -1,0 +1,167 @@
+"""Behavioral tests for the _is_safe_content_path traversal guard.
+
+Covers src/services/ai/rag/content_extraction.py line 14 (import os,
+transitively), the helper at lines 32-49, and its two call sites at 203
+(PDF block) and 354 (document activity). Block file paths are persisted from
+user input, so the guard rejects empty/NUL/absolute/`..` paths before any
+file read.
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from src.services.ai.rag import content_extraction as ce
+
+
+# --- direct unit tests of the helper -------------------------------------
+
+def test_rejects_none():
+    assert ce._is_safe_content_path(None) is False
+
+
+def test_rejects_empty_string():
+    assert ce._is_safe_content_path("") is False
+
+
+def test_rejects_non_string():
+    assert ce._is_safe_content_path(12345) is False
+
+
+def test_rejects_absolute_unix_path():
+    assert ce._is_safe_content_path("/etc/passwd") is False
+
+
+def test_rejects_parent_traversal():
+    assert ce._is_safe_content_path("../../x") is False
+
+
+def test_rejects_traversal_in_middle():
+    assert ce._is_safe_content_path("orgs/1/../../etc/passwd") is False
+
+
+def test_rejects_nul_byte():
+    assert ce._is_safe_content_path("a\x00b") is False
+
+
+def test_rejects_backslash_absolute():
+    # backslashes are normalized to forward slashes before the leading-slash check
+    assert ce._is_safe_content_path("\\windows\\system32") is False
+
+
+def test_accepts_safe_relative_path():
+    assert ce._is_safe_content_path("orgs/1/courses/2/file.pdf") is True
+
+
+def test_accepts_simple_filename():
+    assert ce._is_safe_content_path("file.pdf") is True
+
+
+def test_dotdot_substring_in_filename_is_allowed():
+    # ".." must be a whole path *component* to be rejected; a filename that
+    # merely contains the substring is fine.
+    assert ce._is_safe_content_path("orgs/my..notes/file.pdf") is True
+
+
+# --- call site coverage: PDF block (line 203) ----------------------------
+
+class _FakeBlock:
+    def __init__(self, file_path):
+        self.block_type = ce.BlockTypeEnum.BLOCK_DOCUMENT_PDF
+        self.content = {"file_id": file_path}
+
+
+def _pdf_block(file_path):
+    return ce._extract_block_content(_FakeBlock(file_path), activity_name="A")
+
+
+def test_pdf_block_unsafe_path_short_circuits_without_reading():
+    with patch.object(ce, "read_file_content") as read_mock:
+        assert _pdf_block("/etc/passwd") is None
+        read_mock.assert_not_called()
+
+
+def test_pdf_block_safe_path_proceeds_to_read():
+    with patch.object(ce, "read_file_content", return_value=b"%PDF-1.4 bytes") as read_mock, \
+         patch.object(ce, "extract_text_from_pdf", return_value="extracted text"):
+        result = _pdf_block("orgs/1/courses/2/file.pdf")
+        read_mock.assert_called_once_with("orgs/1/courses/2/file.pdf")
+        assert result == {"text": "extracted text", "source_type": "pdf_block"}
+
+
+# --- call site coverage: document activity (line 354) --------------------
+
+class _Result:
+    """Stand-in for the object returned by AsyncSession.execute()."""
+
+    def __init__(self, items):
+        self._items = items
+
+    def scalars(self):
+        return self
+
+    def first(self):
+        return self._items[0] if self._items else None
+
+    def all(self):
+        return self._items
+
+
+class _FakeDBSession:
+    """Returns queued results in call order for each execute()."""
+
+    def __init__(self, results):
+        self._results = list(results)
+
+    async def execute(self, _query):
+        return self._results.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_document_activity_guard_blocks_unsafe_path():
+    course = SimpleNamespace(id=1, name="Course")
+    activity = SimpleNamespace(
+        id=10,
+        name="Doc",
+        activity_uuid="act_1",
+        activity_type=ce.ActivityTypeEnum.TYPE_DOCUMENT,
+        content={"file_id": "../../etc/passwd"},
+        course_id=1,
+    )
+    # execute() call order: course, chapters, activities, chapter_activity
+    db = _FakeDBSession([
+        _Result([course]),
+        _Result([]),          # chapters
+        _Result([activity]),  # activities
+        _Result([]),          # chapter_activity join
+    ])
+    with patch.object(ce, "read_file_content") as read_mock:
+        results = await ce.extract_all_course_content(1, 1, db)
+        read_mock.assert_not_called()
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_document_activity_safe_path_extracts_text():
+    course = SimpleNamespace(id=1, name="Course")
+    activity = SimpleNamespace(
+        id=10,
+        name="Doc",
+        activity_uuid="act_1",
+        activity_type=ce.ActivityTypeEnum.TYPE_DOCUMENT,
+        content={"file_id": "orgs/1/courses/2/file.pdf"},
+        course_id=1,
+    )
+    db = _FakeDBSession([
+        _Result([course]),
+        _Result([]),
+        _Result([activity]),
+        _Result([]),
+    ])
+    with patch.object(ce, "read_file_content", return_value=b"%PDF bytes") as read_mock, \
+         patch.object(ce, "extract_text_from_pdf", return_value="doc text"):
+        results = await ce.extract_all_course_content(1, 1, db)
+        read_mock.assert_called_once_with("orgs/1/courses/2/file.pdf")
+    assert len(results) == 1
+    assert results[0]["text"] == "doc text"
+    assert results[0]["source_type"] == "document_activity"

--- a/apps/api/src/tests/services/test_email_utils_service.py
+++ b/apps/api/src/tests/services/test_email_utils_service.py
@@ -111,18 +111,24 @@ class TestEmailUtilsService:
             assert await get_org_signup_base_url("acme", request) == "https://fallback.test"
             mock_base_url.assert_called_once_with(request)
 
-    def test_is_allowed_base_url_accepts_request_host_in_single_tenancy(self):
-        # In single tenancy the operator's host is authoritative — any
-        # http(s) URL with a non-empty hostname is acceptable, so VPS
-        # deployments don't need to enumerate `allowed_origins`.
+    def test_is_allowed_base_url_pins_to_configured_host_in_single_tenancy(self):
         with patch(
             "src.services.email.utils.get_learnhouse_config",
             return_value=_config(tenancy="single"),
         ):
-            assert _is_allowed_base_url("https://learn.example.org")
-            assert _is_allowed_base_url("http://localhost:3000")
+            assert _is_allowed_base_url("https://app.learnhouse.app")
+            assert _is_allowed_base_url("https://learnhouse.app")
+            assert _is_allowed_base_url("https://www.learnhouse.app")
+            assert not _is_allowed_base_url("https://learn.example.org")
             assert not _is_allowed_base_url("javascript:alert(1)")
             assert not _is_allowed_base_url("https://")
+            assert not _is_allowed_base_url("http://localhost:3000")
+
+        with patch(
+            "src.services.email.utils.get_learnhouse_config",
+            return_value=_config(tenancy="single", development_mode=True),
+        ):
+            assert _is_allowed_base_url("http://localhost:3000")
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/apps/api/src/tests/services/test_email_utils_service.py
+++ b/apps/api/src/tests/services/test_email_utils_service.py
@@ -130,6 +130,21 @@ class TestEmailUtilsService:
         ):
             assert _is_allowed_base_url("http://localhost:3000")
 
+    def test_is_allowed_base_url_skips_blank_configured_host_in_single_tenancy(self):
+        # Line 36: a blank/whitespace configured value (here frontend_domain) is
+        # skipped via `continue`; only the non-empty `domain` is honored.
+        with patch(
+            "src.services.email.utils.get_learnhouse_config",
+            return_value=_config(
+                tenancy="single",
+                frontend_domain="   ",
+                domain="learnhouse.app",
+            ),
+        ):
+            assert _is_allowed_base_url("https://learnhouse.app")
+            # The blank frontend_domain contributed no allowed host.
+            assert not _is_allowed_base_url("https://other.example.org")
+
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "ssl,expected",

--- a/apps/api/src/tests/services/test_email_utils_service.py
+++ b/apps/api/src/tests/services/test_email_utils_service.py
@@ -130,6 +130,23 @@ class TestEmailUtilsService:
         ):
             assert _is_allowed_base_url("http://localhost:3000")
 
+    def test_is_allowed_base_url_accepts_host_with_port_config_in_single_tenancy(self):
+        # The shipped default config uses schemeless "host:port" values
+        # (e.g. "localhost:3000"). The configured host must still match the
+        # always-port-less request host instead of being silently rejected.
+        with patch(
+            "src.services.email.utils.get_learnhouse_config",
+            return_value=_config(
+                tenancy="single",
+                frontend_domain="localhost:3000",
+                domain="learn.myschool.org:8443",
+            ),
+        ):
+            assert _is_allowed_base_url("http://localhost:3000")
+            assert _is_allowed_base_url("https://learn.myschool.org:8443")
+            assert _is_allowed_base_url("https://learn.myschool.org")
+            assert not _is_allowed_base_url("https://evil.example.org")
+
     def test_is_allowed_base_url_skips_blank_configured_host_in_single_tenancy(self):
         # Line 36: a blank/whitespace configured value (here frontend_domain) is
         # skipped via `continue`; only the non-empty `domain` is honored.

--- a/apps/api/src/tests/services/test_import_service.py
+++ b/apps/api/src/tests/services/test_import_service.py
@@ -25,6 +25,7 @@ from src.services.courses.transfer.import_service import (
     _import_block,
     _import_chapter,
     _import_single_course,
+    _safe_manifest_join,
     analyze_import_package,
     cleanup_old_temp_imports,
     import_courses,
@@ -85,6 +86,46 @@ class TestImportHelpers:
             result = sanitize_path("course/file.txt")
 
         assert result == ""
+
+    def test_safe_manifest_join_rejects_none_and_empty(self, tmp_path):
+        # Lines 103, 106: None / non-str / empty-after-sanitize -> None.
+        assert _safe_manifest_join(str(tmp_path), None) is None
+        assert _safe_manifest_join(str(tmp_path), "") is None
+        assert _safe_manifest_join(str(tmp_path), 123) is None  # type: ignore[arg-type]
+        # ".." sanitizes to "" -> None
+        assert _safe_manifest_join(str(tmp_path), "..") is None
+
+    def test_safe_manifest_join_strips_traversal_to_contained_path(self, tmp_path):
+        # sanitize_path strips leading "../" components, so "../escape" becomes
+        # the contained "escape" under extract_dir rather than escaping it.
+        result = _safe_manifest_join(str(tmp_path), "../escape")
+        assert result == os.path.join(str(tmp_path), "escape")
+        assert os.path.realpath(result).startswith(os.path.realpath(str(tmp_path)))
+
+        result2 = _safe_manifest_join(str(tmp_path), "../../etc/passwd")
+        assert result2 == os.path.join(str(tmp_path), "etc/passwd")
+
+    def test_safe_manifest_join_returns_contained_path(self, tmp_path):
+        result = _safe_manifest_join(str(tmp_path), "course/file.txt")
+        assert result == os.path.join(str(tmp_path), "course/file.txt")
+        # The joined path stays inside extract_dir.
+        assert os.path.realpath(result).startswith(os.path.realpath(str(tmp_path)))
+
+    def test_safe_manifest_join_rejects_when_commonpath_mismatch(self, tmp_path):
+        # Line 112: commonpath resolves outside extract_dir -> None.
+        with patch(
+            "src.services.courses.transfer.import_service.os.path.commonpath",
+            return_value="/some/other/root",
+        ):
+            assert _safe_manifest_join(str(tmp_path), "course/file.txt") is None
+
+    def test_safe_manifest_join_rejects_when_commonpath_raises(self, tmp_path):
+        # Lines 113-114: ValueError from commonpath -> treated as unsafe -> None.
+        with patch(
+            "src.services.courses.transfer.import_service.os.path.commonpath",
+            side_effect=ValueError("mixed drives"),
+        ):
+            assert _safe_manifest_join(str(tmp_path), "course/file.txt") is None
 
     @pytest.mark.asyncio
     async def test_analyze_import_package_rejects_oversized_package(

--- a/apps/api/src/tests/services/test_import_service.py
+++ b/apps/api/src/tests/services/test_import_service.py
@@ -128,6 +128,86 @@ class TestImportHelpers:
             assert _safe_manifest_join(str(tmp_path), "course/file.txt") is None
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_path", ["", "/extract/../../etc"])
+    async def test_import_single_course_rejects_unsafe_course_path(
+        self, db, org, admin_user, bad_path
+    ):
+        # Line 503: empty or '..'-containing course_path is refused with 400
+        # before any file is opened.
+        with pytest.raises(HTTPException) as exc:
+            await _import_single_course(
+                course_path=bad_path,
+                organization=org,
+                current_user=admin_user,
+                options=ImportOptions(course_uuids=["c1"]),
+                db_session=db,
+                new_course_uuid="c1-new",
+            )
+        assert exc.value.status_code == 400
+        assert "Invalid course path" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_analyze_import_package_skips_unsafe_manifest_course_path(
+        self, db, org, admin_user, mock_request, tmp_path, monkeypatch
+    ):
+        # Line 280: a manifest course path that _safe_manifest_join rejects
+        # (".." sanitizes to "" -> None) is skipped -> no valid courses.
+        _set_import_temp_dir(monkeypatch, tmp_path)
+        manifest = {
+            "format": "learnhouse-course-export",
+            "version": "2.0.0",
+            "courses": [{"course_uuid": "c1", "path": ".."}],
+        }
+        package_bytes = _zip_bytes({"manifest.json": json.dumps(manifest).encode()})
+
+        with patch(
+            "src.services.courses.transfer.import_service.check_resource_access",
+            new_callable=AsyncMock,
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await analyze_import_package(
+                    mock_request, _upload_file(package_bytes), org.id, admin_user, db
+                )
+
+        assert exc.value.status_code == 400
+        assert "No valid courses found" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_analyze_import_package_skips_entry_on_commonpath_valueerror(
+        self, db, org, admin_user, mock_request, tmp_path, monkeypatch
+    ):
+        # Lines 240-241: a ValueError from commonpath during extraction is
+        # treated as "not contained" so the entry is skipped (defense in depth).
+        _set_import_temp_dir(monkeypatch, tmp_path)
+        manifest = {
+            "format": "learnhouse-course-export",
+            "version": "2.0.0",
+            "courses": [{"course_uuid": "c1", "path": "c1"}],
+        }
+        package_bytes = _zip_bytes(
+            {
+                "manifest.json": json.dumps(manifest).encode(),
+                "c1/course.json": json.dumps({"course_uuid": "c1", "name": "X"}).encode(),
+            }
+        )
+
+        with patch(
+            "src.services.courses.transfer.import_service.check_resource_access",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.services.courses.transfer.import_service.os.path.commonpath",
+            side_effect=ValueError("mixed drives"),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await analyze_import_package(
+                    mock_request, _upload_file(package_bytes), org.id, admin_user, db
+                )
+
+        # Every entry skipped → manifest.json is never written to disk.
+        assert exc.value.status_code == 400
+        assert "manifest.json not found" in exc.value.detail
+
+    @pytest.mark.asyncio
     async def test_analyze_import_package_rejects_oversized_package(
         self, db, org, admin_user, mock_request, tmp_path, monkeypatch
     ):

--- a/apps/api/src/tests/services/test_magicblocks_schema.py
+++ b/apps/api/src/tests/services/test_magicblocks_schema.py
@@ -1,0 +1,49 @@
+"""Behavioral tests for the new user_id field on MagicBlockSessionData.
+
+Covers src/services/ai/schemas/magicblocks.py line 49
+(``user_id: Optional[int] = None``).
+"""
+from src.services.ai.schemas.magicblocks import (
+    MagicBlockContext,
+    MagicBlockSessionData,
+)
+
+
+def _context():
+    return MagicBlockContext(
+        course_title="C",
+        course_description="D",
+        activity_name="A",
+        activity_content_summary="S",
+    )
+
+
+def _base_kwargs():
+    return dict(
+        session_uuid="mb_1",
+        block_uuid="b",
+        activity_uuid="a",
+        iteration_count=0,
+        max_iterations=6,
+        message_history=[],
+        current_html=None,
+        context=_context(),
+    )
+
+
+def test_user_id_defaults_to_none_when_omitted():
+    session = MagicBlockSessionData(**_base_kwargs())
+    assert session.user_id is None
+
+
+def test_user_id_is_stored_when_provided():
+    session = MagicBlockSessionData(user_id=42, **_base_kwargs())
+    assert session.user_id == 42
+
+
+def test_user_id_round_trips_through_model_dump():
+    session = MagicBlockSessionData(user_id=42, **_base_kwargs())
+    dumped = session.model_dump()
+    assert dumped["user_id"] == 42
+    rebuilt = MagicBlockSessionData(**dumped)
+    assert rebuilt.user_id == 42

--- a/apps/api/src/tests/services/test_org_usage_cache_service.py
+++ b/apps/api/src/tests/services/test_org_usage_cache_service.py
@@ -229,7 +229,7 @@ class TestOrgUsageHelpers:
             return_value=2,
         ), patch(
             "src.services.orgs.usage.get_plan_limit",
-            side_effect=[4, 2],
+            side_effect=[4],
         ) as get_plan_limit, patch(
             "src.services.orgs.usage.get_purchased_member_seats",
             return_value=5,
@@ -238,6 +238,7 @@ class TestOrgUsageHelpers:
             side_effect=[
                 {"enabled": True, "limit": 0},
                 {"enabled": True, "limit": 6},
+                {"enabled": True, "limit": 2},
             ],
         ) as resolve_feature, patch(
             "src.services.orgs.usage._set_cached_usage",
@@ -265,8 +266,8 @@ class TestOrgUsageHelpers:
         assert result["features"]["admin_seats"]["limit_reached"] is True
         resolve_feature.assert_any_call("courses", {"config_version": "2.0", "plan": "pro", "admin_toggles": {}}, org.id)
         resolve_feature.assert_any_call("members", {"config_version": "2.0", "plan": "pro", "admin_toggles": {}}, org.id)
+        resolve_feature.assert_any_call("admin_seats", {"config_version": "2.0", "plan": "pro", "admin_toggles": {}}, org.id)
         get_plan_limit.assert_any_call("pro", "members")
-        get_plan_limit.assert_any_call("pro", "admin_seats")
         purchased.assert_called_once_with(org.id)
         set_cached.assert_called_once_with(org.id, result)
 
@@ -313,6 +314,7 @@ class TestOrgUsageHelpers:
             side_effect=[
                 {"enabled": True, "limit": 3},
                 {"enabled": True, "limit": 4},
+                {"enabled": True, "limit": 0},
             ],
         ), patch(
             "src.services.orgs.usage._set_cached_usage",

--- a/apps/api/src/tests/services/test_org_usage_cache_service.py
+++ b/apps/api/src/tests/services/test_org_usage_cache_service.py
@@ -229,7 +229,7 @@ class TestOrgUsageHelpers:
             return_value=2,
         ), patch(
             "src.services.orgs.usage.get_plan_limit",
-            side_effect=[4],
+            side_effect=[4, 2],
         ) as get_plan_limit, patch(
             "src.services.orgs.usage.get_purchased_member_seats",
             return_value=5,
@@ -238,7 +238,6 @@ class TestOrgUsageHelpers:
             side_effect=[
                 {"enabled": True, "limit": 0},
                 {"enabled": True, "limit": 6},
-                {"enabled": True, "limit": 2},
             ],
         ) as resolve_feature, patch(
             "src.services.orgs.usage._set_cached_usage",
@@ -266,8 +265,8 @@ class TestOrgUsageHelpers:
         assert result["features"]["admin_seats"]["limit_reached"] is True
         resolve_feature.assert_any_call("courses", {"config_version": "2.0", "plan": "pro", "admin_toggles": {}}, org.id)
         resolve_feature.assert_any_call("members", {"config_version": "2.0", "plan": "pro", "admin_toggles": {}}, org.id)
-        resolve_feature.assert_any_call("admin_seats", {"config_version": "2.0", "plan": "pro", "admin_toggles": {}}, org.id)
         get_plan_limit.assert_any_call("pro", "members")
+        get_plan_limit.assert_any_call("pro", "admin_seats")
         purchased.assert_called_once_with(org.id)
         set_cached.assert_called_once_with(org.id, result)
 

--- a/apps/api/src/tests/services/test_orgs_users_csv.py
+++ b/apps/api/src/tests/services/test_orgs_users_csv.py
@@ -1,0 +1,35 @@
+"""Tests for the _csv_safe CSV-injection neutralizer in src/services/orgs/users.py."""
+
+import pytest
+
+from src.services.orgs.users import _csv_safe
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("=cmd", "'=cmd"),
+        ("+1", "'+1"),
+        ("@x", "'@x"),
+        ("-1", "'-1"),
+        ("\tdanger", "'\tdanger"),
+        ("\rdanger", "'\rdanger"),
+    ],
+)
+def test_csv_safe_prefixes_dangerous_leading_chars(value, expected):
+    assert _csv_safe(value) == expected
+
+
+def test_csv_safe_leaves_normal_string_unchanged():
+    assert _csv_safe("Alice") == "Alice"
+    assert _csv_safe("user@example.com is not leading @") == "user@example.com is not leading @"
+
+
+def test_csv_safe_empty_string_unchanged():
+    assert _csv_safe("") == ""
+
+
+def test_csv_safe_non_string_values_unchanged():
+    assert _csv_safe(123) == 123
+    assert _csv_safe(None) is None
+    assert _csv_safe(True) is True

--- a/apps/api/src/tests/services/test_storage_utils_service.py
+++ b/apps/api/src/tests/services/test_storage_utils_service.py
@@ -131,17 +131,21 @@ class TestStorageClientHelpers:
 
 
 class TestFileReadAndExistenceHelpers:
-    def test_read_file_content_covers_filesystem_and_s3_fallbacks(self, tmp_path):
-        local_file = tmp_path / "content.txt"
-        local_file.write_bytes(b"local-bytes")
+    def test_read_file_content_covers_filesystem_and_s3_fallbacks(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        content_dir = tmp_path / "content"
+        content_dir.mkdir()
+        (content_dir / "content.txt").write_bytes(b"local-bytes")
 
         with patch.object(
             storage_utils,
             "get_content_delivery_type",
             return_value="filesystem",
         ):
-            assert storage_utils.read_file_content(str(local_file)) == b"local-bytes"
-            assert storage_utils.read_file_content(str(tmp_path / "missing.txt")) is None
+            assert storage_utils.read_file_content("content/content.txt") == b"local-bytes"
+            assert storage_utils.read_file_content("content/missing.txt") is None
+            assert storage_utils.read_file_content("content/../../etc/passwd") is None
+            assert storage_utils.read_file_content("/etc/passwd") is None
 
         body = Mock()
         body.read.return_value = b"s3-bytes"

--- a/apps/api/src/tests/services/test_storage_utils_service.py
+++ b/apps/api/src/tests/services/test_storage_utils_service.py
@@ -45,6 +45,49 @@ def reset_storage_utils_state():
     storage_utils._s3_client = None
 
 
+class TestValidateLocalPath:
+    """Direct tests for _validate_local_path (security gate for local reads)."""
+
+    def test_rejects_empty_and_nul_byte(self):
+        # Line 38: empty or NUL-containing paths are rejected outright.
+        assert storage_utils._validate_local_path("") is None
+        assert storage_utils._validate_local_path("content/file\x00.txt") is None
+
+    def test_rejects_absolute_and_traversal(self):
+        assert storage_utils._validate_local_path("/etc/passwd") is None
+        assert storage_utils._validate_local_path("../../etc/passwd") is None
+        assert storage_utils._validate_local_path("content/../../etc/passwd") is None
+
+    def test_accepts_contained_relative_path(self, tmp_path, monkeypatch):
+        # Resolve under the content root so commonpath containment holds.
+        monkeypatch.chdir(tmp_path)
+        content_dir = tmp_path / "content"
+        content_dir.mkdir()
+        (content_dir / "ok.txt").write_text("data")
+
+        assert storage_utils._validate_local_path("content/ok.txt") == "content/ok.txt"
+
+    def test_rejects_path_escaping_content_root(self, tmp_path, monkeypatch):
+        # A path that normalizes inside but realpath-escapes the content root
+        # is rejected by the commonpath check (lines 50-51).
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "content").mkdir()
+        # "sibling/file" resolves to tmp_path/sibling/file which is NOT under
+        # tmp_path/content.
+        assert storage_utils._validate_local_path("sibling/file.txt") is None
+
+    def test_rejects_when_commonpath_raises_value_error(self, tmp_path, monkeypatch):
+        # Lines 52-53: os.path.commonpath raises ValueError (e.g. mixed drives on
+        # Windows) -> treated as unsafe and rejected.
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "content").mkdir()
+        with patch(
+            "src.services.courses.transfer.storage_utils.os.path.commonpath",
+            side_effect=ValueError("paths don't have the same drive"),
+        ):
+            assert storage_utils._validate_local_path("content/ok.txt") is None
+
+
 class TestStorageClientHelpers:
     def test_cached_config_helpers_cover_delivery_bucket_and_s3_flag(self):
         with patch.object(

--- a/apps/api/src/tests/services/test_trail_service.py
+++ b/apps/api/src/tests/services/test_trail_service.py
@@ -152,7 +152,7 @@ class TestTrailService:
         assert empty.runs == []
         assert populated.runs[0].course["course_uuid"] == course.course_uuid
         assert populated.runs[0].course_total_steps == 0
-        assert populated.runs[0].steps[0].data["course"].course_uuid == extra_course.course_uuid
+        assert populated.runs[0].steps[0].data["course"]["course_uuid"] == extra_course.course_uuid
 
     @pytest.mark.asyncio
     async def test_check_trail_presence_creates_trail_and_gets_existing_trail(

--- a/apps/api/src/tests/services/test_usergroups_service.py
+++ b/apps/api/src/tests/services/test_usergroups_service.py
@@ -293,7 +293,7 @@ class TestUsergroupsService:
                     admin_user,
                     UserGroupCreate(name="UG2", description="Desc", org_id=999999),
                 )
-        assert missing_org_exc.value.status_code == 400
+        assert missing_org_exc.value.status_code == 403
 
         with patch(
             "src.services.users.usergroups.rbac_check",

--- a/apps/web/app/auth/callback/google/page.tsx
+++ b/apps/web/app/auth/callback/google/page.tsx
@@ -271,7 +271,7 @@ export default function GoogleCallbackPage() {
           </p>
           <div className="space-y-3">
             <Link
-              href="/login"
+              href="/auth/login"
               className="block w-full py-2 px-4 bg-black text-white rounded-md hover:bg-gray-800 transition-colors"
             >
               Go to Login
@@ -303,7 +303,7 @@ export default function GoogleCallbackPage() {
           <p className="text-gray-600 mb-6">{error}</p>
           <div className="space-y-3">
             <Link
-              href="/login"
+              href="/auth/login"
               className="block w-full py-2 px-4 bg-black text-white rounded-md hover:bg-gray-800 transition-colors"
             >
               Try Again

--- a/apps/web/components/Contexts/AI/AIChatBotContext.tsx
+++ b/apps/web/components/Contexts/AI/AIChatBotContext.tsx
@@ -68,13 +68,13 @@ function aiChatBotReducer(state: any, action: any) {
     case 'addMessage':
       return { ...state, messages: [...state.messages, action.payload] }
     case 'setIsModalOpen':
-      return { ...state, isModalOpen: true }
+      return { ...state, isModalOpen: action.payload ?? true }
     case 'setIsModalClose':
       return { ...state, isModalOpen: false }
     case 'setAichat_uuid':
       return { ...state, aichat_uuid: action.payload }
     case 'setIsWaitingForResponse':
-      return { ...state, isWaitingForResponse: true }
+      return { ...state, isWaitingForResponse: action.payload ?? true }
     case 'setIsNoLongerWaitingForResponse':
       return { ...state, isWaitingForResponse: false }
     case 'setChatInputValue':

--- a/apps/web/components/Contexts/AuthContext.tsx
+++ b/apps/web/components/Contexts/AuthContext.tsx
@@ -78,7 +78,7 @@ interface AuthContextValue {
   session: Session | null
   status: SessionStatus
   accessToken: string | null
-  refreshSession: (force?: boolean) => Promise<void>
+  refreshSession: (force?: boolean) => Promise<string | null>
   signIn: (provider: string, options?: SignInOptions) => Promise<SignInResult | void>
   signOut: (options?: SignOutOptions) => Promise<void>
 }
@@ -167,6 +167,11 @@ export function SessionProvider({
   const intervalRef = useRef<NodeJS.Timeout | null>(null)
   const broadcastChannelRef = useRef<BroadcastChannel | null>(null)
 
+  const accessTokenRef = useRef<string | null>(accessToken)
+  accessTokenRef.current = accessToken
+
+  const refreshSessionInternalRef = useRef<() => Promise<void>>(async () => {})
+
   // Use ref for refresh promise to avoid issues with stale closures
   // but still deduplicate within the same tab
   const refreshPromiseRef = useRef<Promise<{ access_token: string; expiry?: number } | null> | null>(null)
@@ -187,7 +192,7 @@ export function SessionProvider({
           sessionCacheRef.current = null
         } else if (event.data.type === 'LOGIN') {
           // Another tab logged in, refresh our session
-          refreshSessionInternal()
+          refreshSessionInternalRef.current()
         }
       }
     }
@@ -311,8 +316,10 @@ export function SessionProvider({
     }
   }, [refreshAccessToken, fetchUserSession])
 
+  refreshSessionInternalRef.current = refreshSessionInternal
+
   // Main session refresh function
-  const refreshSession = useCallback(async (force?: boolean) => {
+  const refreshSession = useCallback(async (force?: boolean): Promise<string | null> => {
     // Check cache first (skip if force refresh requested)
     const now = Date.now()
     if (
@@ -322,7 +329,7 @@ export function SessionProvider({
     ) {
       setSession(sessionCacheRef.current.data)
       setStatus('authenticated')
-      return
+      return accessTokenRef.current
     }
 
     // Invalidate cache when forcing
@@ -349,7 +356,7 @@ export function SessionProvider({
           setAccessToken(null)
           setTokenExpiry(null)
           sessionCacheRef.current = null
-          return
+          return null
         }
       }
 
@@ -362,15 +369,18 @@ export function SessionProvider({
           data: sessionData,
           timestamp: now,
         }
+        return currentToken
       } else {
         setSession(null)
         setStatus('unauthenticated')
         sessionCacheRef.current = null
+        return null
       }
     } catch (error) {
       console.error('Session refresh error:', error)
       setSession(null)
       setStatus('unauthenticated')
+      return null
     }
   }, [accessToken, tokenExpiry, fetchUserSession, isTokenExpiringSoon, refreshAccessToken])
 
@@ -719,7 +729,9 @@ export function useSession(): UseSessionReturn {
   return {
     data: context.session,
     status: context.status,
-    update: context.refreshSession,
+    update: async (force?: boolean) => {
+      await context.refreshSession(force)
+    },
   }
 }
 
@@ -889,7 +901,8 @@ export function useAuth() {
       if (context.accessToken) {
         const expiry = context.session?.tokens?.expiry
         if (expiry && Date.now() + TOKEN_REFRESH_THRESHOLD >= expiry) {
-          await context.refreshSession()
+          const refreshed = await context.refreshSession()
+          return refreshed ?? context.accessToken
         }
         return context.accessToken
       }

--- a/apps/web/components/Contexts/AuthContext.tsx
+++ b/apps/web/components/Contexts/AuthContext.tsx
@@ -31,7 +31,7 @@ export type SessionStatus = 'loading' | 'authenticated' | 'unauthenticated'
 export interface UseSessionReturn {
   data: Session | null
   status: SessionStatus
-  update: (force?: boolean) => Promise<void>
+  update: (_force?: boolean) => Promise<void>
 }
 
 export interface SignInOptions {
@@ -78,9 +78,9 @@ interface AuthContextValue {
   session: Session | null
   status: SessionStatus
   accessToken: string | null
-  refreshSession: (force?: boolean) => Promise<string | null>
-  signIn: (provider: string, options?: SignInOptions) => Promise<SignInResult | void>
-  signOut: (options?: SignOutOptions) => Promise<void>
+  refreshSession: (_force?: boolean) => Promise<string | null>
+  signIn: (_provider: string, _options?: SignInOptions) => Promise<SignInResult | void>
+  signOut: (_options?: SignOutOptions) => Promise<void>
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)
@@ -140,7 +140,9 @@ function getOAuthStateCookie(): { csrf: string; timestamp: number } | null {
         return JSON.parse(decodeURIComponent(rest.join('=')))
       }
     }
-  } catch {}
+  } catch {
+    /* ignore */
+  }
   return null
 }
 
@@ -164,7 +166,7 @@ export function SessionProvider({
   const [accessToken, setAccessToken] = useState<string | null>(null)
   const [tokenExpiry, setTokenExpiry] = useState<number | null>(null)
   const sessionCacheRef = useRef<SessionCache | null>(null)
-  const intervalRef = useRef<NodeJS.Timeout | null>(null)
+  const intervalRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const broadcastChannelRef = useRef<BroadcastChannel | null>(null)
 
   const accessTokenRef = useRef<string | null>(accessToken)
@@ -678,7 +680,7 @@ export function SessionProvider({
     isRefreshingRef.current = false
 
     // Clear any auth cookies on client side
-    const { secureAttr, domainAttr, sameSiteAttr } = getCookieAttributes()
+    const { secureAttr, domainAttr } = getCookieAttributes()
     const expireAttr = '; expires=Thu, 01 Jan 1970 00:00:00 GMT'
     document.cookie = `LH_oauth_orgslug=; path=/${expireAttr}${secureAttr}${domainAttr}`
     document.cookie = `LH_oauth_org_id=; path=/${expireAttr}${secureAttr}${domainAttr}`
@@ -783,9 +785,6 @@ export async function signIn(
   // For now, we'll handle it differently for Google OAuth which needs redirect
 
   if (provider === 'google') {
-    const { secureAttr, domainAttr, sameSiteAttr } = getCookieAttributes()
-    const baseAttributes = `; path=/${sameSiteAttr}${secureAttr}`
-
     // Store org context from cookies if present (for compatibility)
     // The options should contain orgSlug and orgId if needed
 
@@ -859,7 +858,7 @@ export async function signOut(options?: SignOutOptions): Promise<void> {
   }
 
   // Clear cookies
-  const { secureAttr, domainAttr, sameSiteAttr } = getCookieAttributes()
+  const { secureAttr, domainAttr } = getCookieAttributes()
   const expireAttr = '; expires=Thu, 01 Jan 1970 00:00:00 GMT'
   document.cookie = `LH_oauth_orgslug=; path=/${expireAttr}${secureAttr}${domainAttr}`
   document.cookie = `LH_oauth_org_id=; path=/${expireAttr}${secureAttr}${domainAttr}`

--- a/apps/web/components/Hooks/useOnboarding.ts
+++ b/apps/web/components/Hooks/useOnboarding.ts
@@ -1,5 +1,5 @@
 'use client'
-import { useState, useCallback, useEffect, useRef } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 
 export type OnboardingStep = {
   id: string
@@ -92,22 +92,28 @@ function saveState(state: OnboardingState) {
 
 export function useOnboarding() {
   const [state, setState] = useState<OnboardingState>(loadState)
-  const isExternalUpdate = useRef(false)
 
-  // Sync to localStorage on every change (skip if update came from listener)
-  useEffect(() => {
-    if (isExternalUpdate.current) {
-      isExternalUpdate.current = false
-      return
-    }
-    saveState(state)
-  }, [state])
+  const applyLocalChange = useCallback(
+    (updater: (prev: OnboardingState) => OnboardingState) => {
+      setState((prev) => {
+        const next = updater(prev)
+        if (next !== prev) {
+          saveState(next)
+        }
+        return next
+      })
+    },
+    []
+  )
 
   // Listen for changes from other instances of this hook
   useEffect(() => {
     const handler = () => {
-      isExternalUpdate.current = true
-      setState(loadState())
+      setState((prev) => {
+        const loaded = loadState()
+        if (JSON.stringify(loaded) === JSON.stringify(prev)) return prev
+        return loaded
+      })
     }
     window.addEventListener('lh_onboarding_change', handler)
     return () => window.removeEventListener('lh_onboarding_change', handler)
@@ -125,42 +131,42 @@ export function useOnboarding() {
   const progress = steps.length > 0 ? steps.filter((s) => s.completed).length / steps.length : 0
 
   const completeStep = useCallback((stepId: string) => {
-    setState((prev) => {
+    applyLocalChange((prev) => {
       if (prev.completedSteps.includes(stepId)) return prev
       return { ...prev, completedSteps: [...prev.completedSteps, stepId] }
     })
-  }, [])
+  }, [applyLocalChange])
 
   const toggleMinimized = useCallback(() => {
-    setState((prev) => ({ ...prev, minimized: !prev.minimized }))
-  }, [])
+    applyLocalChange((prev) => ({ ...prev, minimized: !prev.minimized }))
+  }, [applyLocalChange])
 
   const toggleExpanded = useCallback(() => {
-    setState((prev) => ({ ...prev, expanded: !prev.expanded }))
-  }, [])
+    applyLocalChange((prev) => ({ ...prev, expanded: !prev.expanded }))
+  }, [applyLocalChange])
 
   const toggleShowAllSteps = useCallback(() => {
-    setState((prev) => ({ ...prev, showAllSteps: !prev.showAllSteps }))
-  }, [])
+    applyLocalChange((prev) => ({ ...prev, showAllSteps: !prev.showAllSteps }))
+  }, [applyLocalChange])
 
   const dismiss = useCallback(() => {
-    setState((prev) => ({ ...prev, dismissed: true }))
-  }, [])
+    applyLocalChange((prev) => (prev.dismissed ? prev : { ...prev, dismissed: true }))
+  }, [applyLocalChange])
 
   const markWelcomeSeen = useCallback(() => {
-    setState((prev) => ({ ...prev, welcomeSeen: true }))
-  }, [])
+    applyLocalChange((prev) => (prev.welcomeSeen ? prev : { ...prev, welcomeSeen: true }))
+  }, [applyLocalChange])
 
   const skipStep = useCallback((stepId: string) => {
-    setState((prev) => {
+    applyLocalChange((prev) => {
       if (prev.skippedSteps.includes(stepId)) return prev
       return { ...prev, skippedSteps: [...prev.skippedSteps, stepId] }
     })
-  }, [])
+  }, [applyLocalChange])
 
   const reset = useCallback(() => {
-    setState({ completedSteps: [], skippedSteps: [], minimized: false, expanded: false, showAllSteps: false, dismissed: false, welcomeSeen: false })
-  }, [])
+    applyLocalChange(() => ({ completedSteps: [], skippedSteps: [], minimized: false, expanded: false, showAllSteps: false, dismissed: false, welcomeSeen: false }))
+  }, [applyLocalChange])
 
   return {
     steps,

--- a/apps/web/components/Hooks/useOnboarding.ts
+++ b/apps/web/components/Hooks/useOnboarding.ts
@@ -79,7 +79,9 @@ function loadState(): OnboardingState {
         welcomeSeen: parsed.welcomeSeen || false,
       }
     }
-  } catch {}
+  } catch {
+    /* ignore */
+  }
   return { completedSteps: [], skippedSteps: [], minimized: false, expanded: false, showAllSteps: false, dismissed: false, welcomeSeen: false }
 }
 
@@ -87,14 +89,16 @@ function saveState(state: OnboardingState) {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
     window.dispatchEvent(new Event('lh_onboarding_change'))
-  } catch {}
+  } catch {
+    /* ignore */
+  }
 }
 
 export function useOnboarding() {
   const [state, setState] = useState<OnboardingState>(loadState)
 
   const applyLocalChange = useCallback(
-    (updater: (prev: OnboardingState) => OnboardingState) => {
+    (updater: (_prev: OnboardingState) => OnboardingState) => {
       setState((prev) => {
         const next = updater(prev)
         if (next !== prev) {

--- a/apps/web/components/Objects/Communities/CommentSection.tsx
+++ b/apps/web/components/Objects/Communities/CommentSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 import React, { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { MessageSquare, Send, Loader2, User, AlertCircle, Lock, UserPlus } from 'lucide-react'
+import { Loader2, User, AlertCircle, Lock, UserPlus } from 'lucide-react'
 import toast from 'react-hot-toast'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
 import { useOrgMembership } from '@components/Contexts/OrgContext'
@@ -12,7 +12,6 @@ import {
   DiscussionCommentWithAuthor,
 } from '@services/communities/discussions'
 import { CommentCard } from './CommentCard'
-import UserAvatar from '@components/Objects/UserAvatar'
 
 interface CommentSectionProps {
   discussionUuid: string
@@ -25,7 +24,6 @@ export function CommentSection({ discussionUuid, communityUuid, isLocked = false
   const session = useLHSession() as any
   const accessToken = session?.data?.tokens?.access_token
   const isAuthenticated = session?.status === 'authenticated'
-  const currentUser = session?.data?.user
   const { isUserPartOfTheOrg } = useOrgMembership()
   const { canManageCommunity } = useCommunityRights(communityUuid || '')
   const canComment = isAuthenticated && isUserPartOfTheOrg
@@ -48,7 +46,7 @@ export function CommentSection({ discussionUuid, communityUuid, isLocked = false
         if (!stale) {
           setComments(result || [])
         }
-      } catch (_error) {
+      } catch {
         // silent — loading errors are handled by the empty state
       } finally {
         if (!stale) {

--- a/apps/web/components/Objects/Communities/CommentSection.tsx
+++ b/apps/web/components/Objects/Communities/CommentSection.tsx
@@ -38,21 +38,31 @@ export function CommentSection({ discussionUuid, communityUuid, isLocked = false
   const [error, setError] = useState<string | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
-  const fetchComments = async () => {
-    setIsLoading(true)
-    try {
-      const result = await getComments(discussionUuid, 1, 100, null, accessToken)
-      setComments(result || [])
-    } catch (_error) {
-      // silent — loading errors are handled by the empty state
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
   useEffect(() => {
+    let stale = false
+
+    const fetchComments = async () => {
+      setIsLoading(true)
+      try {
+        const result = await getComments(discussionUuid, 1, 100, null, accessToken)
+        if (!stale) {
+          setComments(result || [])
+        }
+      } catch (_error) {
+        // silent — loading errors are handled by the empty state
+      } finally {
+        if (!stale) {
+          setIsLoading(false)
+        }
+      }
+    }
+
     fetchComments()
-  }, [discussionUuid])
+
+    return () => {
+      stale = true
+    }
+  }, [discussionUuid, accessToken])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/apps/web/components/Objects/Courses/CourseProgress/CourseProgress.tsx
+++ b/apps/web/components/Objects/Courses/CourseProgress/CourseProgress.tsx
@@ -62,10 +62,6 @@ const CourseProgress: React.FC<CourseProgressProps> = ({ course, orgslug, isOpen
     }
   }
 
-  const progressPercentage = totalActivities > 0 ? (completedActivities / totalActivities) * 100 : 0
-  const radius = 40
-  const circumference = 2 * Math.PI * radius
-
   const dialogContent = (
     <div className="space-y-4">
       {(course.chapters ?? []).map((chapter: any) => (

--- a/apps/web/components/Objects/Courses/CourseProgress/CourseProgress.tsx
+++ b/apps/web/components/Objects/Courses/CourseProgress/CourseProgress.tsx
@@ -65,7 +65,6 @@ const CourseProgress: React.FC<CourseProgressProps> = ({ course, orgslug, isOpen
   const progressPercentage = totalActivities > 0 ? (completedActivities / totalActivities) * 100 : 0
   const radius = 40
   const circumference = 2 * Math.PI * radius
-  const strokeDashoffset = circumference - (progressPercentage / 100) * circumference
 
   const dialogContent = (
     <div className="space-y-4">

--- a/apps/web/components/Objects/Courses/CourseProgress/CourseProgress.tsx
+++ b/apps/web/components/Objects/Courses/CourseProgress/CourseProgress.tsx
@@ -20,8 +20,8 @@ const CourseProgress: React.FC<CourseProgressProps> = ({ course, orgslug, isOpen
     let total = 0
     let completed = 0
 
-    course.chapters.forEach((chapter: any) => {
-      chapter.activities.forEach((activity: any) => {
+    ;(course.chapters ?? []).forEach((chapter: any) => {
+      (chapter.activities ?? []).forEach((activity: any) => {
         total++
         if (isActivityDone(activity)) {
           completed++
@@ -69,14 +69,14 @@ const CourseProgress: React.FC<CourseProgressProps> = ({ course, orgslug, isOpen
 
   const dialogContent = (
     <div className="space-y-4">
-      {course.chapters.map((chapter: any) => (
+      {(course.chapters ?? []).map((chapter: any) => (
         <div key={chapter.chapter_uuid} className="bg-gray-50 rounded-lg overflow-hidden">
           <div className="px-4 py-3 bg-gray-100 font-semibold text-gray-700 flex items-center space-x-2">
             <Folder size={16} className="text-gray-400" />
             <span>{chapter.name}</span>
           </div>
           <div className="divide-y divide-gray-100">
-            {chapter.activities.map((activity: any) => {
+            {(chapter.activities ?? []).map((activity: any) => {
               const activityId = activity.activity_uuid.replace('activity_', '')
               const courseId = course.course_uuid.replace('course_', '')
               return (

--- a/apps/web/components/Objects/Search/SearchBar.tsx
+++ b/apps/web/components/Objects/Search/SearchBar.tsx
@@ -132,10 +132,14 @@ export const SearchBar: React.FC<SearchBarProps> = ({
   }, []);
 
   useEffect(() => {
+    let stale = false;
+
     const fetchResults = async () => {
       if (debouncedSearch.trim().length === 0) {
-        setSearchResults({ courses: [], collections: [], users: [] });
-        setIsLoading(false);
+        if (!stale) {
+          setSearchResults({ courses: [], collections: [], users: [] });
+          setIsLoading(false);
+        }
         return;
       }
 
@@ -149,7 +153,9 @@ export const SearchBar: React.FC<SearchBarProps> = ({
           null,
           session?.data?.tokens?.access_token
         );
-        
+
+        if (stale) return;
+
         // Type assertion and safe access
         const typedResponse = response.data as any;
 
@@ -169,13 +175,21 @@ export const SearchBar: React.FC<SearchBarProps> = ({
         });
       } catch (error) {
         console.error('Error searching content:', error);
-        setSearchResults({ courses: [], collections: [], users: [] });
+        if (!stale) {
+          setSearchResults({ courses: [], collections: [], users: [] });
+        }
       }
-      setIsLoading(false);
-      setIsInitialLoad(false);
+      if (!stale) {
+        setIsLoading(false);
+        setIsInitialLoad(false);
+      }
     };
 
     fetchResults();
+
+    return () => {
+      stale = true;
+    };
   }, [debouncedSearch, orgslug, session?.data?.tokens?.access_token]);
 
   const MemoizedEmptyState = useMemo(() => {

--- a/apps/web/components/OrgScripts/OrgScripts.tsx
+++ b/apps/web/components/OrgScripts/OrgScripts.tsx
@@ -4,6 +4,14 @@ import React, { useEffect } from 'react'
 import { useOrg } from '@/components/Contexts/OrgContext'
 import DOMPurify from 'dompurify'
 
+if (typeof window !== 'undefined') {
+  DOMPurify.addHook('afterSanitizeAttributes', function (node) {
+    if (node.nodeName === 'SCRIPT') {
+      node.setAttribute('type', 'text/javascript')
+    }
+  })
+}
+
 const OrgScripts: React.FC = () => {
   const org = useOrg() as any
 
@@ -41,12 +49,6 @@ const OrgScripts: React.FC = () => {
     if (typeof window === 'undefined') {
       return content;
     }
-
-    DOMPurify.addHook('afterSanitizeAttributes', function(node) {
-      if (node.nodeName === 'SCRIPT') {
-        node.setAttribute('type', 'text/javascript');
-      }
-    });
 
     const purifyConfig = {
       ALLOWED_TAGS: ['script'],

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -15,6 +15,7 @@ export default [
             "@next/next/no-img-element": "off",
             "unused-imports/no-unused-imports": "warn",
             "no-console": "warn",
+            "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_", "caughtErrorsIgnorePattern": "^_" }],
         },
     },
 ];

--- a/apps/web/hooks/useContributorStatus.ts
+++ b/apps/web/hooks/useContributorStatus.ts
@@ -7,7 +7,7 @@ import { queryKeys } from '@/lib/query/keys';
 export type ContributorStatus = 'NONE' | 'PENDING' | 'ACTIVE' | 'INACTIVE';
 
 interface Contributor {
-  user_id: string;
+  user_id: string | number;
   authorship_status: ContributorStatus;
 }
 
@@ -30,7 +30,7 @@ export function useContributorStatus(courseUuid: string) {
   const contributorStatus = useMemo<ContributorStatus>(() => {
     if (!userId || !data || !Array.isArray(data)) return 'NONE';
     const currentUser = data.find(
-      (contributor: Contributor) => contributor.user_id === userId
+      (contributor: Contributor) => String(contributor.user_id) === String(userId)
     );
     return currentUser ? (currentUser.authorship_status as ContributorStatus) : 'NONE';
   }, [data, userId]);

--- a/apps/web/hooks/useDebounce.ts
+++ b/apps/web/hooks/useDebounce.ts
@@ -1,59 +1,39 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-// Function debouncing
-export function useDebounce<T extends (...args: any[]) => any>(
-  callback: T,
-  delay: number
-): T;
-
-// Value debouncing
-export function useDebounce<T>(value: T, delay: number): T;
-
-// Implementation
 export function useDebounce<T>(valueOrCallback: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState<T>(valueOrCallback);
-  const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
-
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const callbackRef = useRef(valueOrCallback);
-  callbackRef.current = valueOrCallback;
+
+  useEffect(() => {
+    callbackRef.current = valueOrCallback;
+  }, [valueOrCallback]);
 
   const debouncedFn = useCallback((...args: any[]) => {
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
     }
-
     timeoutRef.current = setTimeout(() => {
-      (callbackRef.current as Function)(...args);
+      (callbackRef.current as (...a: any[]) => any)(...args);
     }, delay);
   }, [delay]);
 
   useEffect(() => {
-    // If it's a function, return a debounced version of it
     if (typeof valueOrCallback === 'function') {
       return () => {
-        if (timeoutRef.current) {
-          clearTimeout(timeoutRef.current);
-        }
+        if (timeoutRef.current) clearTimeout(timeoutRef.current);
       };
     }
-
-    // For values, update the debounced value after the delay
     timeoutRef.current = setTimeout(() => {
       setDebouncedValue(valueOrCallback);
     }, delay);
-
     return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
   }, [valueOrCallback, delay]);
 
-  // If it's a function, return a debounced version
   if (typeof valueOrCallback === 'function') {
     return debouncedFn as T;
   }
-
-  // For values, return the debounced value
   return debouncedValue;
 }

--- a/apps/web/hooks/useDebounce.ts
+++ b/apps/web/hooks/useDebounce.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 // Function debouncing
 export function useDebounce<T extends (...args: any[]) => any>(
@@ -13,6 +13,19 @@ export function useDebounce<T>(value: T, delay: number): T;
 export function useDebounce<T>(valueOrCallback: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState<T>(valueOrCallback);
   const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
+
+  const callbackRef = useRef(valueOrCallback);
+  callbackRef.current = valueOrCallback;
+
+  const debouncedFn = useCallback((...args: any[]) => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      (callbackRef.current as Function)(...args);
+    }, delay);
+  }, [delay]);
 
   useEffect(() => {
     // If it's a function, return a debounced version of it
@@ -38,17 +51,9 @@ export function useDebounce<T>(valueOrCallback: T, delay: number): T {
 
   // If it's a function, return a debounced version
   if (typeof valueOrCallback === 'function') {
-    return ((...args: any[]) => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-
-      timeoutRef.current = setTimeout(() => {
-        (valueOrCallback as Function)(...args);
-      }, delay);
-    }) as T;
+    return debouncedFn as T;
   }
 
   // For values, return the debounced value
   return debouncedValue;
-} 
+}

--- a/apps/web/hooks/useDebounce.ts
+++ b/apps/web/hooks/useDebounce.ts
@@ -14,7 +14,7 @@ export function useDebounce<T>(valueOrCallback: T, delay: number): T {
       clearTimeout(timeoutRef.current);
     }
     timeoutRef.current = setTimeout(() => {
-      (callbackRef.current as (...a: any[]) => any)(...args);
+      (callbackRef.current as Function)(...args);
     }, delay);
   }, [delay]);
 


### PR DESCRIPTION
## Summary
High-severity bug fixes and backend security hardening from a full audit of the FastAPI backend and Next.js frontend. **57 files, +886 / −267.**

Verified: backend **2529 tests pass / 0 fail**, app boots (full router+service graph imports); frontend `tsc --noEmit` clean. Tests that asserted pre-fix behavior were updated to assert the new behavior.

## Backend security — broken access control / IDOR
- Cross-org creation checks (`require_org_membership`) for **usergroups, courses, podcasts, boards**; bind `course.org_id` to the validated param (was a no-op using the request body)
- Usergroup: validate added users belong to the org
- MagicBlocks: org-membership check before reserving AI credits; session bound to owner; ownership verified on read/iterate
- RAG chat: verify session belongs to caller
- Chapter update: removed `org_id`/`course_id` from `ChapterUpdate` (mass-assignment relocation)
- Reorder: validate chapter/activity's own course/org (blocks cross-org grafting, keeps legit editor flow)
- Assignments: block student self-grading; enforce `due_date`
- Org `explore` flag removed from update model (superadmin-only)
- Collections: same-org course links; Trail: READ-access check before enroll; content_files: default-deny on unknown paths

## Backend security — injection / file / config
- RAG arbitrary file read (path containment); course-import manifest path traversal; `upload_sqlite` traversal
- Upload type/extension derived from validated content, not client filename
- CSV formula injection neutralized in org + analytics exports
- Magic-link open redirect (`/\evil.com`); email link + CORS pinned to configured domain (no origin reflection w/ credentials)
- CSRF: `fullmatch` + removed dev-mode fail-open; JWT purpose confusion; playground org resolution

## Backend bugs
`await` on 2 broken AI endpoints; AI credit refunds on stream failure; cookie `max_age` (was malformed `expires`); `third_party_login` unbound-var guard; credit summary includes `extra_limit`; `admin_seats` honors purchased seats; trail step serialization; certificate completion counts only live activities; race-safe upvote; bounded webhook-log prune; `join_org` single transaction.

## Frontend bugs
Fetch-race guards (SearchBar/CommentSection); DOMPurify global-hook leak; stable `useDebounce`; `useOnboarding` persistence; OAuth `/auth/login` route; CourseProgress null-guards; AuthContext BroadcastChannel stale closure + `getAccessToken` returns refreshed token; AIChatBot reducer payload; contributor id-type normalization.

## Deferred (need coordinated/architectural work)
sync→async Redis; org-config cache invalidation redesign; JWT `aud` claims; `/refresh` GET→POST; cookie-domain allowlist; Redis revocation fail-open (deliberate availability tradeoff).
