### PR TITLE
fix(cli): actually pull new image during `learnhouse update`

### DIFF
--- a/apps/cli/src/commands/update.ts
+++ b/apps/cli/src/commands/update.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 import * as p from '@clack/prompts'
 import pc from 'picocolors'
 import { findInstallDir, readConfig } from '../services/config-store.js'
-import { dockerComposeDown, dockerComposeUp } from '../services/docker.js'
+import { dockerComposeDown, dockerComposeUp, dockerComposePull } from '../services/docker.js'
 import { migrateContentVolume } from '../services/content-volume-migration.js'
 import { waitForHealth } from '../services/health.js'
 import {
@@ -135,8 +135,8 @@ export async function updateCommand(options: { version?: string; migrate?: boole
     writeFileSync(composePath, updatedCompose)
 
     s.start('Pulling image')
-    // docker compose up with --pull always handles the pull
-    s.stop('Image reference updated')
+    dockerComposePull(config.installDir)
+    s.stop('Image pulled')
 
     // Preserve any uploaded media before the container is recreated.
     s.start('Checking content storage')
@@ -169,7 +169,7 @@ export async function updateCommand(options: { version?: string; migrate?: boole
 
     s.start('Restarting services')
     dockerComposeDown(config.installDir)
-    dockerComposeUp(config.installDir)
+    dockerComposeUp(config.installDir, false, true)
     s.stop('Services restarted')
 
     // 4) Wait for the app, then run migrations via the shared helper.

--- a/apps/cli/src/services/docker.ts
+++ b/apps/cli/src/services/docker.ts
@@ -26,8 +26,10 @@ export function isDockerRunning(): boolean {
   }
 }
 
-export function dockerComposeUp(cwd: string, pull = false): void {
-  const cmd = pull ? 'docker compose up -d --pull always' : 'docker compose up -d'
+export function dockerComposeUp(cwd: string, pull = false, forceRecreate = false): void {
+  let cmd = 'docker compose up -d'
+  if (pull) cmd += ' --pull always'
+  if (forceRecreate) cmd += ' --force-recreate'
   execSync(cmd, {
     cwd,
     stdio: 'inherit',

--- a/apps/cli/tests/unit.test.ts
+++ b/apps/cli/tests/unit.test.ts
@@ -447,6 +447,14 @@ vi.mock('../src/services/docker.js', async () => {
   return { ...actual, isContainerRunning: vi.fn(() => false) }
 })
 
+// Stub child_process so the docker helpers below build their command
+// strings without shelling out to a real Docker daemon. importActual keeps
+// spawn/spawnSync intact; only execSync is captured.
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process')
+  return { ...actual, execSync: vi.fn(() => Buffer.from('')) }
+})
+
 describe('findInstallDir — picks the running install over a stale one', () => {
   const fakeHome = path.join(os.tmpdir(), 'lh-findinstall-' + Date.now())
   const lhBase = path.join(fakeHome, '.learnhouse')
@@ -564,5 +572,60 @@ describe('validateEmail — reserved TLDs', () => {
 
   it('is case-insensitive on the TLD', () => {
     expect(validateEmail('admin@SCHOOL.LOCAL')).toMatch(/RFC 6761|reserved/i)
+  })
+})
+
+// ─── Regression: `update` must pull the new image, not reuse cache ──
+//
+// The update command rewrote docker-compose.yml with the new tag but
+// skipped the pull, so `docker compose up -d` reused the cached layer
+// and the container restarted on the OLD image (reported on Discord by
+// Pierluigi2497 after 1.2.2 → 1.2.6: app.py still read version="1.2.2").
+//
+// The fix calls dockerComposePull() explicitly and recreates the
+// container from the freshly-pulled image (dockerComposeUp with
+// forceRecreate=true). These tests lock in the command strings so the
+// pull/recreate flags can't silently regress again.
+
+describe('docker compose helpers — update pull/recreate flags', () => {
+  let execSync: ReturnType<typeof vi.fn>
+  let dockerComposeUp: typeof import('../src/services/docker.js').dockerComposeUp
+  let dockerComposePull: typeof import('../src/services/docker.js').dockerComposePull
+
+  beforeEach(async () => {
+    const cp = await import('node:child_process')
+    execSync = cp.execSync as unknown as ReturnType<typeof vi.fn>
+    execSync.mockClear()
+    ;({ dockerComposeUp, dockerComposePull } = await import('../src/services/docker.js'))
+  })
+
+  const lastCmd = () => execSync.mock.calls.at(-1)?.[0] as string
+  const lastOpts = () => execSync.mock.calls.at(-1)?.[1] as { cwd?: string }
+
+  it('plain up uses neither --pull nor --force-recreate', () => {
+    dockerComposeUp('/srv/lh')
+    expect(lastCmd()).toBe('docker compose up -d')
+    expect(lastOpts().cwd).toBe('/srv/lh')
+  })
+
+  it('pull=true adds --pull always', () => {
+    dockerComposeUp('/srv/lh', true)
+    expect(lastCmd()).toBe('docker compose up -d --pull always')
+  })
+
+  it('forceRecreate=true adds --force-recreate (the update path)', () => {
+    dockerComposeUp('/srv/lh', false, true)
+    expect(lastCmd()).toBe('docker compose up -d --force-recreate')
+  })
+
+  it('both flags compose in a stable order', () => {
+    dockerComposeUp('/srv/lh', true, true)
+    expect(lastCmd()).toBe('docker compose up -d --pull always --force-recreate')
+  })
+
+  it('dockerComposePull runs `docker compose pull` in the install dir', () => {
+    dockerComposePull('/srv/lh')
+    expect(lastCmd()).toBe('docker compose pull')
+    expect(lastOpts().cwd).toBe('/srv/lh')
   })
 })


### PR DESCRIPTION
## Root cause

The `update` command updated `docker-compose.yml` with the new image tag but **never actually pulled the image**. The spinner at step 3 started and immediately stopped — the code had a stale comment:

```typescript
s.start('Pulling image')
// docker compose up with --pull always handles the pull
s.stop('Image reference updated')   // ← pulled nothing
```

But `dockerComposeUp()` was called without `pull = true`, so Docker reused the locally-cached layer. The container restarted on the old image regardless of what tag was in `docker-compose.yml`.

Reported on Discord by Pierluigi2497 after upgrading from 1.2.2 → 1.2.6:
> "I checked the volume and in the file `app/api/app.py` there was `version="1.2.2"` instead of `version="1.2.6"`"
> Workaround: `docker compose pull learnhouse-app && docker compose up -d --force-recreate learnhouse-app`

## Fix

- Call `dockerComposePull(installDir)` explicitly so the new image is fetched before the container restarts.
- Pass `forceRecreate = true` to `dockerComposeUp` so the container is always recreated from the freshly-pulled image (matches the manual workaround users discovered).
- Add `forceRecreate` parameter to `dockerComposeUp` in `docker.ts` (backward-compatible default `false`).

## Files changed

- `apps/cli/src/commands/update.ts` — import + call `dockerComposePull`, pass `forceRecreate=true`
- `apps/cli/src/services/docker.ts` — add `forceRecreate` flag to `dockerComposeUp`