### PR TITLE
fix(plans): add fetchPlanLimits() with static fallback [LEA-38]

### DIFF
--- a/apps/web/services/plans/plans.ts
+++ b/apps/web/services/plans/plans.ts
@@ -8,9 +8,10 @@
  *   - PlanLevel type
  *   - Plan hierarchy for UI comparisons (plan badges, upgrade prompts)
  *   - Deployment mode helpers (OSS/EE bypass)
+ *   - fetchPlanLimits() — fetches per-plan resource limits from the API
  */
 
-import { getDeploymentMode } from '@services/config/config'
+import { getDeploymentMode, getServerAPIUrl } from '@services/config/config'
 
 export type PlanLevel = 'free' | 'personal' | 'family' | 'standard' | 'pro' | 'enterprise' | 'oss'
 
@@ -51,4 +52,51 @@ export function isFeatureAvailable(featureKey: string, _currentPlan?: PlanLevel)
   // SaaS: resolved_features from the API is the source of truth.
   // Return true here — callers gate on resolved_features separately.
   return true
+}
+
+// ---------------------------------------------------------------------------
+// Plan limit types and fetching
+// ---------------------------------------------------------------------------
+
+export interface PlanLimitEntry {
+  courses: number     // 0 = unlimited
+  members: number     // 0 = unlimited
+  admin_seats: number
+  ai_credits: number  // 0 = no access, -1 = unlimited
+}
+
+// String keys — intentionally not PlanLevel. The API returns 'personal-family'
+// while PlanLevel currently has 'family'; using string avoids that mismatch here.
+export type PlanLimitsMap = Record<string, PlanLimitEntry>
+
+// Safety-net fallback mirroring apps/api/src/security/features_utils/plans.py.
+// Used only when the API is unreachable. ai_credits values come from
+// AI_CREDIT_LIMITS (distinct from PLAN_FEATURE_CONFIGS["features"]["ai"]["limit"]).
+const STATIC_PLAN_LIMITS: PlanLimitsMap = {
+  free:              { courses: 1,   members: 10,   admin_seats: 1,   ai_credits: 0    },
+  personal:          { courses: 0,   members: 1,    admin_seats: 1,   ai_credits: 500  },
+  'personal-family': { courses: 0,   members: 4,    admin_seats: 4,   ai_credits: 3000 },
+  standard:          { courses: 0,   members: 500,  admin_seats: 2,   ai_credits: 1000 },
+  pro:               { courses: 0,   members: 1000, admin_seats: 10,  ai_credits: 3000 },
+  enterprise:        { courses: 0,   members: 0,    admin_seats: 100, ai_credits: -1   },
+}
+
+/**
+ * Fetch per-plan resource limits from the API.
+ * Falls back to STATIC_PLAN_LIMITS when the API is unreachable so callers
+ * never throw — the onboarding page stays functional regardless of backend
+ * connectivity.
+ *
+ * Always called server-side (Next.js server action); uses getServerAPIUrl()
+ * which always returns a full URL, never a relative path.
+ */
+export async function fetchPlanLimits(): Promise<PlanLimitsMap> {
+  try {
+    const response = await fetch(`${getServerAPIUrl()}plans`)
+    if (!response.ok) throw new Error(`GET /api/v1/plans returned ${response.status}`)
+    return response.json()
+  } catch (err) {
+    console.error('[plans] fetchPlanLimits failed, using static fallback:', err)
+    return STATIC_PLAN_LIMITS
+  }
 }


### PR DESCRIPTION
## Problem

`fetchPlanLimits()` in the onboarding flow calls `GET /api/v1/plans` and receives a 404, crashing `/dashboard/new` for 1,024 users (Sentry: LEARNHOUSE-PLATFORM-1, 1,587 events since April 23).

Root cause: `NEXT_PUBLIC_LEARNHOUSE_BACKEND_URL` on Vercel points to the frontend URL, creating a server-side loopback through the catch-all proxy at `app/api/v1/[...path]`. Next.js returns 404 for such self-referential requests.

## What this PR does

Adds four new exports to `apps/web/services/plans/plans.ts` — **purely additive, zero changes to existing exports**:

| Export | Purpose |
|--------|---------|
| `PlanLimitEntry` | Interface matching the API response shape |
| `PlanLimitsMap` | `Record<string, PlanLimitEntry>` — string keys to correctly handle `'personal-family'` from the API |
| `STATIC_PLAN_LIMITS` | Fallback data mirroring `apps/api/src/security/features_utils/plans.py` exactly |
| `fetchPlanLimits()` | Calls `GET /api/v1/plans` via `getServerAPIUrl()`, falls back to static data on any error |

`fetchPlanLimits()` never throws — the fallback ensures `/dashboard/new` renders with correct plan data even while the infra root cause (`NEXT_PUBLIC_LEARNHOUSE_BACKEND_URL`) is being fixed separately.

## What does NOT change

- `PlanLevel` type — unchanged
- `PLAN_HIERARCHY` — unchanged  
- `planMeetsRequirement()` — unchanged
- `isFeatureAvailable()` — unchanged
- No component, hook, or page files touched

## Callers

The existing `fetchPlanLimits` in the private `services/stripe/stripe.ts` (wrong home — plan limits aren't a Stripe concept) should be removed and replaced with an import from this file:

```typescript
import { fetchPlanLimits } from '@services/plans/plans'
```

## Follow-up

- **Infra (required):** Set `NEXT_PUBLIC_LEARNHOUSE_BACKEND_URL` in Vercel to the actual Python backend URL — this fixes the loopback for all `/api/v1/*` routes
- **LEA-39 (separate):** Rename `PlanLevel` `'family'` → `'personal-family'` to match the API, and update the two callers in `courses/client.tsx` and `courses/courses.tsx`

## Blast-radius audit

Searched entire `apps/web` for `'family'` as a plan literal — only 2 files use it, both in a `currentPlan === 'family'` check unrelated to plan limits. Neither is touched by this PR. TypeScript will enforce correctness at the call sites when this is imported.