### PR TITLE
Make library resource cards clickable (communities, boards, playgrounds, podcasts)

### DIFF
--- a/apps/web/app/orgs/[orgslug]/(withmenu)/library/library-cards.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/library/library-cards.tsx
@@ -11,6 +11,7 @@ import { getFolderThumbnailMediaDirectory } from '@services/media/media'
 import { getMediaFileDirectory } from '@services/media/media-resource'
 import { folderTone } from '@components/Dashboard/Library/LibraryToolbar'
 import { shareFolderLink } from '@components/Dashboard/Library/shareFolder'
+import { resourceHref, safeExternalUrl } from '@components/Dashboard/Library/resourceLink'
 import MediaPreview from '@components/Dashboard/Library/MediaPreview'
 import {
   FolderSimple,
@@ -120,12 +121,13 @@ export function LibraryItemCard({ item, orgslug }: { item: any; orgslug: string 
   let href: string | null = null
   let external = false
   let fileUrl: string | null = null
-  if (type === 'podcasts') {
-    href = getUriWithOrg(orgslug, `/podcasts`)
-  } else if (type === 'media') {
+  if (type === 'media') {
     if (resource.file_id) fileUrl = getMediaFileDirectory(org?.org_uuid, resource.media_uuid || item.resource_uuid, resource.file_id)
-    if (resource.media_type === 'EMBED' && resource.url) { href = resource.url; external = true }
+    if (resource.media_type === 'EMBED' && resource.url) { href = safeExternalUrl(resource.url); external = !!href }
     else if (fileUrl) { href = fileUrl; external = true }
+  } else {
+    // Podcasts, communities, boards, playgrounds → their own resource page.
+    href = resourceHref(type, resource, orgslug, 'public')
   }
   const isUpload = type === 'media' && resource.media_type !== 'EMBED'
 

--- a/apps/web/components/Dashboard/Library/LibraryItemCard.tsx
+++ b/apps/web/components/Dashboard/Library/LibraryItemCard.tsx
@@ -4,7 +4,9 @@ import ConfirmationModal from '@components/Objects/StyledElements/ConfirmationMo
 import Modal from '@components/Objects/StyledElements/Modal/Modal'
 import ManageAccessPopover from '@components/Dashboard/Library/ManageAccessPopover'
 import MediaPreview from '@components/Dashboard/Library/MediaPreview'
+import { resourceHref, safeExternalUrl } from '@components/Dashboard/Library/resourceLink'
 import { getMediaFileDirectory } from '@services/media/media-resource'
+import Link from 'next/link'
 import {
   MicrophoneStage,
   ChatsCircle,
@@ -81,12 +83,16 @@ export default function LibraryItemCard({ item, orgslug, onRemove }: Props) {
   const Icon = typeIcon(type, resource)
   const isUploadMedia = type === 'media' && resource.media_type !== 'EMBED'
 
-  let href: string | null = null
+  let href: string | null = null          // external (media file / embed url)
+  let internalHref: string | null = null  // resource detail page (same-tab)
   let fileUrl: string | null = null
   if (type === 'media') {
     if (resource.file_id) fileUrl = getMediaFileDirectory(org?.org_uuid, resource.media_uuid || item.resource_uuid, resource.file_id)
-    if (resource.media_type === 'EMBED' && resource.url) href = resource.url
+    if (resource.media_type === 'EMBED' && resource.url) href = safeExternalUrl(resource.url)
     else if (fileUrl) href = fileUrl
+  } else {
+    // Podcasts, communities, boards, playgrounds → their dashboard page.
+    internalHref = resourceHref(type, resource, orgslug, 'dashboard')
   }
   const typeLabel = t(`library.tabs.${type}`)
 
@@ -104,7 +110,7 @@ export default function LibraryItemCard({ item, orgslug, onRemove }: Props) {
         <h3 className="text-base font-bold text-gray-900 leading-tight line-clamp-1">{name}</h3>
         <div className="pt-1.5 flex items-center justify-between border-t border-gray-100">
           <span className="text-[10px] font-bold uppercase tracking-wider text-gray-400">{typeLabel}</span>
-          {href && (
+          {(href || internalHref) && (
             <span className="text-[10px] font-bold uppercase tracking-wider text-gray-400 inline-flex items-center gap-1">
               {isUploadMedia ? t('media.download') : t('library.open_resource')}
               {isUploadMedia ? <DownloadSimple size={11} /> : <ArrowSquareOut size={11} />}
@@ -161,6 +167,10 @@ export default function LibraryItemCard({ item, orgslug, onRemove }: Props) {
         <a href={href} target="_blank" rel="noopener noreferrer" className="block">
           {body}
         </a>
+      ) : internalHref ? (
+        <Link href={internalHref} className="block">
+          {body}
+        </Link>
       ) : (
         <div>{body}</div>
       )}

--- a/apps/web/components/Dashboard/Library/resourceLink.ts
+++ b/apps/web/components/Dashboard/Library/resourceLink.ts
@@ -1,0 +1,56 @@
+import { getUriWithOrg } from '@services/config/config'
+
+export type LibraryContext = 'dashboard' | 'public'
+
+/**
+ * Guard for binding an external URL to an anchor href: only allow http(s) so an
+ * untrusted scheme (e.g. javascript:) from a user-entered embed URL can't run.
+ */
+export function safeExternalUrl(url?: string | null): string | null {
+  if (!url) return null
+  return /^https?:\/\//i.test(url) ? url : null
+}
+
+/**
+ * Internal navigation URL for a resource placed in the library, by type.
+ * Mirrors each resource's canonical link (and uuid-prefix handling) used by its
+ * own card elsewhere in the app. Returns null for types handled separately
+ * (courses use CourseThumbnail; media links to its file/embed URL).
+ */
+export function resourceHref(
+  type: string,
+  resource: any,
+  orgslug: string,
+  ctx: LibraryContext
+): string | null {
+  if (!resource) return null
+  const dash = ctx === 'dashboard'
+  switch (type) {
+    case 'communities': {
+      const id = (resource.community_uuid || '').replace('community_', '')
+      return id
+        ? getUriWithOrg(orgslug, dash ? `/dash/communities/${id}/general` : `/community/${id}`)
+        : null
+    }
+    case 'boards': {
+      const id = (resource.board_uuid || '').replace('board_', '')
+      return id
+        ? getUriWithOrg(orgslug, dash ? `/dash/boards/${id}/general` : `/board/${id}`)
+        : null
+    }
+    case 'podcasts': {
+      const id = (resource.podcast_uuid || '').replace('podcast_', '')
+      return id
+        ? getUriWithOrg(orgslug, dash ? `/dash/podcasts/podcast/${id}/general` : `/podcast/${id}`)
+        : null
+    }
+    case 'playgrounds': {
+      // Playgrounds use the full prefixed uuid and have no separate dash route.
+      return resource.playground_uuid
+        ? getUriWithOrg(orgslug, `/playground/${resource.playground_uuid}`)
+        : null
+    }
+    default:
+      return null
+  }
+}


### PR DESCRIPTION
## What

In the library, only **courses** and **media** were clickable — **community, board, playground, and podcast** items rendered as dead cards in **both** the dashboard and the public area. This makes them navigate to their own resource page.

## How

A shared `resourceHref(type, resource, orgslug, ctx)` helper builds the correct link per type, mirroring each resource's existing card/list link — including the right uuid‑prefix handling and the dashboard‑vs‑public route:

| type | dashboard | public |
|---|---|---|
| communities | `/dash/communities/{id}/general` | `/community/{id}` |
| boards | `/dash/boards/{id}/general` | `/board/{id}` |
| podcasts | `/dash/podcasts/podcast/{id}/general` | `/podcast/{id}` |
| playgrounds | `/playground/{uuid}` | `/playground/{uuid}` |

Internal links use `next/link` (same tab); media keeps its external file/embed link.

## Bonus hardening

Adds `safeExternalUrl()` — user‑entered media **embed URLs** are now scheme‑checked (http/https only) before being bound to an anchor `href`, so a `javascript:` URI can't be made clickable (same XSS class flagged on the PDF link).

Stacked on the folders PR (#882); retarget to `dev` once that merges.
