### PR TITLE
ci(web-lint): make strict lint gate diff-aware

### DIFF
--- a/.github/workflows/web-lint.yaml
+++ b/.github/workflows/web-lint.yaml
@@ -35,21 +35,14 @@ jobs:
           fi
           echo "ESLint ran to completion (exit ${EXIT_CODE:-0}); lint debt is reported above but not enforced yet."
         working-directory: ./apps/web
-      # Strict gate: files changed in a PR must be lint-clean. This stops new
-      # debt while the backlog shrinks, without blocking on pre-existing issues.
-      - name: Strict lint on changed files (PRs)
+      # Strict gate: stops *new* lint debt without blocking on pre-existing
+      # issues. Diff-aware — it lints the files a PR touches but only fails on
+      # errors that land on lines the PR added/modified, so a PR that merely
+      # edits a file carrying old debt is not punished for that debt. The
+      # report-only full-project step above still surfaces the backlog.
+      - name: Strict lint on changed lines (PRs)
         if: github.event_name == 'pull_request'
         working-directory: ./apps/web
-        run: |
-          # Pathspecs are resolved relative to working-directory (apps/web),
-          # while --name-only output stays repo-root-relative — hence the sed.
-          CHANGED=$(git diff --name-only --diff-filter=ACMR "origin/${GITHUB_BASE_REF}...HEAD" -- \
-            '**/*.ts' '**/*.tsx' '**/*.js' '**/*.jsx' '**/*.mjs' \
-            | sed 's|^apps/web/||')
-          if [ -z "$CHANGED" ]; then
-            echo "No changed lintable files."
-            exit 0
-          fi
-          echo "Strict-linting changed files:"
-          echo "$CHANGED"
-          echo "$CHANGED" | xargs bun run lint:strict --no-error-on-unmatched-pattern
+        env:
+          LINT_DIFF_BASE: origin/${{ github.base_ref }}
+        run: node scripts/lint-changed-lines.mjs

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,8 @@
     "start": "next start",
     "lint": "eslint . || true",
     "lint:fix": "eslint --fix . || true",
-    "lint:strict": "eslint"
+    "lint:strict": "eslint",
+    "lint:changed": "node scripts/lint-changed-lines.mjs"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.18.4",

