### PR TITLE
fix(api): high-impact backend security & reliability fixes (~145)

### DIFF
--- a/apps/api/src/core/events/autoinstall.py
+++ b/apps/api/src/core/events/autoinstall.py
@@ -19,11 +19,17 @@ async def auto_install():
     engine = create_engine(
         sync_connection_string, echo=False, pool_pre_ping=True
     )
-    SQLModel.metadata.create_all(engine)
+    try:
+        SQLModel.metadata.create_all(engine)
 
-    # Check for existing orgs using the sync engine
-    with Session(engine) as db_session:
-        any_org = db_session.exec(select(Organization)).first()
+        # Check for existing orgs using the sync engine
+        with Session(engine) as db_session:
+            any_org = db_session.exec(select(Organization)).first()
+    finally:
+        # Always release the sync engine's pooled connections; this engine is
+        # only used for the startup org check and must not leak a pool for the
+        # lifetime of the process.
+        engine.dispose()
 
     if not any_org:
         logger.info("No organizations found. Starting auto-installation")
@@ -33,12 +39,39 @@ async def auto_install():
     # Refresh global default roles (IDs 1-4) so this release's new permission
     # keys (e.g. playgrounds, boards) land in the DB. Idempotent.
     try:
-        async_connection_string = (
-            str(sync_connection_string)
-            .replace("postgresql://", "postgresql+asyncpg://")
-            .replace("postgresql+psycopg2://", "postgresql+asyncpg://")
+        async_connection_string = str(sync_connection_string)
+        # Normalise every supported sync/driver prefix to asyncpg. Order matters:
+        # the more specific "postgresql+psycopg2://" must be handled before the
+        # generic "postgresql://", and the "postgres://" alias (Heroku/Supabase
+        # style) must be converted too — otherwise create_async_engine() raises
+        # because the default psycopg2/no driver is not async-capable.
+        if async_connection_string.startswith("postgresql+psycopg2://"):
+            async_connection_string = async_connection_string.replace(
+                "postgresql+psycopg2://", "postgresql+asyncpg://", 1
+            )
+        elif async_connection_string.startswith("postgresql://"):
+            async_connection_string = async_connection_string.replace(
+                "postgresql://", "postgresql+asyncpg://", 1
+            )
+        elif async_connection_string.startswith("postgres://"):
+            async_connection_string = async_connection_string.replace(
+                "postgres://", "postgresql+asyncpg://", 1
+            )
+        # On pooled Postgres (PgBouncer / Supavisor transaction mode) asyncpg's
+        # named prepared statements collide across recycled backend connections,
+        # raising DuplicatePreparedStatementError. Mirror the main engine's
+        # connect_args so this refresh works on pooled deployments instead of
+        # silently failing and leaving new RBAC permission keys out of the DB.
+        async_engine = create_async_engine(
+            async_connection_string,
+            echo=False,
+            pool_pre_ping=True,
+            connect_args={
+                "statement_cache_size": 0,
+                "prepared_statement_name_func": lambda: "",
+                "prepared_statement_cache_size": 0,
+            },
         )
-        async_engine = create_async_engine(async_connection_string, echo=False, pool_pre_ping=True)
         factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
         try:
             async with factory() as session:

--- a/apps/api/src/core/middleware/cors.py
+++ b/apps/api/src/core/middleware/cors.py
@@ -36,7 +36,11 @@ def _single_tenancy_origin_regex(config) -> str:
         config.hosting_config.domain,
     ):
         host = _host_from(cfg_value)
-        if host and "localhost" not in host:
+        # Exclude only the loopback hosts themselves (added separately below).
+        # Use an exact match, not a substring check, so a legitimate operator
+        # domain that merely contains "localhost" (e.g. "my-localhost-app.com")
+        # is not silently dropped — which would break CORS for their frontend.
+        if host and host not in ("localhost", "127.0.0.1"):
             hosts.add(host)
 
     if not hosts:
@@ -65,7 +69,18 @@ def get_cors_origin_regex() -> str:
     config = get_learnhouse_config()
     if config.hosting_config.tenancy == "single":
         return _single_tenancy_origin_regex(config)
-    return config.hosting_config.allowed_regexp
+    # Multi-tenancy: use the configured regexp. If the operator left it empty
+    # (it is not required for multi mode, only the base domain is), fall back to
+    # a domain-and-subdomain regex derived from the configured domain. Returning
+    # an empty/None value here makes CORSMiddleware reject every cross-origin
+    # request with credentials, taking the whole SaaS frontend offline.
+    allowed_regexp = config.hosting_config.allowed_regexp
+    if allowed_regexp:
+        return allowed_regexp
+    domain = _host_from(config.hosting_config.domain)
+    if domain:
+        return rf"^https?://(?:[a-z0-9-]+\.)*{re.escape(domain)}(:\d+)?$"
+    return _SINGLE_TENANCY_LOCALHOST_REGEX
 
 
 def configure_cors(app: FastAPI) -> None:

--- a/apps/api/src/db/boards.py
+++ b/apps/api/src/db/boards.py
@@ -14,7 +14,13 @@ class BoardBase(SQLModel):
     name: str
     description: Optional[str] = None
     thumbnail_image: Optional[str] = Field(default="")
-    public: bool = Field(default=True)
+    # Secure-by-default: new boards are private. Boards are gated for anonymous
+    # access by this flag alone (has_published_field=False in RBAC config), so
+    # defaulting to True would make every new board anonymously readable. This
+    # default only affects newly-created rows; existing boards keep their stored
+    # value, so flipping it does not retroactively change current boards. Owners
+    # opt into public sharing via BoardCreate.public=True or BoardUpdate.public.
+    public: bool = Field(default=False)
 
 
 class Board(BoardBase, table=True):
@@ -47,6 +53,10 @@ class BoardCreate(SQLModel):
     name: str
     description: Optional[str] = None
     thumbnail_image: Optional[str] = Field(default="")
+    # Explicit opt-in for public boards; defaults to private (secure default).
+    # The frontend create flow should surface a "make public" toggle for users
+    # who want the board listed in the public gallery.
+    public: bool = Field(default=False)
 
 
 class BoardUpdate(SQLModel):

--- a/apps/api/src/db/communities/communities.py
+++ b/apps/api/src/db/communities/communities.py
@@ -38,7 +38,7 @@ class Community(CommunityBase, table=True):
         sa_column=Column(Integer, ForeignKey("course.id", ondelete="SET NULL"))
     )
     community_uuid: str = Field(default="", index=True)
-    moderation_words: List[str] = Field(default=[], sa_column=Column(JSON, default=[]))
+    moderation_words: List[str] = Field(default_factory=list, sa_column=Column(JSON, default=list))
     moderation_settings: Optional[Dict[str, Any]] = Field(
         default=None, sa_column=Column(JSON, nullable=True)
     )

--- a/apps/api/src/db/communities/discussion_comments.py
+++ b/apps/api/src/db/communities/discussion_comments.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from sqlalchemy import Column, ForeignKey, Integer, Text, Index
 from sqlmodel import Field, SQLModel
-from src.db.users import UserRead
+from src.db.users import UserReadAuthor
 
 
 class DiscussionCommentBase(SQLModel):
@@ -47,7 +47,7 @@ class DiscussionCommentRead(DiscussionCommentBase):
 
 
 class DiscussionCommentReadWithAuthor(DiscussionCommentRead):
-    author: Optional[UserRead] = None
+    author: Optional[UserReadAuthor] = None
 
 
 class DiscussionCommentReadWithVoteStatus(DiscussionCommentReadWithAuthor):

--- a/apps/api/src/db/communities/discussion_comments.py
+++ b/apps/api/src/db/communities/discussion_comments.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from sqlalchemy import Column, ForeignKey, Integer, Text
+from sqlalchemy import Column, ForeignKey, Integer, Text, Index
 from sqlmodel import Field, SQLModel
 from src.db.users import UserRead
 
@@ -10,6 +10,9 @@ class DiscussionCommentBase(SQLModel):
 
 class DiscussionComment(DiscussionCommentBase, table=True):
     __tablename__ = "discussioncomment"
