### PR TITLE
Make a failed PDF preview a clickable "Open PDF" link

### DIFF
--- a/apps/web/components/Dashboard/Library/PdfThumbnail.tsx
+++ b/apps/web/components/Dashboard/Library/PdfThumbnail.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import React from 'react'
-import { FilePdf } from '@phosphor-icons/react'
+import { FilePdf, ArrowSquareOut } from '@phosphor-icons/react'
+import { useTranslation } from 'react-i18next'
 
 /**
  * Renders the FIRST PAGE of a PDF as a thumbnail image inside an
@@ -9,7 +10,8 @@ import { FilePdf } from '@phosphor-icons/react'
  * to render page 1 to a <canvas>.
  *
  * - Shows a subtle shimmer while loading.
- * - Falls back to a FilePdf icon tile on any error.
+ * - On any error (e.g. the file host is unreachable or blocks the cross-origin
+ *   fetch), falls back to a clickable "Open PDF" tile rather than a dead icon.
  */
 
 // pdfjs-dist is a heavy, browser-only dependency: import it lazily and keep a
@@ -28,6 +30,7 @@ function loadPdfjs() {
 }
 
 export default function PdfThumbnail({ url }: { url: string }) {
+  const { t } = useTranslation()
   const canvasRef = React.useRef<HTMLCanvasElement | null>(null)
   const [state, setState] = React.useState<'loading' | 'done' | 'error'>('loading')
 
@@ -85,10 +88,32 @@ export default function PdfThumbnail({ url }: { url: string }) {
   }, [url])
 
   if (state === 'error') {
+    // Page-1 render failed (unreachable file / blocked cross-origin fetch).
+    // Only offer a clickable link for http(s) URLs — never bind an untrusted
+    // scheme (e.g. javascript:) to href. Otherwise fall back to a plain tile.
+    const isHttp = /^https?:\/\//i.test(url)
+    if (!isHttp) {
+      return (
+        <div className="relative aspect-video flex items-center justify-center bg-amber-50 text-amber-500">
+          <FilePdf size={46} weight="fill" />
+        </div>
+      )
+    }
     return (
-      <div className="relative aspect-video flex items-center justify-center bg-amber-50 text-amber-500">
-        <FilePdf size={46} weight="fill" />
-      </div>
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        title={t('media.open_pdf')}
+        className="group relative aspect-video flex flex-col items-center justify-center gap-1.5 bg-amber-50 text-amber-500 hover:bg-amber-100 transition-colors"
+      >
+        <FilePdf size={42} weight="fill" />
+        <span className="inline-flex items-center gap-1 text-[11px] font-semibold text-amber-600/80 group-hover:text-amber-700">
+          {t('media.open_pdf')}
+          <ArrowSquareOut size={11} weight="bold" />
+        </span>
+      </a>
     )
   }
 

--- a/apps/web/locales/ar.json
+++ b/apps/web/locales/ar.json
@@ -5203,7 +5203,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {

--- a/apps/web/locales/bn.json
+++ b/apps/web/locales/bn.json
@@ -5212,7 +5212,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {

--- a/apps/web/locales/de.json
+++ b/apps/web/locales/de.json
@@ -5189,7 +5189,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -1251,7 +1251,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "folders": {
     "folder": "Folder",

--- a/apps/web/locales/es.json
+++ b/apps/web/locales/es.json
@@ -5189,7 +5189,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {

--- a/apps/web/locales/fr.json
+++ b/apps/web/locales/fr.json
@@ -5189,7 +5189,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {

--- a/apps/web/locales/hi.json
+++ b/apps/web/locales/hi.json
@@ -5212,7 +5212,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {

--- a/apps/web/locales/id.json
+++ b/apps/web/locales/id.json
@@ -5212,7 +5212,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {

--- a/apps/web/locales/it.json
+++ b/apps/web/locales/it.json
@@ -5189,7 +5189,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {

--- a/apps/web/locales/ja.json
+++ b/apps/web/locales/ja.json
@@ -5199,7 +5199,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {

--- a/apps/web/locales/ko.json
+++ b/apps/web/locales/ko.json
@@ -5201,7 +5201,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -5191,7 +5191,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {

--- a/apps/web/locales/pl.json
+++ b/apps/web/locales/pl.json
@@ -5214,7 +5214,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {

--- a/apps/web/locales/pt.json
+++ b/apps/web/locales/pt.json
@@ -5191,7 +5191,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {

--- a/apps/web/locales/ru.json
+++ b/apps/web/locales/ru.json
@@ -5214,7 +5214,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {

--- a/apps/web/locales/sk.json
+++ b/apps/web/locales/sk.json
@@ -5205,7 +5205,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {

--- a/apps/web/locales/th.json
+++ b/apps/web/locales/th.json
@@ -5214,7 +5214,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {

--- a/apps/web/locales/tr.json
+++ b/apps/web/locales/tr.json
@@ -5214,7 +5214,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {

--- a/apps/web/locales/uk.json
+++ b/apps/web/locales/uk.json
@@ -5221,7 +5221,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {

--- a/apps/web/locales/vi.json
+++ b/apps/web/locales/vi.json
@@ -5214,7 +5214,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {

--- a/apps/web/locales/zh.json
+++ b/apps/web/locales/zh.json
@@ -5201,7 +5201,8 @@
     "url": "URL",
     "url_required": "A URL is required",
     "upload_hint": "Images, video, audio, PDF, Office docs & ZIP",
-    "remove": "Remove"
+    "remove": "Remove",
+    "open_pdf": "Open PDF"
   },
   "access": {
     "public": {


### PR DESCRIPTION
When pdfjs can't render page 1 (file unreachable or a blocked cross-origin fetch), the card now degrades to a clickable tile that opens the PDF in a new tab instead of showing a dead icon. Adds the media.open_pdf string.