--- a/apps/web/scripts/lint-changed-lines.mjs
+++ b/apps/web/scripts/lint-changed-lines.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// Diff-aware strict lint gate.
+//
+// The previous strict gate ran ESLint over *entire* files a PR touched, so it
+// failed on pre-existing debt in any file a PR happened to edit — contradicting
+// its own intent ("stop new debt ... without blocking on pre-existing issues").
+//
+// This version lints the changed files but only *fails* on errors that land on
+// lines the PR actually added/modified. Pre-existing debt on untouched lines is
+// still surfaced by the report-only full-project gate, just not blocking here.
+//
+// Security: all dynamic values (base ref, PR-controlled file paths) are passed
+// as argv via execFileSync — never interpolated into a shell string.
+//
+// Env:
+//   LINT_DIFF_BASE   base ref to diff against (default: origin/$GITHUB_BASE_REF, else origin/dev)
+// Exit: 0 = clean, 1 = new error(s) on changed lines, 2 = tooling failure.
+
+import { execFileSync } from 'node:child_process'
+
+const EXTS = ['ts', 'tsx', 'js', 'jsx', 'mjs']
+const base =
+    process.env.LINT_DIFF_BASE ||
+    (process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : 'origin/dev')
+
+const git = (args, opts = {}) =>
+    execFileSync('git', args, { encoding: 'utf8', maxBuffer: 128 * 1024 * 1024, ...opts })
+
+const root = git(['rev-parse', '--show-toplevel']).trim()
+const pathspecs = EXTS.map((e) => `apps/web/**/*.${e}`)
+
+// 1. Changed lintable files under apps/web (repo-root-relative paths).
+const files = git([
+    '-C', root, 'diff', '--name-only', '--diff-filter=ACMR',
+    `${base}...HEAD`, '--', ...pathspecs,
+]).split('\n').filter(Boolean)
+
+if (files.length === 0) {
+    console.log('No changed lintable files under apps/web.')
+    process.exit(0)
+}
+
+// 2. Added/modified line numbers per file, from a zero-context diff.
+const addedLines = {} // webRelPath -> Set<number>
+for (const f of files) {
+    const webRel = f.replace(/^apps\/web\//, '')
+    const set = new Set()
+    const diff = git([
+        '-C', root, 'diff', '--unified=0', '--diff-filter=ACMR',
+        `${base}...HEAD`, '--', f,
+    ])
+    let cur = 0
+    for (const line of diff.split('\n')) {
+        const hunk = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/)
+        if (hunk) {
+            cur = parseInt(hunk[1], 10)
+            continue
+        }
+        if (line.startsWith('+') && !line.startsWith('+++')) {
+            set.add(cur)
+            cur++
+        }
+        // '-' lines and headers don't advance the new-file line counter.
+    }
+    addedLines[webRel] = set
+}
+
+// 3. Run ESLint (JSON) on the changed files; ESLint exits 1 when it reports
+//    errors but still prints JSON to stdout — capture both paths.
+const webFiles = files.map((f) => f.replace(/^apps\/web\//, ''))
+let results
+try {
+    const out = execFileSync(
+        'bunx',
+        ['eslint', '-f', 'json', '--no-error-on-unmatched-pattern', ...webFiles],
+        { encoding: 'utf8', maxBuffer: 128 * 1024 * 1024, cwd: `${root}/apps/web` },
+    )
+    results = JSON.parse(out)
+} catch (e) {
+    if (e.stdout && String(e.stdout).trim().startsWith('[')) {
+        results = JSON.parse(e.stdout)
+    } else {
+        console.error('ESLint failed to run (exit 2 / crash):')
+        console.error(e.stderr || e.message)
+        process.exit(2)
+    }
+}
+
+// 4. Keep only error-severity messages that fall on added/modified lines.
+const offenders = []
+for (const r of results) {
+    const webRel = r.filePath.split('/apps/web/').pop()
+    const added = addedLines[webRel]
+    if (!added) continue
+    for (const m of r.messages) {
+        if (m.severity !== 2) continue // errors only; warnings are non-blocking
+        if (added.has(m.line || 0)) {
+            offenders.push(`${webRel}:${m.line}:${m.column}  ${m.ruleId || '(parse error)'}  ${m.message}`)
+        }
+    }
+}
+
+if (offenders.length) {
+    console.error('New lint errors introduced on changed lines:\n')
+    for (const o of offenders) console.error('  ' + o)
+    console.error(`\n✖ ${offenders.length} new error(s) on changed lines — fix these before merging.`)
+    process.exit(1)
+}
+
+console.log(`Diff-aware lint clean: no new errors on changed lines across ${files.length} file(s).`)
+process.exit(0)


### PR DESCRIPTION
## Problem

The strict `next-lint` gate runs ESLint over **entire files** a PR touches, so it fails on **pre-existing debt** in any edited file — directly contradicting its own comment ("stop new debt … without blocking on pre-existing issues").

This blocked legitimate PRs through no fault of their own. Concrete case: **#858** (adds `type="button"` to editor components) introduces **zero** new lint errors — verified 40 errors on `dev` vs 40 on the PR, identical file-by-file — yet `next-lint` failed on the editor backlog it merely touched. Same structural issue hit #818.

## Fix

A **diff-aware** strict gate (`apps/web/scripts/lint-changed-lines.mjs`): lints the changed files but only **fails on errors that land on lines the PR added/modified**. Pre-existing debt on untouched lines stays visible via the existing report-only full-project step.

- `.github/workflows/web-lint.yaml` — strict step now runs the script; base ref passed via `env:` (safe pattern).
- `apps/web/package.json` — adds `bun run lint:changed` for local pre-push checks.
- Security: all dynamic inputs (base ref, PR-controlled paths) go through `execFileSync` argv arrays — no shell, no injection.

## Verification (local)

| Test | Expect | Result |
|---|---|---|
| #858 (40 pre-existing errors, none on changed lines) | pass | exit 0 |
| Synthetic new error on a changed line | fail + pinpoint | exit 1, exact file:line |
| New script linted under project config | clean | 0 errors |

Unblocks #858 and every future PR that edits a file carrying old debt.