+    __table_args__ = (
+        Index("ix_discussioncomment_discussion_id", "discussion_id"),
+    )
 
     id: Optional[int] = Field(default=None, primary_key=True)
     discussion_id: int = Field(
@@ -18,7 +21,7 @@ class DiscussionComment(DiscussionCommentBase, table=True):
     author_id: int = Field(
         sa_column=Column(Integer, ForeignKey("user.id", ondelete="CASCADE"))
     )
-    comment_uuid: str = ""
+    comment_uuid: str = Field(default="", index=True)
     upvote_count: int = 0
     creation_date: str = ""
     update_date: str = ""

--- a/apps/api/src/db/communities/discussions.py
+++ b/apps/api/src/db/communities/discussions.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from sqlalchemy import Column, ForeignKey, Integer, Text, Boolean, String
+from sqlalchemy import Column, ForeignKey, Integer, Text, Boolean, String, Index
 from sqlmodel import Field, SQLModel
 from src.db.users import UserRead
 
@@ -22,6 +22,9 @@ class DiscussionBase(SQLModel):
 
 
 class Discussion(DiscussionBase, table=True):
+    __table_args__ = (
+        Index("ix_discussion_community_id", "community_id"),
+    )
     id: Optional[int] = Field(default=None, primary_key=True)
     community_id: int = Field(
         sa_column=Column(Integer, ForeignKey("community.id", ondelete="CASCADE"))
@@ -32,7 +35,7 @@ class Discussion(DiscussionBase, table=True):
     author_id: int = Field(
         sa_column=Column(Integer, ForeignKey("user.id", ondelete="CASCADE"))
     )
-    discussion_uuid: str = ""
+    discussion_uuid: str = Field(default="", index=True)
     upvote_count: int = 0
     edit_count: int = 0
     is_pinned: bool = Field(default=False, sa_column=Column(Boolean, default=False))

--- a/apps/api/src/db/communities/discussions.py
+++ b/apps/api/src/db/communities/discussions.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from sqlalchemy import Column, ForeignKey, Integer, Text, Boolean, String, Index
 from sqlmodel import Field, SQLModel
-from src.db.users import UserRead
+from src.db.users import UserReadAuthor
 
 
 # Available discussion labels
@@ -88,7 +88,7 @@ class DiscussionRead(SQLModel):
 
 
 class DiscussionReadWithAuthor(DiscussionRead):
-    author: Optional[UserRead] = None
+    author: Optional[UserReadAuthor] = None
 
 
 class DiscussionReadWithVoteStatus(DiscussionReadWithAuthor):

--- a/apps/api/src/db/courses/activities.py
+++ b/apps/api/src/db/courses/activities.py
@@ -87,8 +87,6 @@ class ActivityUpdate(SQLModel):
     activity_sub_type: Optional[ActivitySubTypeEnum] = None
     details: Optional[dict] = None
     published: Optional[bool] = None
-    published_version: Optional[int] = None
-    version: Optional[int] = None
     lock_type: Optional[ActivityLockType] = None
     extra_metadata: Optional[dict] = None
 

--- a/apps/api/src/db/courses/assignments.py
+++ b/apps/api/src/db/courses/assignments.py
@@ -321,10 +321,22 @@ class AssignmentUserSubmissionBase(SQLModel):
 
 
 class AssignmentUserSubmissionCreate(SQLModel):
-    """Model for creating a new assignment user submission."""
+    """Model for creating/updating an assignment user submission.
+
+    Carries the editable submission fields so the instructor update endpoint
+    can actually persist them. These are Optional because the update path only
+    applies non-None values and strips the privileged ones for students.
+    """
 
     assignment_id: int
-    pass  # Inherits all fields from AssignmentUserSubmissionBase
+    # Only the fields the update endpoint guards for students are exposed here.
+    # attempt_number / overall_feedback are intentionally NOT settable through
+    # this model: the update service does not strip them for non-instructors,
+    # so exposing them would let a student reset their own retry counter
+    # (attempt_number) or overwrite the instructor's feedback.
+    submission_status: Optional[AssignmentUserSubmissionStatus] = None
+    grade: Optional[int] = None
+    user_id: Optional[int] = None
 
 
 class AssignmentUserSubmissionRead(AssignmentUserSubmissionBase):
@@ -339,7 +351,7 @@ class AssignmentUserSubmissionUpdate(SQLModel):
     """Model for updating an assignment user submission."""
 
     submission_status: Optional[AssignmentUserSubmissionStatus] = None
-    grade: Optional[str] = None
+    grade: Optional[int] = None
     overall_feedback: Optional[str] = None
     attempt_number: Optional[int] = None
     user_id: Optional[int] = None

--- a/apps/api/src/db/trail_runs.py
+++ b/apps/api/src/db/trail_runs.py
@@ -1,6 +1,6 @@
 from typing import Optional
 from pydantic import BaseModel
-from sqlalchemy import JSON, Column, ForeignKey, Integer
+from sqlalchemy import JSON, Column, ForeignKey, Integer, UniqueConstraint
 from sqlmodel import Field, SQLModel
 from enum import Enum
 
@@ -19,7 +19,18 @@ class StatusEnum(str, Enum):
 
 
 class TrailRun(SQLModel, table=True):
-    __table_args__ = {"extend_existing": True}
+    # A user can have at most one run per course inside a trail. The service
+    # does a check-then-insert (select existing, else create), which races
+    # under concurrent requests (e.g. double-clicking "enroll"), producing
+    # duplicate runs that corrupt progress display and make .first() lookups
+    # nondeterministic. The DB constraint closes that window. (Requires a
+    # matching migration to apply to the live DB.)
+    __table_args__ = (
+        UniqueConstraint(
+            "trail_id", "course_id", "user_id", name="uq_trailrun_trail_course_user"
+        ),
+        {"extend_existing": True},
+    )
     id: Optional[int] = Field(default=None, primary_key=True)
     data: dict = Field(default_factory=dict, sa_column=Column(JSON))
     status: StatusEnum = StatusEnum.STATUS_IN_PROGRESS

--- a/apps/api/src/db/trail_steps.py
+++ b/apps/api/src/db/trail_steps.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Optional
 from sqlmodel import Field, SQLModel
-from sqlalchemy import ForeignKey, JSON, Column, Index, Integer
+from sqlalchemy import ForeignKey, JSON, Column, Index, Integer, UniqueConstraint
 
 
 class TrailStepTypeEnum(str, Enum):
@@ -13,6 +13,15 @@ class TrailStepTypeEnum(str, Enum):
 class TrailStep(SQLModel, table=True):
     __table_args__ = (
         Index("ix_trailstep_trailrun_user", "trailrun_id", "user_id"),
+        # One completion step per (run, activity, user). The service does a
+        # racy check-then-insert; without this constraint concurrent requests
+        # create duplicate steps, which inflates completion counts and can
+        # trigger duplicate certificate issuance / COURSE_COMPLETED webhooks.
+        # (Requires a matching migration to apply to the live DB.)
+        UniqueConstraint(
+            "trailrun_id", "activity_id", "user_id",
+            name="uq_trailstep_run_activity_user",
+        ),
     )
     id: Optional[int] = Field(default=None, primary_key=True)
     complete: bool

--- a/apps/api/src/db/user_organizations.py
+++ b/apps/api/src/db/user_organizations.py
@@ -13,7 +13,7 @@ class UserOrganization(SQLModel, table=True):
         sa_column=Column(Integer, ForeignKey("user.id", ondelete="CASCADE"), nullable=False, index=True)
     )
     org_id: int = Field(
-        sa_column=Column(Integer, ForeignKey("organization.id", ondelete="CASCADE"), index=True)
+        sa_column=Column(Integer, ForeignKey("organization.id", ondelete="CASCADE"), nullable=False, index=True)
     )
     role_id: int = Field(default=None, foreign_key="role.id", index=True)
     creation_date: str

--- a/apps/api/src/db/usergroup_user.py
+++ b/apps/api/src/db/usergroup_user.py
@@ -6,13 +6,13 @@ from sqlmodel import Field, SQLModel
 class UserGroupUser(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     usergroup_id: int = Field(
-        sa_column=Column(Integer, ForeignKey("usergroup.id", ondelete="CASCADE"))
+        sa_column=Column(Integer, ForeignKey("usergroup.id", ondelete="CASCADE"), nullable=False)
     )
     user_id: int = Field(
-        sa_column=Column(Integer, ForeignKey("user.id", ondelete="CASCADE"))
+        sa_column=Column(Integer, ForeignKey("user.id", ondelete="CASCADE"), nullable=False)
     )
     org_id: int = Field(
-        sa_column=Column(Integer, ForeignKey("organization.id", ondelete="CASCADE"))
+        sa_column=Column(Integer, ForeignKey("organization.id", ondelete="CASCADE"), nullable=False)
     )
     creation_date: str = ""
     update_date: str = ""

--- a/apps/api/src/db/usergroups.py
+++ b/apps/api/src/db/usergroups.py
@@ -10,7 +10,7 @@ class UserGroupBase(SQLModel):
 class UserGroup(UserGroupBase, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     org_id: int = Field(
-        sa_column=Column(Integer, ForeignKey("organization.id", ondelete="CASCADE"))
+        sa_column=Column(Integer, ForeignKey("organization.id", ondelete="CASCADE"), nullable=False)
     )
     usergroup_uuid: str = ""
     creation_date: str = ""

--- a/apps/api/src/db/users.py
+++ b/apps/api/src/db/users.py
@@ -57,13 +57,28 @@ class UserRead(UserBase):
     is_superadmin: bool = False
 
 
-class UserReadPublic(UserBase):
-    """User model for public-facing endpoints — excludes sensitive fields."""
+class UserReadPublic(SQLModel):
+    """User model for public-facing endpoints — excludes sensitive fields.
+
+    SECURITY: This is the view returned to *any* authenticated user when they
+    look up *another* user (by id/uuid/username, or via usergroup member lists).
+    It must therefore NOT inherit from ``UserBase``, because ``UserBase`` (and
+    ``UserRead``) expose PII / internal fields — ``email``, ``signup_method``,
+    ``is_superadmin``, ``extra_metadata`` — that would leak to anyone who can
+    enumerate user ids. ``details`` and ``profile`` ARE included: they are the
+    user's own public profile content (bio extension, links, etc.) that the
+    public profile page renders, so they are intentionally exposed.
+    """
     id: int
     user_uuid: str
+    username: str
+    first_name: str
+    last_name: str
     email_verified: bool = False
     avatar_image: Optional[str] = ""
     bio: Optional[str] = ""
+    details: Optional[dict] = None
+    profile: Optional[dict] = None
 
 
 class PublicUser(UserRead):

--- a/apps/api/src/db/users.py
+++ b/apps/api/src/db/users.py
@@ -81,6 +81,23 @@ class UserReadPublic(SQLModel):
     profile: Optional[dict] = None
 
 
+class UserReadAuthor(SQLModel):
+    """Minimal author projection for community comments/discussions.
+
+    SECURITY: comment/discussion authors are returned to *every* reader of a
+    thread (often anonymous). It must therefore expose ONLY the fields needed to
+    render an author chip — never ``email``, ``is_superadmin``, ``signup_method``
+    or the raw ``details``/``profile``/``extra_metadata`` blobs that ``UserRead``
+    carries. The frontend reads only id/user_uuid/username/name/avatar.
+    """
+    id: int
+    user_uuid: str
+    username: str
+    first_name: str
+    last_name: str
+    avatar_image: Optional[str] = ""
+
+
 class PublicUser(UserRead):
     pass
 

--- a/apps/api/src/routers/ai/courseplanning.py
+++ b/apps/api/src/routers/ai/courseplanning.py
@@ -601,17 +601,24 @@ async def save_activity_content(
     logger.info("[Save Activity Content] === START ===")
     logger.info(f"[Save Activity Content] Activity UUID: {activity_uuid}")
     logger.info(f"[Save Activity Content] Content type: {type(content)}")
-    if isinstance(content, dict):
-        logger.info(f"[Save Activity Content] Content keys: {list(content.keys())}")
-        content_str = json.dumps(content)
-        logger.info(f"[Save Activity Content] Content size: {len(content_str)} bytes")
-        logger.info(f"[Save Activity Content] Content preview: {content_str[:500]}")
+    # Content MUST be a ProseMirror document object. A non-dict payload (list,
+    # string, etc.) previously skipped validation entirely and got written
+    # straight into activity.content, corrupting the activity so the editor
+    # fails to render it. Reject it up front.
+    if not isinstance(content, dict):
+        logger.error(f"[Save Activity Content] Content is not an object: {type(content)}")
+        raise HTTPException(status_code=400, detail="Invalid content structure: Content must be a JSON object")
 
-        # Validate ProseMirror structure
-        is_valid, validation_error = validate_prosemirror_content(content)
-        if not is_valid:
-            logger.error(f"[Save Activity Content] Validation failed: {validation_error}")
-            raise HTTPException(status_code=400, detail=f"Invalid content structure: {validation_error}")
+    logger.info(f"[Save Activity Content] Content keys: {list(content.keys())}")
+    content_str = json.dumps(content)
+    logger.info(f"[Save Activity Content] Content size: {len(content_str)} bytes")
+    logger.info(f"[Save Activity Content] Content preview: {content_str[:500]}")
+
+    # Validate ProseMirror structure
+    is_valid, validation_error = validate_prosemirror_content(content)
+    if not is_valid:
+        logger.error(f"[Save Activity Content] Validation failed: {validation_error}")
+        raise HTTPException(status_code=400, detail=f"Invalid content structure: {validation_error}")
 
     # Validate activity exists first
     statement = select(Activity).where(Activity.activity_uuid == activity_uuid)
@@ -700,6 +707,14 @@ async def get_session_state(
     session = get_course_planning_session(session_uuid)
 
     if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    # Cross-tenant IDOR guard: without this, any authenticated user can read
+    # ANY planning session by UUID — leaking another org's full course plan and
+    # the entire AI message history. Require membership of the session's org.
+    if not await verify_user_org_membership(
+        resolve_acting_user_id(current_user), session.org_id, db_session
+    ):
         raise HTTPException(status_code=404, detail="Session not found")
 
     return CoursePlanningSessionResponse(

--- a/apps/api/src/routers/ai/magicblocks.py
+++ b/apps/api/src/routers/ai/magicblocks.py
@@ -63,7 +63,11 @@ async def event_generator(
         # Send completion event
         yield f"data: {json.dumps({'type': 'done', 'session_uuid': session_uuid})}\n\n"
     except asyncio.CancelledError:
-        stream_failed = True
+        # Client disconnect / cancellation. Do NOT force a refund here: if the
+        # model already produced output the credits were legitimately spent.
+        # The finally block still refunds when nothing was produced
+        # (produced_content False), so a disconnect *after* output can't be
+        # abused to get free generations. Re-raise so Starlette observes it.
         raise
     except Exception:
         stream_failed = True

--- a/apps/api/src/routers/ai/rag.py
+++ b/apps/api/src/routers/ai/rag.py
@@ -83,7 +83,10 @@ async def rag_chat_event_generator(
     org_id: Optional[int] = None,
 ):
     """Convert async generator to SSE format with source references."""
+    from src.security.features_utils.usage import refund_ai_credit
+
     full_response = ""
+    stream_failed = False
     try:
         # Send start event
         yield f"data: {json.dumps({'type': 'start', 'aichat_uuid': aichat_uuid})}\n\n"
@@ -119,8 +122,18 @@ async def rag_chat_event_generator(
             yield f"data: {json.dumps({'type': 'session_title', 'title': title})}\n\n"
 
     except Exception:
+        stream_failed = True
         logger.exception("Error in rag_chat_event_generator")
         yield f"data: {json.dumps({'type': 'error', 'message': 'An internal error occurred while processing the AI chat request.'})}\n\n"
+    finally:
+        # Refund the 2 reserved credits if the stream produced nothing useful
+        # (upstream error before any model output). Without this a flaky
+        # embedding/generation call permanently drains the org's quota.
+        if org_id is not None and (stream_failed or not full_response):
+            try:
+                refund_ai_credit(org_id, 2)
+            except Exception:
+                logger.debug("RAG AI credit refund failed", exc_info=True)
 
 
 # ============================================================================
@@ -220,15 +233,19 @@ async def api_rag_chat(
     from src.services.security.rate_limiting import enforce_ai_rate_limit
     enforce_ai_rate_limit(chat_acting_user_id, org_id)
 
-    # Atomic credit reservation — RAG chat makes 2 API calls (embedding + generation)
-    await reserve_ai_credit(org_id, db_session, amount=2)
-
-    # Get or create chat session
+    # Validate session ownership BEFORE reserving credits. Reserving first means
+    # a request that targets someone else's session (or probes random UUIDs)
+    # still raises 404 but silently burns the org's credits with no refund.
     is_new_session = chat_request.aichat_uuid is None
     if not is_new_session and not chat_session_belongs_to_user(
         chat_request.aichat_uuid, chat_acting_user_id
     ):
         raise HTTPException(status_code=404, detail="Chat session not found")
+
+    # Atomic credit reservation — RAG chat makes 2 API calls (embedding + generation)
+    await reserve_ai_credit(org_id, db_session, amount=2)
+
+    # Get or create chat session
     chat_session = get_chat_session_history(chat_request.aichat_uuid)
 
     # Perform RAG query with streaming

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -824,10 +824,14 @@ async def export_analytics(
     course_uuid = request.query_params.get("course_uuid")
     safe_course_uuid = _validate_course_uuid(course_uuid) if course_uuid else None
 
-    days_param = request.query_params.get("days", "30")
+    # Only treat ``days`` as an explicit override when the caller actually
+    # passed it. Otherwise each query must fall back to its own default
+    # window (e.g. advanced queries default to 90/180 days) — hard-coding a
+    # 30-day default here silently truncated long-window exports.
+    days_param = request.query_params.get("days")
     try:
         safe_org_id = int(org_id)
-        safe_days = int(days_param)
+        safe_days = int(days_param) if days_param else None
     except (ValueError, TypeError):
         raise HTTPException(status_code=400, detail="Invalid parameter")
 
@@ -836,6 +840,32 @@ async def export_analytics(
         allowed = {**COURSE_QUERIES, **COURSE_DETAIL_QUERIES}
     else:
         allowed = {**ALL_QUERIES}
+
+    # Plan gating — /export must enforce the same plan limits as the
+    # individual dashboard endpoints, otherwise an admin on a free/lower
+    # plan could exfiltrate course-level (Pro) and advanced (Enterprise)
+    # analytics simply by exporting them.
+    from src.security.features_utils.plan_check import _check_mode_bypass
+
+    requested = [q for q in query_names if q in allowed]
+    if safe_course_uuid and requested:
+        # All course-scoped analytics require Pro or higher.
+        current_plan = await get_org_plan(org_id, db_session)
+        if not plan_meets_requirement(current_plan, "pro"):
+            raise HTTPException(
+                status_code=403,
+                detail="Course analytics requires a Pro plan or higher.",
+            )
+    elif any(q in ADVANCED_QUERIES for q in requested):
+        # Advanced queries require an Enterprise plan in SaaS mode.
+        bypass = _check_mode_bypass("analytics_advanced")
+        if bypass is None:
+            current_plan = await get_org_plan(org_id, db_session)
+            if not plan_meets_requirement(current_plan, "enterprise"):
+                raise HTTPException(
+                    status_code=403,
+                    detail="Advanced analytics requires an Enterprise plan or higher.",
+                )
 
     # Execute requested queries
     results: dict[str, dict] = {}
@@ -858,14 +888,26 @@ async def export_analytics(
         rows = result.get("data", [])
         output.write(f"# {qname}\n")
         if rows:
-            writer = csv.DictWriter(output, fieldnames=rows[0].keys())
+            # Rows can have heterogeneous keys after PostgreSQL enrichment
+            # (e.g. only some rows get course_name/activity_name). Build the
+            # header from the union of all keys and ignore extras so
+            # csv.DictWriter never raises ValueError on a row with a key not
+            # present in the first row.
+            fieldnames: list = []
+            seen: set = set()
+            for row in rows:
+                for k in row.keys():
+                    if k not in seen:
+                        seen.add(k)
+                        fieldnames.append(k)
+            writer = csv.DictWriter(output, fieldnames=fieldnames, extrasaction="ignore")
             writer.writeheader()
             writer.writerows(
                 {k: _csv_safe(v) for k, v in row.items()} for row in rows
             )
         output.write("\n")
 
-    filename = f"analytics_export_{safe_org_id}_{safe_days}d.csv"
+    filename = f"analytics_export_{safe_org_id}_{safe_days or 'default'}d.csv"
     return StreamingResponse(
         iter([output.getvalue()]),
         media_type="text/csv",

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -18,13 +18,14 @@ from src.security.auth import (
     extract_jwt_from_request,
     revoke_user_sessions_before,
     _is_token_revoked_for_user,
+    _mark_refresh_jti_used,
     JWT_ACCESS_TOKEN_EXPIRES,
     JWT_REFRESH_TOKEN_EXPIRES,
     JWT_REFRESH_COOKIE_NAME,
     JWT_COOKIE_NAME,
 )
 from src.services.users.users import security_get_user
-from src.services.auth.utils import signWithGoogle
+from src.services.auth.utils import signWithGoogle, get_google_user_info
 from src.services.dev.dev import isDevModeEnabled
 from src.services.security.rate_limiting import (
     check_login_rate_limit,
@@ -258,6 +259,21 @@ async def refresh(
     if _is_token_revoked_for_user(user.id, issued_at):
         raise credentials_exception
 
+    # One-time-use rotation with replay detection. Atomically mark this
+    # refresh token's jti as consumed. The FIRST presentation succeeds; any
+    # subsequent presentation of the SAME token (a replay) is treated as
+    # theft — we revoke every session for the user and reject the request.
+    # Without this, a stolen refresh token could be replayed indefinitely
+    # for its entire 30-day lifetime with no detection.
+    jti = payload.get("jti")
+    if jti:
+        first_use = _mark_refresh_jti_used(user.id, jti)
+        if not first_use:
+            # Replay of an already-consumed refresh token: revoke all sessions
+            # so neither the legitimate user's nor the attacker's tokens work.
+            revoke_user_sessions_before(user.id)
+            raise credentials_exception
+
     new_access_token = create_access_token(
         data={"sub": email},
         expires_delta=JWT_ACCESS_TOKEN_EXPIRES,
@@ -465,17 +481,47 @@ async def third_party_login(
                 detail="Invalid org_id",
             )
 
+        # SECURITY: resolve the identity from the Google-verified email, NOT
+        # from the attacker-controlled body.email. signWithGoogle keys the
+        # account on the Google-returned email but honors org_id to grant
+        # membership. If the invite gate trusted body.email, an attacker could
+        # supply a victim's invited address (passing the gate) while
+        # authenticating with their own Google token, and get their own account
+        # joined to an org they were never invited to. The invite must be
+        # checked against the same email that will own the account.
+        if body.provider == "google":
+            _google_user = await get_google_user_info(body.access_token)
+            _verified_email = _google_user.get("email")
+            if not _verified_email or not _google_user.get("email_verified"):
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Google did not return a verified email for this account",
+                )
+            _invite_email = _verified_email.strip().lower()
+        else:
+            _invite_email = body.email
+
         # Check that a pending email invite exists for this address in the org
         _invite_found = False
+        _r = None
         try:
             _lh_config = get_learnhouse_config()
             _redis_url = _lh_config.redis_config.redis_connection_string
             if _redis_url:
                 _r = _redis.Redis.from_url(_redis_url)
-                _invite_key = f"invited_user:{body.email}:org:{org_record.org_uuid}"
+                _invite_key = f"invited_user:{_invite_email}:org:{org_record.org_uuid}"
                 _invite_found = bool(_r.get(_invite_key))
         except Exception as e:
             _logger.error("Redis unavailable for invite validation, org_id will be ignored: %s", e)
+        finally:
+            # Always release the Redis connection pool created by from_url;
+            # otherwise every OAuth login leaks a connection pool/socket and
+            # the API eventually exhausts file descriptors / Redis connections.
+            if _r is not None:
+                try:
+                    _r.close()
+                except Exception:
+                    pass
 
         if not _invite_found:
             _logger.warning(
@@ -605,8 +651,14 @@ async def api_verify_email(
     """
     Verify user email with token.
     """
-    # Rate limit: 5 attempts per 5 minutes (keyed on email when provided, user_uuid otherwise)
-    is_allowed, retry_after = check_email_verification_rate_limit(body.email or body.user_uuid)
+    # Rate limit: 5 attempts per 5 minutes. Key strictly on the stable
+    # user_uuid (+ org_uuid) identity, NOT on the attacker-controllable
+    # ``email`` field. ``email`` is not used by verify_email_token at all, so
+    # keying on it let a caller bypass the limit entirely by rotating the
+    # email value while brute-forcing tokens for a fixed user_uuid.
+    is_allowed, retry_after = check_email_verification_rate_limit(
+        f"{body.user_uuid}:{body.org_uuid}"
+    )
     if not is_allowed:
         raise HTTPException(
             status_code=429,

--- a/apps/api/src/routers/boards/boards_playground.py
+++ b/apps/api/src/routers/boards/boards_playground.py
@@ -221,6 +221,30 @@ async def get_session_state(
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
 
+    # SECURITY: a playground session exposes generated HTML, prompts and the
+    # full message history. Without an authorization check any authenticated
+    # user could read another tenant's session by guessing/enumerating the
+    # session_uuid. Mirror the org-membership gate used by /start and /iterate:
+    # resolve the session's board -> org and require membership.
+    board = (await db_session.execute(
+        select(Board).where(Board.board_uuid == session.board_uuid)
+    )).scalars().first()
+    if not board:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    org = (await db_session.execute(
+        select(Organization).where(Organization.id == board.org_id)
+    )).scalars().first()
+    if not org or org.id is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    acting_user_id = resolve_acting_user_id(current_user)
+    if not await is_org_member(acting_user_id, org.id, db_session):
+        raise HTTPException(
+            status_code=403,
+            detail="You are not a member of this organization",
+        )
+
     return BoardsPlaygroundSessionResponse(
         session_uuid=session.session_uuid,
         iteration_count=session.iteration_count,

--- a/apps/api/src/routers/code_execution.py
+++ b/apps/api/src/routers/code_execution.py
@@ -27,6 +27,12 @@ router = APIRouter()
 
 JUDGE0_TIMEOUT = 30.0
 
+# Hard limits for batch execution. Without these a single authenticated user
+# could submit an arbitrarily large `test_cases` list and fan out unbounded
+# parallel requests to Judge0, exhausting connections / CPU and racking up cost.
+MAX_BATCH_TEST_CASES = 50
+MAX_BATCH_CONCURRENCY = 8
+
 # SQL language ID (Judge0)
 SQL_LANGUAGE_ID = 82
 # We run SQL via Python's sqlite3 module
@@ -318,6 +324,12 @@ async def execute_batch(
 ):
     judge0_cfg = _get_judge0_config()
 
+    if len(body.test_cases) > MAX_BATCH_TEST_CASES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Too many test cases (max {MAX_BATCH_TEST_CASES})",
+        )
+
     language_id = body.language_id
     source_code = body.source_code
     additional_files_b64 = None
@@ -338,10 +350,14 @@ async def execute_batch(
     elif zip_files:
         additional_files_b64 = _make_additional_files_zip(text_files=zip_files)
 
+    # Bound how many submissions hit Judge0 simultaneously.
+    semaphore = asyncio.Semaphore(MAX_BATCH_CONCURRENCY)
+
     async def run_test(tc: TestCase) -> dict:
-        r = await _submit_single(
-            judge0_cfg, language_id, source_code, tc.stdin, additional_files_b64
-        )
+        async with semaphore:
+            r = await _submit_single(
+                judge0_cfg, language_id, source_code, tc.stdin, additional_files_b64
+            )
         status = r.get("status", {})
         # Normalize both outputs before comparing:
         # - splitlines handles \n, \r\n, and \r equivalently

--- a/apps/api/src/routers/code_submissions.py
+++ b/apps/api/src/routers/code_submissions.py
@@ -1,5 +1,5 @@
 from typing import Union
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import func
 from sqlmodel import select, col
@@ -38,8 +38,8 @@ class SaveSubmissionRequest(BaseModel):
 async def get_submission_history(
     activity_uuid: str,
     block_id: str,
-    page: int = 1,
-    limit: int = 20,
+    page: int = Query(1, ge=1),
+    limit: int = Query(20, ge=1, le=100),
     current_user: Union[PublicUser, AnonymousUser] = Depends(get_current_user),
     db_session: AsyncSession = Depends(get_db_session),
 ) -> dict:

--- a/apps/api/src/routers/communities/communities.py
+++ b/apps/api/src/routers/communities/communities.py
@@ -1,5 +1,5 @@
 from typing import List
-from fastapi import APIRouter, Depends, Request, UploadFile
+from fastapi import APIRouter, Depends, Request, UploadFile, Path
 from pydantic import BaseModel
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -60,6 +60,25 @@ async def api_create_community(
     """
     from src.db.communities.communities import CommunityCreate
 
+    # SECURITY: If a course is to be linked on creation, verify it exists and
+    # belongs to this organization. Without this check a client could attach a
+    # community to a course in another tenant by guessing its id (the create
+    # service writes course_id directly with no validation), causing
+    # cross-tenant data linkage.
+    if community_data.course_id is not None:
+        from fastapi import HTTPException
+        from src.db.courses.courses import Course
+
+        course_statement = select(Course).where(Course.id == community_data.course_id)
+        course = (await db_session.execute(course_statement)).scalars().first()
+        if not course:
+            raise HTTPException(status_code=404, detail="Course not found")
+        if course.org_id != org_id:
+            raise HTTPException(
+                status_code=400,
+                detail="Course must belong to the same organization as the community",
+            )
+
     community_create = CommunityCreate(
         name=community_data.name,
         description=community_data.description,
@@ -112,8 +131,10 @@ async def api_get_community(
 async def api_get_communities_by_org(
     request: Request,
     org_id: int,
-    page: int = 1,
-    limit: int = 10,
+    page: int = Path(ge=1),
+    # Upper bound guards against negative/absurd values (the original 500 bug)
+    # while staying above real callers — the sitemap requests limit=1000.
+    limit: int = Path(ge=1, le=1000),
     current_user: PublicUser = Depends(get_current_user),
     db_session: AsyncSession = Depends(get_db_session),
 ) -> List[CommunityRead]:

--- a/apps/api/src/routers/communities/discussions.py
+++ b/apps/api/src/routers/communities/discussions.py
@@ -358,6 +358,15 @@ async def api_get_user_votes_batch(
 
     Returns a dictionary mapping discussion_uuid to voted status.
     """
+    # SECURITY: Bound the batch size. An unbounded list is built into a single
+    # SQL IN (...) clause downstream; very large lists exhaust DB driver
+    # parameter limits (raising a 500) and allow trivial resource-exhaustion.
+    if len(discussion_uuids) > 200:
+        from fastapi import HTTPException
+        raise HTTPException(
+            status_code=400,
+            detail="Too many discussion_uuids; maximum 200 per request",
+        )
     return await get_user_votes_for_discussions(
         request, discussion_uuids, current_user, db_session
     )
@@ -437,20 +446,27 @@ async def api_get_comments_by_discussion(
 @router.get(
     "/discussions/{discussion_uuid}/comments/count",
     summary="Get comment count for a discussion",
-    description="Return the total number of comments on a discussion. This endpoint is unauthenticated and safe to call for counters.",
+    description="Return the total number of comments on a discussion. The caller must be able to read the parent community (public communities are readable by anyone, including anonymous users).",
     responses={
         200: {"description": "Object with the comment count (e.g. {\"count\": 42})."},
+        403: {"description": "Caller cannot read this discussion's community"},
         404: {"description": "Discussion not found"},
     },
 )
 async def api_get_comment_count(
+    request: Request,
     discussion_uuid: str,
+    current_user: PublicUser = Depends(get_current_user),
     db_session: AsyncSession = Depends(get_db_session),
 ) -> dict:
     """
     Get the count of comments for a discussion.
+
+    Authorized by community read access (not blanket auth): public-community
+    counts remain visible to anonymous callers, while private-community counts
+    require membership — matching the discussion read endpoint.
     """
-    count = await get_comment_count(discussion_uuid, db_session)
+    count = await get_comment_count(request, discussion_uuid, current_user, db_session)
     return {"count": count}
 
 

--- a/apps/api/src/routers/courses/activities/activities.py
+++ b/apps/api/src/routers/courses/activities/activities.py
@@ -68,6 +68,23 @@ def _parse_extra_metadata(raw: Optional[str]) -> Optional[dict]:
     return parsed
 
 
+def _validate_details(raw: str) -> str:
+    """Validate that a ``details`` form field is a JSON object before it is
+    handed to the service layer (which calls ``json.loads`` unguarded). Without
+    this, malformed JSON would surface as an unhandled 500 instead of a 422."""
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        raise HTTPException(
+            status_code=422, detail="details must be a JSON object"
+        )
+    if not isinstance(parsed, dict):
+        raise HTTPException(
+            status_code=422, detail="details must be a JSON object"
+        )
+    return raw
+
+
 @router.post(
     "/",
     response_model=ActivityRead,
@@ -115,8 +132,8 @@ async def api_create_activity(
 async def api_get_activity_versions(
     request: Request,
     activity_uuid: str,
-    limit: int = Query(default=20, le=100),
-    offset: int = Query(default=0),
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
     current_user: PublicUser = Depends(get_current_user),
     db_session=Depends(get_db_session),
 ) -> List[ActivityVersionRead]:
@@ -405,7 +422,7 @@ async def api_create_video_activity(
         current_user,
         db_session,
         video_file,
-        details,
+        _validate_details(details),
         extra_metadata=_parse_extra_metadata(extra_metadata),
     )
 
@@ -504,9 +521,9 @@ async def api_update_video_activity(
     if end_time is not None:
         details_dict["endTime"] = end_time
     if autoplay is not None:
-        details_dict["autoplay"] = autoplay.lower() == "true"
+        details_dict["autoplay"] = autoplay.strip().lower() in ("true", "1", "yes", "on")
     if muted is not None:
-        details_dict["muted"] = muted.lower() == "true"
+        details_dict["muted"] = muted.strip().lower() in ("true", "1", "yes", "on")
     details_str = json.dumps(details_dict) if details_dict else None
     return await update_video_activity(
         request, activity_uuid, current_user, db_session, name, video_file, details_str

--- a/apps/api/src/routers/courses/certifications.py
+++ b/apps/api/src/routers/courses/certifications.py
@@ -9,7 +9,7 @@ from src.db.courses.certifications import (
     CertificationUpdate,
 )
 from src.db.users import PublicUser
-from src.security.auth import get_current_user
+from src.security.auth import get_current_user, get_authenticated_user
 from src.services.courses.certifications import (
     create_certification,
     get_certification,
@@ -159,7 +159,7 @@ async def api_delete_certification(
 async def api_get_user_certificates_for_course(
     request: Request,
     course_uuid: str,
-    current_user: PublicUser = Depends(get_current_user),
+    current_user: PublicUser = Depends(get_authenticated_user),
     db_session: AsyncSession = Depends(get_db_session),
 ) -> List[dict]:
     """
@@ -203,7 +203,7 @@ async def api_get_certificate_by_user_certification_uuid(
 )
 async def api_get_all_user_certificates(
     request: Request,
-    current_user: PublicUser = Depends(get_current_user),
+    current_user: PublicUser = Depends(get_authenticated_user),
     db_session: AsyncSession = Depends(get_db_session),
 ) -> List[dict]:
     """

--- a/apps/api/src/routers/courses/chapters.py
+++ b/apps/api/src/routers/courses/chapters.py
@@ -151,7 +151,13 @@ async def api_get_chapter_by(
     Get Course Chapters by page and limit
     """
     return await get_course_chapters(
-        request, course_id, db_session, current_user, page, limit
+        request,
+        course_id,
+        db_session,
+        current_user,
+        with_unpublished_activities=False,
+        page=page,
+        limit=limit,
     )
 
 

--- a/apps/api/src/routers/courses/courses.py
+++ b/apps/api/src/routers/courses/courses.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, UploadFile, Form, Request
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, field_validator
 
+from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from src.core.events.database import get_db_session
 from src.db.courses.course_updates import (
@@ -14,6 +15,7 @@ from src.db.courses.course_updates import (
 )
 from src.db.users import PublicUser
 from src.db.courses.courses import (
+    Course,
     CourseCreate,
     CourseRead,
     CourseUpdate,
@@ -22,6 +24,7 @@ from src.db.courses.courses import (
 )
 from src.security.auth import get_current_user
 from src.security.features_utils.dependencies import require_courses_feature
+from src.security.rbac import check_resource_access, AccessAction
 from src.services.courses.courses import (
     create_course,
     get_course,
@@ -429,6 +432,24 @@ async def api_get_course_meta(
     Get single Course Metadata (chapters, activities) by course_uuid.
     Use slim=true to exclude heavy activity content/details (useful for navigation).
     """
+    # SECURITY: with_unpublished_activities is client-controlled and is passed
+    # straight through to the data layer without any privilege gating. Only
+    # users who can edit the course (authors/admins) should be able to see
+    # unpublished/draft activities; otherwise any reader of a public course
+    # could leak drafts via ?with_unpublished_activities=true. Downgrade the
+    # flag to False for callers without UPDATE access.
+    if with_unpublished_activities:
+        decision = await check_resource_access(
+            request,
+            db_session,
+            current_user,
+            course_uuid,
+            AccessAction.UPDATE,
+            raise_on_deny=False,
+        )
+        if not decision.allowed:
+            with_unpublished_activities = False
+
     return await get_course_meta(
         request, course_uuid, with_unpublished_activities, current_user=current_user, db_session=db_session, slim=slim
     )
@@ -692,6 +713,22 @@ async def api_apply_course_contributor(
     """
     Apply to be a contributor for a course
     """
+    # SECURITY: Respect the course owner's "open_to_contributors" setting. The
+    # underlying service never checks this flag, so without this guard any
+    # authenticated user could submit contributor applications to courses whose
+    # owners have explicitly closed them to outside contributors.
+    course = (
+        await db_session.execute(
+            select(Course).where(Course.course_uuid == course_uuid)
+        )
+    ).scalars().first()
+    if not course:
+        raise HTTPException(status_code=404, detail="Course not found")
+    if not course.open_to_contributors:
+        raise HTTPException(
+            status_code=403, detail="This course is not open to contributors"
+        )
+
     return await apply_course_contributor(request, course_uuid, current_user, db_session)
 
 
@@ -715,6 +752,14 @@ async def api_get_course_updates(
     """
     Get Course Updates by course_uuid
     """
+
+    # SECURITY: Enforce read access on the parent course before returning its
+    # updates. The underlying service only checks course existence, so without
+    # this guard any user (including anonymous) could read updates of private /
+    # unpublished courses.
+    await check_resource_access(
+        request, db_session, current_user, course_uuid, AccessAction.READ
+    )
 
     return await get_updates_by_course_uuid(
         request, course_uuid, current_user, db_session

--- a/apps/api/src/routers/courses/migration.py
+++ b/apps/api/src/routers/courses/migration.py
@@ -4,8 +4,8 @@ from typing import Optional
 from fastapi import APIRouter, Request, UploadFile, File, Depends, Query, HTTPException
 
 
-from src.db.users import PublicUser, AnonymousUser
-from src.security.auth import get_current_user, get_authenticated_user
+from src.db.users import PublicUser
+from src.security.auth import get_authenticated_user
 from sqlmodel.ext.asyncio.session import AsyncSession
 from src.core.events.database import get_db_session
 from src.services.courses.migration.models import (
@@ -109,7 +109,7 @@ async def api_create_from_migration(
     request: Request,
     org_id: int,
     body: CreateFromMigrationRequest,
-    current_user: PublicUser | AnonymousUser = Depends(get_current_user),
+    current_user: PublicUser = Depends(get_authenticated_user),
     db_session: AsyncSession = Depends(get_db_session),
 ):
     """Create a course from the finalized migration tree structure."""

--- a/apps/api/src/routers/integrations/zapier.py
+++ b/apps/api/src/routers/integrations/zapier.py
@@ -210,7 +210,7 @@ async def zapier_list_courses(
         select(Course)
         .where(Course.org_id == api_user.org_id)
         .order_by(col(Course.creation_date).desc())
-        .limit(min(limit, 500))
+        .limit(max(1, min(limit, 500)))
     )
     courses = (await db_session.execute(query)).scalars().all()
     return [
@@ -239,7 +239,7 @@ async def zapier_list_users(
         select(User)
         .join(UserOrganization, UserOrganization.user_id == User.id)  # type: ignore
         .where(UserOrganization.org_id == api_user.org_id)
-        .limit(min(limit, 500))
+        .limit(max(1, min(limit, 500)))
     )
     users = (await db_session.execute(query)).scalars().all()
     return [
@@ -274,7 +274,7 @@ async def zapier_list_usergroups(
     query = (
         select(UserGroup)
         .where(UserGroup.org_id == api_user.org_id)
-        .limit(min(limit, 500))
+        .limit(max(1, min(limit, 500)))
     )
     groups = (await db_session.execute(query)).scalars().all()
     return [

--- a/apps/api/src/routers/local_content.py
+++ b/apps/api/src/routers/local_content.py
@@ -161,9 +161,13 @@ async def _check_content_access(
     if len(parts) >= 2 and parts[0] == 'users':
         return
 
-    # Unknown path pattern — require auth as a safe default
+    # Unknown path pattern — deny by default. Previously this only blocked
+    # anonymous users and silently served the file to any authenticated user,
+    # which leaked content across tenants for any path layout that didn't match
+    # the recognised org/user prefixes. Mirror the S3 router and deny.
     if isinstance(current_user, AnonymousUser):
         raise HTTPException(status_code=401, detail="Authentication required")
+    raise HTTPException(status_code=403, detail="Access denied")
 
 
 # MIME type mapping
@@ -218,7 +222,14 @@ async def serve_local_content(
     if resolved is None:
         raise HTTPException(status_code=400, detail="Invalid path")
 
-    await _check_content_access(file_path, current_user, db_session, request=request)
+    # Run the access check against the same fully-decoded, content-relative path
+    # that the filesystem lookup resolves to. Using the raw ``file_path`` here
+    # would let an attacker URL-encode path segments so the access-control
+    # pattern matching fails to recognise private activity/podcast content while
+    # the resolved path still points at the real file (auth bypass / IDOR).
+    base_real = os.path.realpath(str(CONTENT_DIR))
+    rel_path = os.path.relpath(str(resolved), base_real).replace(os.sep, '/')
+    await _check_content_access(rel_path, current_user, db_session, request=request)
 
     if not resolved.is_file():
         raise HTTPException(status_code=404, detail="File not found")
@@ -259,7 +270,11 @@ async def head_local_content(
     if resolved is None:
         raise HTTPException(status_code=400, detail="Invalid path")
 
-    await _check_content_access(file_path, current_user, db_session, request=request)
+    # See serve_local_content: check access against the resolved content-relative
+    # path, not the raw (possibly URL-encoded) request path.
+    base_real = os.path.realpath(str(CONTENT_DIR))
+    rel_path = os.path.relpath(str(resolved), base_real).replace(os.sep, '/')
+    await _check_content_access(rel_path, current_user, db_session, request=request)
 
     if not resolved.is_file():
         raise HTTPException(status_code=404, detail="File not found")

--- a/apps/api/src/routers/monitoring.py
+++ b/apps/api/src/routers/monitoring.py
@@ -48,7 +48,9 @@ async def submit_feedback(
     for upload in files:
         if not upload or not upload.filename:
             continue
-        data = await upload.read()
+        # Bound the read itself: reading the whole upload before truncating
+        # would let a single multi-gigabyte attachment exhaust server memory.
+        data = await upload.read(_MAX_ATTACHMENT_BYTES + 1)
         if not data:
             continue
         if len(data) > _MAX_ATTACHMENT_BYTES:

--- a/apps/api/src/routers/orgs/ai_credits.py
+++ b/apps/api/src/routers/orgs/ai_credits.py
@@ -121,6 +121,14 @@ async def get_org_ai_credits(
     if not org:
         raise HTTPException(status_code=404, detail="Organization not found")
 
+    # API tokens are scoped to a single org; do not let a token authenticate
+    # against a different org just because its creator is a member there.
+    if isinstance(current_user, APITokenUser) and current_user.org_id != org_id:
+        raise HTTPException(
+            status_code=403,
+            detail="API token is not scoped to this organization",
+        )
+
     # Verify user is a member of the organization
     if not await verify_user_is_org_member(resolve_acting_user_id(current_user), org_id, db_session):
         raise HTTPException(
@@ -139,15 +147,16 @@ async def get_org_ai_credits(
 @router.post(
     "/{org_id}/ai-credits/add",
     response_model=AddCreditsResponse,
-    summary="Add purchased AI credits",
+    summary="Add purchased AI credits (superadmin only)",
     description=(
-        "Add purchased AI credits to an organization. Only organization admins "
-        "can add credits and the amount must be a positive integer."
+        "Add purchased AI credits to an organization. Restricted to superadmins "
+        "because it grants paid quota with no payment verification; the amount "
+        "must be a positive integer."
     ),
     responses={
         200: {"description": "Credits added and new purchased total returned.", "model": AddCreditsResponse},
         400: {"description": "Credit amount must be a positive number"},
-        403: {"description": "Only organization admins can add AI credits"},
+        403: {"description": "Superadmin access required"},
         404: {"description": "Organization not found"},
     },
 )
@@ -160,7 +169,7 @@ async def add_org_ai_credits(
     """
     Add purchased AI credits to an organization.
 
-    Only organization admins can add credits.
+    Restricted to superadmins (grants paid quota with no payment check).
 
     Args:
         org_id: The organization ID
@@ -176,11 +185,16 @@ async def add_org_ai_credits(
     if not org:
         raise HTTPException(status_code=404, detail="Organization not found")
 
-    # Verify user is an admin of the organization
-    if not await verify_user_is_org_admin(resolve_acting_user_id(current_user), org_id, db_session):
+    # Granting "purchased" AI credits adds paid quota for an arbitrary,
+    # client-supplied amount with NO payment verification. Allowing any org
+    # admin here lets a tenant mint unlimited free AI credits for itself
+    # (revenue/quota bypass), so this must be a billing-platform / superadmin
+    # operation — same posture as the /set endpoint.
+    user_id = resolve_acting_user_id(current_user)
+    if not user_id or not await is_user_superadmin(user_id, db_session):
         raise HTTPException(
             status_code=403,
-            detail="Only organization admins can add AI credits",
+            detail="Superadmin access required",
         )
 
     # Validate amount
@@ -203,14 +217,15 @@ async def add_org_ai_credits(
 @router.post(
     "/{org_id}/ai-credits/reset",
     response_model=ResetCreditsResponse,
-    summary="Reset AI credits usage",
+    summary="Reset AI credits usage (superadmin only)",
     description=(
         "Reset AI credits usage for an organization. Typically used at the "
-        "start of a new billing period. Only organization admins can reset credits."
+        "start of a new billing period. Restricted to superadmins because it "
+        "clears metered usage and would otherwise let a tenant bypass its quota."
     ),
     responses={
         200: {"description": "AI credits usage reset to zero.", "model": ResetCreditsResponse},
-        403: {"description": "Only organization admins can reset AI credits"},
+        403: {"description": "Superadmin access required"},
         404: {"description": "Organization not found"},
     },
 )
@@ -223,7 +238,7 @@ async def reset_org_ai_credits(
     Reset AI credits usage for an organization.
 
     This is typically used at the start of a new billing period.
-    Only organization admins can reset credits.
+    Restricted to superadmins (clears metered usage / quota).
 
     Args:
         org_id: The organization ID
@@ -238,11 +253,14 @@ async def reset_org_ai_credits(
     if not org:
         raise HTTPException(status_code=404, detail="Organization not found")
 
-    # Verify user is an admin of the organization
-    if not await verify_user_is_org_admin(resolve_acting_user_id(current_user), org_id, db_session):
+    # Resetting consumed usage effectively grants free metered AI usage, letting
+    # a tenant zero out its own usage at will and bypass the plan's AI quota.
+    # This is a billing-platform / superadmin operation (same posture as /set).
+    user_id = resolve_acting_user_id(current_user)
+    if not user_id or not await is_user_superadmin(user_id, db_session):
         raise HTTPException(
             status_code=403,
-            detail="Only organization admins can reset AI credits",
+            detail="Superadmin access required",
         )
 
     # Reset usage

--- a/apps/api/src/routers/orgs/orgs.py
+++ b/apps/api/src/routers/orgs/orgs.py
@@ -1,5 +1,5 @@
 from typing import List, Literal, Optional, Union
-from fastapi import APIRouter, Depends, Request, UploadFile, Query
+from fastapi import APIRouter, Depends, Request, UploadFile, Query, Path, HTTPException
 from sqlmodel.ext.asyncio.session import AsyncSession
 from src.services.orgs.invites import (
     create_invite_code,
@@ -118,6 +118,14 @@ async def api_create_org_withconfig(
     """
     Create new organization
     """
+    # SECURITY: create_org_with_config() persists the client-supplied config
+    # verbatim. The config carries the org's billing plan (cloud.plan), so a
+    # self-service caller could otherwise mint a free "enterprise"/"pro" org and
+    # unlock every paid feature/limit without paying. The standard create_org
+    # path always provisions a "free" plan; force the same here so the plan can
+    # only ever be elevated through the billing system, not the request body.
+    if config_object.cloud is not None:
+        config_object.cloud.plan = "free"
     return await create_org_with_config(
         request, org_object, current_user, db_session, config_object
     )
@@ -238,12 +246,24 @@ async def api_get_org_users(
 async def api_join_an_org(
     request: Request,
     args: JoinOrg,
-    current_user: PublicUser = Depends(get_current_user),
+    current_user: PublicUser = Depends(get_authenticated_user),
     db_session: AsyncSession = Depends(get_db_session),
 ):
     """
     Get single Org by ID
     """
+    # SECURITY: the downstream join_org() trusts the body-supplied user_id and
+    # joins THAT user into the org without verifying it is the caller. Without
+    # this guard any authenticated user could force-add (or, on an "open" org,
+    # silently enroll) an arbitrary other account into an organization. Pin the
+    # join to the authenticated identity. user_id in the body may be either the
+    # numeric id or the user_uuid, so accept either form of the caller's own id.
+    target = str(args.user_id)
+    if target not in (str(current_user.id), str(getattr(current_user, "user_uuid", ""))):
+        raise HTTPException(
+            status_code=403,
+            detail="You can only join an organization as yourself.",
+        )
     return await join_org(request, args, current_user, db_session)
 
 
@@ -1161,8 +1181,8 @@ async def api_update_org_preview(
 )
 async def api_user_orgs(
     request: Request,
-    page: int,
-    limit: int,
+    page: int = Path(..., ge=1, description="Page number (1-based)"),
+    limit: int = Path(..., ge=1, le=100, description="Items per page (max 100)"),
     current_user: Union[PublicUser, AnonymousUser] = Depends(get_current_user),
     db_session: AsyncSession = Depends(get_db_session),
 ) -> List[OrganizationRead]:
@@ -1186,8 +1206,8 @@ async def api_user_orgs(
 )
 async def api_user_orgs_admin(
     request: Request,
-    page: int,
-    limit: int,
+    page: int = Path(..., ge=1, description="Page number (1-based)"),
+    limit: int = Path(..., ge=1, le=100, description="Items per page (max 100)"),
     current_user: Union[PublicUser, AnonymousUser] = Depends(get_current_user),
     db_session: AsyncSession = Depends(get_db_session),
 ) -> List[OrganizationRead]:
@@ -1327,6 +1347,15 @@ async def api_get_org_usage(
     Get organization usage and limits for plan-based features.
     Returns current usage, limits, and remaining quota.
     """
+    # SECURITY: usage data (plan, member/course counts, billing limits) is
+    # tenant-scoped. The downstream service only checks that the caller is
+    # authenticated, not that they belong to this org, so enforce membership
+    # here to prevent cross-tenant data leakage via /{org_id}/usage.
+    from src.security.auth import resolve_acting_user_id
+    from src.security.org_auth import require_org_membership
+    await require_org_membership(
+        resolve_acting_user_id(current_user), org_id, db_session
+    )
     from src.services.orgs.usage import get_org_usage_and_limits
     return await get_org_usage_and_limits(request, org_id, current_user, db_session)
 

--- a/apps/api/src/routers/orgs/packs.py
+++ b/apps/api/src/routers/orgs/packs.py
@@ -192,6 +192,11 @@ async def api_get_org_packs(
     if not org:
         raise HTTPException(status_code=404, detail="Organization not found")
 
+    # API tokens are scoped to a single org; do not let a token act against a
+    # different org just because its creator is an admin there.
+    if isinstance(current_user, APITokenUser) and current_user.org_id != org_id:
+        raise HTTPException(status_code=403, detail="API token is not scoped to this organization")
+
     if not await is_org_admin(resolve_acting_user_id(current_user), org_id, db_session):
         raise HTTPException(status_code=403, detail="Only organization admins can view packs")
 
@@ -227,6 +232,11 @@ async def api_get_org_pack_summary(
     org = (await db_session.execute(select(Organization).where(Organization.id == org_id))).scalars().first()
     if not org:
         raise HTTPException(status_code=404, detail="Organization not found")
+
+    # API tokens are scoped to a single org; do not let a token act against a
+    # different org just because its creator is an admin there.
+    if isinstance(current_user, APITokenUser) and current_user.org_id != org_id:
+        raise HTTPException(status_code=403, detail="API token is not scoped to this organization")
 
     if not await is_org_admin(resolve_acting_user_id(current_user), org_id, db_session):
         raise HTTPException(status_code=403, detail="Only organization admins can view pack summary")

--- a/apps/api/src/routers/playgrounds/playgrounds_generator.py
+++ b/apps/api/src/routers/playgrounds/playgrounds_generator.py
@@ -106,6 +106,11 @@ async def start_playground_session(
     if not org or org.id is None:
         raise HTTPException(status_code=404, detail="Organization not found")
 
+    # Enforce API-token org scope: a token is bound to a single org and must not
+    # be usable to drive (and bill) AI generation against another org's playground.
+    if isinstance(current_user, APITokenUser) and current_user.org_id != playground.org_id:
+        raise HTTPException(status_code=403, detail="Insufficient permissions to generate content")
+
     # Verify user can edit (must be creator or have update rights)
     generate_acting_user_id = resolve_acting_user_id(current_user)
     from src.services.playgrounds.playgrounds import _get_user_rights
@@ -201,6 +206,11 @@ async def iterate_playground_session(
     if not org or org.id is None:
         raise HTTPException(status_code=404, detail="Organization not found")
 
+    # Enforce API-token org scope: a token is bound to a single org and must not
+    # be usable to drive (and bill) AI generation against another org's playground.
+    if isinstance(current_user, APITokenUser) and current_user.org_id != playground.org_id:
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
+
     # Verify user can edit
     iterate_acting_user_id = resolve_acting_user_id(current_user)
     from src.services.playgrounds.playgrounds import _get_user_rights
@@ -269,6 +279,28 @@ async def get_session_state(
     session = get_playground_session(session_uuid)
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
+
+    # Authorize: a session exposes generated HTML + full message history, so the
+    # caller must have edit rights on the underlying playground. Without this
+    # check any authenticated user could read another org's session content by
+    # its uuid (cross-tenant IDOR), while /generate/start and /generate/iterate
+    # both enforce the same check.
+    playground = (await db_session.execute(
+        select(Playground).where(Playground.playground_uuid == session.playground_uuid)
+    )).scalars().first()
+    if not playground:
+        raise HTTPException(status_code=404, detail="Playground not found")
+
+    state_acting_user_id = resolve_acting_user_id(current_user)
+    from src.services.playgrounds.playgrounds import _get_user_rights
+    rights = await _get_user_rights(state_acting_user_id, playground.org_id, db_session)
+    pg_rights = rights.get("playgrounds", {})
+    is_owner = playground.created_by == state_acting_user_id
+    can_edit = pg_rights.get("action_update", False) or (
+        is_owner and pg_rights.get("action_update_own", False)
+    )
+    if not can_edit:
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
 
     return PlaygroundSessionResponse(
         session_uuid=session.session_uuid,

--- a/apps/api/src/routers/podcasts/podcasts.py
+++ b/apps/api/src/routers/podcasts/podcasts.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from fastapi import APIRouter, Depends, File, Form, Request, UploadFile
+from fastapi import APIRouter, Depends, File, Form, Path, Request, UploadFile
 from sqlmodel.ext.asyncio.session import AsyncSession
 from src.db.podcasts.podcasts import (
     PodcastRead,
@@ -132,8 +132,11 @@ async def api_get_podcast_meta(
 async def api_get_podcasts_orgslug(
     request: Request,
     org_slug: str,
-    page: int,
-    limit: int,
+    # page must be >= 1: the service computes offset = (page - 1) * limit, so
+    # page=0 or negative produces a negative SQL OFFSET and a 500. limit is
+    # bounded to avoid an unbounded/expensive query (DoS) from a huge value.
+    page: int = Path(ge=1),
+    limit: int = Path(ge=1, le=100),
     include_unpublished: bool = False,
     current_user=Depends(get_current_user),
     db_session: AsyncSession = Depends(get_db_session),
@@ -287,6 +290,7 @@ async def api_get_podcast_episodes(
     """Get all episodes for a podcast"""
     from sqlmodel import select
     from src.db.podcasts.podcasts import Podcast
+    from src.security.rbac import check_resource_access, AccessAction
 
     # Get the podcast
     podcast_statement = select(Podcast).where(Podcast.podcast_uuid == podcast_uuid)
@@ -295,6 +299,15 @@ async def api_get_podcast_episodes(
     if not podcast:
         from fastapi import HTTPException
         raise HTTPException(status_code=404, detail="Podcast not found")
+
+    # SECURITY: enforce read access on the parent podcast before listing its
+    # episodes. get_episodes_by_podcast() only filters unpublished episodes and
+    # does NOT run an RBAC read check, so without this any caller could
+    # enumerate episodes of private/cross-org podcasts (every other episode
+    # endpoint performs this check).
+    await check_resource_access(
+        request, db_session, current_user, podcast.podcast_uuid, AccessAction.READ
+    )
 
     episodes = await get_episodes_by_podcast(
         request, podcast.id, db_session, current_user, include_unpublished

--- a/apps/api/src/routers/search.py
+++ b/apps/api/src/routers/search.py
@@ -5,7 +5,11 @@ from src.core.events.database import get_db_session
 from src.db.users import AnonymousUser, PublicUser, APITokenUser
 from src.security.auth import get_current_user, resolve_acting_user_id
 from src.services.search.search import search_across_org, SearchResult
-from src.services.security.rate_limiting import check_search_rate_limit
+from src.services.security.rate_limiting import (
+    check_search_rate_limit,
+    check_rate_limit,
+    get_client_ip,
+)
 
 router = APIRouter()
 
@@ -45,12 +49,23 @@ async def api_search_across_org(
     caller_id = resolve_acting_user_id(current_user)
     if caller_id and not isinstance(current_user, AnonymousUser):
         is_allowed, retry_after = check_search_rate_limit(caller_id)
-        if not is_allowed:
-            raise HTTPException(
-                status_code=429,
-                detail="Too many search queries. Please slow down.",
-                headers={"Retry-After": str(retry_after)},
-            )
+    else:
+        # Anonymous (and id-less) callers have no stable user id, so they must
+        # be throttled by client IP. Otherwise unauthenticated clients bypass
+        # the search throttle entirely and can hammer the full-text indexes,
+        # driving unbounded DB load (DoS).
+        ip = get_client_ip(request)
+        is_allowed, _count, retry_after = check_rate_limit(
+            key=f"search_anon:{ip}",
+            max_attempts=30,
+            window_seconds=60,
+        )
+    if not is_allowed:
+        raise HTTPException(
+            status_code=429,
+            detail="Too many search queries. Please slow down.",
+            headers={"Retry-After": str(retry_after)},
+        )
 
     return await search_across_org(
         request=request,

--- a/apps/api/src/routers/usergroups.py
+++ b/apps/api/src/routers/usergroups.py
@@ -1,7 +1,7 @@
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlmodel.ext.asyncio.session import AsyncSession
 from src.db.usergroups import UserGroupCreate, UserGroupRead, UserGroupUpdate
-from src.db.users import PublicUser, UserRead
+from src.db.users import PublicUser, UserReadPublic
 from src.services.users.usergroups import (
     add_resources_to_usergroup,
     add_users_to_usergroup,
@@ -77,12 +77,12 @@ async def api_get_usergroup(
 
 @router.get(
     "/{usergroup_id}/users",
-    response_model=list[UserRead],
+    response_model=list[UserReadPublic],
     tags=["usergroups"],
     summary="List users in a usergroup",
-    description="Retrieve the list of users that belong to a specific usergroup.",
+    description="Retrieve the list of users that belong to a specific usergroup. Sensitive fields (is_superadmin, signup_method) are excluded.",
     responses={
-        200: {"description": "Users linked to the usergroup.", "model": list[UserRead]},
+        200: {"description": "Users linked to the usergroup.", "model": list[UserReadPublic]},
         401: {"description": "Authentication required"},
         403: {"description": "User lacks permission to view usergroup members"},
         404: {"description": "Usergroup not found"},
@@ -94,7 +94,7 @@ async def api_get_users_linked_to_usergroup(
     db_session: AsyncSession = Depends(get_db_session),
     current_user: PublicUser = Depends(get_current_user),
     usergroup_id: int,
-) -> list[UserRead]:
+) -> list[UserReadPublic]:
     """
     Get Users linked to UserGroup
     """
@@ -262,6 +262,15 @@ async def api_add_users_to_usergroup(
     """
     Add Users to UserGroup
     """
+    # Validate the comma-separated id list before it reaches the service, which
+    # does int(uid) unconditionally and would otherwise raise an unhandled 500
+    # on any non-numeric (or empty) input.
+    parts = [uid.strip() for uid in user_ids.split(",")]
+    if not all(part.isdigit() for part in parts):
+        raise HTTPException(
+            status_code=422,
+            detail="user_ids must be a comma-separated list of integer user IDs",
+        )
     return await add_users_to_usergroup(
         request, db_session, current_user, usergroup_id, user_ids
     )
@@ -290,6 +299,14 @@ async def api_delete_users_from_usergroup(
     """
     Delete Users from UserGroup
     """
+    # Validate before the service does int(uid) on each part, which would
+    # otherwise raise an unhandled 500 on non-numeric / empty input.
+    parts = [uid.strip() for uid in user_ids.split(",")]
+    if not all(part.isdigit() for part in parts):
+        raise HTTPException(
+            status_code=422,
+            detail="user_ids must be a comma-separated list of integer user IDs",
+        )
     return await remove_users_from_usergroup(
         request, db_session, current_user, usergroup_id, user_ids
     )

--- a/apps/api/src/routers/users.py
+++ b/apps/api/src/routers/users.py
@@ -556,6 +556,15 @@ async def api_send_password_reset_email_v2(
     current_user: PublicUser = Depends(get_current_user),
     body: SendResetCodeRequest,
 ):
+    # Rate limit: 5 attempts per 5 minutes per email. Without this an attacker
+    # can spam reset-code emails to any address (email bombing) and probe for
+    # registered accounts. Mirrors the platform send endpoint.
+    is_allowed, retry_after = check_password_reset_rate_limit(body.email)
+    if not is_allowed:
+        raise HTTPException(
+            status_code=429,
+            detail=f"Too many password reset attempts. Please try again in {retry_after // 60} minutes.",
+        )
     return await send_reset_password_code(
         request, db_session, current_user, body.org_id, body.email
     )
@@ -580,6 +589,14 @@ async def api_send_password_reset_email(
     email: EmailStr,
     org_id: int,
 ):
+    # Rate limit: 5 attempts per 5 minutes per email (email bombing / account
+    # probing protection), matching the body-based and platform variants.
+    is_allowed, retry_after = check_password_reset_rate_limit(email)
+    if not is_allowed:
+        raise HTTPException(
+            status_code=429,
+            detail=f"Too many password reset attempts. Please try again in {retry_after // 60} minutes.",
+        )
     return await send_reset_password_code(
         request, db_session, current_user, org_id, email
     )

--- a/apps/api/src/routers/webhooks.py
+++ b/apps/api/src/routers/webhooks.py
@@ -1,5 +1,5 @@
 from typing import List
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from src.core.events.database import get_db_session
@@ -261,7 +261,7 @@ async def api_get_webhook_deliveries(
     request: Request,
     org_id: int,
     webhook_uuid: str,
-    limit: int = 50,
+    limit: int = Query(50, ge=1, le=200),
     current_user: PublicUser = Depends(get_current_user),
     db_session: AsyncSession = Depends(get_db_session),
 ) -> List[WebhookDeliveryLogRead]:

--- a/apps/api/src/security/auth.py
+++ b/apps/api/src/security/auth.py
@@ -316,8 +316,13 @@ async def _verify_api_token_org_boundary(
     """
     path_params = request.path_params
 
-    # Check org_id in path
+    # Check org_id in path AND query string. Many list/collection endpoints take
+    # org_id as a query parameter (e.g. ?org_id=42), not a path param — checking
+    # only path params let an org-scoped token reach another org's data simply by
+    # passing a different org_id in the query string.
     org_id_param = path_params.get("org_id")
+    if org_id_param is None:
+        org_id_param = request.query_params.get("org_id")
     if org_id_param is not None:
         try:
             if int(org_id_param) != api_token_user.org_id:
@@ -328,8 +333,10 @@ async def _verify_api_token_org_boundary(
         except (ValueError, TypeError):
             pass
 
-    # Check org_slug in path
+    # Check org_slug in path AND query string.
     org_slug_param = path_params.get("org_slug")
+    if org_slug_param is None:
+        org_slug_param = request.query_params.get("org_slug")
     if org_slug_param is not None:
         from src.db.organizations import Organization
         org = (await db_session.execute(

--- a/apps/api/src/security/features_utils/usage.py
+++ b/apps/api/src/security/features_utils/usage.py
@@ -867,18 +867,25 @@ async def reserve_ai_credit(
     org_plan = _get_org_plan(org_config)
     base_credits = get_ai_credit_limit(org_plan)
 
-    if base_credits == 0:
-        raise HTTPException(
-            status_code=403,
-            detail="AI credits are not available on the free plan. Please upgrade to Standard or Pro.",
-        )
-
     config = org_config.config or {}
     extra = 0
     if config.get("config_version", "1.0").startswith("2"):
         extra = config.get("overrides", {}).get("ai", {}).get("extra_limit", 0) or 0
 
     r = _get_redis_client()
+
+    if base_credits == 0:
+        # The plan grants no base credits, but the org may still have *purchased*
+        # AI credit packs (or been granted an override extra_limit). Only reject
+        # when there is genuinely no available capacity — otherwise a paying
+        # customer would be denied access to credits they already bought.
+        purchased = int(r.get(f"ai_credits_purchased:{org_id}") or 0)
+        if extra + purchased <= 0:
+            raise HTTPException(
+                status_code=403,
+                detail="AI credits are not available on the free plan. Please upgrade to Standard or Pro.",
+            )
+
     unlimited = "1" if base_credits == -1 else "0"
 
     try:

--- a/apps/api/src/security/file_validation.py
+++ b/apps/api/src/security/file_validation.py
@@ -265,34 +265,40 @@ def validate_upload(
     """
     if not file or not file.filename:
         raise HTTPException(status_code=400, detail="No file provided")
-    
-    # Read file content once
-    content = file.file.read()
-    file.file.seek(0)
-    
+
     # Get file extension and block SVG explicitly
     ext = '.' + file.filename.split('.')[-1].lower()
     if ext == '.svg':
         raise HTTPException(status_code=415, detail="SVG files are not allowed for security reasons")
-    
+
     # Find matching file type configuration
     config = None
     for file_type in allowed_types:
         if file_type in FILE_TYPES and ext in FILE_TYPES[file_type]['extensions']:
             config = FILE_TYPES[file_type]
             break
-    
+
     if not config:
         allowed_exts = [ext for t in allowed_types for ext in FILE_TYPES.get(t, {}).get('extensions', [])]
         raise HTTPException(status_code=415, detail=f"File type not allowed. Allowed: {allowed_exts}")
-    
-    # Check file size (skip if no limit set)
+
+    # SECURITY: enforce the size limit WHILE reading so an oversized upload can
+    # never be fully buffered into memory. Reading the whole stream first (the
+    # previous behaviour) let a single multi-GB upload exhaust process RAM
+    # before the limit was ever checked. We read at most size_limit + 1 bytes,
+    # which is enough to detect (and reject) any file that exceeds the cap.
     size_limit = max_size or config.get('max_size')
-    if size_limit and len(content) > size_limit:
-        raise HTTPException(
-            status_code=413,
-            detail=f"File too large ({len(content)/1024/1024:.1f}MB > {size_limit/1024/1024:.1f}MB)"
-        )
+    if size_limit:
+        content = file.file.read(size_limit + 1)
+        if len(content) > size_limit:
+            file.file.seek(0)
+            raise HTTPException(
+                status_code=413,
+                detail=f"File too large (> {size_limit/1024/1024:.1f}MB)"
+            )
+    else:
+        content = file.file.read()
+    file.file.seek(0)
     
     # Validate file content
     if not config['validator'](content):

--- a/apps/api/src/security/org_auth.py
+++ b/apps/api/src/security/org_auth.py
@@ -33,7 +33,13 @@ async def get_user_org(user_id: int, org_id: int, db_session: AsyncSession) -> O
         UserOrganization.org_id == org_id,
     )
     result = (await db_session.execute(statement)).scalars().first()
-    _cache[key] = result
+    # Only cache positive memberships. Caching a None ("not a member") result
+    # is unsafe: a membership granted later within the same request/session
+    # (e.g. add-to-org immediately followed by an authz check) would otherwise
+    # keep returning the stale "not a member" answer and incorrectly deny
+    # access. Positive rows are safe to memoize for the request's lifetime.
+    if result is not None:
+        _cache[key] = result
     return result
 
 

--- a/apps/api/src/security/rbac/rbac.py
+++ b/apps/api/src/security/rbac/rbac.py
@@ -407,6 +407,15 @@ async def authorization_verify_based_on_roles_and_authorship(
     )
     logger.info("[RBAC] isRole=%s", isRole)
 
+    # Authors and role-holders (e.g. course admins/maintainers) must never be
+    # blocked by the paywall on a resource they own or manage. Grant access
+    # immediately so the UserGroup/paid-offer check below cannot raise a 402
+    # against them (check_usergroup_access raises HTTP 402 for paid offers, which
+    # would otherwise lock the author/admin out of their own paid resource).
+    if isAuthor or isRole:
+        logger.info("[RBAC] Access GRANTED via author/role before usergroup check")
+        return True
+
     # For read actions, also check UserGroup membership
     # UserGroups allow access to resources that are not public but restricted to group members
     hasUserGroupAccess = False

--- a/apps/api/src/services/admin/admin.py
+++ b/apps/api/src/services/admin/admin.py
@@ -699,7 +699,7 @@ async def complete_course(
         "completed_count": new_count,
         "already_completed_count": len(already_completed),
         "total_activities": len(activity_ids),
-        "course_completed": True,
+        "course_completed": course_completed,
         "certificate_awarded": course_completed,
     }
 
@@ -1897,6 +1897,12 @@ async def change_user_role(
     )).scalars().first()
     if not membership:
         raise HTTPException(status_code=404, detail="User not in org")
+
+    # Defense-in-depth: API tokens must never be able to mint Admin/Maintainer
+    # or grant a role above their creator's privilege — same guard enforced at
+    # provisioning time. Without this, a low-privilege token could escalate any
+    # member to org Admin via this endpoint.
+    await _check_token_can_assign_role(token_user, role, db_session)
 
     if membership.role_id == ADMIN_ROLE_ID and new_role_id != ADMIN_ROLE_ID:
         admin_count = len((await db_session.execute(

--- a/apps/api/src/services/ai/ai.py
+++ b/apps/api/src/services/ai/ai.py
@@ -50,6 +50,12 @@ async def ai_start_activity_chat_session(
     )
     activity = (await db_session.execute(statement)).scalars().first()
 
+    if not activity:
+        raise HTTPException(
+            status_code=404,
+            detail="Activity not found",
+        )
+
     activity = ActivityRead.model_validate(activity)
 
     # Get the Course with authors
@@ -111,12 +117,6 @@ async def ai_start_activity_chat_session(
 
     # Reserve credit atomically before the AI call; refund below on failure.
     await reserve_ai_credit(org.id, db_session)
-
-    if not activity:
-        raise HTTPException(
-            status_code=404,
-            detail="Activity not found",
-        )
 
     # Get Activity Content Blocks
     content = activity.content
@@ -200,6 +200,12 @@ async def ai_send_activity_chat_message(
     )
     activity = (await db_session.execute(statement)).scalars().first()
 
+    if not activity:
+        raise HTTPException(
+            status_code=404,
+            detail="Activity not found",
+        )
+
     activity = ActivityRead.model_validate(activity)
 
     # Get the Course with authors
@@ -253,12 +259,6 @@ async def ai_send_activity_chat_message(
 
     # Reserve credit atomically before the AI call; refund below on failure.
     await reserve_ai_credit(course.org_id, db_session)
-
-    if not activity:
-        raise HTTPException(
-            status_code=404,
-            detail="Activity not found",
-        )
 
     # Get Activity Content Blocks
     content = activity.content

--- a/apps/api/src/services/ai/editor.py
+++ b/apps/api/src/services/ai/editor.py
@@ -68,8 +68,11 @@ def _serialize_tiptap_content_to_text(content: Any) -> str:
                 for q in questions:
                     text_parts.append(f"\n[QUIZ] {q.get('question', '')}")
                     for a in q.get('answers', []):
-                        marker = '(correct)' if a.get('isCorrect') else ''
-                        text_parts.append(f"\n  - {a.get('text', '')} {marker}")
+                        # TipTap quiz answers use 'answer'/'correct' (see Quiz block schema);
+                        # accept legacy 'text'/'isCorrect' as a fallback.
+                        marker = '(correct)' if (a.get('correct') or a.get('isCorrect')) else ''
+                        answer_text = a.get('answer', '') or a.get('text', '')
+                        text_parts.append(f"\n  - {answer_text} {marker}")
                 return
 
             # Handle flipcards

--- a/apps/api/src/services/ai/llm/client.py
+++ b/apps/api/src/services/ai/llm/client.py
@@ -83,7 +83,15 @@ def attachments_to_parts(attachments: Any) -> list:
         if a_type == "youtube" and url:
             parts.append(VideoUrl(url=url))
         elif a_type in ("image", "file") and b64 and mime:
-            parts.append(BinaryContent(data=base64.b64decode(b64), media_type=mime))
+            # content_base64 is user-supplied; a malformed/truncated value would
+            # raise binascii.Error and surface as an unhandled 500. Skip the bad
+            # attachment instead of crashing the whole request.
+            try:
+                decoded = base64.b64decode(b64)
+            except Exception:
+                logger.warning("Skipping attachment with invalid base64 content")
+                continue
+            parts.append(BinaryContent(data=decoded, media_type=mime))
         elif a_type == "image" and url:
             parts.append(ImageUrl(url=url))
         elif a_type == "file" and url:

--- a/apps/api/src/services/analytics/cache.py
+++ b/apps/api/src/services/analytics/cache.py
@@ -54,6 +54,12 @@ def get_ttl_for_query(query_name: str) -> int:
         return CACHE_TTL_COURSE
     if query_name.startswith("detail_"):
         return CACHE_TTL_DETAIL
+    # Detail queries are not all prefixed with "detail_" (e.g.
+    # "learner_engagement_score"); they must still use the short detail TTL so
+    # the per-user drill-down data stays fresh instead of being cached as core.
+    from src.services.analytics.queries import DETAIL_QUERIES
+    if query_name in DETAIL_QUERIES:
+        return CACHE_TTL_DETAIL
     # Everything else — check if it's in the advanced set (imported lazily)
     from src.services.analytics.queries import ADVANCED_QUERIES
     if query_name in ADVANCED_QUERIES:

--- a/apps/api/src/services/api_tokens/api_tokens.py
+++ b/apps/api/src/services/api_tokens/api_tokens.py
@@ -20,7 +20,6 @@ from src.security.rbac.rbac import (
     authorization_verify_if_user_is_anon,
 )
 from src.security.org_auth import (
-    require_org_membership,
     require_org_role_permission,
     get_user_org_role,
 )
@@ -241,10 +240,13 @@ async def get_api_token(
     # VERIFICATION 1: User must be authenticated
     await authorization_verify_if_user_is_anon(current_user.id)
 
-    # VERIFICATION 2: Membership (superadmins bypass)
-    await require_org_membership(current_user.id, org_id, db_session)
+    # VERIFICATION 2+3: Membership + permission (superadmins bypass).
+    # Reading a token record must require the same 'roles' read permission as
+    # listing them; otherwise any low-privilege org member could enumerate
+    # token metadata (rights, creator, expiry) by guessing UUIDs.
+    await require_org_role_permission(current_user.id, org_id, db_session, "roles", "action_read")
 
-    # VERIFICATION 3: Get the token
+    # VERIFICATION 4: Get the token
     statement = select(APIToken).where(
         APIToken.token_uuid == token_uuid,
         APIToken.org_id == org_id
@@ -521,10 +523,17 @@ async def validate_rights_structure(
 
                 for perm_key, perm_value in right_permissions.items():
                     if isinstance(perm_value, bool) and perm_value:
-                        if isinstance(user_right_permissions, dict) and perm_key in user_right_permissions:
-                            user_has_perm = user_right_permissions[perm_key]
-                            if not user_has_perm:
-                                raise HTTPException(
-                                    status_code=status.HTTP_403_FORBIDDEN,
-                                    detail=f"Cannot grant '{perm_key}' permission for '{right_key}' as you don't have this permission yourself",
-                                )
+                        # The user must explicitly hold this permission to grant
+                        # it. Previously, if the permission key was absent from
+                        # the user's own rights object the check was skipped,
+                        # letting a user mint a token with a permission they do
+                        # not possess. Treat absent/false alike as not-granted.
+                        user_has_perm = (
+                            isinstance(user_right_permissions, dict)
+                            and bool(user_right_permissions.get(perm_key))
+                        )
+                        if not user_has_perm:
+                            raise HTTPException(
+                                status_code=status.HTTP_403_FORBIDDEN,
+                                detail=f"Cannot grant '{perm_key}' permission for '{right_key}' as you don't have this permission yourself",
+                            )

--- a/apps/api/src/services/auth/utils.py
+++ b/apps/api/src/services/auth/utils.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from typing import Optional
 from fastapi import Depends, HTTPException, Request
 import httpx
-from sqlmodel import select
+from sqlmodel import select, func
 from sqlmodel.ext.asyncio.session import AsyncSession
 from src.core.events.database import get_db_session
 from src.db.users import User, UserCreate, UserRead
@@ -113,7 +113,19 @@ async def signWithGoogle(
     # but is no longer used for identity resolution.
     google_email = google_user.get("email")
     google_email_verified = google_user.get("email_verified")
-    if not google_email or not google_email_verified:
+    # SECURITY: Google's userinfo/tokeninfo endpoints sometimes serialise
+    # ``email_verified`` as the JSON *string* ``"true"``/``"false"`` (notably
+    # the v1/v2 userinfo and some Workspace federated accounts) rather than a
+    # native boolean. A plain truthiness test (``not google_email_verified``)
+    # treats the string ``"false"`` as verified, which would let an attacker
+    # who controls an *unverified* Google account matching a victim's address
+    # take over the LearnHouse account. Accept only an explicit boolean ``True``
+    # or the string ``"true"`` (case-insensitive).
+    if isinstance(google_email_verified, str):
+        email_is_verified = google_email_verified.strip().lower() == "true"
+    else:
+        email_is_verified = google_email_verified is True
+    if not google_email or not email_is_verified:
         raise HTTPException(
             status_code=401,
             detail="Google did not return a verified email for this account",
@@ -121,8 +133,14 @@ async def signWithGoogle(
     # Normalise to lower-case to match the DB unique-ish invariant on email.
     user_email = google_email.strip().lower()
 
+    # Match existing accounts case-insensitively. Local email/password signups
+    # store the email exactly as submitted (no lower-casing), so an account
+    # registered as "Victim@Gmail.com" would NOT be matched by an exact compare
+    # against the lower-cased Google address. That mismatch would silently
+    # create a duplicate account (or raise on a case-insensitive unique index),
+    # stranding the user in an empty second account or breaking OAuth login.
     user = (await db_session.execute(
-        select(User).where(User.email == user_email)
+        select(User).where(func.lower(User.email) == user_email)
     )).scalars().first()
 
     if not user:
@@ -148,7 +166,13 @@ async def signWithGoogle(
         if not username_parts:
             username_parts.append("user")
 
-        username = "".join(username_parts) + str(random.randint(10, 99))
+        # Use a wide random suffix to make username collisions vanishingly
+        # unlikely. The previous 2-digit suffix (only 90 possible values) made
+        # collisions probable for common names/email prefixes; a collision
+        # bubbles up from create_user[_without_org] as a 400 "already in use",
+        # which permanently blocks an otherwise-new Google account from signing
+        # up because the conflict is on the generated username, not the email.
+        username = "".join(username_parts) + str(random.randint(100000, 999999))
 
         user_object = UserCreate(
             email=user_email,
@@ -188,6 +212,42 @@ async def signWithGoogle(
         db_session.add(user)
         await db_session.commit()
         await db_session.refresh(user)
+
+    # If the caller supplied (and the router validated, via a pending invite)
+    # an ``org_id``, an *existing* user signing in with Google must still be
+    # added to that organization. The new-user branch above does this through
+    # ``create_user``; previously the existing-user branch dropped ``org_id``
+    # entirely, so a person who already had a LearnHouse account and accepted
+    # an org invite via Google was authenticated but never actually joined the
+    # org. We mirror create_user's behaviour: enforce the member quota, avoid
+    # double-counting on repeat logins, then create the membership link.
+    if org_id is not None and user.id is not None:
+        from src.db.user_organizations import UserOrganization
+        from src.security.features_utils.usage import (
+            check_limits_with_usage,
+            increase_feature_usage,
+        )
+
+        existing_membership = (await db_session.execute(
+            select(UserOrganization).where(
+                (UserOrganization.user_id == user.id)
+                & (UserOrganization.org_id == org_id)
+            )
+        )).scalars().first()
+
+        if not existing_membership:
+            await check_limits_with_usage("members", org_id, db_session)
+            user_organization = UserOrganization(
+                user_id=user.id,
+                org_id=org_id,
+                role_id=4,
+                creation_date=str(datetime.now()),
+                update_date=str(datetime.now()),
+            )
+            db_session.add(user_organization)
+            await db_session.commit()
+            await db_session.refresh(user_organization)
+            await increase_feature_usage("members", org_id, db_session)
 
     # Update last login info
     client_ip = get_client_ip(request)

--- a/apps/api/src/services/blocks/block_types/audioBlock/audioBlock.py
+++ b/apps/api/src/services/blocks/block_types/audioBlock/audioBlock.py
@@ -31,6 +31,11 @@ async def create_audio_block(
     statement = select(Organization).where(Organization.id == activity.org_id)
     org = (await db_session.execute(statement)).scalars().first()
 
+    if not org:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found"
+        )
+
     # get course
     statement = select(Course).where(Course.id == activity.course_id)
     course = (await db_session.execute(statement)).scalars().first()
@@ -40,8 +45,15 @@ async def create_audio_block(
             status_code=status.HTTP_404_NOT_FOUND, detail="Course not found"
         )
 
-    if current_user:
-        await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
+    # Require authentication and always enforce UPDATE access. current_user
+    # defaults to None, so a guarded check would silently fail open for any
+    # caller that omits it; reject None explicitly and let check_resource_access
+    # deny anonymous/unauthorized users.
+    if current_user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required"
+        )
+    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
 
     # get block id
     block_uuid = str(f"block_{uuid4()}")

--- a/apps/api/src/services/blocks/block_types/imageBlock/imageBlock.py
+++ b/apps/api/src/services/blocks/block_types/imageBlock/imageBlock.py
@@ -31,6 +31,11 @@ async def create_image_block(
     statement = select(Organization).where(Organization.id == activity.org_id)
     org = (await db_session.execute(statement)).scalars().first()
 
+    if not org:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found"
+        )
+
     # get course
     statement = select(Course).where(Course.id == activity.course_id)
     course = (await db_session.execute(statement)).scalars().first()
@@ -40,8 +45,15 @@ async def create_image_block(
             status_code=status.HTTP_404_NOT_FOUND, detail="Course not found"
         )
 
-    if current_user:
-        await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
+    # Require authentication and always enforce UPDATE access. current_user
+    # defaults to None, so a guarded check would silently fail open for any
+    # caller that omits it; reject None explicitly and let check_resource_access
+    # deny anonymous/unauthorized users.
+    if current_user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required"
+        )
+    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
 
     # get block id
     block_uuid = str(f"block_{uuid4()}")

--- a/apps/api/src/services/blocks/block_types/pdfBlock/pdfBlock.py
+++ b/apps/api/src/services/blocks/block_types/pdfBlock/pdfBlock.py
@@ -31,6 +31,11 @@ async def create_pdf_block(
     statement = select(Organization).where(Organization.id == activity.org_id)
     org = (await db_session.execute(statement)).scalars().first()
 
+    if not org:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found"
+        )
+
     # get course
     statement = select(Course).where(Course.id == activity.course_id)
     course = (await db_session.execute(statement)).scalars().first()
@@ -40,8 +45,15 @@ async def create_pdf_block(
             status_code=status.HTTP_404_NOT_FOUND, detail="Course not found"
         )
 
-    if current_user:
-        await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
+    # Require authentication and always enforce UPDATE access. current_user
+    # defaults to None, so a guarded check would silently fail open for any
+    # caller that omits it; reject None explicitly and let check_resource_access
+    # deny anonymous/unauthorized users.
+    if current_user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required"
+        )
+    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
 
     # get block id
     block_uuid = str(f"block_{uuid4()}")

--- a/apps/api/src/services/blocks/block_types/videoBlock/videoBlock.py
+++ b/apps/api/src/services/blocks/block_types/videoBlock/videoBlock.py
@@ -31,6 +31,11 @@ async def create_video_block(
     statement = select(Organization).where(Organization.id == activity.org_id)
     org = (await db_session.execute(statement)).scalars().first()
 
+    if not org:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found"
+        )
+
     # get course
     statement = select(Course).where(Course.id == activity.course_id)
     course = (await db_session.execute(statement)).scalars().first()
@@ -40,8 +45,15 @@ async def create_video_block(
             status_code=status.HTTP_404_NOT_FOUND, detail="Course not found"
         )
 
-    if current_user:
-        await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
+    # Require authentication and always enforce UPDATE access. current_user
+    # defaults to None, so a guarded check would silently fail open for any
+    # caller that omits it; reject None explicitly and let check_resource_access
+    # deny anonymous/unauthorized users.
+    if current_user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required"
+        )
+    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
 
     # get block id
     block_uuid = str(f"block_{uuid4()}")
@@ -51,7 +63,7 @@ async def create_video_block(
         video_file,
         activity_uuid,
         block_uuid,
-        ["mp4", "webm", "ogg"],
+        ["mp4", "webm"],
         block_type,
         org.org_uuid,
         str(course.course_uuid),

--- a/apps/api/src/services/blocks/utils/upload_files.py
+++ b/apps/api/src/services/blocks/utils/upload_files.py
@@ -41,10 +41,15 @@ async def upload_file_and_return_file_object(
         filename_prefix=f"block_{file_id}"
     )
 
-    # Get file metadata
-    file.file.seek(0)
-    content = await file.read()
-    
+    # Get file metadata. Use the size already known from the multipart parse
+    # instead of reading the whole file into memory again (videos can be up to
+    # several GB, so a second full read would double peak memory usage).
+    if file.size is not None:
+        file_size = file.size
+    else:
+        file.file.seek(0)
+        file_size = len(await file.read())
+
     # Extract actual name on disk and extension
     parts = filename.rsplit(".", 1)
     name_on_disk = parts[0]
@@ -53,8 +58,8 @@ async def upload_file_and_return_file_object(
     return BlockFile(
         file_id=name_on_disk,
         file_format=ext,
-        file_name=file.filename,
-        file_size=len(content),
-        file_type=file.content_type,
+        file_name=file.filename or name_on_disk,
+        file_size=file_size,
+        file_type=file.content_type or "application/octet-stream",
         activity_uuid=activity_uuid,
     )

--- a/apps/api/src/services/boards/boards.py
+++ b/apps/api/src/services/boards/boards.py
@@ -226,6 +226,16 @@ async def add_board_member(
     board = await _get_board_or_404(board_uuid, db_session)
     await check_resource_access(request, db_session, current_user, board.board_uuid, AccessAction.UPDATE)
 
+    # Validate the requested role against the allowed set. The schema types
+    # `role` as a bare str, so without this an arbitrary string (or a second
+    # "owner") could be persisted, corrupting role-based access logic.
+    role = _validate_member_role(member_object.role)
+
+    # Ensure the target user actually belongs to this board's organization.
+    # Otherwise a board manager could add users from *other* organizations,
+    # leaking the board (and the foreign user's profile) across tenants.
+    await require_org_membership(member_object.user_id, board.org_id, db_session)
+
     # Check member limit (max 10 per board)
     member_count = (await db_session.execute(
         select(func.count(BoardMember.id)).where(BoardMember.board_id == board.id)
@@ -246,7 +256,7 @@ async def add_board_member(
     member = BoardMember(
         board_id=board.id,
         user_id=member_object.user_id,
-        role=member_object.role,
+        role=role,
         creation_date=str(datetime.now()),
     )
     db_session.add(member)
@@ -259,7 +269,7 @@ async def add_board_member(
         data={
             "board_uuid": board.board_uuid,
             "user_id": member_object.user_id,
-            "role": member_object.role.value,
+            "role": role.value,
         },
     )
 
@@ -288,6 +298,11 @@ async def add_board_members_batch(
         if member_count + len(added) >= 10:
             break
 
+        # Validate role and ensure the user belongs to this board's org
+        # (prevents cross-tenant member additions and invalid/escalated roles).
+        role = _validate_member_role(member_create.role)
+        await require_org_membership(member_create.user_id, board.org_id, db_session)
+
         # Skip duplicates silently
         existing = (await db_session.execute(
             select(BoardMember).where(
@@ -301,7 +316,7 @@ async def add_board_members_batch(
         member = BoardMember(
             board_id=board.id,
             user_id=member_create.user_id,
-            role=member_create.role,
+            role=role,
             creation_date=str(datetime.now()),
         )
         db_session.add(member)
@@ -484,6 +499,22 @@ async def store_ydoc_state(
     db_session.add(board)
     await db_session.commit()
     return {"detail": "Ydoc state stored"}
+
+
+def _validate_member_role(role) -> BoardMemberRole:
+    """Coerce/validate an incoming board-member role into the allowed enum.
+
+    The API schema types `role` as a plain str, so we must reject anything
+    outside BoardMemberRole (e.g. arbitrary strings, or escalating to
+    "owner") before it is persisted.
+    """
+    try:
+        return BoardMemberRole(role.value if isinstance(role, BoardMemberRole) else role)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid board member role. Allowed: {', '.join(r.value for r in BoardMemberRole)}",
+        )
 
 
 async def _get_board_or_404(board_uuid: str, db_session: AsyncSession) -> Board:

--- a/apps/api/src/services/boards/boards_playground.py
+++ b/apps/api/src/services/boards/boards_playground.py
@@ -21,11 +21,21 @@ SESSION_TTL = 2160000  # 25 days
 MAX_ITERATIONS = 6
 
 
+_redis_client = None
+
+
 def get_redis_connection():
+    # Reuse a single client (and its connection pool) across calls. Creating a
+    # new redis.from_url() client on every session read/write — as the playground
+    # hot path does — spawns a fresh connection pool each time and leaks sockets.
+    global _redis_client
+    if _redis_client is not None:
+        return _redis_client
     redis_conn_string = LH_CONFIG.redis_config.redis_connection_string
     if redis_conn_string:
         try:
-            return redis.from_url(redis_conn_string)
+            _redis_client = redis.from_url(redis_conn_string)
+            return _redis_client
         except Exception as e:
             logger.error("Failed to connect to Redis: %s", e, exc_info=True)
     return None

--- a/apps/api/src/services/communities/comment_votes.py
+++ b/apps/api/src/services/communities/comment_votes.py
@@ -3,6 +3,8 @@ from uuid import uuid4
 from datetime import datetime
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlalchemy import update as sql_update
+from sqlalchemy.exc import IntegrityError
 from fastapi import HTTPException, Request
 
 from src.db.users import PublicUser, AnonymousUser, APITokenUser
@@ -83,13 +85,26 @@ async def upvote_comment(
         creation_date=str(datetime.now()),
     )
 
-    db_session.add(vote)
+    try:
+        db_session.add(vote)
+        # Atomic increment to avoid lost updates when multiple users upvote
+        # concurrently (read-modify-write on the Python object would clobber
+        # parallel increments and undercount).
+        await db_session.execute(
+            sql_update(DiscussionComment)
+            .where(DiscussionComment.id == comment.id)
+            .values(upvote_count=DiscussionComment.upvote_count + 1)
+        )
+        await db_session.commit()
+    except IntegrityError:
+        # Lost the race against a concurrent vote from the same user; the unique
+        # (comment_id, user_id) constraint rejected the duplicate insert.
+        await db_session.rollback()
+        raise HTTPException(
+            status_code=400,
+            detail="You have already upvoted this comment",
+        )
 
-    # Increment upvote count
-    comment.upvote_count += 1
-    db_session.add(comment)
-
-    await db_session.commit()
     await db_session.refresh(vote)
 
     return DiscussionCommentVoteRead.model_validate(vote.model_dump())
@@ -134,9 +149,12 @@ async def remove_comment_upvote(
     # Delete vote
     await db_session.delete(vote)
 
-    # Decrement upvote count (minimum 0)
-    comment.upvote_count = max(0, comment.upvote_count - 1)
-    db_session.add(comment)
+    # Atomic decrement (floored at 0) to avoid lost updates under concurrency.
+    await db_session.execute(
+        sql_update(DiscussionComment)
+        .where(DiscussionComment.id == comment.id, DiscussionComment.upvote_count > 0)
+        .values(upvote_count=DiscussionComment.upvote_count - 1)
+    )
 
     await db_session.commit()
 

--- a/apps/api/src/services/communities/comments.py
+++ b/apps/api/src/services/communities/comments.py
@@ -313,11 +313,17 @@ async def delete_comment(
 
 
 async def get_comment_count(
+    request: Request,
     discussion_uuid: str,
+    current_user: Union[PublicUser, AnonymousUser, APITokenUser],
     db_session: AsyncSession,
 ) -> int:
     """
     Get the count of comments for a discussion.
+
+    The caller must be able to READ the parent community; otherwise the count
+    would leak activity from private communities to anyone who can guess a
+    discussion uuid. This mirrors the authorization of ``get_discussion``.
     """
     discussion_statement = select(Discussion).where(
         Discussion.discussion_uuid == discussion_uuid
@@ -325,7 +331,17 @@ async def get_comment_count(
     discussion = (await db_session.execute(discussion_statement)).scalars().first()
 
     if not discussion:
-        return 0
+        raise HTTPException(status_code=404, detail="Discussion not found")
+
+    community = (await db_session.execute(
+        select(Community).where(Community.id == discussion.community_id)
+    )).scalars().first()
+    if not community:
+        raise HTTPException(status_code=404, detail="Community not found")
+
+    await check_resource_access(
+        request, db_session, current_user, community.community_uuid, AccessAction.READ
+    )
 
     from sqlalchemy import func
     count_statement = select(func.count(DiscussionComment.id)).where(

--- a/apps/api/src/services/communities/comments.py
+++ b/apps/api/src/services/communities/comments.py
@@ -5,7 +5,7 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from fastapi import HTTPException, Request
 
-from src.db.users import PublicUser, AnonymousUser, APITokenUser, User, UserRead
+from src.db.users import PublicUser, AnonymousUser, APITokenUser, User, UserReadAuthor
 from src.db.communities.communities import Community
 from src.db.communities.discussions import Discussion
 from src.db.communities.discussion_comments import (
@@ -100,7 +100,7 @@ async def create_comment(
 
     return DiscussionCommentReadWithVoteStatus(
         **comment.model_dump(),
-        author=UserRead.model_validate(author.model_dump()) if author else None,
+        author=UserReadAuthor.model_validate(author.model_dump()) if author else None,
         has_voted=False,  # User just created it, hasn't voted yet
     )
 
@@ -170,7 +170,7 @@ async def get_comments_by_discussion(
         result.append(
             DiscussionCommentReadWithVoteStatus(
                 **comment.model_dump(),
-                author=UserRead.model_validate(author.model_dump()) if author else None,
+                author=UserReadAuthor.model_validate(author.model_dump()) if author else None,
                 has_voted=user_votes.get(comment.id, False),
             )
         )
@@ -241,7 +241,7 @@ async def update_comment(
 
     return DiscussionCommentReadWithVoteStatus(
         **comment.model_dump(),
-        author=UserRead.model_validate(author.model_dump()) if author else None,
+        author=UserReadAuthor.model_validate(author.model_dump()) if author else None,
         has_voted=user_votes.get(comment.id, False),
     )
 

--- a/apps/api/src/services/communities/communities.py
+++ b/apps/api/src/services/communities/communities.py
@@ -141,13 +141,26 @@ async def get_communities_by_org(
         return [CommunityRead.model_validate(c.model_dump()) for c in communities]
 
     # Check if user has admin-level permissions (can read all communities)
-    # First check role-based permissions, then fall back to org admin status
+    # First check role-based permissions, then fall back to org admin status.
+    # NOTE: the RBAC helpers resolve the target org by UUID, so we must pass the
+    # organization's org_uuid (e.g. "org_<uuid>"), not the numeric org_id.
+    # Passing "org_<int>"/"community_<int>" never resolves an org, which made
+    # both checks silently return False and dropped org admins/moderators into
+    # the restricted member view (they could not see private communities).
+    org_lookup = (
+        await db_session.execute(select(Organization).where(Organization.id == org_id))
+    ).scalars().first()
+    if not org_lookup:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
     has_admin_read = await authorization_verify_based_on_roles(
-        request, acting_user_id, "update", f"community_{org_id}", db_session
+        request, acting_user_id, "update", f"community_{org_lookup.org_uuid}", db_session
     )
     is_admin_or_maintainer = has_admin_read or await authorization_verify_based_on_org_admin_status(
-        request, acting_user_id, "read", f"org_{org_id}", db_session
+        request, acting_user_id, "read", org_lookup.org_uuid, db_session
     )
+    # ``org_lookup.org_uuid`` already carries the "org_" prefix expected by the
+    # RBAC org resolver, so it is passed through unchanged above.
 
     if is_admin_or_maintainer:
         # Admins see all communities

--- a/apps/api/src/services/communities/discussions.py
+++ b/apps/api/src/services/communities/discussions.py
@@ -6,7 +6,7 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from fastapi import HTTPException, Request
 
-from src.db.users import PublicUser, AnonymousUser, APITokenUser, User, UserRead
+from src.db.users import PublicUser, AnonymousUser, APITokenUser, User, UserReadAuthor
 from src.security.auth import resolve_acting_user_id
 from src.db.communities.communities import Community
 from src.services.analytics.analytics import track
@@ -179,7 +179,7 @@ async def create_discussion(
 
     return DiscussionReadWithVoteStatus(
         **discussion.model_dump(),
-        author=UserRead.model_validate(author.model_dump()) if author else None,
+        author=UserReadAuthor.model_validate(author.model_dump()) if author else None,
         has_voted=True,
     )
 
@@ -225,7 +225,7 @@ async def get_discussion(
 
     return DiscussionReadWithVoteStatus(
         **discussion.model_dump(),
-        author=UserRead.model_validate(author.model_dump()) if author else None,
+        author=UserReadAuthor.model_validate(author.model_dump()) if author else None,
         has_voted=has_voted,
     )
 
@@ -347,7 +347,7 @@ async def get_discussions_by_community(
         result.append(
             DiscussionReadWithVoteStatus(
                 **discussion.model_dump(),
-                author=UserRead.model_validate(author.model_dump()) if author else None,
+                author=UserReadAuthor.model_validate(author.model_dump()) if author else None,
                 has_voted=has_voted,
             )
         )
@@ -452,7 +452,7 @@ async def update_discussion(
 
     return DiscussionReadWithVoteStatus(
         **discussion.model_dump(),
-        author=UserRead.model_validate(author.model_dump()) if author else None,
+        author=UserReadAuthor.model_validate(author.model_dump()) if author else None,
         has_voted=vote is not None,
     )
 
@@ -521,7 +521,7 @@ async def pin_discussion(
 
     return DiscussionReadWithVoteStatus(
         **discussion.model_dump(),
-        author=UserRead.model_validate(author.model_dump()) if author else None,
+        author=UserReadAuthor.model_validate(author.model_dump()) if author else None,
         has_voted=vote is not None,
     )
 
@@ -590,7 +590,7 @@ async def lock_discussion(
 
     return DiscussionReadWithVoteStatus(
         **discussion.model_dump(),
-        author=UserRead.model_validate(author.model_dump()) if author else None,
+        author=UserReadAuthor.model_validate(author.model_dump()) if author else None,
         has_voted=vote is not None,
     )
 

--- a/apps/api/src/services/communities/discussions.py
+++ b/apps/api/src/services/communities/discussions.py
@@ -132,6 +132,23 @@ async def create_discussion(
     )
 
     db_session.add(discussion)
+    # Flush to assign discussion.id without ending the transaction, so the
+    # author's auto-upvote vote row is written atomically with the discussion.
+    # Previously the vote was committed in a *second* transaction after the
+    # discussion was already persisted; if that second commit failed the
+    # discussion was left with upvote_count=1 but no matching vote row — a
+    # permanently inflated, unremovable phantom upvote.
+    await db_session.flush()
+
+    # Create auto-upvote from author in the same transaction
+    vote = DiscussionVote(
+        discussion_id=discussion.id,
+        user_id=current_user.id,
+        vote_uuid=f"vote_{uuid4()}",
+        creation_date=str(datetime.now()),
+    )
+    db_session.add(vote)
+
     await db_session.commit()
     await db_session.refresh(discussion)
 
@@ -155,16 +172,6 @@ async def create_discussion(
             "community": {"community_uuid": community_uuid},
         },
     )
-
-    # Create auto-upvote from author
-    vote = DiscussionVote(
-        discussion_id=discussion.id,
-        user_id=current_user.id,
-        vote_uuid=f"vote_{uuid4()}",
-        creation_date=str(datetime.now()),
-    )
-    db_session.add(vote)
-    await db_session.commit()
 
     # Get author info
     author_statement = select(User).where(User.id == discussion.author_id)

--- a/apps/api/src/services/communities/votes.py
+++ b/apps/api/src/services/communities/votes.py
@@ -140,9 +140,15 @@ async def remove_upvote(
     # Delete vote
     await db_session.delete(vote)
 
-    # Decrement upvote count (minimum 0)
-    discussion.upvote_count = max(0, discussion.upvote_count - 1)
-    db_session.add(discussion)
+    # Atomic decrement (floored at 0). upvote_discussion uses an atomic SQL
+    # increment, so the removal path must mirror it: a Python read-modify-write
+    # here loses concurrent updates and lets the cached count drift away from
+    # the real number of vote rows.
+    await db_session.execute(
+        sql_update(Discussion)
+        .where(Discussion.id == discussion.id, Discussion.upvote_count > 0)
+        .values(upvote_count=Discussion.upvote_count - 1)
+    )
 
     await db_session.commit()
 

--- a/apps/api/src/services/courses/chapters.py
+++ b/apps/api/src/services/courses/chapters.py
@@ -243,6 +243,15 @@ async def get_course_chapters(
         statement = select(Course).where(Course.id == course_id)
         course = (await db_session.execute(statement)).scalars().first()
 
+    # A non-existent course_id (e.g. from the public
+    # /chapters/course/{course_id}/page/... endpoint) must return a clean 404.
+    # Without this guard the RBAC check below dereferences course.course_uuid
+    # on None and the request 500s instead.
+    if course is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Course does not exist"
+        )
+
     statement = (
         select(Chapter)
         .join(CourseChapter, Chapter.id == CourseChapter.chapter_id) # type: ignore

--- a/apps/api/src/services/courses/courses.py
+++ b/apps/api/src/services/courses/courses.py
@@ -190,9 +190,17 @@ async def get_course_meta(
         context=AccessContext.DASHBOARD,
     )
 
-    # Permission check passed — try Redis cache for the heavy data
-    # (shared across all authorized users for this course)
-    if course.published and not with_unpublished_activities:
+    # Permission check passed — try Redis cache for the heavy data.
+    # SECURITY: chapter/activity content is lock-stripped PER USER in
+    # _apply_locks_to_chapters (restricted items are blanked for users not in
+    # the right usergroup, while admins/members see everything). The meta cache
+    # is keyed only by course_uuid+slim and shared across users, so caching an
+    # authenticated user's view would leak restricted content to others (or
+    # hide it from those who should see it). Only the anonymous view is uniform
+    # (always the public, fully-stripped projection), so restrict the shared
+    # cache to anonymous readers.
+    is_anonymous = isinstance(current_user, AnonymousUser)
+    if is_anonymous and course.published and not with_unpublished_activities:
         from src.services.courses.cache import get_cached_course_meta
         cached = get_cached_course_meta(course_uuid, slim)
         if cached is not None:
@@ -232,8 +240,9 @@ async def get_course_meta(
         chapters=chapters
     )
 
-    # Cache for published courses (safe to share across users)
-    if course.published and not with_unpublished_activities:
+    # Cache only the anonymous (public, uniformly-stripped) view. See the read
+    # path above for why per-user views must not populate this shared key.
+    if is_anonymous and course.published and not with_unpublished_activities:
         from src.services.courses.cache import set_cached_course_meta
         set_cached_course_meta(course_uuid, slim, course_read.model_dump())
 
@@ -922,9 +931,6 @@ async def delete_course(
     # RBAC check
     await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.DELETE)
 
-    # Feature usage
-    await decrease_feature_usage("courses", course.org_id, db_session)
-
     # Clean up content files from storage
     org_statement = select(Organization).where(Organization.id == course.org_id)
     org = (await db_session.execute(org_statement)).scalars().first()
@@ -939,6 +945,13 @@ async def delete_course(
 
     await db_session.delete(course)
     await db_session.commit()
+
+    # Feature usage — decrement only AFTER the row is actually gone. The usage
+    # counter lives in Redis and is written immediately/irreversibly; doing it
+    # before the delete meant a failed delete/commit (or storage error) left the
+    # org's course count permanently under-counted, letting them create an extra
+    # course past their plan limit.
+    await decrease_feature_usage("courses", course_org_id, db_session)
 
     await dispatch_webhooks(
         event_name="course_deleted",
@@ -962,7 +975,18 @@ async def get_user_courses(
 ) -> List[CourseRead]:
     # Verify user is not anonymous
     await authorization_verify_if_user_is_anon(current_user.id)
-    
+
+    # SECURITY: This endpoint takes an arbitrary target user_id. Without a
+    # visibility filter, any logged-in user could enumerate another user's
+    # UNPUBLISHED / private courses just by passing their id (IDOR / content
+    # disclosure). A caller may only see another user's unpublished courses if
+    # they are that user or a superadmin; everyone else is limited to the
+    # published + public courses that user authored.
+    can_see_unpublished = (
+        int(current_user.id) == int(user_id)
+        or await is_user_superadmin(int(current_user.id), db_session)
+    )
+
     # Fetch courses the user has authored using a single JOIN query with pagination
     statement = (
         select(Course)
@@ -971,6 +995,11 @@ async def get_user_courses(
             ResourceAuthor.user_id == user_id,
             ResourceAuthor.authorship_status == ResourceAuthorshipStatusEnum.ACTIVE,
         )
+    )
+    if not can_see_unpublished:
+        statement = statement.where(Course.published == True, Course.public == True)
+    statement = (
+        statement
         .offset((page - 1) * limit)
         .limit(limit)
     )
@@ -1134,6 +1163,16 @@ async def clone_course(
 
     # Also check if user can create courses
     await check_resource_access(request, db_session, current_user, "course_x", AccessAction.CREATE)
+
+    # SECURITY: The clone is written into the ORIGINAL course's org. READ access
+    # to that course can come from it simply being public, and the "course_x"
+    # create check is not bound to a concrete org. Without an explicit membership
+    # check, a user from org A who can merely view a public course in org B could
+    # clone it (with all its content + files) into org B and make themselves its
+    # creator. Require membership in the target org, consistent with create_course.
+    await require_org_membership(
+        resolve_acting_user_id(current_user), original_course.org_id, db_session
+    )
 
     # Usage check for creating new course
     await check_limits_with_usage("courses", original_course.org_id, db_session)

--- a/apps/api/src/services/courses/updates.py
+++ b/apps/api/src/services/courses/updates.py
@@ -152,6 +152,11 @@ async def get_updates_by_course_uuid(
             status_code=status.HTTP_409_CONFLICT, detail="Course does not exist"
         )
 
+    # RBAC check — course updates inherit the course's visibility. Without this
+    # any caller (including anonymous users) could read the update feed of a
+    # private / unpublished course just by knowing its uuid.
+    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
+
     statement = (
         select(CourseUpdate)
         .where(CourseUpdate.course_id == course.id)

--- a/apps/api/src/services/explore/explore.py
+++ b/apps/api/src/services/explore/explore.py
@@ -90,7 +90,7 @@ async def get_courses_for_an_org_explore(
 
     statement = (
         select(Course)
-        .where(Course.org_id == org.id, Course.public == True)
+        .where(Course.org_id == org.id, Course.public == True, Course.published == True)
         .offset((page - 1) * limit)
         .limit(limit)
     )
@@ -102,7 +102,11 @@ async def get_course_for_explore(
     course_id: int,
     db_session: AsyncSession,
 ) -> CourseRead:
-    statement = select(Course).where(Course.id == course_id)
+    statement = select(Course).where(
+        Course.id == course_id,
+        Course.public == True,
+        Course.published == True,
+    )
     result = await db_session.execute(statement)
 
     course = result.scalars().first()
@@ -146,6 +150,11 @@ async def search_orgs_for_explore(
 ) -> list[OrganizationRead]:
     # Tokenize on unicode whitespace after NFC-normalizing so emoji + diacritics
     # in the query don't drop terms or split mid-grapheme.
+    # Enforce maximum limit to prevent data dumping and clamp page to avoid a
+    # negative OFFSET (Postgres rejects negative OFFSET, which would 500).
+    limit = min(max(limit, 1), 50)
+    page = max(page, 1)
+
     search_terms = normalize_search_term(search_query).split()
     search_conditions = []
 

--- a/apps/api/src/services/health/health.py
+++ b/apps/api/src/services/health/health.py
@@ -4,12 +4,16 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 
 async def check_database_health(db_session: AsyncSession) -> bool:
-    result = await db_session.execute(text("SELECT 1"))
-
-    if not result:
+    # A Result object is always truthy, so the previous `if not result` was dead
+    # code and an actual DB outage raised an uncaught exception (500) instead of
+    # being reported as unhealthy. Materialize the scalar and fail closed.
+    try:
+        result = await db_session.execute(text("SELECT 1"))
+        value = result.scalar()
+    except Exception:
         return False
 
-    return True
+    return value == 1
 
 async def check_health(db_session: AsyncSession) -> bool:
     # Check database health

--- a/apps/api/src/services/orgs/invites.py
+++ b/apps/api/src/services/orgs/invites.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 import secrets
 import string
 import uuid
@@ -199,6 +200,11 @@ async def get_invite_codes(
 
     for invite_code in invite_codes:  # type: ignore
         invite_code = r.get(invite_code)
+        # The key may have expired between scan_iter() and get() (codes carry a
+        # TTL). r.get() then returns None and json.loads(None) raises TypeError,
+        # crashing the whole listing with a 500. Skip vanished keys instead.
+        if invite_code is None:
+            continue
         invite_code = json.loads(invite_code)  # type: ignore
 
         # Enrich with usergroup name if linked
@@ -313,6 +319,17 @@ async def delete_invite_code(
         raise HTTPException(
             status_code=500,
             detail="Could not connect to Redis",
+        )
+
+    # SECURITY: the UUID is interpolated into a Redis SCAN glob pattern. Without
+    # validation an admin could pass wildcard characters (e.g. "*") to match —
+    # and delete — every invite code key for the org in a single call, instead
+    # of the one resource the endpoint is meant to address. Restrict to the
+    # exact "org_invite_code_<uuid4>" shape this codebase generates.
+    if not re.fullmatch(r"org_invite_code_[0-9a-fA-F-]{36}", invite_code_uuid):
+        raise HTTPException(
+            status_code=404,
+            detail="Invite code not found",
         )
 
     # Delete invite code (use scan_iter to avoid blocking Redis)

--- a/apps/api/src/services/orgs/join.py
+++ b/apps/api/src/services/orgs/join.py
@@ -64,6 +64,16 @@ async def join_org(
             detail="User not found",
         )
 
+    # SECURITY: a user may only join an organization as themselves. Without this
+    # check, any authenticated caller could pass an arbitrary user_id in the
+    # request body and force-join (or, in inviteOnly orgs, force-attach to a
+    # usergroup) any other account — an IDOR / privilege-escalation flaw.
+    if isinstance(current_user, AnonymousUser) or str(user.id) != str(current_user.id):
+        raise HTTPException(
+            status_code=403,
+            detail="You can only join an organization as yourself.",
+        )
+
     # Check if user's email is verified
     if not user.email_verified:
         raise HTTPException(

--- a/apps/api/src/services/orgs/orgs.py
+++ b/apps/api/src/services/orgs/orgs.py
@@ -634,7 +634,10 @@ async def get_orgs_by_user_admin(
             UserOrganization.user_id == user_id,
             UserOrganization.role_id == ADMIN_ROLE_ID,  # Only where the user is admin
             UserOrganization.org_id == Organization.id,
-            OrganizationConfig.org_id == Organization.id
+            # NOTE: the OrganizationConfig join predicate must NOT live in WHERE.
+            # Placing it here filters out rows where the outer-joined config is
+            # NULL, silently turning the OUTER join into an INNER join and
+            # dropping any org that has no config row from the admin's list.
         )
         .offset((page - 1) * limit)
         .limit(limit)
@@ -668,7 +671,10 @@ async def get_orgs_by_user(
         .where(
             UserOrganization.user_id == user_id,
             UserOrganization.org_id == Organization.id,
-            OrganizationConfig.org_id == Organization.id
+            # NOTE: the OrganizationConfig join predicate must NOT live in WHERE.
+            # Placing it here filters out rows where the outer-joined config is
+            # NULL, silently turning the OUTER join into an INNER join and
+            # dropping any org that has no config row from the user's list.
         )
         .offset((page - 1) * limit)
         .limit(limit)

--- a/apps/api/src/services/packs/packs.py
+++ b/apps/api/src/services/packs/packs.py
@@ -110,8 +110,13 @@ async def activate_pack(
         db_session.add(existing)
         await db_session.flush()
 
-        # Add credits/seats to Redis — use stored quantity from DB record
-        _apply_pack_credits(org_id, pack_def)
+        # Add credits/seats to Redis — use stored quantity/type from DB record
+        # (the DB record is the source of truth; pack_def may have drifted or
+        # a different pack_id may have been supplied for the same subscription).
+        if existing.pack_type == PackTypeEnum.ai_credits:
+            add_ai_credits(org_id, existing.quantity)
+        elif existing.pack_type == PackTypeEnum.member_seats:
+            _add_member_seats(org_id, existing.quantity)
 
         await db_session.commit()
         await db_session.refresh(existing)
@@ -179,13 +184,20 @@ async def deactivate_pack(
     org_pack.status = PackStatusEnum.cancelled
     org_pack.cancelled_at = datetime.now()
     db_session.add(org_pack)
-    await db_session.flush()
 
-    # Remove credits/seats from Redis
-    _revoke_pack_credits(org_id, org_pack.pack_type, org_pack.quantity)
+    # Capture values needed for Redis BEFORE commit (refresh may expire them),
+    # but only mutate Redis AFTER the DB commit succeeds. The DB is the source
+    # of truth (see reconcile_pack_credits); revoking credits before the commit
+    # means a failed/rolled-back commit would strip a still-paying customer's
+    # purchased credits/seats.
+    pack_type = org_pack.pack_type
+    quantity = org_pack.quantity
 
     await db_session.commit()
     await db_session.refresh(org_pack)
+
+    # Remove credits/seats from Redis
+    _revoke_pack_credits(org_id, pack_type, quantity)
 
     _task = asyncio.create_task(dispatch_webhooks(
         event_name="pack_deactivated",

--- a/apps/api/src/services/playgrounds/playground_reactions.py
+++ b/apps/api/src/services/playgrounds/playground_reactions.py
@@ -1,6 +1,7 @@
 from typing import List, Union
 from uuid import uuid4
 from datetime import datetime, timezone
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from fastapi import HTTPException, Request
@@ -12,6 +13,7 @@ from src.db.playground_reactions import (
     PlaygroundReactionSummary,
     ReactionUser,
 )
+from src.security.auth import resolve_acting_user_id
 from src.services.playgrounds.playgrounds import _check_read_access
 
 
@@ -28,6 +30,15 @@ async def get_playground_reactions(
         raise HTTPException(status_code=404, detail="Playground not found")
 
     await _check_read_access(playground, current_user, db_session)
+
+    # Resolve the real user id: an API token's .id is the token id, not a user
+    # id, so comparing it against reaction.user_id would yield a wrong
+    # has_reacted flag.
+    viewer_user_id = (
+        None
+        if isinstance(current_user, AnonymousUser)
+        else resolve_acting_user_id(current_user)
+    )
 
     reactions = (await db_session.execute(
         select(PlaygroundReaction).where(
@@ -54,11 +65,7 @@ async def get_playground_reactions(
             )
             for u in users
         ]
-        has_reacted = (
-            current_user.id in user_ids
-            if not isinstance(current_user, AnonymousUser)
-            else False
-        )
+        has_reacted = viewer_user_id is not None and viewer_user_id in user_ids
         summaries.append(
             PlaygroundReactionSummary(
                 emoji=emoji,
@@ -90,10 +97,14 @@ async def toggle_playground_reaction(
 
     await _check_read_access(playground, current_user, db_session)
 
+    # An API token's .id is the token id, not a user id; reaction.user_id is a FK
+    # to user.id, so we must record/match against the real acting user.
+    acting_user_id = resolve_acting_user_id(current_user)
+
     existing = (await db_session.execute(
         select(PlaygroundReaction).where(
             PlaygroundReaction.playground_id == playground.id,
-            PlaygroundReaction.user_id == current_user.id,
+            PlaygroundReaction.user_id == acting_user_id,
             PlaygroundReaction.emoji == emoji,
         )
     )).scalars().first()
@@ -105,11 +116,18 @@ async def toggle_playground_reaction(
 
     reaction = PlaygroundReaction(
         playground_id=playground.id,
-        user_id=current_user.id,
+        user_id=acting_user_id,
         emoji=emoji,
         reaction_uuid=f"reaction_{uuid4()}",
         creation_date=str(datetime.now(timezone.utc).replace(tzinfo=None)),
     )
     db_session.add(reaction)
-    await db_session.commit()
+    try:
+        await db_session.commit()
+    except IntegrityError:
+        # Concurrent duplicate insert (e.g. rapid double-click) violates the
+        # (playground_id, user_id, emoji) unique constraint. Without this guard
+        # the request fails with an unhandled 500; treat it as an idempotent
+        # "already added" instead.
+        await db_session.rollback()
     return {"action": "added", "emoji": emoji}

--- a/apps/api/src/services/playgrounds/playgrounds.py
+++ b/apps/api/src/services/playgrounds/playgrounds.py
@@ -153,8 +153,13 @@ async def create_playground(
     if not org:
         raise HTTPException(status_code=404, detail="Organization not found")
 
-    # Check rights
-    rights = await _get_user_rights(current_user.id, org_id, db_session)
+    # Check rights. Resolve the real acting user id: an API token authenticates
+    # as APITokenUser whose .id is the token id (often 0), not a user id. Using
+    # current_user.id directly would (a) make every rights/ownership check fail
+    # for token callers and (b) store the token id as created_by, which is a FK
+    # to user.id — corrupting the author reference.
+    acting_user_id = resolve_acting_user_id(current_user)
+    rights = await _get_user_rights(acting_user_id, org_id, db_session)
     pg_rights = rights.get("playgrounds", {})
     if not pg_rights.get("action_create", False):
         raise HTTPException(status_code=403, detail="Insufficient permissions to create playgrounds")
@@ -180,7 +185,7 @@ async def create_playground(
         org_id=org_id,
         playground_uuid=str(uuid4()),
         course_id=course_id,
-        created_by=current_user.id,
+        created_by=acting_user_id,
         creation_date=now,
         update_date=now,
     )
@@ -194,7 +199,7 @@ async def create_playground(
         data={
             "playground_uuid": playground.playground_uuid,
             "name": playground.name,
-            "created_by": current_user.id,
+            "created_by": acting_user_id,
         },
     )
 
@@ -214,6 +219,21 @@ async def get_playground(
         raise HTTPException(status_code=404, detail="Playground not found")
 
     await _check_read_access(playground, current_user, db_session)
+
+    # Unpublished (draft) playgrounds must never be exposed by uuid to anyone
+    # other than the owner or an org admin. _check_read_access only validates
+    # access_type, so without this guard a draft PUBLIC/AUTHENTICATED playground
+    # would be readable by anonymous/any authenticated user via its uuid — the
+    # same content list_org_playgrounds deliberately hides.
+    if not playground.published:
+        if isinstance(current_user, AnonymousUser):
+            raise HTTPException(status_code=404, detail="Playground not found")
+        acting_user_id = resolve_acting_user_id(current_user)
+        if playground.created_by != acting_user_id and not await _is_org_admin(
+            acting_user_id, playground.org_id, db_session
+        ):
+            raise HTTPException(status_code=404, detail="Playground not found")
+
     return await _playground_to_read(playground, db_session)
 
 
@@ -230,7 +250,9 @@ async def list_org_playgrounds(
         return []
 
     is_anon = isinstance(current_user, AnonymousUser)
-    user_id = None if is_anon else current_user.id
+    # An API token's .id is the token id, not a user id; resolve to the real
+    # acting user so ownership/admin visibility checks below evaluate correctly.
+    user_id = None if is_anon else resolve_acting_user_id(current_user)
 
     is_admin = False if is_anon else await _is_org_admin(user_id, org_id, db_session)
 
@@ -330,10 +352,11 @@ async def update_playground(
     if not playground:
         raise HTTPException(status_code=404, detail="Playground not found")
 
-    rights = await _get_user_rights(current_user.id, playground.org_id, db_session)
+    acting_user_id = resolve_acting_user_id(current_user)
+    rights = await _get_user_rights(acting_user_id, playground.org_id, db_session)
     pg_rights = rights.get("playgrounds", {})
 
-    is_owner = playground.created_by == current_user.id
+    is_owner = playground.created_by == acting_user_id
     can_update = pg_rights.get("action_update", False) or (
         is_owner and pg_rights.get("action_update_own", False)
     )
@@ -378,10 +401,11 @@ async def delete_playground(
     if not playground:
         raise HTTPException(status_code=404, detail="Playground not found")
 
-    rights = await _get_user_rights(current_user.id, playground.org_id, db_session)
+    acting_user_id = resolve_acting_user_id(current_user)
+    rights = await _get_user_rights(acting_user_id, playground.org_id, db_session)
     pg_rights = rights.get("playgrounds", {})
 
-    is_owner = playground.created_by == current_user.id
+    is_owner = playground.created_by == acting_user_id
     can_delete = pg_rights.get("action_delete", False) or (
         is_owner and pg_rights.get("action_delete_own", False)
     )
@@ -414,7 +438,8 @@ async def duplicate_playground(
     if not playground:
         raise HTTPException(status_code=404, detail="Playground not found")
 
-    rights = await _get_user_rights(current_user.id, playground.org_id, db_session)
+    acting_user_id = resolve_acting_user_id(current_user)
+    rights = await _get_user_rights(acting_user_id, playground.org_id, db_session)
     pg_rights = rights.get("playgrounds", {})
     if not pg_rights.get("action_create", False):
         raise HTTPException(status_code=403, detail="Insufficient permissions to create playgrounds")
@@ -431,7 +456,7 @@ async def duplicate_playground(
         org_id=playground.org_id,
         playground_uuid=str(uuid4()),
         course_id=playground.course_id,
-        created_by=current_user.id,
+        created_by=acting_user_id,
         creation_date=now,
         update_date=now,
     )
@@ -454,9 +479,10 @@ async def add_usergroup_to_playground(
     if not playground:
         raise HTTPException(status_code=404, detail="Playground not found")
 
-    rights = await _get_user_rights(current_user.id, playground.org_id, db_session)
+    acting_user_id = resolve_acting_user_id(current_user)
+    rights = await _get_user_rights(acting_user_id, playground.org_id, db_session)
     pg_rights = rights.get("playgrounds", {})
-    is_owner = playground.created_by == current_user.id
+    is_owner = playground.created_by == acting_user_id
     can_update = pg_rights.get("action_update", False) or (
         is_owner and pg_rights.get("action_update_own", False)
     )
@@ -505,9 +531,10 @@ async def remove_usergroup_from_playground(
     if not playground:
         raise HTTPException(status_code=404, detail="Playground not found")
 
-    rights = await _get_user_rights(current_user.id, playground.org_id, db_session)
+    acting_user_id = resolve_acting_user_id(current_user)
+    rights = await _get_user_rights(acting_user_id, playground.org_id, db_session)
     pg_rights = rights.get("playgrounds", {})
-    is_owner = playground.created_by == current_user.id
+    is_owner = playground.created_by == acting_user_id
     can_update = pg_rights.get("action_update", False) or (
         is_owner and pg_rights.get("action_update_own", False)
     )
@@ -548,9 +575,10 @@ async def update_playground_thumbnail(
     if not playground:
         raise HTTPException(status_code=404, detail="Playground not found")
 
-    rights = await _get_user_rights(current_user.id, playground.org_id, db_session)
+    acting_user_id = resolve_acting_user_id(current_user)
+    rights = await _get_user_rights(acting_user_id, playground.org_id, db_session)
     pg_rights = rights.get("playgrounds", {})
-    is_owner = playground.created_by == current_user.id
+    is_owner = playground.created_by == acting_user_id
     can_update = pg_rights.get("action_update", False) or (
         is_owner and pg_rights.get("action_update_own", False)
     )

--- a/apps/api/src/services/playgrounds/playgrounds_generator.py
+++ b/apps/api/src/services/playgrounds/playgrounds_generator.py
@@ -243,8 +243,12 @@ Please modify the HTML code above according to the user's request. Output ONLY t
 
         save_playground_session(session)
 
-    except Exception as e:
-        yield f"Error: {str(e)}"
+    except Exception:
+        # Never surface raw exception text to the client stream: it can contain
+        # internal details (provider error bodies, keys, stack context). Log it
+        # server-side and emit a generic message instead.
+        logger.exception("Playground generation stream failed")
+        yield "Error: An internal error occurred while generating content."
 
 
 def extract_html_from_response(response: str) -> str:

--- a/apps/api/src/services/podcasts/episodes.py
+++ b/apps/api/src/services/podcasts/episodes.py
@@ -20,6 +20,7 @@ from fastapi import HTTPException, Request, UploadFile
 from datetime import datetime
 from src.security.rbac import check_resource_access, AccessAction
 from src.security.rbac.constants import ADMIN_OR_MAINTAINER_ROLE_IDS
+from src.security.features_utils.usage import check_feature_access
 from src.services.webhooks.dispatch import dispatch_webhooks
 from src.security.superadmin import is_user_superadmin
 
@@ -130,9 +131,13 @@ async def get_episodes_by_podcast(
     # Check if user can view unpublished episodes
     can_view_unpublished = False
     if include_unpublished and not isinstance(current_user, AnonymousUser):
+        # Resolve API-token callers to their creator (tokens have id=0) so the
+        # author / org-role checks run against a real user_id instead of 0.
+        acting_user_id = resolve_acting_user_id(current_user)
+
         author_statement = select(ResourceAuthor).where(
             ResourceAuthor.resource_uuid == podcast.podcast_uuid,
-            ResourceAuthor.user_id == current_user.id,
+            ResourceAuthor.user_id == acting_user_id,
             ResourceAuthor.authorship_status == ResourceAuthorshipStatusEnum.ACTIVE
         )
         is_author = (await db_session.execute(author_statement)).scalars().first()
@@ -144,7 +149,7 @@ async def get_episodes_by_podcast(
                 select(Role)
                 .join(UserOrganization)
                 .where(UserOrganization.org_id == podcast.org_id)
-                .where(UserOrganization.user_id == current_user.id)
+                .where(UserOrganization.user_id == acting_user_id)
             )
             user_roles = (await db_session.execute(role_statement)).scalars().all()
             for role in user_roles:
@@ -186,6 +191,11 @@ async def create_episode(
 
     # RBAC check
     await check_resource_access(request, db_session, current_user, podcast.podcast_uuid, AccessAction.CREATE)
+
+    # Plan access check (podcasts require standard+ plan). Without this, an org
+    # whose plan no longer includes podcasts could keep adding episodes to
+    # existing podcasts, bypassing the plan gate enforced on podcast creation.
+    await check_feature_access("podcasts", podcast.org_id, db_session)
 
     # Get organization
     org_statement = select(Organization).where(Organization.id == podcast.org_id)

--- a/apps/api/src/services/podcasts/podcasts.py
+++ b/apps/api/src/services/podcasts/podcasts.py
@@ -681,8 +681,14 @@ async def update_podcast(
             )
 
     # Update only the fields that were passed in
+    # Skip empty strings for the thumbnail field to prevent accidental clearing
+    # (PodcastUpdate.thumbnail_image defaults to "", not None, so an unchanged
+    # value would otherwise wipe the existing thumbnail on every partial update).
+    file_fields = {"thumbnail_image"}
     for var, value in vars(podcast_object).items():
         if value is not None:
+            if var in file_fields and value == "":
+                continue
             setattr(podcast, var, value)
 
     # Complete the podcast object
@@ -848,7 +854,7 @@ async def get_podcast_user_rights(
         rights["roles"]["is_instructor"] = True
 
     has_user_permissions = await authorization_verify_based_on_roles(
-        request, current_user.id, "read", podcast_uuid, db_session
+        request, acting_user_id, "read", podcast_uuid, db_session
     )
 
     if has_user_permissions:

--- a/apps/api/src/services/roles/roles.py
+++ b/apps/api/src/services/roles/roles.py
@@ -181,6 +181,11 @@ async def create_role(
         user_role = await get_user_org_role(create_role_user_id, role.org_id, db_session)
         if role.rights and isinstance(role.rights, dict) and user_role and user_role.rights and isinstance(user_role.rights, dict):
             for right_key, right_permissions in role.rights.items():
+                # right_permissions may be a non-dict value for unexpected keys
+                # in a raw rights dict; calling .items() on it would raise an
+                # AttributeError (HTTP 500). Skip anything that isn't a dict.
+                if not isinstance(right_permissions, dict):
+                    continue
                 if right_key in user_role.rights:
                     user_right_permissions = user_role.rights[right_key]
                     for perm_key, perm_value in right_permissions.items():
@@ -477,6 +482,27 @@ async def update_role(
         if not isinstance(role.rights, dict):
             role.rights = rights_dict
 
+    # ============================================================================
+    # VERIFICATION: Ensure user cannot escalate a role to have higher permissions
+    # than they themselves hold (superadmins skip this check).
+    # ============================================================================
+    update_role_user_id = resolve_acting_user_id(current_user)
+    if 'rights' in update_data and not await is_user_superadmin(update_role_user_id, db_session):
+        user_role = await get_user_org_role(update_role_user_id, role.org_id, db_session)
+        if role.rights and isinstance(role.rights, dict) and user_role and user_role.rights and isinstance(user_role.rights, dict):
+            for right_key, right_permissions in role.rights.items():
+                if not isinstance(right_permissions, dict):
+                    continue
+                user_right_permissions = user_role.rights.get(right_key)
+                for perm_key, perm_value in right_permissions.items():
+                    if isinstance(perm_value, bool) and perm_value:
+                        if isinstance(user_right_permissions, dict) and user_right_permissions.get(perm_key):
+                            continue
+                        raise HTTPException(
+                            status_code=403,
+                            detail=f"You cannot grant a role the '{perm_key}' permission for '{right_key}' as you don't have this permission yourself",
+                        )
+
     db_session.add(role)
     await db_session.commit()
     await db_session.refresh(role)
@@ -548,10 +574,15 @@ async def rbac_check(
     role_uuid: str,
     db_session: AsyncSession,
 ):
-    await authorization_verify_if_user_is_anon(current_user.id)
+    # Resolve the real acting user id. For API tokens, current_user.id is the
+    # token id (0), not a user id — using it directly makes the anon check
+    # reject every API token and runs the role/authorship check against id 0.
+    acting_user_id = resolve_acting_user_id(current_user)
+
+    await authorization_verify_if_user_is_anon(acting_user_id)
 
     await authorization_verify_based_on_roles_and_authorship(
-        request, current_user.id, action, role_uuid, db_session
+        request, acting_user_id, action, role_uuid, db_session
     )
 
 

--- a/apps/api/src/services/search/search.py
+++ b/apps/api/src/services/search/search.py
@@ -194,7 +194,7 @@ async def search_across_org(
         .where(Folder.org_id == org.id)
         .where(_ilike_any([Folder.name, Folder.description], pattern))
     )
-    if is_anon:
+    if only_public:
         folders_q = folders_q.where(Folder.public == sa_true())
     folders, total_folders = await _paginate_and_count(
         db_session, folders_q, page, limit

--- a/apps/api/src/services/security/rate_limiting.py
+++ b/apps/api/src/services/security/rate_limiting.py
@@ -125,8 +125,14 @@ def check_rate_limit(
         # Rate limit exceeded
         return False, current_count, ttl if ttl > 0 else window_seconds
 
-    # Increment counter
+    # Increment counter atomically. If the key expired between the GET above
+    # and this INCR, Redis recreates it WITHOUT a TTL, which would leave a
+    # counter that never resets and permanently blocks the key. Re-assert the
+    # expiry whenever the key has no TTL so the window always rolls over.
     new_count = r.incr(rate_limit_key)
+    if new_count == 1 or ttl is None or ttl < 0:
+        r.expire(rate_limit_key, window_seconds)
+        ttl = window_seconds
     return True, new_count, ttl if ttl > 0 else window_seconds
 
 

--- a/apps/api/src/services/trail/trail.py
+++ b/apps/api/src/services/trail/trail.py
@@ -100,10 +100,16 @@ async def _build_trail_read(
 
 async def create_user_trail(
     request: Request,
-    user: PublicUser,
+    user: PublicUser | AnonymousUser,
     trail_object: TrailCreate,
     db_session: AsyncSession,
 ) -> Trail:
+    if isinstance(user, AnonymousUser):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Anonymous users cannot access this endpoint",
+        )
+
     statement = select(Trail).where(
         Trail.org_id == trail_object.org_id, Trail.user_id == user.id
     )
@@ -132,9 +138,15 @@ async def create_user_trail(
 
 async def get_user_trails(
     request: Request,
-    user: PublicUser,
+    user: PublicUser | AnonymousUser,
     db_session: AsyncSession,
 ) -> TrailRead:
+    if isinstance(user, AnonymousUser):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Anonymous users cannot access this endpoint",
+        )
+
     statement = select(Trail).where(Trail.user_id == user.id)
     trail = (await db_session.execute(statement)).scalars().first()
 
@@ -200,10 +212,16 @@ async def get_user_trail_with_orgid(
 
 async def add_activity_to_trail(
     request: Request,
-    user: PublicUser,
+    user: PublicUser | AnonymousUser,
     activity_uuid: str,
     db_session: AsyncSession,
 ) -> TrailRead:
+    if isinstance(user, AnonymousUser):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Anonymous users cannot access this endpoint",
+        )
+
     # Look for the activity
     statement = select(Activity).where(Activity.activity_uuid == activity_uuid)
     activity = (await db_session.execute(statement)).scalars().first()
@@ -346,10 +364,16 @@ async def add_activity_to_trail(
 
 async def remove_activity_from_trail(
     request: Request,
-    user: PublicUser,
+    user: PublicUser | AnonymousUser,
     activity_uuid: str,
     db_session: AsyncSession,
 ) -> TrailRead:
+    if isinstance(user, AnonymousUser):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Anonymous users cannot access this endpoint",
+        )
+
     # Look for the activity
     statement = select(Activity).where(Activity.activity_uuid == activity_uuid)
     activity = (await db_session.execute(statement)).scalars().first()
@@ -398,10 +422,16 @@ async def remove_activity_from_trail(
 
 async def add_course_to_trail(
     request: Request,
-    user: PublicUser,
+    user: PublicUser | AnonymousUser,
     course_uuid: str,
     db_session: AsyncSession,
 ) -> TrailRead:
+    if isinstance(user, AnonymousUser):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Anonymous users cannot access this endpoint",
+        )
+
     statement = select(Course).where(Course.course_uuid == course_uuid)
     course = (await db_session.execute(statement)).scalars().first()
 
@@ -477,10 +507,16 @@ async def add_course_to_trail(
 
 async def remove_course_from_trail(
     request: Request,
-    user: PublicUser,
+    user: PublicUser | AnonymousUser,
     course_uuid: str,
     db_session: AsyncSession,
 ) -> TrailRead:
+    if isinstance(user, AnonymousUser):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Anonymous users cannot access this endpoint",
+        )
+
     statement = select(Course).where(Course.course_uuid == course_uuid)
     course = (await db_session.execute(statement)).scalars().first()
 
@@ -506,9 +542,11 @@ async def remove_course_from_trail(
 
     if trail_run:
         await db_session.delete(trail_run)
-        await db_session.commit()
 
-    # Delete all trail steps for this course in a single statement
+    # Delete all trail steps for this course in a single statement.
+    # Both the TrailRun delete and the TrailStep delete are committed together
+    # so a failure cannot leave orphaned (and still "complete") TrailSteps that
+    # would resurrect the course's completion state if it is re-added later.
     await db_session.execute(
         sql_delete(TrailStep).where(
             TrailStep.course_id == course.id,

--- a/apps/api/src/services/users/usergroups.py
+++ b/apps/api/src/services/users/usergroups.py
@@ -8,6 +8,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from src.security.features_utils.usage import (
     check_limits_with_usage,
     increase_feature_usage,
+    decrease_feature_usage,
 )
 from src.security.rbac.rbac import (
     authorization_verify_based_on_roles_and_authorship,
@@ -415,8 +416,8 @@ async def delete_usergroup_by_id(
         org_id=usergroup.org_id,
     )
 
-    # Feature usage
-    await increase_feature_usage("usergroups", usergroup.org_id, db_session)
+    # Feature usage — deleting a usergroup must DECREASE the counter, not increase it.
+    await decrease_feature_usage("usergroups", usergroup.org_id, db_session)
 
     usergroup_uuid_val = usergroup.usergroup_uuid
     usergroup_name_val = usergroup.name
@@ -464,7 +465,13 @@ async def add_users_to_usergroup(
         org_id=usergroup.org_id,
     )
 
-    user_ids_array = [int(uid) for uid in user_ids.split(",")]
+    try:
+        user_ids_array = [int(uid) for uid in user_ids.split(",") if uid.strip() != ""]
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail="user_ids must be a comma-separated list of integers",
+        )
 
     for user_id in user_ids_array:
         statement = select(User).where(User.id == user_id)
@@ -552,7 +559,13 @@ async def remove_users_from_usergroup(
         org_id=usergroup.org_id,
     )
 
-    user_ids_array = [int(uid) for uid in user_ids.split(",")]
+    try:
+        user_ids_array = [int(uid) for uid in user_ids.split(",") if uid.strip() != ""]
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail="user_ids must be a comma-separated list of integers",
+        )
 
     for user_id in user_ids_array:
         statement = select(UserGroupUser).where(

--- a/apps/api/src/services/users/users.py
+++ b/apps/api/src/services/users/users.py
@@ -229,7 +229,8 @@ async def create_user_with_invite(
             str(user.id),
         )
 
-    await increase_feature_usage("members", org_id, db_session)
+    # NOTE: members usage is already incremented inside create_user(); do not
+    # increment again here or every invited signup double-counts the member quota.
 
     # Mark the invitation as no longer pending in Redis
     try:
@@ -376,7 +377,7 @@ async def update_user(
     conflict = (await db_session.execute(
         select(User).where(
             ((User.username == user_object.username) | (User.email == user_object.email))
-            & (User.id != current_user.id)
+            & (User.id != user.id)
         )
     )).scalars().first()
 

--- a/apps/api/src/services/utils/video_streaming.py
+++ b/apps/api/src/services/utils/video_streaming.py
@@ -267,7 +267,13 @@ def validate_video_path(base_content_dir: str, *path_parts: str) -> Optional[str
             resolved_path = os.path.realpath(full_path)
             base_resolved = os.path.realpath(base_content_dir)
 
-            if not resolved_path.startswith(base_resolved):
+            # Use commonpath rather than a bare startswith: a plain prefix check
+            # treats "/data/content-secret" as inside "/data/content", letting a
+            # crafted path escape the content dir into a sibling directory.
+            if (
+                resolved_path != base_resolved
+                and os.path.commonpath([resolved_path, base_resolved]) != base_resolved
+            ):
                 return None
 
             return resolved_path

--- a/apps/api/src/services/webhooks/dispatch.py
+++ b/apps/api/src/services/webhooks/dispatch.py
@@ -110,8 +110,12 @@ async def _deliver_webhooks(
         endpoints: list[_EndpointInfo] = []
         async with _async_session_factory() as db_session:
             if webhook_ids:
+                # Always scope by org_id even when targeting specific ids, so a
+                # mismatched/forged id list can never deliver an org's event
+                # payload to an endpoint belonging to a different organization.
                 statement = select(WebhookEndpoint).where(
                     WebhookEndpoint.id.in_(webhook_ids),  # type: ignore
+                    WebhookEndpoint.org_id == org_id,
                     WebhookEndpoint.is_active == True,
                 )
             else:

--- a/apps/api/src/tests/admin/test_admin_api.py
+++ b/apps/api/src/tests/admin/test_admin_api.py
@@ -2063,17 +2063,38 @@ class TestUpdateUserProfile:
 
 class TestChangeUserRole:
 
-    async def test_changes_role(self, token_user, user, student_role, admin_role, db):
-        result = await change_user_role(token_user, user.id, admin_role.id, db)
-        assert result["role_id"] == admin_role.id
+    async def test_changes_role(self, token_user, user, student_role, db):
+        # Change a separate (non-admin) member's role; `user` stays the org admin
+        # so the last-admin guard is not triggered.
+        target = User(
+            id=50, username="target50", first_name="T", last_name="U",
+            email="target50@example.com", password="hashed", user_uuid="user_target50",
+        )
+        db.add(target)
+        await db.commit()
+        await db.refresh(target)
+        db.add(UserOrganization(
+            user_id=target.id, org_id=token_user.org_id, role_id=3,
+            creation_date=str(datetime.now()), update_date=str(datetime.now()),
+        ))
+        await db.commit()
+
+        result = await change_user_role(token_user, target.id, student_role.id, db)
+        assert result["role_id"] == student_role.id
 
         membership = (await db.execute(
             select(UserOrganization).where(
-                UserOrganization.user_id == user.id,
+                UserOrganization.user_id == target.id,
                 UserOrganization.org_id == token_user.org_id,
             )
         )).scalars().first()
-        assert membership.role_id == admin_role.id
+        assert membership.role_id == student_role.id
+
+    async def test_api_token_cannot_grant_admin_role(self, token_user, user, admin_role, db):
+        # API tokens must never be able to mint org admins/maintainers.
+        with pytest.raises(HTTPException) as exc:
+            await change_user_role(token_user, user.id, admin_role.id, db)
+        assert exc.value.status_code == 403
 
     async def test_role_not_found(self, token_user, user, db):
         with pytest.raises(HTTPException) as exc:

--- a/apps/api/src/tests/core/test_core_events.py
+++ b/apps/api/src/tests/core/test_core_events.py
@@ -54,7 +54,7 @@ async def test_auto_install_triggers_install_when_no_orgs_exist(monkeypatch):
         installs.append(short)
 
     monkeypatch.setattr(autoinstall, "get_learnhouse_config", lambda: config)
-    monkeypatch.setattr(autoinstall, "create_engine", lambda *args, **kwargs: created_engines.append((args, kwargs)) or object())
+    monkeypatch.setattr(autoinstall, "create_engine", lambda *args, **kwargs: created_engines.append((args, kwargs)) or SimpleNamespace(dispose=lambda: None))
     monkeypatch.setattr(autoinstall.SQLModel.metadata, "create_all", lambda engine: created_tables.append(engine))
     monkeypatch.setattr(autoinstall, "Session", lambda engine: _FakeSession(engine, row=None))
     monkeypatch.setattr(autoinstall, "_install_async", fake_install_async)
@@ -95,7 +95,7 @@ async def test_auto_install_refreshes_default_roles_when_any_org_exists(monkeypa
         installs.append(short)
 
     monkeypatch.setattr(autoinstall, "get_learnhouse_config", lambda: config)
-    monkeypatch.setattr(autoinstall, "create_engine", lambda *args, **kwargs: object())
+    monkeypatch.setattr(autoinstall, "create_engine", lambda *args, **kwargs: SimpleNamespace(dispose=lambda: None))
     monkeypatch.setattr(autoinstall, "create_async_engine", lambda *args, **kwargs: _FakeAsyncEngine())
     monkeypatch.setattr(autoinstall, "async_sessionmaker", lambda *args, **kwargs: _FakeAsyncSessionmaker())
     monkeypatch.setattr(autoinstall.SQLModel.metadata, "create_all", lambda engine: created_tables.append(engine))

--- a/apps/api/src/tests/core/test_core_events_runtime.py
+++ b/apps/api/src/tests/core/test_core_events_runtime.py
@@ -70,7 +70,7 @@ async def test_auto_install_branches(monkeypatch):
         refreshes.append(db)
 
     monkeypatch.setattr(autoinstall, "get_learnhouse_config", lambda: fake_config)
-    monkeypatch.setattr(autoinstall, "create_engine", lambda *args, **kwargs: object())
+    monkeypatch.setattr(autoinstall, "create_engine", lambda *args, **kwargs: SimpleNamespace(dispose=lambda: None))
     monkeypatch.setattr(autoinstall, "create_async_engine", lambda *args, **kwargs: _FakeAsyncEngine())
     monkeypatch.setattr(autoinstall, "async_sessionmaker", lambda *args, **kwargs: _FakeAsyncSessionmaker())
     monkeypatch.setattr(

--- a/apps/api/src/tests/core/test_core_events_runtime.py
+++ b/apps/api/src/tests/core/test_core_events_runtime.py
@@ -107,6 +107,82 @@ async def test_auto_install_branches(monkeypatch):
     assert len(refreshes) == 1  # existing-install path always refreshes
 
 
+@pytest.mark.parametrize(
+    "sync_conn,expected_async_conn",
+    [
+        # autoinstall.py:48-51 (psycopg2 prefix) — must be checked before the
+        # generic postgresql:// branch.
+        (
+            "postgresql+psycopg2://u:p@host:5432/db",
+            "postgresql+asyncpg://u:p@host:5432/db",
+        ),
+        # autoinstall.py:52-55 (generic postgresql:// prefix).
+        (
+            "postgresql://u:p@host:5432/db",
+            "postgresql+asyncpg://u:p@host:5432/db",
+        ),
+        # autoinstall.py:56-59 (postgres:// Heroku/Supabase alias).
+        (
+            "postgres://u:p@host:5432/db",
+            "postgresql+asyncpg://u:p@host:5432/db",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_auto_install_normalises_async_connection_string(
+    monkeypatch, sync_conn, expected_async_conn
+):
+    captured_async_conn = []
+    refreshes = []
+
+    fake_config = SimpleNamespace(
+        database_config=SimpleNamespace(sql_connection_string=sync_conn)
+    )
+
+    fake_session = SimpleNamespace()
+
+    @contextlib.asynccontextmanager
+    async def fake_async_session_factory():
+        yield fake_session
+
+    class _FakeAsyncSessionmaker:
+        def __call__(self):
+            return fake_async_session_factory()
+
+    class _FakeAsyncEngine:
+        async def dispose(self):
+            pass
+
+    async def fake_install_default_elements(db):
+        refreshes.append(db)
+
+    def fake_create_async_engine(conn, *args, **kwargs):
+        captured_async_conn.append(conn)
+        return _FakeAsyncEngine()
+
+    monkeypatch.setattr(autoinstall, "get_learnhouse_config", lambda: fake_config)
+    monkeypatch.setattr(
+        autoinstall, "create_engine", lambda *a, **k: SimpleNamespace(dispose=lambda: None)
+    )
+    monkeypatch.setattr(autoinstall, "create_async_engine", fake_create_async_engine)
+    monkeypatch.setattr(
+        autoinstall, "async_sessionmaker", lambda *a, **k: _FakeAsyncSessionmaker()
+    )
+    monkeypatch.setattr(autoinstall.SQLModel.metadata, "create_all", lambda engine: None)
+    monkeypatch.setattr(
+        autoinstall, "install_default_elements", fake_install_default_elements
+    )
+    # An existing org forces the refresh path (which builds the async engine).
+    monkeypatch.setattr(
+        autoinstall, "Session", lambda engine: _FakeSession(SimpleNamespace(slug="x"))
+    )
+
+    await autoinstall.auto_install()
+
+    assert captured_async_conn == [expected_async_conn]
+    assert len(refreshes) == 1
+
+
 @pytest.mark.asyncio
 async def test_content_and_logs_helpers(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)

--- a/apps/api/src/tests/core/test_middleware_cors.py
+++ b/apps/api/src/tests/core/test_middleware_cors.py
@@ -61,6 +61,31 @@ class TestGetCorsOriginRegex:
         ):
             assert get_cors_origin_regex() == configured
 
+    def test_multi_tenancy_falls_back_to_domain_when_regexp_empty(self):
+        # cors.py:80-82 - with no allowed_regexp configured, multi mode must
+        # derive a domain-and-subdomain regex from the base domain rather than
+        # returning an empty value (which would take the SaaS frontend offline).
+        with patch(
+            "src.core.middleware.cors.get_learnhouse_config",
+            return_value=_config("multi", allowed_regexp="", domain="learnhouse.io"),
+        ):
+            regex = get_cors_origin_regex()
+            assert re.fullmatch(regex, "https://learnhouse.io")
+            assert re.fullmatch(regex, "https://acme.learnhouse.io")
+            assert re.fullmatch(regex, "https://deep.sub.learnhouse.io:8443")
+            assert not re.fullmatch(regex, "https://evil.example.org")
+
+    def test_multi_tenancy_falls_back_to_localhost_when_regexp_and_domain_empty(self):
+        # cors.py:83 - with neither allowed_regexp nor domain configured, multi
+        # mode falls back to the localhost regex.
+        with patch(
+            "src.core.middleware.cors.get_learnhouse_config",
+            return_value=_config("multi", allowed_regexp="", domain=""),
+        ):
+            regex = get_cors_origin_regex()
+            assert regex == _SINGLE_TENANCY_LOCALHOST_REGEX
+            assert re.fullmatch(regex, "http://localhost:3000")
+
 
 class TestSingleTenancyRegex:
     """The single-mode regex must accept the configured operator origin(s)

--- a/apps/api/src/tests/routers/test_ai_credits_router.py
+++ b/apps/api/src/tests/routers/test_ai_credits_router.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from src.core.events.database import get_db_session
+from src.db.users import APITokenUser
 from src.routers.orgs.ai_credits import (
     router as ai_credits_router,
     verify_user_is_org_admin,
@@ -103,6 +104,17 @@ class TestAICreditsRouter:
 
         response = await client.get("/api/v1/orgs/9999/ai-credits")
         assert response.status_code == 404
+
+    async def test_get_org_ai_credits_api_token_wrong_org(self, app, client, org):
+        # An API token scoped to a different org must be rejected with 403
+        # before the membership check runs.
+        app.dependency_overrides[get_current_user] = lambda: APITokenUser(
+            org_id=org.id + 999, created_by_user_id=1
+        )
+        response = await client.get(f"/api/v1/orgs/{org.id}/ai-credits")
+
+        assert response.status_code == 403
+        assert "not scoped" in response.json()["detail"]
 
     async def test_add_org_ai_credits_success_and_validation(self, client, org):
         # Adding "purchased" credits has no payment check, so it is superadmin-only.

--- a/apps/api/src/tests/routers/test_ai_credits_router.py
+++ b/apps/api/src/tests/routers/test_ai_credits_router.py
@@ -105,8 +105,9 @@ class TestAICreditsRouter:
         assert response.status_code == 404
 
     async def test_add_org_ai_credits_success_and_validation(self, client, org):
+        # Adding "purchased" credits has no payment check, so it is superadmin-only.
         with patch(
-            "src.routers.orgs.ai_credits.verify_user_is_org_admin",
+            "src.routers.orgs.ai_credits.is_user_superadmin",
             new_callable=AsyncMock,
             return_value=True,
         ), patch(
@@ -122,7 +123,7 @@ class TestAICreditsRouter:
         assert response.json()["new_purchased_total"] == 250
 
         with patch(
-            "src.routers.orgs.ai_credits.verify_user_is_org_admin",
+            "src.routers.orgs.ai_credits.is_user_superadmin",
             new_callable=AsyncMock,
             return_value=True,
         ):
@@ -139,8 +140,9 @@ class TestAICreditsRouter:
         )
         assert response.status_code == 404
 
+        # A mere org admin (non-superadmin) must be rejected.
         with patch(
-            "src.routers.orgs.ai_credits.verify_user_is_org_admin",
+            "src.routers.orgs.ai_credits.is_user_superadmin",
             new_callable=AsyncMock,
             return_value=False,
         ):
@@ -152,7 +154,7 @@ class TestAICreditsRouter:
 
     async def test_reset_org_ai_credits_success_and_forbidden(self, client, org):
         with patch(
-            "src.routers.orgs.ai_credits.verify_user_is_org_admin",
+            "src.routers.orgs.ai_credits.is_user_superadmin",
             new_callable=AsyncMock,
             return_value=True,
         ), patch("src.routers.orgs.ai_credits.reset_ai_credits_usage") as reset_mock:
@@ -161,8 +163,9 @@ class TestAICreditsRouter:
         assert response.status_code == 200
         reset_mock.assert_called_once_with(org.id)
 
+        # A mere org admin (non-superadmin) must be rejected.
         with patch(
-            "src.routers.orgs.ai_credits.verify_user_is_org_admin",
+            "src.routers.orgs.ai_credits.is_user_superadmin",
             new_callable=AsyncMock,
             return_value=False,
         ):

--- a/apps/api/src/tests/routers/test_analytics_router.py
+++ b/apps/api/src/tests/routers/test_analytics_router.py
@@ -664,6 +664,70 @@ class TestAnalyticsRouter:
             )
         assert response.status_code == 200
 
+    async def test_export_course_scoped_requires_pro_plan(self, client):
+        # Course-scoped export on a sub-Pro plan must be rejected with 403.
+        with _analytics_guard_patches(), patch(
+            "src.routers.analytics.get_org_plan",
+            new_callable=AsyncMock,
+            return_value="starter",
+        ) as mock_plan, patch(
+            "src.routers.analytics.plan_meets_requirement",
+            return_value=False,
+        ):
+            response = await client.get(
+                "/api/v1/analytics/export?org_id=1&format=json"
+                "&queries=course_overview_stats&course_uuid=course_1"
+            )
+        assert response.status_code == 403
+        assert "Pro plan" in response.json()["detail"]
+        mock_plan.assert_awaited_once()
+
+    async def test_export_course_scoped_allows_pro_plan(self, client):
+        # When the plan meets Pro the course export proceeds past the gate.
+        with _analytics_guard_patches(), patch(
+            "src.routers.analytics.get_org_plan",
+            new_callable=AsyncMock,
+            return_value="pro",
+        ), patch(
+            "src.routers.analytics.plan_meets_requirement",
+            return_value=True,
+        ), patch(
+            "src.routers.analytics._enrich_with_metadata",
+            new_callable=AsyncMock,
+            side_effect=lambda rows, db: rows,
+        ), patch(
+            "src.routers.analytics._execute_tinybird_query",
+            new_callable=AsyncMock,
+            return_value={"data": [], "rows": 0, "meta": []},
+        ):
+            response = await client.get(
+                "/api/v1/analytics/export?org_id=1&format=json"
+                "&queries=course_overview_stats&course_uuid=course_1"
+            )
+        assert response.status_code == 200
+
+    async def test_export_advanced_query_requires_enterprise_plan(self, client):
+        # Advanced (org-level) queries require Enterprise in SaaS mode; when no
+        # bypass applies and the plan is below Enterprise the export is rejected.
+        with _analytics_guard_patches(), patch(
+            "src.security.features_utils.plan_check._check_mode_bypass",
+            return_value=None,
+        ), patch(
+            "src.routers.analytics.get_org_plan",
+            new_callable=AsyncMock,
+            return_value="pro",
+        ) as mock_plan, patch(
+            "src.routers.analytics.plan_meets_requirement",
+            return_value=False,
+        ):
+            response = await client.get(
+                "/api/v1/analytics/export?org_id=1&format=json"
+                "&queries=peak_usage_hours"
+            )
+        assert response.status_code == 403
+        assert "Enterprise plan" in response.json()["detail"]
+        mock_plan.assert_awaited_once()
+
     async def test_dashboard_unknown_and_course_plan_and_query_validation(self, client):
         with _analytics_guard_patches():
             response = await client.get("/api/v1/analytics/dashboard/detail/unknown_detail?org_id=1")

--- a/apps/api/src/tests/routers/test_auth_router.py
+++ b/apps/api/src/tests/routers/test_auth_router.py
@@ -252,6 +252,42 @@ class TestAuthRouter:
         assert response.status_code == 200
         assert response.json()["access_token"] == "new-access-token"
 
+    async def test_refresh_replay_revokes_sessions_and_401(self, client, auth_user):
+        """Replay detection: presenting an already-consumed refresh token
+        (``_mark_refresh_jti_used`` returns False) must revoke every session for
+        the user and reject the request with 401."""
+        with patch(
+            "src.routers.auth.check_refresh_rate_limit",
+            return_value=(True, None),
+        ), patch(
+            "src.routers.auth.decode_refresh_token",
+            return_value={
+                "sub": auth_user.email,
+                "iat": 1,
+                "exp": 9_999_999_999,
+                "jti": "replayed-jti",
+            },
+        ), patch(
+            "src.routers.auth.security_get_user",
+            new_callable=AsyncMock,
+            return_value=auth_user,
+        ), patch(
+            "src.routers.auth._is_token_revoked_for_user",
+            return_value=False,
+        ), patch(
+            "src.routers.auth._mark_refresh_jti_used",
+            return_value=False,
+        ), patch(
+            "src.routers.auth.revoke_user_sessions_before",
+        ) as revoke_mock:
+            response = await client.get(
+                "/api/v1/auth/refresh",
+                cookies={JWT_REFRESH_COOKIE_NAME: "refresh-token"},
+            )
+
+        assert response.status_code == 401
+        revoke_mock.assert_called_once_with(auth_user.id)
+
     async def test_refresh_invalid_token(self, client):
         with patch(
             "src.routers.auth.check_refresh_rate_limit",
@@ -556,6 +592,71 @@ class TestAuthRouter:
                 },
             )
         assert response.status_code == 401
+
+    async def test_oauth_org_id_google_unverified_email_returns_401(self, client, db, org):
+        """OAuth org_id invite gate for provider=google: when Google does not
+        return a verified email the request is rejected with 401 (lines 493-499)."""
+        with patch(
+            "src.routers.auth.get_google_user_info",
+            new_callable=AsyncMock,
+            return_value={"email": "", "email_verified": False},
+        ):
+            response = await client.post(
+                "/api/v1/auth/oauth",
+                params={"org_id": 1},
+                json={
+                    "email": "user@test.com",
+                    "provider": "google",
+                    "access_token": "google-token",
+                },
+            )
+        assert response.status_code == 401
+        assert "verified email" in response.json()["detail"].lower()
+
+    async def test_oauth_org_id_google_verified_checks_invite_and_closes_redis(
+        self, client, db, org
+    ):
+        """Google returns a verified email -> the invite email is normalised
+        (line 500), the Redis invite key is read (lines 506-513) and the Redis
+        connection is closed in the finally block (lines 520-524). The invite is
+        not found here, so org_id is cleared and signWithGoogle returns None ->
+        401."""
+        # close() raising must be swallowed by the finally block's
+        # ``except Exception: pass`` (lines 523-524).
+        close_mock = Mock(side_effect=RuntimeError("close failed"))
+        mock_redis = Mock(get=Mock(return_value=None), close=close_mock)
+        mock_config = SimpleNamespace(
+            redis_config=SimpleNamespace(redis_connection_string="redis://localhost:6379")
+        )
+        with patch(
+            "src.routers.auth.get_google_user_info",
+            new_callable=AsyncMock,
+            return_value={"email": "User@Test.com", "email_verified": True},
+        ), patch(
+            "src.routers.auth.get_learnhouse_config", return_value=mock_config
+        ), patch(
+            "redis.Redis.from_url", return_value=mock_redis
+        ) as from_url_mock, patch(
+            "src.routers.auth.signWithGoogle",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            response = await client.post(
+                "/api/v1/auth/oauth",
+                params={"org_id": 1},
+                json={
+                    "email": "user@test.com",
+                    "provider": "google",
+                    "access_token": "google-token",
+                },
+            )
+
+        assert response.status_code == 401
+        # Invite key was looked up using the lower-cased Google email.
+        mock_redis.get.assert_called_once_with("invited_user:user@test.com:org:org_test")
+        # The Redis connection from from_url was always closed (finally block).
+        from_url_mock.assert_called_once()
+        close_mock.assert_called_once()
 
     async def test_verify_email_rate_limited_and_logout_unauthenticated(self, client):
         with patch(

--- a/apps/api/src/tests/routers/test_auth_router.py
+++ b/apps/api/src/tests/routers/test_auth_router.py
@@ -226,6 +226,9 @@ class TestAuthRouter:
             "src.routers.auth._is_token_revoked_for_user",
             return_value=False,
         ), patch(
+            "src.routers.auth._mark_refresh_jti_used",
+            return_value=True,
+        ), patch(
             "src.routers.auth.create_access_token",
             return_value="new-access-token",
         ), patch(

--- a/apps/api/src/tests/routers/test_auth_third_party.py
+++ b/apps/api/src/tests/routers/test_auth_third_party.py
@@ -5,7 +5,7 @@ provider other than the supported ones (currently only "google").
 """
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi import HTTPException, Response, status
@@ -34,5 +34,44 @@ async def test_third_party_login_rejects_unsupported_provider():
             db_session=AsyncMock(),
         )
 
+    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert exc_info.value.detail == "Unsupported provider"
+
+
+@pytest.mark.asyncio
+async def test_third_party_login_non_google_org_id_uses_body_email(db, org):
+    """With a valid org_id but a non-google provider, the invite-email is taken
+    from ``body.email`` (the ``else`` branch, line 502), the Redis invite key is
+    read, and the Redis connection is closed in the finally block before the
+    unsupported-provider guard rejects the request with 400."""
+    body = SimpleNamespace(
+        email="invitee@example.com",
+        provider="facebook",
+        access_token="tok",
+    )
+    close_mock = Mock()
+    mock_redis = Mock(get=Mock(return_value=None), close=close_mock)
+    mock_config = SimpleNamespace(
+        redis_config=SimpleNamespace(redis_connection_string="redis://localhost:6379")
+    )
+
+    with patch(
+        "src.routers.auth.get_learnhouse_config", return_value=mock_config
+    ), patch("redis.Redis.from_url", return_value=mock_redis):
+        with pytest.raises(HTTPException) as exc_info:
+            await third_party_login(
+                request=SimpleNamespace(),
+                response=Response(),
+                body=body,
+                org_id=org.id,
+                current_user=AnonymousUser(),
+                db_session=db,
+            )
+
+    # Non-google providers key the invite on the raw body email.
+    mock_redis.get.assert_called_once_with(
+        f"invited_user:invitee@example.com:org:{org.org_uuid}"
+    )
+    close_mock.assert_called_once()
     assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
     assert exc_info.value.detail == "Unsupported provider"

--- a/apps/api/src/tests/routers/test_boards_router.py
+++ b/apps/api/src/tests/routers/test_boards_router.py
@@ -701,6 +701,89 @@ class TestBoardsRouter:
         assert response.status_code == 200
         assert response.json()["session_uuid"] == "session1"
 
+    async def test_boards_playground_session_state_authz_branches(
+        self, client, db, org, admin_user
+    ):
+        """get_session_state authorization guards:
+        line 233 (board not found -> 404), line 239 (org not found -> 404),
+        line 243 (caller not an org member -> 403)."""
+        board = Board(
+            id=70,
+            org_id=org.id,
+            name="Board",
+            description="Desc",
+            thumbnail_image="",
+            public=True,
+            board_uuid="board_state_authz",
+            created_by=admin_user.id,
+            creation_date="2024-01-01",
+            update_date="2024-01-01",
+        )
+        orphan_board = Board(
+            id=71,
+            org_id=999,
+            name="Orphan",
+            description="Desc",
+            thumbnail_image="",
+            public=True,
+            board_uuid="board_state_orphan",
+            created_by=admin_user.id,
+            creation_date="2024-01-01",
+            update_date="2024-01-01",
+        )
+        db.add(board)
+        db.add(orphan_board)
+        await db.commit()
+
+        # Line 233: session references a board that does not exist -> 404.
+        with patch(
+            "src.routers.boards.boards_playground.get_boards_playground_session",
+            return_value=SimpleNamespace(
+                session_uuid="session1",
+                iteration_count=1,
+                max_iterations=3,
+                current_html="<div></div>",
+                board_uuid="board_does_not_exist",
+                message_history=[],
+            ),
+        ):
+            response = await client.get("/api/v1/boards/playground/session/session1")
+        assert response.status_code == 404
+
+        # Line 239: board exists but its org does not -> 404.
+        with patch(
+            "src.routers.boards.boards_playground.get_boards_playground_session",
+            return_value=SimpleNamespace(
+                session_uuid="session1",
+                iteration_count=1,
+                max_iterations=3,
+                current_html="<div></div>",
+                board_uuid="board_state_orphan",
+                message_history=[],
+            ),
+        ):
+            response = await client.get("/api/v1/boards/playground/session/session1")
+        assert response.status_code == 404
+
+        # Line 243: board + org exist but the caller is not an org member -> 403.
+        with patch(
+            "src.routers.boards.boards_playground.get_boards_playground_session",
+            return_value=SimpleNamespace(
+                session_uuid="session1",
+                iteration_count=1,
+                max_iterations=3,
+                current_html="<div></div>",
+                board_uuid="board_state_authz",
+                message_history=[],
+            ),
+        ), patch(
+            "src.routers.boards.boards_playground.is_org_member",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            response = await client.get("/api/v1/boards/playground/session/session1")
+        assert response.status_code == 403
+
     async def test_boards_playground_iterate_session_not_found(self, client):
         with patch(
             "src.routers.boards.boards_playground.get_boards_playground_session",

--- a/apps/api/src/tests/routers/test_boards_router.py
+++ b/apps/api/src/tests/routers/test_boards_router.py
@@ -690,6 +690,7 @@ class TestBoardsRouter:
             iteration_count=1,
             max_iterations=3,
             current_html="<div>done</div>",
+            board_uuid="board_test",
             message_history=[SimpleNamespace(role="user", content="Prompt")],
         )
         with patch(

--- a/apps/api/src/tests/routers/test_communities_router.py
+++ b/apps/api/src/tests/routers/test_communities_router.py
@@ -228,6 +228,51 @@ class TestCommunitiesRouter:
             response = await client.post("/api/v1/discussions/d1/reactions", json={"emoji": "👍"})
         assert response.status_code == 200
 
+    async def test_create_community_with_course_id_validation(self, client, db, org):
+        """Covers communities router lines 68-80: when course_id is supplied on
+        create, the endpoint verifies the course exists (404) and belongs to the
+        same org (400) BEFORE delegating to create_community."""
+        from src.db.courses.courses import Course
+
+        # 404: course_id does not resolve to any course
+        response = await client.post(
+            "/api/v1/communities/?org_id=1",
+            json={"name": "C", "description": "D", "public": True, "course_id": 999999},
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Course not found"
+
+        # 400: course exists but belongs to a different organization
+        other_org_course = Course(
+            id=4242,
+            name="Other Org Course",
+            description="Desc",
+            public=True,
+            published=True,
+            open_to_contributors=False,
+            org_id=999,
+            course_uuid="course_other_org_router",
+            creation_date="2024-01-01",
+            update_date="2024-01-01",
+        )
+        db.add(other_org_course)
+        await db.commit()
+
+        response = await client.post(
+            "/api/v1/communities/?org_id=1",
+            json={"name": "C", "description": "D", "public": True, "course_id": 4242},
+        )
+        assert response.status_code == 400
+        assert "same organization" in response.json()["detail"]
+
+    async def test_batch_user_votes_too_many_uuids(self, client):
+        """Covers discussions router lines 364-369: a batch larger than 200
+        discussion_uuids is rejected with 400 before hitting the DB."""
+        too_many = [f"d{i}" for i in range(201)]
+        response = await client.post("/api/v1/discussions/votes/batch", json=too_many)
+        assert response.status_code == 400
+        assert "maximum 200" in response.json()["detail"]
+
     async def test_community_thumbnail_endpoint_branches(self, client, db, org, admin_user):
         community = Community(
             id=21,

--- a/apps/api/src/tests/routers/test_courses_router.py
+++ b/apps/api/src/tests/routers/test_courses_router.py
@@ -390,6 +390,59 @@ class TestCourseDetailEndpoints:
         assert response.status_code == 200
         assert response.json()["course_uuid"] == "course_test"
 
+    async def test_get_course_meta_downgrades_unpublished_flag_when_denied(self, client):
+        # SECURITY (courses.py:451): a caller without UPDATE access must not see
+        # unpublished activities; the router downgrades the flag to False before
+        # calling get_course_meta.
+        from src.security.rbac.types import AccessDecision
+
+        captured = {}
+
+        async def _fake_get_course_meta(request, course_uuid, with_unpublished_activities, **kwargs):
+            captured["with_unpublished_activities"] = with_unpublished_activities
+            return _mock_full_course_read()
+
+        with patch(
+            "src.routers.courses.courses.check_resource_access",
+            new_callable=AsyncMock,
+            return_value=AccessDecision(allowed=False, reason="no update access"),
+        ), patch(
+            "src.routers.courses.courses.get_course_meta",
+            side_effect=_fake_get_course_meta,
+        ):
+            response = await client.get(
+                "/api/v1/courses/course_test/meta?with_unpublished_activities=true"
+            )
+
+        assert response.status_code == 200
+        assert captured["with_unpublished_activities"] is False
+
+    async def test_get_course_meta_keeps_unpublished_flag_when_allowed(self, client):
+        # When UPDATE access is granted the flag is preserved (covers the allowed
+        # branch alongside the deny path).
+        from src.security.rbac.types import AccessDecision
+
+        captured = {}
+
+        async def _fake_get_course_meta(request, course_uuid, with_unpublished_activities, **kwargs):
+            captured["with_unpublished_activities"] = with_unpublished_activities
+            return _mock_full_course_read()
+
+        with patch(
+            "src.routers.courses.courses.check_resource_access",
+            new_callable=AsyncMock,
+            return_value=AccessDecision(allowed=True, reason="ok"),
+        ), patch(
+            "src.routers.courses.courses.get_course_meta",
+            side_effect=_fake_get_course_meta,
+        ):
+            response = await client.get(
+                "/api/v1/courses/course_test/meta?with_unpublished_activities=true"
+            )
+
+        assert response.status_code == 200
+        assert captured["with_unpublished_activities"] is True
+
     async def test_search_courses(self, client):
         with patch(
             "src.routers.courses.courses.search_courses",
@@ -481,6 +534,41 @@ class TestContributorEndpoints:
 
         assert response.status_code == 200
         assert response.json()["detail"] == "applied"
+
+    async def test_apply_course_contributor_missing_course_returns_404(self, client):
+        # courses.py:726 - applying to a non-existent course yields a clean 404.
+        response = await client.post(
+            "/api/v1/courses/course_does_not_exist/apply-contributor"
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Course not found"
+
+    async def test_apply_course_contributor_closed_course_returns_403(self, client, db, org):
+        # courses.py:728 - a course that is NOT open to contributors must reject
+        # applications with 403 even for an authenticated user.
+        from datetime import datetime
+        from src.db.courses.courses import Course
+
+        db.add(Course(
+            id=778, name="Closed Course", description="d", public=True, published=True,
+            open_to_contributors=False, org_id=org.id, course_uuid="course_closed_contrib",
+            creation_date=str(datetime.now()), update_date=str(datetime.now()),
+        ))
+        await db.commit()
+
+        with patch(
+            "src.routers.courses.courses.apply_course_contributor",
+            new_callable=AsyncMock,
+            return_value={"detail": "applied"},
+        ) as mock_apply:
+            response = await client.post(
+                "/api/v1/courses/course_closed_contrib/apply-contributor"
+            )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "This course is not open to contributors"
+        # The guard must short-circuit before the service is ever called.
+        mock_apply.assert_not_called()
 
     async def test_get_course_contributors(self, client):
         with patch(

--- a/apps/api/src/tests/routers/test_courses_router.py
+++ b/apps/api/src/tests/routers/test_courses_router.py
@@ -461,13 +461,23 @@ class TestDeleteCourse:
 
 
 class TestContributorEndpoints:
-    async def test_apply_course_contributor(self, client):
+    async def test_apply_course_contributor(self, client, db, org):
+        # The endpoint now honours the course's open_to_contributors flag, so a
+        # course that is actually open to contributors must exist.
+        from datetime import datetime
+        from src.db.courses.courses import Course
+        db.add(Course(
+            id=777, name="Open Course", description="d", public=True, published=True,
+            open_to_contributors=True, org_id=org.id, course_uuid="course_open_contrib",
+            creation_date=str(datetime.now()), update_date=str(datetime.now()),
+        ))
+        await db.commit()
         with patch(
             "src.routers.courses.courses.apply_course_contributor",
             new_callable=AsyncMock,
             return_value={"detail": "applied"},
         ):
-            response = await client.post("/api/v1/courses/course_test/apply-contributor")
+            response = await client.post("/api/v1/courses/course_open_contrib/apply-contributor")
 
         assert response.status_code == 200
         assert response.json()["detail"] == "applied"
@@ -542,6 +552,10 @@ class TestCourseUpdateEndpoints:
             "src.routers.courses.courses.get_updates_by_course_uuid",
             new_callable=AsyncMock,
             return_value=[_mock_course_update_read()],
+        ), patch(
+            # The endpoint now enforces READ access on the parent course.
+            "src.routers.courses.courses.check_resource_access",
+            new_callable=AsyncMock,
         ):
             response = await client.get("/api/v1/courses/course_test/updates")
 

--- a/apps/api/src/tests/routers/test_monitoring_router.py
+++ b/apps/api/src/tests/routers/test_monitoring_router.py
@@ -1,0 +1,96 @@
+"""Router tests for src/routers/monitoring.py (Sentry feedback relay)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.routers.monitoring import router as monitoring_router
+
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+    app.include_router(monitoring_router, prefix="/monitoring")
+    return app
+
+
+@pytest.fixture
+async def client(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+class TestSubmitFeedback:
+    async def test_empty_message_returns_400(self, client):
+        response = await client.post("/monitoring/feedback", data={"message": "   "})
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Feedback message is required"
+
+    async def test_returns_early_when_sentry_inactive(self, client):
+        # Line 43-44: when Sentry has no active client we short-circuit before
+        # touching attachments / capture_event.
+        inactive_client = MagicMock()
+        inactive_client.is_active.return_value = False
+        with patch("src.routers.monitoring.sentry_sdk.get_client", return_value=inactive_client), \
+             patch("src.routers.monitoring.sentry_sdk.capture_event") as cap:
+            response = await client.post(
+                "/monitoring/feedback", data={"message": "hello"}
+            )
+        assert response.status_code == 204
+        cap.assert_not_called()
+
+    async def test_reads_attachment_when_sentry_active(self, client):
+        # Line 53: with an active Sentry client and an attachment that has a
+        # filename, the handler reads the (bounded) attachment bytes and forwards
+        # the feedback event with the attachment added to the scope.
+        active_client = MagicMock()
+        active_client.is_active.return_value = True
+
+        scope = MagicMock()
+        scope_cm = MagicMock()
+        scope_cm.__enter__.return_value = scope
+        scope_cm.__exit__.return_value = False
+
+        with patch("src.routers.monitoring.sentry_sdk.get_client", return_value=active_client), \
+             patch("src.routers.monitoring.sentry_sdk.new_scope", return_value=scope_cm), \
+             patch("src.routers.monitoring.sentry_sdk.capture_event") as cap:
+            response = await client.post(
+                "/monitoring/feedback",
+                data={"message": "broken page", "name": "Tester", "email": "t@example.com"},
+                files={"attachments": ("log.txt", b"trace-bytes", "text/plain")},
+            )
+
+        assert response.status_code == 204
+        cap.assert_called_once()
+        # The attachment was read and added to the scope.
+        scope.add_attachment.assert_called_once()
+        kwargs = scope.add_attachment.call_args.kwargs
+        assert kwargs["bytes"] == b"trace-bytes"
+        assert kwargs["filename"] == "log.txt"
+
+    async def test_active_sentry_without_attachments_still_captures(self, client):
+        # Active Sentry, no attachments: the event is still captured (no scope
+        # attachment added).
+        active_client = MagicMock()
+        active_client.is_active.return_value = True
+
+        scope = MagicMock()
+        scope_cm = MagicMock()
+        scope_cm.__enter__.return_value = scope
+        scope_cm.__exit__.return_value = False
+
+        with patch("src.routers.monitoring.sentry_sdk.get_client", return_value=active_client), \
+             patch("src.routers.monitoring.sentry_sdk.new_scope", return_value=scope_cm), \
+             patch("src.routers.monitoring.sentry_sdk.capture_event") as cap:
+            response = await client.post(
+                "/monitoring/feedback",
+                data={"message": "no attachments here"},
+            )
+
+        assert response.status_code == 204
+        cap.assert_called_once()
+        scope.add_attachment.assert_not_called()

--- a/apps/api/src/tests/routers/test_orgs_router.py
+++ b/apps/api/src/tests/routers/test_orgs_router.py
@@ -258,6 +258,22 @@ class TestOrgUserEndpoints:
         assert response.status_code == 200
         assert response.json()["detail"] == "joined"
 
+    async def test_join_org_as_another_user_forbidden(self, client):
+        # admin_user has id=1; joining with a different user_id must be rejected
+        # before join_org() is ever called.
+        with patch(
+            "src.routers.orgs.orgs.join_org",
+            new_callable=AsyncMock,
+        ) as join_mock:
+            response = await client.post(
+                "/api/v1/orgs/join",
+                json={"org_id": 1, "user_id": 999, "invite_code": "abc123"},
+            )
+
+        assert response.status_code == 403
+        assert "only join an organization as yourself" in response.json()["detail"]
+        join_mock.assert_not_called()
+
     async def test_update_user_role(self, client):
         with patch(
             "src.routers.orgs.orgs.update_user_role",

--- a/apps/api/src/tests/routers/test_packs_router.py
+++ b/apps/api/src/tests/routers/test_packs_router.py
@@ -10,6 +10,7 @@ from httpx import ASGITransport, AsyncClient
 
 from src.core.events.database import get_db_session
 from src.db.packs import OrgPackRead
+from src.db.users import APITokenUser
 from src.routers.orgs.packs import internal_router, router as packs_router
 from src.security.auth import get_current_user
 
@@ -225,3 +226,23 @@ class TestOrgPacksRouter:
         response = await client.get("/api/v1/orgs/999/packs/summary")
 
         assert response.status_code == 404
+
+    async def test_get_org_packs_api_token_wrong_org(self, app, client, org):
+        # An API token scoped to a different org must not act against this org,
+        # even before the admin check runs.
+        app.dependency_overrides[get_current_user] = lambda: APITokenUser(
+            org_id=org.id + 999, created_by_user_id=1
+        )
+        response = await client.get(f"/api/v1/orgs/{org.id}/packs")
+
+        assert response.status_code == 403
+        assert "not scoped" in response.json()["detail"]
+
+    async def test_get_org_pack_summary_api_token_wrong_org(self, app, client, org):
+        app.dependency_overrides[get_current_user] = lambda: APITokenUser(
+            org_id=org.id + 999, created_by_user_id=1
+        )
+        response = await client.get(f"/api/v1/orgs/{org.id}/packs/summary")
+
+        assert response.status_code == 403
+        assert "not scoped" in response.json()["detail"]

--- a/apps/api/src/tests/routers/test_playgrounds_router.py
+++ b/apps/api/src/tests/routers/test_playgrounds_router.py
@@ -12,6 +12,7 @@ from src.core.events.database import get_db_session
 from src.db.courses.courses import Course
 from src.db.playground_reactions import PlaygroundReactionSummary, ReactionUser
 from src.db.playgrounds import Playground, PlaygroundRead
+from src.db.users import APITokenUser
 from src.routers.playgrounds.playgrounds import router as playgrounds_router
 from src.routers.playgrounds.playgrounds_generator import router as playgrounds_generator_router
 from src.routers.playgrounds.playgrounds_generator import (
@@ -648,6 +649,147 @@ class TestPlaygroundsRouter:
             response = await client.get("/api/v1/playgrounds/generate/session/session1")
         assert response.status_code == 200
         assert response.json()["session_uuid"] == "session1"
+
+    async def test_playground_generator_rejects_cross_org_api_token(
+        self, app, client, db, org, admin_user
+    ):
+        """Lines 112 & 212: an API token bound to a different org must not be
+        able to drive (and bill) generation against this org's playground."""
+        playground = Playground(
+            id=80,
+            org_id=org.id,
+            name="Playground",
+            description="Desc",
+            thumbnail_image="",
+            access_type="authenticated",
+            published=False,
+            course_uuid=None,
+            html_content="<div>seed</div>",
+            playground_uuid="playground_token_scope",
+            course_id=None,
+            created_by=admin_user.id,
+            creation_date="2024-01-01",
+            update_date="2024-01-01",
+        )
+        db.add(playground)
+        await db.commit()
+
+        # API token scoped to a *different* org than the playground's org.
+        token_user = APITokenUser(
+            id=0,
+            org_id=org.id + 999,
+            created_by_user_id=admin_user.id,
+        )
+        app.dependency_overrides[get_current_user] = lambda: token_user
+
+        # Line 112: /generate/start rejects the cross-org token with 403.
+        with patch(
+            "src.routers.playgrounds.playgrounds_generator.reserve_ai_credit"
+        ), patch(
+            "src.routers.playgrounds.playgrounds_generator.get_org_ai_model",
+            return_value="gemini-test",
+        ):
+            response = await client.post(
+                "/api/v1/playgrounds/generate/start",
+                json={
+                    "playground_uuid": "playground_token_scope",
+                    "prompt": "Build it",
+                    "context": {
+                        "playground_name": "Playground",
+                        "playground_description": "Desc",
+                    },
+                },
+            )
+        assert response.status_code == 403
+
+        # Line 212: /generate/iterate rejects the same cross-org token with 403.
+        with patch(
+            "src.routers.playgrounds.playgrounds_generator.get_playground_session",
+            return_value=SimpleNamespace(
+                session_uuid="session1",
+                iteration_count=0,
+                max_iterations=3,
+                current_html="<div></div>",
+                playground_uuid="playground_token_scope",
+                context=SimpleNamespace(course_uuid=None),
+                message_history=[],
+            ),
+        ), patch(
+            "src.routers.playgrounds.playgrounds_generator.reserve_ai_credit"
+        ), patch(
+            "src.routers.playgrounds.playgrounds_generator.get_org_ai_model",
+            return_value="gemini-test",
+        ):
+            response = await client.post(
+                "/api/v1/playgrounds/generate/iterate",
+                json={
+                    "session_uuid": "session1",
+                    "playground_uuid": "playground_token_scope",
+                    "message": "Refine it",
+                },
+            )
+        assert response.status_code == 403
+
+    async def test_playground_generator_session_state_authz_branches(
+        self, client, db, org, admin_user
+    ):
+        """get_session_state guards: line 292 (playground not found -> 404),
+        line 303 (caller lacks edit rights -> 403)."""
+        playground = Playground(
+            id=81,
+            org_id=org.id,
+            name="Playground",
+            description="Desc",
+            thumbnail_image="",
+            access_type="authenticated",
+            published=False,
+            course_uuid=None,
+            html_content="<div>seed</div>",
+            playground_uuid="playground_state_authz",
+            course_id=None,
+            created_by=admin_user.id,
+            creation_date="2024-01-01",
+            update_date="2024-01-01",
+        )
+        db.add(playground)
+        await db.commit()
+
+        # Line 292: session references a playground that no longer exists -> 404.
+        with patch(
+            "src.routers.playgrounds.playgrounds_generator.get_playground_session",
+            return_value=SimpleNamespace(
+                session_uuid="session1",
+                iteration_count=1,
+                max_iterations=3,
+                current_html="<div></div>",
+                playground_uuid="playground_state_missing",
+                message_history=[],
+            ),
+        ):
+            response = await client.get(
+                "/api/v1/playgrounds/generate/session/session1"
+            )
+        assert response.status_code == 404
+
+        # Line 303: playground exists but the caller has no edit rights -> 403.
+        with patch(
+            "src.routers.playgrounds.playgrounds_generator.get_playground_session",
+            return_value=SimpleNamespace(
+                session_uuid="session1",
+                iteration_count=1,
+                max_iterations=3,
+                current_html="<div></div>",
+                playground_uuid="playground_state_authz",
+                message_history=[],
+            ),
+        ), patch(
+            "src.services.playgrounds.playgrounds._get_user_rights",
+            return_value={"playgrounds": {"action_update": False, "action_update_own": False}},
+        ):
+            response = await client.get(
+                "/api/v1/playgrounds/generate/session/session1"
+            )
+        assert response.status_code == 403
 
     async def test_playground_generator_rejects_missing_session(self, client):
         with patch(

--- a/apps/api/src/tests/routers/test_playgrounds_router.py
+++ b/apps/api/src/tests/routers/test_playgrounds_router.py
@@ -638,6 +638,7 @@ class TestPlaygroundsRouter:
             iteration_count=1,
             max_iterations=3,
             current_html="<div>done</div>",
+            playground_uuid="playground_test",
             message_history=[SimpleNamespace(role="user", content="Build it")],
         )
         with patch(

--- a/apps/api/src/tests/routers/test_search_router.py
+++ b/apps/api/src/tests/routers/test_search_router.py
@@ -11,6 +11,7 @@ from httpx import ASGITransport, AsyncClient
 from fastapi import FastAPI
 
 from src.core.events.database import get_db_session
+from src.db.users import AnonymousUser
 from src.security.auth import get_current_user
 from src.routers.search import router
 
@@ -66,6 +67,70 @@ class TestSearchRouter:
         assert "courses" in body
         assert "folders" in body
         assert "users" in body
+
+    @patch(
+        "src.services.search.search.search_courses",
+        new_callable=AsyncMock,
+        return_value=[],
+    )
+    @patch(
+        "src.services.search.search.is_org_member",
+        return_value=True,
+    )
+    @patch("src.routers.search.get_client_ip", return_value="9.9.9.9")
+    @patch(
+        "src.routers.search.check_rate_limit",
+        return_value=(True, 1, 0),
+    )
+    async def test_anonymous_caller_uses_ip_throttle(
+        self,
+        mock_check_rate_limit,
+        mock_get_client_ip,
+        mock_is_org_member,
+        mock_search_courses,
+        app,
+        client,
+        org,
+    ):
+        # Anonymous (id-less) callers fall through to the IP-keyed throttle
+        # branch instead of the per-user search rate limit.
+        app.dependency_overrides[get_current_user] = lambda: AnonymousUser()
+        response = await client.get(
+            "/api/v1/search/org_slug/test-org", params={"query": "test"}
+        )
+
+        assert response.status_code == 200
+        mock_get_client_ip.assert_called_once()
+        mock_check_rate_limit.assert_called_once()
+        # IP-keyed throttle, not the per-user search limit.
+        _, kwargs = mock_check_rate_limit.call_args
+        assert kwargs["key"] == "search_anon:9.9.9.9"
+        assert kwargs["max_attempts"] == 30
+        assert kwargs["window_seconds"] == 60
+
+    @patch("src.routers.search.get_client_ip", return_value="9.9.9.9")
+    @patch(
+        "src.routers.search.check_rate_limit",
+        return_value=(False, 31, 42),
+    )
+    async def test_anonymous_caller_rate_limited_returns_429(
+        self,
+        mock_check_rate_limit,
+        mock_get_client_ip,
+        app,
+        client,
+        org,
+    ):
+        # When the IP throttle is exhausted the endpoint raises 429 with a
+        # Retry-After header.
+        app.dependency_overrides[get_current_user] = lambda: AnonymousUser()
+        response = await client.get(
+            "/api/v1/search/org_slug/test-org", params={"query": "test"}
+        )
+
+        assert response.status_code == 429
+        assert response.headers.get("Retry-After") == "42"
+        assert "Too many search queries" in response.json()["detail"]
 
     async def test_search_missing_query_returns_422(self, client, org):
         response = await client.get("/api/v1/search/org_slug/test-org")

--- a/apps/api/src/tests/routers/test_usergroups_router.py
+++ b/apps/api/src/tests/routers/test_usergroups_router.py
@@ -108,3 +108,21 @@ class TestUsergroupsRouter:
         with patch("src.routers.usergroups.remove_resources_from_usergroup", new_callable=AsyncMock, return_value="ok"):
             response = await client.request("DELETE", "/api/v1/usergroups/1/remove_resources?resource_uuids=course_test")
         assert response.status_code == 200
+
+    async def test_add_users_rejects_non_numeric_ids(self, client):
+        # Non-numeric user_ids must be rejected with 422 before reaching the
+        # service (which does int(uid) and would otherwise 500).
+        with patch("src.routers.usergroups.add_users_to_usergroup", new_callable=AsyncMock) as service_mock:
+            response = await client.post("/api/v1/usergroups/1/add_users?user_ids=1,abc")
+        assert response.status_code == 422
+        assert "integer user IDs" in response.json()["detail"]
+        service_mock.assert_not_awaited()
+
+    async def test_remove_users_rejects_non_numeric_ids(self, client):
+        with patch("src.routers.usergroups.remove_users_from_usergroup", new_callable=AsyncMock) as service_mock:
+            response = await client.request(
+                "DELETE", "/api/v1/usergroups/1/remove_users?user_ids=1,xyz"
+            )
+        assert response.status_code == 422
+        assert "integer user IDs" in response.json()["detail"]
+        service_mock.assert_not_awaited()

--- a/apps/api/src/tests/routers/test_users_router_extra.py
+++ b/apps/api/src/tests/routers/test_users_router_extra.py
@@ -478,6 +478,10 @@ class TestPasswordResetEndpoints:
     async def test_send_password_reset_code_success(self, client):
         with (
             patch(
+                "src.routers.users.check_password_reset_rate_limit",
+                return_value=(True, 0),
+            ),
+            patch(
                 "src.routers.users.send_reset_password_code",
                 new_callable=AsyncMock,
                 return_value={"detail": "sent"},

--- a/apps/api/src/tests/routers/test_users_router_extra.py
+++ b/apps/api/src/tests/routers/test_users_router_extra.py
@@ -475,6 +475,67 @@ class TestPasswordResetEndpoints:
         assert response.status_code == 429
         assert "too many password reset attempts" in response.json()["detail"].lower()
 
+    async def test_send_password_reset_code_body_success(self, client):
+        with (
+            patch(
+                "src.routers.users.check_password_reset_rate_limit",
+                return_value=(True, 0),
+            ),
+            patch(
+                "src.routers.users.send_reset_password_code",
+                new_callable=AsyncMock,
+                return_value={"detail": "sent"},
+            ) as send_mock,
+        ):
+            response = await client.post(
+                "/api/v1/users/reset_password/send_reset_code",
+                json={"email": "user@test.com", "org_id": 1},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["detail"] == "sent"
+        send_mock.assert_awaited_once()
+
+    async def test_send_password_reset_code_body_rate_limited(self, client):
+        with (
+            patch(
+                "src.routers.users.check_password_reset_rate_limit",
+                return_value=(False, 180),
+            ),
+            patch(
+                "src.routers.users.send_reset_password_code",
+                new_callable=AsyncMock,
+            ) as send_mock,
+        ):
+            response = await client.post(
+                "/api/v1/users/reset_password/send_reset_code",
+                json={"email": "user@test.com", "org_id": 1},
+            )
+
+        assert response.status_code == 429
+        assert "too many password reset attempts" in response.json()["detail"].lower()
+        send_mock.assert_not_awaited()
+
+    async def test_send_password_reset_code_legacy_rate_limited(self, client):
+        with (
+            patch(
+                "src.routers.users.check_password_reset_rate_limit",
+                return_value=(False, 240),
+            ),
+            patch(
+                "src.routers.users.send_reset_password_code",
+                new_callable=AsyncMock,
+            ) as send_mock,
+        ):
+            response = await client.post(
+                "/api/v1/users/reset_password/send_reset_code/user@test.com",
+                params={"org_id": 1},
+            )
+
+        assert response.status_code == 429
+        assert "too many password reset attempts" in response.json()["detail"].lower()
+        send_mock.assert_not_awaited()
+
     async def test_send_password_reset_code_success(self, client):
         with (
             patch(

--- a/apps/api/src/tests/security/test_auth_runtime.py
+++ b/apps/api/src/tests/security/test_auth_runtime.py
@@ -22,6 +22,7 @@ def _mock_request(auth_header: str = "", cookies: dict | None = None, path_param
     request.headers.get = Mock(return_value=auth_header)
     request.cookies = cookies or {}
     request.path_params = path_params or {}
+    request.query_params = {}
     request.state = SimpleNamespace()
     return request
 

--- a/apps/api/src/tests/security/test_content_access.py
+++ b/apps/api/src/tests/security/test_content_access.py
@@ -211,14 +211,16 @@ class TestCheckContentAccess:
         assert exc_info.value.status_code == 401
 
     @pytest.mark.asyncio
-    async def test_unknown_path_authenticated_allowed(self):
-        """Unknown path patterns are allowed for authenticated users."""
+    async def test_unknown_path_authenticated_rejected(self):
+        """Unknown path patterns are denied for authenticated users (deny-by-default)."""
         from src.routers.local_content import _check_content_access
         db = self._make_db_session()
-        await _check_content_access(
-            "something/unknown/file.txt",
-            self._make_auth_user(), db
-        )
+        with pytest.raises(HTTPException) as exc_info:
+            await _check_content_access(
+                "something/unknown/file.txt",
+                self._make_auth_user(), db
+            )
+        assert exc_info.value.status_code == 403
 
 
 class TestS3ContentPathValidation:

--- a/apps/api/src/tests/security/test_file_validation_runtime.py
+++ b/apps/api/src/tests/security/test_file_validation_runtime.py
@@ -151,6 +151,29 @@ class TestValidateUpload:
         assert exc_info.value.status_code == 413
         assert "File too large" in exc_info.value.detail
 
+    def test_validate_upload_reads_whole_file_when_no_size_limit(self):
+        # file_validation.py:261 - when neither the max_size arg nor the config's
+        # 'max_size' is set, the function takes the unbounded-read else branch and
+        # reads the whole file.
+        from src.security import file_validation
+
+        content = b"\x89PNG\r\n\x1a\n" + b"0" * 16
+        upload = _upload("photo.png", content, "image/png")
+        patched_types = {
+            "image": {
+                "extensions": [".png"],
+                "max_size": None,
+                "validator": file_validation.validate_image_content,
+            }
+        }
+        with patch.object(file_validation, "FILE_TYPES", patched_types):
+            returned_type, returned_content = file_validation.validate_upload(
+                upload, ["image"]
+            )
+
+        assert returned_content == content
+        assert upload.file.tell() == 0
+
     def test_validate_upload_rejects_invalid_content(self):
         upload = _upload("photo.png", b"not-a-valid-png", "image/png")
         with pytest.raises(HTTPException) as exc_info:

--- a/apps/api/src/tests/security/test_remediation_auth_refresh.py
+++ b/apps/api/src/tests/security/test_remediation_auth_refresh.py
@@ -122,9 +122,12 @@ async def test_refresh_happy_path_rotates_refresh_cookie(client):
     ctxs = [
         patch("src.routers.auth.security_get_user", new_callable=AsyncMock, return_value=user),
         patch("src.routers.auth._is_token_revoked_for_user", return_value=False),
+        # Isolate the one-time-use replay store (real Redis) so a fixed test jti
+        # isn't flagged as a replay across runs; first use returns True.
+        patch("src.routers.auth._mark_refresh_jti_used", return_value=True),
     ]
     with stack[0], stack[1], stack[2], stack[3], stack[4], stack[5], stack[6], \
-         ctxs[0], ctxs[1]:
+         ctxs[0], ctxs[1], ctxs[2]:
         response = await client.get(
             "/api/v1/auth/refresh",
             cookies={JWT_REFRESH_COOKIE_NAME: "legit-token"},

--- a/apps/api/src/tests/services/test_admin_service_extra.py
+++ b/apps/api/src/tests/services/test_admin_service_extra.py
@@ -434,6 +434,11 @@ async def test_change_user_role_invalidate_cache_raises_is_swallowed(db, org, ad
     """Lines 1561-1562: _invalidate_session_cache raises → swallowed, role updated."""
     token_user = _make_token_user(org.id)
 
+    # The token's creator (created_by_user_id=1) must still be a member of the
+    # org for the token to assign roles (defense-in-depth guard).
+    creator = await _create_user(db, user_id=1, username="creator1", email="creator1@test.com")
+    await _add_user_to_org(db, creator, org, role_id=admin_role.id)
+
     # Need at least two admins so we can demote without triggering last-admin guard
     admin1 = await _create_user(db, user_id=81, username="admin81", email="admin81@test.com")
     await _add_user_to_org(db, admin1, org, role_id=admin_role.id)

--- a/apps/api/src/tests/services/test_analytics_cache_service.py
+++ b/apps/api/src/tests/services/test_analytics_cache_service.py
@@ -37,6 +37,9 @@ class TestAnalyticsCacheHelpers:
         assert get_ttl_for_query("course_recent_enrollments") == CACHE_TTL_DETAIL
         assert get_ttl_for_query("course_custom_widget") == CACHE_TTL_COURSE
         assert get_ttl_for_query("detail_custom") == CACHE_TTL_DETAIL
+        # A detail query not prefixed with "detail_"/"course_" must still resolve
+        # to the short detail TTL via the DETAIL_QUERIES membership check.
+        assert get_ttl_for_query("learner_engagement_score") == CACHE_TTL_DETAIL
         assert get_ttl_for_query("peak_usage_hours") == CACHE_TTL_ADVANCED
         assert get_ttl_for_query("event_counts") == CACHE_TTL_CORE
 

--- a/apps/api/src/tests/services/test_block_types_service.py
+++ b/apps/api/src/tests/services/test_block_types_service.py
@@ -5,13 +5,43 @@ upload_file_and_return_file_object is mocked so no real file I/O occurs.
 current_user=None skips the RBAC check in each function.
 """
 
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import UploadFile
+from fastapi import HTTPException, UploadFile
 
+from src.db.courses.activities import (
+    Activity,
+    ActivitySubTypeEnum,
+    ActivityTypeEnum,
+)
 from src.db.courses.blocks import BlockRead
 from src.services.blocks.schemas.files import BlockFile
+
+
+async def _activity_with_missing_org(db, org_id: int, course_id: int) -> Activity:
+    """Persist an activity whose org_id/course_id may point at nonexistent rows.
+
+    Used to drive the org-not-found / course-not-found 404 guards in the
+    create_* block functions.
+    """
+    a = Activity(
+        name="Orphan Activity",
+        activity_type=ActivityTypeEnum.TYPE_DYNAMIC,
+        activity_sub_type=ActivitySubTypeEnum.SUBTYPE_DYNAMIC_PAGE,
+        content={"type": "doc", "content": []},
+        published=True,
+        org_id=org_id,
+        course_id=course_id,
+        activity_uuid="activity_orphan",
+        creation_date=str(datetime.now()),
+        update_date=str(datetime.now()),
+    )
+    db.add(a)
+    await db.commit()
+    await db.refresh(a)
+    return a
 
 
 def _fake_block_file(file_type: str, ext: str, activity_uuid: str) -> BlockFile:
@@ -59,12 +89,36 @@ class TestCreateAudioBlock:
             "src.services.blocks.block_types.audioBlock.audioBlock.upload_file_and_return_file_object",
             new=AsyncMock(),
         ):
-            from fastapi import HTTPException
             with pytest.raises(HTTPException) as exc:
                 await _import_and_call_create_audio(
                     mock_request, _mock_upload_file(), "nonexistent-uuid", db
                 )
         assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_audio_block_org_not_found(self, mock_request, db):
+        # Activity exists but points at a nonexistent org -> 404 (line 35).
+        activity = await _activity_with_missing_org(db, org_id=999, course_id=1)
+        with pytest.raises(HTTPException) as exc:
+            await _import_and_call_create_audio(
+                mock_request, _mock_upload_file(), activity.activity_uuid, db,
+                current_user=None,
+            )
+        assert exc.value.status_code == 404
+        assert exc.value.detail == "Organization not found"
+
+    @pytest.mark.asyncio
+    async def test_audio_block_requires_authentication(
+        self, mock_request, db, org, course, activity
+    ):
+        # Valid activity/org/course but current_user is None -> 401 (line 53).
+        with pytest.raises(HTTPException) as exc:
+            await _import_and_call_create_audio(
+                mock_request, _mock_upload_file(), activity.activity_uuid, db,
+                current_user=None,
+            )
+        assert exc.value.status_code == 401
+        assert exc.value.detail == "Authentication required"
 
 
 class TestCreateImageBlock:
@@ -88,6 +142,29 @@ class TestCreateImageBlock:
         assert isinstance(result, BlockRead)
         assert result.org_id == org.id
 
+    @pytest.mark.asyncio
+    async def test_image_block_org_not_found(self, mock_request, db):
+        activity = await _activity_with_missing_org(db, org_id=999, course_id=1)
+        with pytest.raises(HTTPException) as exc:
+            await _import_and_call_create_image(
+                mock_request, _mock_upload_file(), activity.activity_uuid, db,
+                current_user=None,
+            )
+        assert exc.value.status_code == 404
+        assert exc.value.detail == "Organization not found"
+
+    @pytest.mark.asyncio
+    async def test_image_block_requires_authentication(
+        self, mock_request, db, org, course, activity
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await _import_and_call_create_image(
+                mock_request, _mock_upload_file(), activity.activity_uuid, db,
+                current_user=None,
+            )
+        assert exc.value.status_code == 401
+        assert exc.value.detail == "Authentication required"
+
 
 class TestCreatePdfBlock:
     @pytest.mark.asyncio
@@ -110,6 +187,29 @@ class TestCreatePdfBlock:
         assert isinstance(result, BlockRead)
         assert result.org_id == org.id
 
+    @pytest.mark.asyncio
+    async def test_pdf_block_org_not_found(self, mock_request, db):
+        activity = await _activity_with_missing_org(db, org_id=999, course_id=1)
+        with pytest.raises(HTTPException) as exc:
+            await _import_and_call_create_pdf(
+                mock_request, _mock_upload_file(), activity.activity_uuid, db,
+                current_user=None,
+            )
+        assert exc.value.status_code == 404
+        assert exc.value.detail == "Organization not found"
+
+    @pytest.mark.asyncio
+    async def test_pdf_block_requires_authentication(
+        self, mock_request, db, org, course, activity
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await _import_and_call_create_pdf(
+                mock_request, _mock_upload_file(), activity.activity_uuid, db,
+                current_user=None,
+            )
+        assert exc.value.status_code == 401
+        assert exc.value.detail == "Authentication required"
+
 
 class TestCreateVideoBlock:
     @pytest.mark.asyncio
@@ -131,6 +231,84 @@ class TestCreateVideoBlock:
 
         assert isinstance(result, BlockRead)
         assert result.org_id == org.id
+
+    @pytest.mark.asyncio
+    async def test_video_block_org_not_found(self, mock_request, db):
+        activity = await _activity_with_missing_org(db, org_id=999, course_id=1)
+        with pytest.raises(HTTPException) as exc:
+            await _import_and_call_create_video(
+                mock_request, _mock_upload_file(), activity.activity_uuid, db,
+                current_user=None,
+            )
+        assert exc.value.status_code == 404
+        assert exc.value.detail == "Organization not found"
+
+    @pytest.mark.asyncio
+    async def test_video_block_requires_authentication(
+        self, mock_request, db, org, course, activity
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await _import_and_call_create_video(
+                mock_request, _mock_upload_file(), activity.activity_uuid, db,
+                current_user=None,
+            )
+        assert exc.value.status_code == 401
+        assert exc.value.detail == "Authentication required"
+
+
+class TestUploadFileAndReturnFileObject:
+    """Covers the file-size branches in upload_file_and_return_file_object."""
+
+    @pytest.mark.asyncio
+    async def test_uses_known_multipart_size(self, mock_request):
+        # file.size is not None -> use it directly (lines 47-48).
+        uf = MagicMock(spec=UploadFile)
+        uf.filename = "clip.mp3"
+        uf.content_type = "audio/mpeg"
+        uf.size = 4242
+        uf.file = MagicMock()
+        uf.read = AsyncMock()
+
+        with patch(
+            "src.services.blocks.utils.upload_files.upload_file",
+            new=AsyncMock(return_value="block_abc.mp3"),
+        ):
+            result = await _import_and_call_upload(
+                mock_request, uf, "activity_test", "block_x",
+                ["mp3", "wav", "ogg", "m4a"], "audioBlock",
+                "org_test", "course_test",
+            )
+
+        assert isinstance(result, BlockFile)
+        assert result.file_size == 4242
+        # Known size means we must NOT re-read the file body.
+        uf.read.assert_not_awaited()
+        uf.file.seek.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_reading_body_when_size_unknown(self, mock_request):
+        # file.size is None -> seek(0) + len(await file.read()) (lines 50-51).
+        uf = MagicMock(spec=UploadFile)
+        uf.filename = "clip.mp4"
+        uf.content_type = "video/mp4"
+        uf.size = None
+        uf.file = MagicMock()
+        uf.read = AsyncMock(return_value=b"abcdef")
+
+        with patch(
+            "src.services.blocks.utils.upload_files.upload_file",
+            new=AsyncMock(return_value="block_def.mp4"),
+        ):
+            result = await _import_and_call_upload(
+                mock_request, uf, "activity_test", "block_y",
+                ["mp4", "webm"], "videoBlock",
+                "org_test", "course_test",
+            )
+
+        assert isinstance(result, BlockFile)
+        assert result.file_size == 6
+        uf.file.seek.assert_called_once_with(0)
+        uf.read.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -155,3 +333,16 @@ async def _import_and_call_create_pdf(request, file, activity_uuid, db, current_
 async def _import_and_call_create_video(request, file, activity_uuid, db, current_user=None):
     from src.services.blocks.block_types.videoBlock.videoBlock import create_video_block
     return await create_video_block(request, file, activity_uuid, db, current_user=current_user)
+
+
+async def _import_and_call_upload(
+    request, file, activity_uuid, block_id, allowed_formats, type_of_block,
+    org_uuid, course_uuid,
+):
+    from src.services.blocks.utils.upload_files import (
+        upload_file_and_return_file_object,
+    )
+    return await upload_file_and_return_file_object(
+        request, file, activity_uuid, block_id, allowed_formats, type_of_block,
+        org_uuid, course_uuid,
+    )

--- a/apps/api/src/tests/services/test_block_types_service.py
+++ b/apps/api/src/tests/services/test_block_types_service.py
@@ -35,15 +35,19 @@ def _mock_upload_file() -> MagicMock:
 class TestCreateAudioBlock:
     @pytest.mark.asyncio
     async def test_creates_audio_block_and_persists(
-        self, mock_request, db, org, course, activity
+        self, mock_request, db, org, course, activity, admin_user
     ):
         block_file = _fake_block_file("audio", "mp3", activity.activity_uuid)
         with patch(
             "src.services.blocks.block_types.audioBlock.audioBlock.upload_file_and_return_file_object",
             new=AsyncMock(return_value=block_file),
+        ), patch(
+            "src.services.blocks.block_types.audioBlock.audioBlock.check_resource_access",
+            new_callable=AsyncMock,
         ):
             result = await _import_and_call_create_audio(
-                mock_request, _mock_upload_file(), activity.activity_uuid, db
+                mock_request, _mock_upload_file(), activity.activity_uuid, db,
+                current_user=admin_user,
             )
 
         assert isinstance(result, BlockRead)
@@ -66,15 +70,19 @@ class TestCreateAudioBlock:
 class TestCreateImageBlock:
     @pytest.mark.asyncio
     async def test_creates_image_block_and_persists(
-        self, mock_request, db, org, course, activity
+        self, mock_request, db, org, course, activity, admin_user
     ):
         block_file = _fake_block_file("image", "png", activity.activity_uuid)
         with patch(
             "src.services.blocks.block_types.imageBlock.imageBlock.upload_file_and_return_file_object",
             new=AsyncMock(return_value=block_file),
+        ), patch(
+            "src.services.blocks.block_types.imageBlock.imageBlock.check_resource_access",
+            new_callable=AsyncMock,
         ):
             result = await _import_and_call_create_image(
-                mock_request, _mock_upload_file(), activity.activity_uuid, db
+                mock_request, _mock_upload_file(), activity.activity_uuid, db,
+                current_user=admin_user,
             )
 
         assert isinstance(result, BlockRead)
@@ -84,15 +92,19 @@ class TestCreateImageBlock:
 class TestCreatePdfBlock:
     @pytest.mark.asyncio
     async def test_creates_pdf_block_and_persists(
-        self, mock_request, db, org, course, activity
+        self, mock_request, db, org, course, activity, admin_user
     ):
         block_file = _fake_block_file("document", "pdf", activity.activity_uuid)
         with patch(
             "src.services.blocks.block_types.pdfBlock.pdfBlock.upload_file_and_return_file_object",
             new=AsyncMock(return_value=block_file),
+        ), patch(
+            "src.services.blocks.block_types.pdfBlock.pdfBlock.check_resource_access",
+            new_callable=AsyncMock,
         ):
             result = await _import_and_call_create_pdf(
-                mock_request, _mock_upload_file(), activity.activity_uuid, db
+                mock_request, _mock_upload_file(), activity.activity_uuid, db,
+                current_user=admin_user,
             )
 
         assert isinstance(result, BlockRead)
@@ -102,15 +114,19 @@ class TestCreatePdfBlock:
 class TestCreateVideoBlock:
     @pytest.mark.asyncio
     async def test_creates_video_block_and_persists(
-        self, mock_request, db, org, course, activity
+        self, mock_request, db, org, course, activity, admin_user
     ):
         block_file = _fake_block_file("video", "mp4", activity.activity_uuid)
         with patch(
             "src.services.blocks.block_types.videoBlock.videoBlock.upload_file_and_return_file_object",
             new=AsyncMock(return_value=block_file),
+        ), patch(
+            "src.services.blocks.block_types.videoBlock.videoBlock.check_resource_access",
+            new_callable=AsyncMock,
         ):
             result = await _import_and_call_create_video(
-                mock_request, _mock_upload_file(), activity.activity_uuid, db
+                mock_request, _mock_upload_file(), activity.activity_uuid, db,
+                current_user=admin_user,
             )
 
         assert isinstance(result, BlockRead)
@@ -121,21 +137,21 @@ class TestCreateVideoBlock:
 # Thin import helpers so module-level imports don't pollute coverage counts
 # ---------------------------------------------------------------------------
 
-async def _import_and_call_create_audio(request, file, activity_uuid, db):
+async def _import_and_call_create_audio(request, file, activity_uuid, db, current_user=None):
     from src.services.blocks.block_types.audioBlock.audioBlock import create_audio_block
-    return await create_audio_block(request, file, activity_uuid, db, current_user=None)
+    return await create_audio_block(request, file, activity_uuid, db, current_user=current_user)
 
 
-async def _import_and_call_create_image(request, file, activity_uuid, db):
+async def _import_and_call_create_image(request, file, activity_uuid, db, current_user=None):
     from src.services.blocks.block_types.imageBlock.imageBlock import create_image_block
-    return await create_image_block(request, file, activity_uuid, db, current_user=None)
+    return await create_image_block(request, file, activity_uuid, db, current_user=current_user)
 
 
-async def _import_and_call_create_pdf(request, file, activity_uuid, db):
+async def _import_and_call_create_pdf(request, file, activity_uuid, db, current_user=None):
     from src.services.blocks.block_types.pdfBlock.pdfBlock import create_pdf_block
-    return await create_pdf_block(request, file, activity_uuid, db, current_user=None)
+    return await create_pdf_block(request, file, activity_uuid, db, current_user=current_user)
 
 
-async def _import_and_call_create_video(request, file, activity_uuid, db):
+async def _import_and_call_create_video(request, file, activity_uuid, db, current_user=None):
     from src.services.blocks.block_types.videoBlock.videoBlock import create_video_block
-    return await create_video_block(request, file, activity_uuid, db, current_user=None)
+    return await create_video_block(request, file, activity_uuid, db, current_user=current_user)

--- a/apps/api/src/tests/services/test_boards_playground_service.py
+++ b/apps/api/src/tests/services/test_boards_playground_service.py
@@ -84,6 +84,8 @@ class TestBoardsPlaygroundService:
         )
 
         with patch(
+            "src.services.boards.boards_playground._redis_client", None
+        ), patch(
             "src.services.boards.boards_playground.LH_CONFIG",
             SimpleNamespace(
                 redis_config=SimpleNamespace(redis_connection_string="")
@@ -92,6 +94,8 @@ class TestBoardsPlaygroundService:
             assert get_redis_connection() is None
 
         with patch(
+            "src.services.boards.boards_playground._redis_client", None
+        ), patch(
             "src.services.boards.boards_playground.redis.from_url",
             side_effect=RuntimeError("boom"),
         ), patch(

--- a/apps/api/src/tests/services/test_boards_service.py
+++ b/apps/api/src/tests/services/test_boards_service.py
@@ -19,6 +19,7 @@ from src.db.boards import (
 )
 from src.db.resource_authors import ResourceAuthor
 from src.db.users import User
+from src.db.user_organizations import UserOrganization
 from src.services.boards.boards import (
     add_board_member,
     add_board_members_batch,
@@ -37,7 +38,7 @@ from src.services.boards.boards import (
 )
 
 
-async def _make_user(db, *, id, email, username):
+async def _make_user(db, *, id, email, username, org=None):
     user = User(
         id=id,
         username=username,
@@ -52,6 +53,12 @@ async def _make_user(db, *, id, email, username):
     db.add(user)
     await db.commit()
     await db.refresh(user)
+    if org is not None:
+        db.add(UserOrganization(
+            user_id=user.id, org_id=org.id, role_id=3,
+            creation_date=str(datetime.now()), update_date=str(datetime.now()),
+        ))
+        await db.commit()
     return user
 
 
@@ -165,9 +172,9 @@ class TestBoardsService:
     ):
         board = await _make_board(db, org, admin_user)
         await _make_member(db, board.id, admin_user.id, BoardMemberRole.OWNER)
-        await _make_user(db, id=21, email="first@test.com", username="first")
-        await _make_user(db, id=22, email="second@test.com", username="second")
-        await _make_user(db, id=23, email="third@test.com", username="third")
+        await _make_user(db, id=21, email="first@test.com", username="first", org=org)
+        await _make_user(db, id=22, email="second@test.com", username="second", org=org)
+        await _make_user(db, id=23, email="third@test.com", username="third", org=org)
         member_create = BoardMemberCreate(user_id=21, role=BoardMemberRole.EDITOR)
         member_create.role = BoardMemberRole.EDITOR
         batch_create = BoardMemberBatchCreate(
@@ -212,7 +219,7 @@ class TestBoardsService:
     ):
         board = await _make_board(db, org, admin_user)
         await _make_member(db, board.id, admin_user.id, BoardMemberRole.OWNER)
-        await _make_user(db, id=30, email="dup@test.com", username="dup")
+        await _make_user(db, id=30, email="dup@test.com", username="dup", org=org)
         await _make_member(db, board.id, 30)
 
         with patch(
@@ -232,10 +239,10 @@ class TestBoardsService:
 
         for user_id in range(31, 39):
             await _make_user(
-                db, id=user_id, email=f"user{user_id}@test.com", username=f"user{user_id}"
+                db, id=user_id, email=f"user{user_id}@test.com", username=f"user{user_id}", org=org
             )
             await _make_member(db, board.id, user_id)
-        await _make_user(db, id=39, email="overflow@test.com", username="overflow")
+        await _make_user(db, id=39, email="overflow@test.com", username="overflow", org=org)
 
         with patch(
             "src.services.boards.boards.check_resource_access",
@@ -450,12 +457,12 @@ class TestBoardsService:
         continue` branch in add_board_members_batch)."""
         board = await _make_board(db, org, admin_user, board_uuid="board_batch_dup")
         existing_user = await _make_user(
-            db, id=301, email="existing301@test.com", username="existing301"
+            db, id=301, email="existing301@test.com", username="existing301", org=org
         )
         await _make_member(db, board.id, existing_user.id)
 
         new_user = await _make_user(
-            db, id=302, email="new302@test.com", username="new302"
+            db, id=302, email="new302@test.com", username="new302", org=org
         )
         batch = BoardMemberBatchCreate(
             members=[

--- a/apps/api/src/tests/services/test_boards_service.py
+++ b/apps/api/src/tests/services/test_boards_service.py
@@ -484,6 +484,63 @@ class TestBoardsService:
         assert result[0].user_id == new_user.id
 
     @pytest.mark.asyncio
+    async def test_add_board_member_rejects_invalid_role(
+        self, db, org, admin_user, mock_request
+    ):
+        """Lines 513-514: an out-of-enum role string is rejected with 400 by
+        _validate_member_role before any persistence."""
+        board = await _make_board(db, org, admin_user, board_uuid="board_bad_role")
+        await _make_member(db, board.id, admin_user.id, BoardMemberRole.OWNER)
+        await _make_user(db, id=50, email="badrole@test.com", username="badrole", org=org)
+
+        bad_member = BoardMemberCreate(user_id=50, role=BoardMemberRole.EDITOR)
+        # Schema types `role` as a bare str, so an arbitrary value bypasses
+        # validation until _validate_member_role.
+        bad_member.role = "superuser"
+
+        with patch(
+            "src.services.boards.boards.check_resource_access",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.services.boards.boards.require_org_membership",
+            new_callable=AsyncMock,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await add_board_member(
+                    mock_request, board.board_uuid, bad_member, admin_user, db
+                )
+        assert exc_info.value.status_code == 400
+        assert "Invalid board member role" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_batch_add_member_rejects_invalid_role(
+        self, db, org, admin_user, mock_request
+    ):
+        """Lines 513-514 via the batch path: an out-of-enum role string is
+        rejected with 400 by _validate_member_role."""
+        board = await _make_board(db, org, admin_user, board_uuid="board_bad_role_batch")
+        await _make_user(db, id=51, email="badrole51@test.com", username="badrole51", org=org)
+
+        batch = BoardMemberBatchCreate(
+            members=[BoardMemberCreate(user_id=51, role=BoardMemberRole.EDITOR)]
+        )
+        batch.members[0].role = "godmode"
+
+        with patch(
+            "src.services.boards.boards.check_resource_access",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.services.boards.boards.require_org_membership",
+            new_callable=AsyncMock,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await add_board_members_batch(
+                    mock_request, board.board_uuid, batch, admin_user, db
+                )
+        assert exc_info.value.status_code == 400
+        assert "Invalid board member role" in exc_info.value.detail
+
+    @pytest.mark.asyncio
     async def test_check_board_membership_rbac_fallback(
         self, db, org, admin_user, mock_request
     ):

--- a/apps/api/src/tests/services/test_chapters_service.py
+++ b/apps/api/src/tests/services/test_chapters_service.py
@@ -368,6 +368,24 @@ class TestCourseChapters:
         assert activity.activity_uuid in legacy_result["activities"]
 
     @pytest.mark.asyncio
+    async def test_get_course_chapters_missing_course_raises_404(
+        self, db, admin_user, mock_request
+    ):
+        # chapters.py:251 - when no `course` is supplied and the course_id does
+        # not exist, the lookup returns None and the function must raise a clean
+        # 404 instead of dereferencing None (which would 500).
+        with pytest.raises(HTTPException) as exc_info:
+            await get_course_chapters(
+                mock_request,
+                999999,
+                db,
+                admin_user,
+                with_unpublished_activities=False,
+            )
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
     async def test_deprecated_get_course_chapters_missing_course_raises(
         self, db, admin_user, mock_request
     ):

--- a/apps/api/src/tests/services/test_communities_service.py
+++ b/apps/api/src/tests/services/test_communities_service.py
@@ -534,6 +534,22 @@ class TestCommunitiesService:
             await get_community_user_rights(mock_request, "missing", admin_user, db)
         assert rights_exc.value.status_code == 404
 
+    @pytest.mark.asyncio
+    async def test_get_communities_by_org_missing_org_raises_404(
+        self, db, org, admin_user, mock_request
+    ):
+        """Covers communities service line 154: a non-superadmin listing
+        communities for an org_id that resolves to no Organization gets a 404
+        rather than silently dropping into the restricted member view."""
+        with patch(
+            "src.services.communities.communities.is_user_superadmin",
+            return_value=False,
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await get_communities_by_org(mock_request, 987654, admin_user, db)
+        assert exc.value.status_code == 404
+        assert exc.value.detail == "Organization not found"
+
 
 class TestDiscussionsService:
     def test_hot_score_and_label_validation(self):

--- a/apps/api/src/tests/services/test_communities_service.py
+++ b/apps/api/src/tests/services/test_communities_service.py
@@ -204,6 +204,7 @@ class TestCommunitiesService:
             UserGroupUser(
                 usergroup_id=usergroup.id,
                 user_id=regular_user.id,
+                org_id=usergroup.org_id,
                 creation_date=str(datetime.now()),
                 update_date=str(datetime.now()),
             )

--- a/apps/api/src/tests/services/test_community_comments_votes_service.py
+++ b/apps/api/src/tests/services/test_community_comments_votes_service.py
@@ -552,6 +552,89 @@ class TestCommunityCommentsAndVotes:
         assert rollback_calls, "expected db_session.rollback() to be called"
 
     @pytest.mark.asyncio
+    async def test_upvote_comment_integrity_error_race_rolls_back_and_400(
+        self, db, org, admin_user, regular_user, mock_request
+    ):
+        """Covers comment_votes lines 99,102,103: if the INSERT+UPDATE commit
+        hits an IntegrityError (concurrent duplicate vote race), the service
+        rolls back and raises HTTPException 400 instead of leaking a 500."""
+        community = await _make_community(db, org, community_uuid="community_comment_race")
+        discussion = await _make_discussion(
+            db,
+            community,
+            org,
+            author_id=admin_user.id,
+            discussion_uuid="discussion_comment_race",
+        )
+        comment = await _make_comment(
+            db, discussion, author_id=admin_user.id, comment_uuid="comment_race"
+        )
+
+        original_rollback = db.rollback
+        rollback_calls = []
+
+        async def failing_commit(*args, **kwargs):
+            raise IntegrityError("INSERT", {}, Exception("duplicate key"))
+
+        async def tracking_rollback(*args, **kwargs):
+            rollback_calls.append(True)
+            return await original_rollback(*args, **kwargs)
+
+        with patch(
+            "src.services.communities.comment_votes.authorization_verify_if_user_is_anon",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.services.communities.comment_votes.check_resource_access",
+            new_callable=AsyncMock,
+        ), patch.object(
+            db, "commit", side_effect=failing_commit
+        ), patch.object(
+            db, "rollback", side_effect=tracking_rollback
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await upvote_comment(
+                    mock_request, comment.comment_uuid, regular_user, db
+                )
+
+        assert exc.value.status_code == 400
+        assert "already upvoted" in exc.value.detail
+        # safety-net rolled the failed transaction back
+        assert rollback_calls, "expected db_session.rollback() to be called"
+
+    @pytest.mark.asyncio
+    async def test_get_comment_count_missing_community_raises_404(
+        self, db, org, admin_user, regular_user, mock_request
+    ):
+        """Covers comments line 340: get_comment_count on a discussion whose
+        parent community no longer exists raises 404 (Community not found)."""
+        community = await _make_community(
+            db, org, community_uuid="community_count_orphan"
+        )
+        discussion = await _make_discussion(
+            db,
+            community,
+            org,
+            author_id=admin_user.id,
+            discussion_uuid="discussion_count_orphan",
+        )
+        # Point the discussion at a non-existent community so the community
+        # lookup in get_comment_count returns None.
+        discussion.community_id = 987654
+        db.add(discussion)
+        await db.commit()
+
+        with patch(
+            "src.services.communities.comments.check_resource_access",
+            new_callable=AsyncMock,
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await get_comment_count(
+                    mock_request, discussion.discussion_uuid, regular_user, db
+                )
+        assert exc.value.status_code == 404
+        assert exc.value.detail == "Community not found"
+
+    @pytest.mark.asyncio
     async def test_comment_creation_and_delete_error_branches(
         self, db, org, admin_user, regular_user, mock_request
     ):

--- a/apps/api/src/tests/services/test_community_comments_votes_service.py
+++ b/apps/api/src/tests/services/test_community_comments_votes_service.py
@@ -141,8 +141,18 @@ class TestCommunityCommentsAndVotes:
         assert created.content == "First comment"
         assert comments[0].author.username == regular_user.username
         assert updated.content == "Edited comment"
-        assert await get_comment_count(discussion.discussion_uuid, db) == 1
-        assert await get_comment_count("missing", db) == 0
+        # get_comment_count now enforces community read access; mock it for the
+        # count assertions. A missing discussion raises 404 (was: returned 0).
+        with patch(
+            "src.services.communities.comments.check_resource_access",
+            new_callable=AsyncMock,
+        ):
+            assert await get_comment_count(
+                mock_request, discussion.discussion_uuid, regular_user, db
+            ) == 1
+            with pytest.raises(HTTPException) as missing_exc:
+                await get_comment_count(mock_request, "missing", regular_user, db)
+            assert missing_exc.value.status_code == 404
 
     @pytest.mark.asyncio
     async def test_comment_error_and_delete_paths(

--- a/apps/api/src/tests/services/test_courses_service.py
+++ b/apps/api/src/tests/services/test_courses_service.py
@@ -30,7 +30,7 @@ from src.db.resource_authors import (
     ResourceAuthorshipEnum,
     ResourceAuthorshipStatusEnum,
 )
-from src.db.users import APITokenUser
+from src.db.users import APITokenUser, AnonymousUser
 from src.security.rbac import AccessAction, AccessContext
 from src.services.courses.courses import (
     clone_course,
@@ -165,11 +165,13 @@ class TestGetCourseMeta:
             "src.services.courses.chapters.get_course_chapters",
             new_callable=AsyncMock,
         ) as mock_chapters:
+            # The shared meta cache is only served to anonymous viewers (per-user
+            # lock-stripping means authenticated views must not be cached).
             result = await get_course_meta(
                 mock_request,
                 "course_test",
                 False,
-                admin_user,
+                AnonymousUser(),
                 db,
                 slim=True,
             )
@@ -195,11 +197,12 @@ class TestGetCourseMeta:
             new_callable=AsyncMock,
             return_value=[],
         ) as mock_chapters:
+            anon = AnonymousUser()
             result = await get_course_meta(
                 mock_request,
                 "course_test",
                 False,
-                admin_user,
+                anon,
                 db,
                 slim=True,
             )
@@ -207,7 +210,7 @@ class TestGetCourseMeta:
         assert result.org_uuid == "org_test"
         mock_chapters.assert_awaited_once()
         call = mock_chapters.await_args
-        assert call.args[:5] == (mock_request, course.id, db, admin_user, False)
+        assert call.args[:5] == (mock_request, course.id, db, anon, False)
         assert call.kwargs["slim"] is True
         assert call.kwargs["course"].id == course.id
         mock_set_cache.assert_called_once_with("course_test", True, result.model_dump())
@@ -656,8 +659,10 @@ class TestCourseMutationsAndRights:
                 thumbnail_type=ThumbnailType.IMAGE,
             )
 
+        # Query as the owner: a user may see their own unpublished courses, while
+        # other non-superadmin users only see the author's published+public ones.
         user_courses = await get_user_courses(
-            mock_request, regular_user, admin_user.id, db
+            mock_request, admin_user, admin_user.id, db
         )
 
         assert created.name == "Created Course"
@@ -1182,7 +1187,10 @@ class TestCourseMutationsAndRights:
                     db,
                 )
 
-        assert missing_org_exc.value.status_code == 404
+        # The orphan course belongs to a foreign/non-existent org (999); cloning
+        # now requires membership in the source course's org, so a non-member is
+        # rejected with 403 before the org-existence check.
+        assert missing_org_exc.value.status_code == 403
 
     @pytest.mark.asyncio
     async def test_clone_course_regular_user_and_storage_helpers(

--- a/apps/api/src/tests/services/test_oauth_email_takeover.py
+++ b/apps/api/src/tests/services/test_oauth_email_takeover.py
@@ -113,6 +113,165 @@ async def test_body_email_is_ignored_when_google_returns_different_email(
 
 
 @pytest.mark.asyncio
+async def test_email_verified_string_true_is_accepted(db, mock_request, admin_user):
+    """Google may serialise ``email_verified`` as the JSON string ``"true"``
+    rather than a native boolean (line 125). It must be accepted as verified."""
+    google_payload = {
+        "sub": "google_admin_sub",
+        "email": admin_user.email,
+        "email_verified": "True",  # string, mixed case -> normalised to true
+    }
+    with patch(
+        "src.services.auth.utils.get_google_user_info",
+        new=AsyncMock(return_value=google_payload),
+    ), patch("src.services.auth.utils.update_login_info", return_value=None):
+        result = await signWithGoogle(
+            mock_request,
+            access_token="legit_google_token",
+            email=admin_user.email,
+            org_id=None,
+            current_user=None,
+            db_session=db,
+        )
+
+    assert result.email == admin_user.email
+
+
+@pytest.mark.asyncio
+async def test_email_verified_string_false_is_rejected(db, mock_request, admin_user):
+    """The string ``"false"`` must NOT be treated as verified (truthiness trap)."""
+    google_payload = {
+        "sub": "google_admin_sub",
+        "email": admin_user.email,
+        "email_verified": "false",
+    }
+    with patch(
+        "src.services.auth.utils.get_google_user_info",
+        new=AsyncMock(return_value=google_payload),
+    ):
+        with pytest.raises(HTTPException) as excinfo:
+            await signWithGoogle(
+                mock_request,
+                access_token="legit_google_token",
+                email=admin_user.email,
+                org_id=None,
+                current_user=None,
+                db_session=db,
+            )
+    assert excinfo.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_existing_user_with_org_id_creates_membership(db, mock_request, org):
+    """An *existing* user signing in with Google and a validated ``org_id`` who
+    is not yet a member of that org gets a UserOrganization link created, gated
+    by the member quota (lines 224-250)."""
+    from datetime import datetime as _dt
+
+    from sqlmodel import select
+
+    from src.db.user_organizations import UserOrganization
+    from src.db.users import User
+
+    # An existing account NOT yet a member of ``org``.
+    existing_user = User(
+        id=99,
+        username="googler",
+        first_name="Goo",
+        last_name="Gler",
+        email="googler@test.com",
+        password="hashed_password",
+        user_uuid="user_googler",
+        email_verified=True,
+        creation_date=str(_dt.now()),
+        update_date=str(_dt.now()),
+    )
+    db.add(existing_user)
+    await db.commit()
+    await db.refresh(existing_user)
+
+    google_payload = {
+        "sub": "google_googler_sub",
+        "email": existing_user.email,
+        "email_verified": True,
+    }
+    with patch(
+        "src.services.auth.utils.get_google_user_info",
+        new=AsyncMock(return_value=google_payload),
+    ), patch(
+        "src.services.auth.utils.update_login_info", return_value=None
+    ), patch(
+        "src.security.features_utils.usage.check_limits_with_usage",
+        new=AsyncMock(return_value=True),
+    ) as check_mock, patch(
+        "src.security.features_utils.usage.increase_feature_usage",
+        new=AsyncMock(return_value=None),
+    ) as increase_mock:
+        result = await signWithGoogle(
+            mock_request,
+            access_token="legit_google_token",
+            email=existing_user.email,
+            org_id=org.id,
+            current_user=None,
+            db_session=db,
+        )
+
+    assert result.email == existing_user.email
+    check_mock.assert_awaited_once()
+    increase_mock.assert_awaited_once()
+
+    membership = (await db.execute(
+        select(UserOrganization).where(
+            (UserOrganization.user_id == existing_user.id)
+            & (UserOrganization.org_id == org.id)
+        )
+    )).scalars().first()
+    assert membership is not None
+    assert membership.role_id == 4
+
+
+@pytest.mark.asyncio
+async def test_existing_user_with_org_id_skips_when_already_member(
+    db, mock_request, admin_user, org
+):
+    """If the existing user is already a member of the org, the quota check and
+    membership creation are skipped (the ``if not existing_membership`` guard at
+    line 238 is False)."""
+    # The ``admin_user`` fixture already links the user to ``org``, so the
+    # membership-exists guard (line 238) is False and the create branch is
+    # skipped.
+    google_payload = {
+        "sub": "google_admin_sub",
+        "email": admin_user.email,
+        "email_verified": True,
+    }
+    with patch(
+        "src.services.auth.utils.get_google_user_info",
+        new=AsyncMock(return_value=google_payload),
+    ), patch(
+        "src.services.auth.utils.update_login_info", return_value=None
+    ), patch(
+        "src.security.features_utils.usage.check_limits_with_usage",
+        new=AsyncMock(return_value=True),
+    ) as check_mock, patch(
+        "src.security.features_utils.usage.increase_feature_usage",
+        new=AsyncMock(return_value=None),
+    ) as increase_mock:
+        result = await signWithGoogle(
+            mock_request,
+            access_token="legit_google_token",
+            email=admin_user.email,
+            org_id=org.id,
+            current_user=None,
+            db_session=db,
+        )
+
+    assert result.email == admin_user.email
+    check_mock.assert_not_awaited()
+    increase_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_happy_path_matching_email(db, mock_request, admin_user):
     """A well-formed request where body email matches Google's email still works."""
     google_payload = {

--- a/apps/api/src/tests/services/test_org_invites_service.py
+++ b/apps/api/src/tests/services/test_org_invites_service.py
@@ -406,7 +406,7 @@ class TestOrgInvitesService:
             result = await delete_invite_code(
                 mock_request,
                 org.id,
-                "org_invite_code_test",
+                "org_invite_code_12345678-1234-1234-1234-1234567890ab",
                 admin_user,
                 db,
             )
@@ -428,7 +428,7 @@ class TestOrgInvitesService:
                 await delete_invite_code(
                     mock_request,
                     org.id,
-                    "org_invite_code_missing",
+                    "org_invite_code_99999999-9999-9999-9999-999999999999",
                     admin_user,
                     db,
                 )

--- a/apps/api/src/tests/services/test_org_invites_service.py
+++ b/apps/api/src/tests/services/test_org_invites_service.py
@@ -331,6 +331,41 @@ class TestOrgInvitesService:
         assert result[0]["usergroup_name"] == "Beta Group"
 
     @pytest.mark.asyncio
+    async def test_get_invite_codes_skips_vanished_key(
+        self, mock_request, db, org, admin_user
+    ):
+        # A key found by scan_iter may expire (TTL) before r.get() is called,
+        # returning None. That key must be skipped, not crash the listing.
+        invite_payload = {
+            "invite_code": "LIVE1234",
+            "invite_code_uuid": "org_invite_code_live",
+            "invite_code_expires": 123,
+            "invite_code_type": "signup",
+            "created_at": "2024-01-01T00:00:00",
+            "created_by": admin_user.user_uuid,
+        }
+        fake_redis = _fake_redis(
+            scan_keys=[b"vanished-key", b"live-key"],
+            values={b"live-key": json.dumps(invite_payload)},
+        )
+
+        with patch(
+            "src.services.orgs.invites.get_learnhouse_config",
+            return_value=_fake_config(),
+        ), patch(
+            "src.services.orgs.invites.rbac_check",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.services.orgs.invites._get_redis",
+            return_value=fake_redis,
+        ):
+            result = await get_invite_codes(mock_request, org.id, admin_user, db)
+
+        # Only the live key is returned; the vanished one is silently skipped.
+        assert len(result) == 1
+        assert result[0]["invite_code"] == "LIVE1234"
+
+    @pytest.mark.asyncio
     async def test_get_invite_code_success_and_not_found(
         self, mock_request, db, org, admin_user
     ):

--- a/apps/api/src/tests/services/test_packs_service.py
+++ b/apps/api/src/tests/services/test_packs_service.py
@@ -215,6 +215,58 @@ class TestPackLifecycle:
         background_tasks.discard.assert_called()
 
     @pytest.mark.asyncio
+    async def test_activate_pack_reactivates_cancelled_ai_credits(self, db, org):
+        # Reactivating a cancelled AI-credits pack must re-add the stored
+        # quantity of AI credits to Redis (the ai_credits branch).
+        redis = FakeRedis()
+        background_tasks = Mock()
+        fake_task = FakeTask()
+
+        await _make_pack(
+            db,
+            org,
+            id=40,
+            pack_id="ai_500",
+            pack_type=PackTypeEnum.ai_credits,
+            quantity=500,
+            status=PackStatusEnum.cancelled,
+            platform_subscription_id="sub_ai_reactivate",
+            cancelled_at=datetime(2024, 2, 1),
+            cancel_at_period_end=True,
+        )
+
+        with patch(
+            "src.services.packs.packs._get_redis_client",
+            return_value=redis,
+        ), patch(
+            "src.services.packs.packs.add_ai_credits",
+            side_effect=lambda org_id, amount: redis.incrby(
+                f"ai_credits_purchased:{org_id}", amount
+            ),
+        ) as add_ai_credits, patch(
+            "src.services.packs.packs.dispatch_webhooks",
+            new=Mock(),
+        ), patch(
+            "src.services.packs.packs.asyncio.create_task",
+            side_effect=_fake_create_task(fake_task),
+        ), patch(
+            "src.services.packs.packs._background_tasks",
+            new=background_tasks,
+        ):
+            reactivated = await activate_pack(
+                org.id,
+                "ai_500",
+                "sub_ai_reactivate",
+                db,
+            )
+
+        assert reactivated.status == PackStatusEnum.active
+        assert reactivated.cancel_at_period_end is False
+        assert reactivated.cancelled_at is None
+        add_ai_credits.assert_called_once_with(org.id, 500)
+        assert redis.values["ai_credits_purchased:1"] == 500
+
+    @pytest.mark.asyncio
     async def test_deactivate_pack_and_deactivate_all(self, db, org):
         redis = FakeRedis(
             {

--- a/apps/api/src/tests/services/test_playground_reactions_service.py
+++ b/apps/api/src/tests/services/test_playground_reactions_service.py
@@ -1,7 +1,8 @@
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
 
 from src.db.playground_reactions import PlaygroundReaction
 from src.db.playgrounds import Playground, PlaygroundAccessType
@@ -168,6 +169,46 @@ async def test_toggle_playground_reaction_adds_and_removes(db, playground, react
 
     assert added == {"action": "added", "emoji": ":+1:"}
     assert removed == {"action": "removed", "emoji": ":+1:"}
+
+
+@pytest.mark.asyncio
+async def test_toggle_playground_reaction_concurrent_duplicate_is_idempotent(
+    db, playground, reactor
+):
+    """Lines 127, 132: a concurrent duplicate insert raises IntegrityError on
+    commit; the guard rolls back and still reports the reaction as added
+    (idempotent) instead of surfacing a 500."""
+    current_user, _ = reactor
+
+    real_commit = db.commit
+    real_rollback = db.rollback
+    rollback_calls = {"count": 0}
+
+    async def _raising_commit():
+        # Simulate the unique-constraint violation from a racing insert.
+        raise IntegrityError("INSERT", {}, Exception("duplicate key"))
+
+    async def _tracking_rollback():
+        rollback_calls["count"] += 1
+        await real_rollback()
+
+    with patch("src.services.playgrounds.playground_reactions._check_read_access"), \
+        patch.object(db, "commit", AsyncMock(side_effect=_raising_commit)), \
+        patch.object(db, "rollback", AsyncMock(side_effect=_tracking_rollback)):
+        result = await toggle_playground_reaction(
+            request=None,
+            playground_uuid=playground.playground_uuid,
+            emoji=":+1:",
+            current_user=PublicUser.model_validate(current_user),
+            db_session=db,
+        )
+
+    assert result == {"action": "added", "emoji": ":+1:"}
+    assert rollback_calls["count"] == 1
+
+    # Restore the real session methods for any later teardown.
+    db.commit = real_commit
+    db.rollback = real_rollback
 
 
 @pytest.mark.asyncio

--- a/apps/api/src/tests/services/test_playgrounds_generator_service.py
+++ b/apps/api/src/tests/services/test_playgrounds_generator_service.py
@@ -230,4 +230,4 @@ class TestPlaygroundsGeneratorService:
                 async for chunk in generate_playground_stream("Build it", session)
             ]
 
-        assert error_chunks == ["Error: boom"]
+        assert error_chunks == ["Error: An internal error occurred while generating content."]

--- a/apps/api/src/tests/services/test_playgrounds_service.py
+++ b/apps/api/src/tests/services/test_playgrounds_service.py
@@ -685,6 +685,46 @@ class TestPlaygroundsService:
         assert remove_exc.value.status_code == 404
 
     @pytest.mark.asyncio
+    async def test_get_playground_unpublished_hidden_from_anonymous(
+        self, db, org, admin_user, anonymous_user, mock_request
+    ):
+        """Line 230: a draft (unpublished) PUBLIC playground passes the
+        access_type read check for anonymous users but must still 404 because
+        it is unpublished."""
+        await _make_playground(
+            db,
+            org,
+            admin_user,
+            playground_uuid="pg_draft_public",
+            access_type=PlaygroundAccessType.PUBLIC,
+            published=False,
+            created_by=admin_user.id,
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await get_playground(mock_request, "pg_draft_public", anonymous_user, db)
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_playground_unpublished_hidden_from_non_owner_non_admin(
+        self, db, org, admin_user, regular_user, mock_request
+    ):
+        """Line 235: a draft PUBLIC playground readable by access_type is still
+        hidden (404) from an authenticated user who is neither the owner nor an
+        org admin."""
+        await _make_playground(
+            db,
+            org,
+            admin_user,
+            playground_uuid="pg_draft_public_other",
+            access_type=PlaygroundAccessType.PUBLIC,
+            published=False,
+            created_by=admin_user.id,  # regular_user is not the owner
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await get_playground(mock_request, "pg_draft_public_other", regular_user, db)
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
     async def test_list_org_playgrounds_empty_returns_empty(
         self, db, org, admin_user, mock_request
     ):

--- a/apps/api/src/tests/services/test_playgrounds_service.py
+++ b/apps/api/src/tests/services/test_playgrounds_service.py
@@ -188,6 +188,7 @@ class TestPlaygroundsService:
             UserGroupUser(
                 usergroup_id=usergroup.id,
                 user_id=regular_user.id,
+                org_id=usergroup.org_id,
                 creation_date=str(datetime.now()),
                 update_date=str(datetime.now()),
             )
@@ -626,6 +627,7 @@ class TestPlaygroundsService:
         membership = UserGroupUser(
             usergroup_id=usergroup.id,
             user_id=admin_user.id,
+            org_id=usergroup.org_id,
             creation_date=str(datetime.now()),
             update_date=str(datetime.now()),
         )

--- a/apps/api/src/tests/services/test_rate_limiting_service.py
+++ b/apps/api/src/tests/services/test_rate_limiting_service.py
@@ -204,6 +204,49 @@ def test_check_rate_limit_increments_existing_counter():
     fake_redis.incr.assert_called_once_with("rate_limit:signup:203.0.113.9")
 
 
+def test_check_rate_limit_reasserts_expiry_when_ttl_negative():
+    # rate_limiting.py:134-135 - if the key lost its TTL (e.g. it expired between
+    # the GET and the INCR, so Redis recreated it without an expiry), the window
+    # must be re-asserted via expire() so the counter resets.
+    fake_redis = Mock()
+    fake_redis.get.return_value = b"4"
+    fake_redis.ttl.return_value = -1
+    fake_redis.incr.return_value = 5
+
+    allowed, count, retry_after = check_rate_limit(
+        key="login:203.0.113.9",
+        max_attempts=10,
+        window_seconds=90,
+        r=fake_redis,
+    )
+
+    assert allowed is True
+    assert count == 5
+    assert retry_after == 90
+    fake_redis.expire.assert_called_once_with("rate_limit:login:203.0.113.9", 90)
+
+
+def test_check_rate_limit_reasserts_expiry_when_incr_recreates_key():
+    # rate_limiting.py:134-135 via the `new_count == 1` branch: the key expired
+    # right before INCR, so INCR recreated it at 1 with no TTL.
+    fake_redis = Mock()
+    fake_redis.get.return_value = b"2"
+    fake_redis.ttl.return_value = 5
+    fake_redis.incr.return_value = 1
+
+    allowed, count, retry_after = check_rate_limit(
+        key="signup:203.0.113.9",
+        max_attempts=10,
+        window_seconds=120,
+        r=fake_redis,
+    )
+
+    assert allowed is True
+    assert count == 1
+    assert retry_after == 120
+    fake_redis.expire.assert_called_once_with("rate_limit:signup:203.0.113.9", 120)
+
+
 def test_increment_rate_limit_existing_and_missing_keys():
     fake_redis = Mock()
     fake_redis.exists.side_effect = [True, False]

--- a/apps/api/src/tests/services/test_roles_service.py
+++ b/apps/api/src/tests/services/test_roles_service.py
@@ -723,6 +723,124 @@ class TestRolesService:
         assert expected_detail in exc.value.detail
 
     @pytest.mark.asyncio
+    async def test_create_role_skips_non_dict_right_value(
+        self, db, org, admin_user, admin_role, mock_request
+    ):
+        # A raw rights dict may carry an unexpected key whose value isn't a
+        # dict. The manual validator only checks the 9 required keys, so a dict
+        # holding just those keys (plus an extra non-dict entry) stays a plain
+        # dict (it can't coerce to the Rights model, which needs more keys) and
+        # the escalation loop must skip the non-dict entry (continue) instead of
+        # raising AttributeError / HTTP 500.
+        # Copy whatever required rights the admin role carries (resilient to the
+        # required-rights set changing over time), then add an unexpected
+        # non-dict entry that the escalation loop must skip instead of crashing.
+        rights = {k: copy.deepcopy(v) for k, v in dict(admin_role.rights).items()}
+        rights["unexpected_key"] = True
+
+        with patch(
+            "src.services.roles.roles.rbac_check",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.services.roles.roles.require_org_role_permission"
+        ), patch(
+            "src.services.roles.roles.get_user_org_role",
+            return_value=admin_role,
+        ), patch(
+            "src.services.roles.roles.is_user_superadmin",
+            return_value=False,
+        ):
+            created = await create_role(
+                mock_request,
+                db,
+                RoleCreate(
+                    org_id=org.id,
+                    name="Role With Extra Key",
+                    rights=rights,
+                ),
+                admin_user,
+            )
+
+        assert created.name == "Role With Extra Key"
+
+    @pytest.mark.asyncio
+    async def test_update_role_skips_non_dict_right_value(
+        self, db, org, admin_user, admin_role, mock_request
+    ):
+        # Same defensive skip on the update path: an unexpected non-dict right
+        # entry must be skipped (continue) by the escalation check.
+        role = await _make_role(
+            db,
+            org,
+            id=60,
+            name="Update Extra Key",
+            role_uuid="role_update_extra",
+            rights=admin_role.rights,
+        )
+        # Copy whatever required rights the admin role carries (resilient to the
+        # required-rights set changing over time), then add an unexpected
+        # non-dict entry that the escalation loop must skip instead of crashing.
+        rights = {k: copy.deepcopy(v) for k, v in dict(admin_role.rights).items()}
+        rights["unexpected_key"] = True
+
+        with patch(
+            "src.services.roles.roles.require_org_role_permission"
+        ), patch(
+            "src.services.roles.roles.get_user_org_role",
+            return_value=admin_role,
+        ), patch(
+            "src.services.roles.roles.is_user_superadmin",
+            return_value=False,
+        ):
+            updated = await update_role(
+                mock_request,
+                db,
+                RoleUpdate(role_id=role.id, rights=rights),
+                admin_user,
+            )
+
+        assert updated.id == role.id
+
+    @pytest.mark.asyncio
+    async def test_update_role_blocks_permission_escalation(
+        self, db, org, admin_user, admin_role, user_role, mock_request
+    ):
+        # When the acting user lacks a permission that the updated role would
+        # grant, update_role must raise 403 (the escalation guard).
+        role = await _make_role(
+            db,
+            org,
+            id=61,
+            name="Escalate Target",
+            role_uuid="role_escalate_target",
+            rights=user_role.rights,
+        )
+        # admin rights grant permissions the limited user_role does not have
+        escalated_rights = copy.deepcopy(admin_role.rights)
+
+        with patch(
+            "src.services.roles.roles.require_org_role_permission"
+        ), patch(
+            "src.services.roles.roles.get_user_org_role",
+            new_callable=AsyncMock,
+            return_value=user_role,
+        ), patch(
+            "src.services.roles.roles.is_user_superadmin",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await update_role(
+                    mock_request,
+                    db,
+                    RoleUpdate(role_id=role.id, rights=escalated_rights),
+                    admin_user,
+                )
+
+        assert exc.value.status_code == 403
+        assert "you don't have this permission yourself" in exc.value.detail.lower()
+
+    @pytest.mark.asyncio
     async def test_delete_role_success_and_guards(
         self, db, org, admin_user, regular_user, mock_request
     ):

--- a/apps/api/src/tests/services/test_trail_service.py
+++ b/apps/api/src/tests/services/test_trail_service.py
@@ -450,6 +450,44 @@ class TestTrailService:
         assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
+    async def test_anonymous_users_are_rejected_by_trail_endpoints(
+        self, db, org, mock_request
+    ):
+        # Lines 108, 145, 220, 372, 430, 515: every trail mutation/read entry
+        # point raises 401 for AnonymousUser before touching the DB.
+        anon = AnonymousUser()
+
+        with pytest.raises(HTTPException) as create_exc:
+            await create_user_trail(
+                mock_request,
+                anon,
+                TrailCreate(org_id=org.id, user_id=0),
+                db,
+            )
+
+        with pytest.raises(HTTPException) as get_exc:
+            await get_user_trails(mock_request, anon, db)
+
+        with pytest.raises(HTTPException) as add_activity_exc:
+            await add_activity_to_trail(mock_request, anon, "any-activity", db)
+
+        with pytest.raises(HTTPException) as remove_activity_exc:
+            await remove_activity_from_trail(mock_request, anon, "any-activity", db)
+
+        with pytest.raises(HTTPException) as add_course_exc:
+            await add_course_to_trail(mock_request, anon, "any-course", db)
+
+        with pytest.raises(HTTPException) as remove_course_exc:
+            await remove_course_from_trail(mock_request, anon, "any-course", db)
+
+        assert create_exc.value.status_code == 401
+        assert get_exc.value.status_code == 401
+        assert add_activity_exc.value.status_code == 401
+        assert remove_activity_exc.value.status_code == 401
+        assert add_course_exc.value.status_code == 401
+        assert remove_course_exc.value.status_code == 401
+
+    @pytest.mark.asyncio
     async def test_add_activity_to_trail_swallows_certificate_exception(
         self, db, org, admin_user, mock_request, activity
     ):

--- a/apps/api/src/tests/services/test_trail_service.py
+++ b/apps/api/src/tests/services/test_trail_service.py
@@ -413,7 +413,8 @@ class TestTrailService:
 
         trail = await _make_trail(db, org, admin_user)
         trail_run = await _make_trail_run(db, trail, course, admin_user)
-        await _make_trail_step(db, trail, trail_run, activity, course, admin_user)
+        # One completion step per (run, activity, user) — enforced by a UNIQUE
+        # constraint. A single step is enough to verify removal deletes it.
         await _make_trail_step(db, trail, trail_run, activity, course, admin_user)
 
         removed = await remove_course_from_trail(

--- a/apps/api/src/tests/services/test_usergroups_service.py
+++ b/apps/api/src/tests/services/test_usergroups_service.py
@@ -220,6 +220,8 @@ class TestUsergroupsService:
         ), patch(
             "src.services.users.usergroups.increase_feature_usage"
         ), patch(
+            "src.services.users.usergroups.decrease_feature_usage"
+        ), patch(
             "src.services.users.usergroups.dispatch_webhooks",
             new_callable=AsyncMock,
         ):

--- a/apps/api/src/tests/services/test_usergroups_service.py
+++ b/apps/api/src/tests/services/test_usergroups_service.py
@@ -453,6 +453,46 @@ class TestUsergroupsService:
         assert log_error.call_count >= 4
 
     @pytest.mark.asyncio
+    async def test_add_remove_users_reject_non_integer_ids(
+        self, mock_request, db, org, admin_user
+    ):
+        with patch(
+            "src.services.users.usergroups.rbac_check",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.services.users.usergroups.check_limits_with_usage"
+        ), patch(
+            "src.services.users.usergroups.increase_feature_usage"
+        ), patch(
+            "src.services.users.usergroups.dispatch_webhooks",
+            new_callable=AsyncMock,
+        ):
+            usergroup = await create_usergroup(
+                mock_request,
+                db,
+                admin_user,
+                UserGroupCreate(name="UG", description="Desc", org_id=org.id),
+            )
+
+        with patch(
+            "src.services.users.usergroups.rbac_check",
+            new_callable=AsyncMock,
+        ):
+            with pytest.raises(HTTPException) as add_exc:
+                await add_users_to_usergroup(
+                    mock_request, db, admin_user, usergroup.id, "1,abc"
+                )
+            with pytest.raises(HTTPException) as remove_exc:
+                await remove_users_from_usergroup(
+                    mock_request, db, admin_user, usergroup.id, "1,xyz"
+                )
+
+        assert add_exc.value.status_code == 400
+        assert "comma-separated list of integers" in add_exc.value.detail
+        assert remove_exc.value.status_code == 400
+        assert "comma-separated list of integers" in remove_exc.value.detail
+
+    @pytest.mark.asyncio
     async def test_usergroup_user_and_resource_links(
         self, mock_request, db, org, admin_user, regular_user
     ):

--- a/apps/web/services/communities/discussions.ts
+++ b/apps/web/services/communities/discussions.ts
@@ -47,9 +47,7 @@ export interface DiscussionAuthor {
   username: string
   first_name: string
   last_name: string
-  email: string
   avatar_image: string | null
-  bio: string | null
 }
 
 export interface DiscussionWithAuthor extends Discussion {


### PR DESCRIPTION
## Summary
~145 verified high-impact backend bug fixes (security, reliability, data integrity) across `apps/api`, found via a multi-agent audit and verified against the full test suite plus a production-breakage audit.

## Verification
- Backend suite: **2734 passed** (the 4 `test_llm_ollama` failures are pre-existing — they require a live Ollama server — and are skipped in CI).
- `ruff` clean.
- A production-breakage audit was run after the fixes: client-breaking over-reach (communities limit cap, `UserReadPublic` field removal) was corrected, and follow-up security reviews on the boards default, comment-count authz, and public-profile fields were resolved.
- CI fix: two new Redis-backed calls (rate-limit, usage counter) are now mocked in tests so the no-Redis CI environment passes.

## ⚠️ Deploy prerequisites (NOT auto-applied)
- **DB migrations required** for new constraints to take effect safely (they are no-ops on existing tables until migrated):
  - `TrailRun` unique `(trail_id, course_id, user_id)` — **dedup existing rows first**
  - `TrailStep` unique `(trailrun_id, activity_id, user_id)` — **dedup first**
  - NOT NULL on `user_organizations.org_id`, `usergroup_user.*`, `usergroups.org_id` — **verify/backfill nulls first**
  - Alembic tree currently has 5 heads — resolve before generating.
- **Frontend follow-ups:** board "make public" toggle on create; graceful handling of new 403/429 responses.

## Categories
Cross-tenant / IDOR authorization · auth/session (refresh-token replay, token org-scope, no admin-grant via token) · billing/quota bypass · unbounded-input DoS/500s · non-atomic writes / data loss · sensitive-data leakage · DB model integrity · resource leaks · CORS.
