### PR TITLE
fix(api): keep export ZIP entry names POSIX on Windows (#842)

### DIFF
--- a/apps/api/src/services/courses/transfer/export_service.py
+++ b/apps/api/src/services/courses/transfer/export_service.py
@@ -343,10 +343,13 @@ def _export_directory_to_zip(
     Reads from configured storage (filesystem or S3) based on content_delivery setting.
     Skips re-compression for already-compressed media files to save CPU.
     """
+    # walk_directory yields POSIX roots (#842); normalize defensively and join
+    # with '/' so ZIP entry names never pick up os.sep ('\') on Windows.
+    source_prefix = source_path.replace("\\", "/").rstrip("/") + "/"
     for root, dirs, files in walk_directory(source_path):
         for filename in files:
-            file_path = os.path.join(root, filename)
-            rel_path = os.path.relpath(file_path, source_path)
+            file_path = f"{root.rstrip('/')}/{filename}".replace("\\", "/")
+            rel_path = file_path.removeprefix(source_prefix)
             content = read_file_content(file_path)
             if content:
                 entry_path = f"{zip_path}/{rel_path}"

--- a/apps/api/src/tests/services/test_export_service.py
+++ b/apps/api/src/tests/services/test_export_service.py
@@ -19,6 +19,7 @@ from src.db.organizations import Organization
 from src.security.rbac import AccessAction
 from src.services.courses.transfer.export_service import (
     _build_export_zip,
+    _export_directory_to_zip,
     _load_course_export_data,
     _stored_zipinfo,
     export_course,
@@ -557,6 +558,58 @@ class TestBuildExportZip:
                 _build_export_zip([("course-1", "Course 1", {}, [])], "org-1")
 
         assert not zip_path.exists()
+
+
+class TestExportDirectoryToZip:
+    def test_export_directory_to_zip_writes_posix_entries_from_windows_roots(self):
+        """ZIP entry names stay POSIX even when walk_directory roots arrive
+        with a Windows-style '\\' separator from a downstream join (#842)."""
+        from io import BytesIO
+
+        buffer = BytesIO()
+
+        def _walk_directory(source_path: str):
+            return [
+                (
+                    "content/orgs/org-1/courses/course-1/activities/activity-1",
+                    ["nested"],
+                    ["root.txt"],
+                ),
+                (
+                    "content/orgs/org-1/courses/course-1/activities/activity-1\\nested",
+                    [],
+                    ["child.txt"],
+                ),
+            ]
+
+        def _read_file_content(path: str):
+            normalized = path.replace("\\", "/")
+            mapping = {
+                "content/orgs/org-1/courses/course-1/activities/activity-1/root.txt": b"root",
+                "content/orgs/org-1/courses/course-1/activities/activity-1/nested/child.txt": b"child",
+            }
+            return mapping.get(normalized, b"")
+
+        with patch(
+            "src.services.courses.transfer.export_service.walk_directory",
+            side_effect=_walk_directory,
+        ), patch(
+            "src.services.courses.transfer.export_service.read_file_content",
+            side_effect=_read_file_content,
+        ):
+            with zipfile.ZipFile(buffer, "w") as zip_file:
+                _export_directory_to_zip(
+                    zip_file,
+                    "content/orgs/org-1/courses/course-1/activities/activity-1",
+                    "courses/course-1/chapters/chapter-1/activities/activity-1/files",
+                )
+
+        with zipfile.ZipFile(buffer) as zip_file:
+            assert set(zip_file.namelist()) == {
+                "courses/course-1/chapters/chapter-1/activities/activity-1/files/root.txt",
+                "courses/course-1/chapters/chapter-1/activities/activity-1/files/nested/child.txt",
+            }
+            assert all("\\" not in name for name in zip_file.namelist())
 
 
 class TestStoredZipInfo:

--- a/apps/api/src/tests/services/test_storage_utils_service.py
+++ b/apps/api/src/tests/services/test_storage_utils_service.py
@@ -336,6 +336,7 @@ class TestDirectoryHelpers:
             (nested_dir.as_posix(), ["deeper"], ["child.md"]),
             (deeper_dir.as_posix(), [], ["deep.pdf"]),
         ]
+        assert all("\\" not in root for root, _, _ in walked)
 
         s3_client = Mock()
         paginator = Mock()
@@ -371,6 +372,7 @@ class TestDirectoryHelpers:
             ("content/transfer/nested", ["deeper"], ["child.md"]),
             ("content/transfer/nested/deeper", [], ["deep.pdf"]),
         ]
+        assert all("\\" not in root for root, _, _ in walked)
 
         s3_client.get_paginator.side_effect = _client_error("500", "list_objects_v2")
         with patch.object(
@@ -648,6 +650,7 @@ class TestUploadAndDeleteHelpers:
             "content/course/root.txt",
             "content/course/nested/child.md",
         }
+        assert all("\\" not in key for key in uploaded_paths)
 
     def test_get_storage_client_returns_cached_client_inside_lock(self):
         """Cover line 48: inner double-check guard inside the lock returns cached client."""


### PR DESCRIPTION
## Summary

Closes #842.

PR #819 fixed `walk_directory` to yield POSIX-style roots on every platform. This PR closes the remaining gap in its only consumer.

`_export_directory_to_zip` rebuilt paths with `os.path.join` / `os.path.relpath`. On Windows those reintroduce `os.sep`, so ZIP **entry names** leaked backslashes (e.g. `.../files/nested\child.txt`) even though the walked roots were already normalized. File *reading* still worked (the local-path validator normalizes `\`→`/`), so the corruption was silent — only the archive paths were wrong.

## Changes

- `export_service.py`: build the file path and relative path with `/` and normalize defensively, so ZIP entries stay POSIX regardless of the walked separator. (`os` is still used elsewhere in the module.)
- `test_export_service.py`: new regression test `test_export_directory_to_zip_writes_posix_entries_from_windows_roots` asserting POSIX entry names even from a Windows-style walked root.
- `test_storage_utils_service.py`: explicit no-backslash contract assertions on the `walk_directory` (filesystem + S3) and `upload_directory_to_s3` tests.

## Verification

- `uv run pytest src/tests/services` → **1223 passed, 13 skipped** (Windows).
- Confirmed empirically that `os.path.relpath` returned `nested\child.txt` from a POSIX root before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)