### PR TITLE
fix(upload): show upload errors for pdf and image blocks

### DIFF
--- a/apps/web/components/Objects/Editor/Extensions/Image/ImageBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Image/ImageBlockComponent.tsx
@@ -55,6 +55,7 @@ function ImageBlockComponent(props: any) {
     const file = event.target.files?.[0]
     if (file) {
       setImage(file)
+      setError(null)
       handleUpload(file)
     }
   }
@@ -77,9 +78,9 @@ function ImageBlockComponent(props: any) {
       })
       setImage(null)
     } catch (err: any) {
-      const errorMessage = err?.message || 'Failed to upload image. Please try again.'
+      const errorMessage = err?.message || 'Upload failed — please try again'
       setError(errorMessage)
-      toast.error(errorMessage)
+      toast.error(errorMessage.includes('Upload failed') ? errorMessage : `Upload failed — please try again: ${errorMessage}`)
     } finally {
       setIsLoading(false)
     }
@@ -299,7 +300,13 @@ function ImageBlockComponent(props: any) {
                 onDrop={handleDrop}
                 className={`
                   border-2 border-dashed rounded-lg p-6 text-center cursor-pointer transition-all flex flex-col items-center justify-center min-h-[160px]
-                  ${isDragging ? 'border-neutral-400 bg-neutral-100' : 'border-neutral-200 bg-white hover:border-neutral-400 hover:bg-neutral-50'}
+                  ${
+                    error
+                      ? 'border-red-300 bg-red-50/30 hover:border-red-400 hover:bg-red-50/50'
+                      : isDragging
+                      ? 'border-neutral-400 bg-neutral-100'
+                      : 'border-neutral-200 bg-white hover:border-neutral-400 hover:bg-neutral-50'
+                  }
                 `}
               >
                 <input

--- a/apps/web/components/Objects/Editor/Extensions/PDF/PDFBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/PDF/PDFBlockComponent.tsx
@@ -38,6 +38,7 @@ function PDFBlockComponent(props: any) {
     const file = event.target.files?.[0]
     if (file) {
       setPDF(file)
+      setError(null)
     }
   }
 
@@ -57,9 +58,9 @@ function PDFBlockComponent(props: any) {
       })
       setPDF(null)
     } catch (err: any) {
-      const errorMessage = err?.message || 'Failed to upload PDF. Please try again.'
+      const errorMessage = err?.message || 'Upload failed — please try again'
       setError(errorMessage)
-      toast.error(errorMessage)
+      toast.error(errorMessage.includes('Upload failed') ? errorMessage : `Upload failed — please try again: ${errorMessage}`)
     } finally {
       setIsLoading(false)
     }
@@ -183,7 +184,11 @@ function PDFBlockComponent(props: any) {
             <form onSubmit={handleSubmit}>
               <div
                 onClick={() => fileInputRef.current?.click()}
-                className="border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-all border-neutral-200 bg-white hover:border-blue-400 hover:bg-blue-50/50"
+                className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-all ${
+                  error
+                    ? 'border-red-300 bg-red-50/30 hover:border-red-400 hover:bg-red-50/50'
+                    : 'border-neutral-200 bg-white hover:border-blue-400 hover:bg-blue-50/50'
+                }`}
               >
                 <input
                   ref={fileInputRef}

--- a/apps/web/services/blocks/Image/images.ts
+++ b/apps/web/services/blocks/Image/images.ts
@@ -35,10 +35,22 @@ export async function uploadNewImageFile(
 
 export async function getImageFile(file_id: string, access_token: string) {
   // todo : add course id to url
-  return fetch(
+  const result = await fetch(
     `${getAPIUrl()}blocks/image?file_id=${file_id}`,
     RequestBodyWithAuthHeader('GET', null, null, access_token)
   )
-    .then((result) => result.json())
-    .catch((error) => console.log('error', error))
+
+  const data = await result.json()
+
+  if (!result.ok) {
+    const errorMessage = typeof data?.detail === 'string'
+      ? data.detail
+      : Array.isArray(data?.detail)
+        ? data.detail.map((e: any) => e.msg).join(', ')
+        : 'Failed to retrieve image'
+    throw new Error(errorMessage)
+  }
+
+  return data
 }
+

--- a/apps/web/services/blocks/Pdf/pdf.ts
+++ b/apps/web/services/blocks/Pdf/pdf.ts
@@ -35,10 +35,22 @@ export async function uploadNewPDFFile(
 
 export async function getPDFFile(file_id: string, access_token: string) {
   // todo : add course id to url
-  return fetch(
+  const result = await fetch(
     `${getAPIUrl()}blocks/pdf?file_id=${file_id}`,
     RequestBodyWithAuthHeader('GET', null, null, access_token)
   )
-    .then((result) => result.json())
-    .catch((error) => console.log('error', error))
+
+  const data = await result.json()
+
+  if (!result.ok) {
+    const errorMessage = typeof data?.detail === 'string'
+      ? data.detail
+      : Array.isArray(data?.detail)
+        ? data.detail.map((e: any) => e.msg).join(', ')
+        : 'Failed to retrieve PDF'
+    throw new Error(errorMessage)
+  }
+
+  return data
 }
+


### PR DESCRIPTION
## Summary

Replaces silent upload error handling in PDF and Image upload services.

## Changes

* Removed silent `console.log` error swallowing.
* Added user-facing toast notifications when uploads fail.
* Added visible error states to PDF and Image upload blocks.
* Preserved existing successful upload behavior.

Closes #848