### PR TITLE
fix(api): yield POSIX-style paths from walk_directory on all platforms (#814)

### DIFF
--- a/apps/api/src/services/courses/transfer/storage_utils.py
+++ b/apps/api/src/services/courses/transfer/storage_utils.py
@@ -257,7 +257,9 @@ def walk_directory(base_path: str):
 
         # Yield subdirectories
         for dir_rel in sorted(all_dirs):
-            dir_path = os.path.join(base_path, dir_rel)
+            # POSIX join: S3 keys always use '/', and os.path.join would
+            # produce a backslash on Windows (mixed-separator paths, #814)
+            dir_path = f"{base_path.rstrip('/')}/{dir_rel}"
             files = sorted(dir_files.get(dir_rel, set()))
             # Find immediate subdirs
             subdirs = sorted([
@@ -267,10 +269,11 @@ def walk_directory(base_path: str):
             ])
             yield dir_path, subdirs, files
     else:
-        # Walk local filesystem
+        # Walk local filesystem. Normalize roots to '/' so consumers (and
+        # S3 key builders downstream) see one canonical separator (#814)
         if os.path.exists(base_path):
             for root, dirs, files in os.walk(base_path):
-                yield root, dirs, files
+                yield root.replace(os.sep, '/'), dirs, files
 
 
 def upload_to_s3(file_path: str, content: bytes) -> bool:

--- a/apps/api/src/tests/services/test_storage_utils_service.py
+++ b/apps/api/src/tests/services/test_storage_utils_service.py
@@ -283,10 +283,11 @@ class TestDirectoryHelpers:
         ):
             walked = list(storage_utils.walk_directory(str(base_dir)))
 
+        # walk_directory yields POSIX-style roots on every platform (#814)
         assert walked == [
-            (str(base_dir), ["nested"], ["root.txt"]),
-            (str(nested_dir), ["deeper"], ["child.md"]),
-            (str(deeper_dir), [], ["deep.pdf"]),
+            (base_dir.as_posix(), ["nested"], ["root.txt"]),
+            (nested_dir.as_posix(), ["deeper"], ["child.md"]),
+            (deeper_dir.as_posix(), [], ["deep.pdf"]),
         ]
 
         s3_client = Mock()


### PR DESCRIPTION
## Summary
Fixes the path-separator half of #814 (6 of its 9 Windows test failures): `walk_directory` yielded mixed separators on Windows, because the S3 branch joined its (always `/`-separated) relative keys to the base with `os.path.join`, and the filesystem branch yielded raw `os.walk` roots.

## Changes
- **S3 branch**: `os.path.join(base_path, dir_rel)` → a POSIX string join. S3 keys are `/`-separated by definition, so producing `base\rel` on Windows was never meaningful.
- **Filesystem branch**: normalize `os.walk` roots with `root.replace(os.sep, '/')`, so consumers (including the S3 key builders downstream that previously had to defend with `.replace('\\', '/')`) see one canonical convention on every platform.
- The walk test now asserts with `as_posix()` — identical on Linux CI, correct on Windows.

## Verification
- `test_storage_utils_service.py`: **17/17 pass on Windows** (4 of them failed before)
- Full suite on Linux semantics unaffected — on POSIX systems `os.sep == '/'` makes both changes no-ops
- The remaining 3 failures from #814 are the separate MAX_PATH issue (details and options in the issue thread)
