### PR TITLE
Secure private Library media files + private folders

### DIFF
--- a/apps/api/migrations/versions/5e3a9c7f1b2d_secure_media_storage_and_share_tokens.py
+++ b/apps/api/migrations/versions/5e3a9c7f1b2d_secure_media_storage_and_share_tokens.py
@@ -1,0 +1,74 @@
+"""Secure media: storage_key column + mediasharetoken table
+
+Adds `media.storage_key` (randomized, server-only storage path for uploads) and a
+`mediasharetoken` table backing random, unique, revocable copy links. Both are
+idempotent so re-running on partially-migrated DBs is safe.
+
+Revision ID: 5e3a9c7f1b2d
+Revises: d4e5f6a7b8c9
+Create Date: 2026-06-23
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel  # noqa: F401
+
+
+# revision identifiers, used by Alembic.
+revision: str = '5e3a9c7f1b2d'
+down_revision: Union[str, None] = 'd4e5f6a7b8c9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = set(inspector.get_table_names())
+
+    # media.storage_key (idempotent)
+    if 'media' in tables:
+        cols = {c['name'] for c in inspector.get_columns('media')}
+        if 'storage_key' not in cols:
+            op.add_column(
+                'media',
+                sa.Column(
+                    'storage_key',
+                    sqlmodel.sql.sqltypes.AutoString(),
+                    nullable=True,
+                    server_default='',
+                ),
+            )
+
+    # mediasharetoken table (idempotent)
+    if 'mediasharetoken' not in tables:
+        op.create_table(
+            'mediasharetoken',
+            sa.Column('id', sa.Integer(), primary_key=True, nullable=False),
+            sa.Column('token', sqlmodel.sql.sqltypes.AutoString(), nullable=False, server_default=''),
+            sa.Column('media_uuid', sqlmodel.sql.sqltypes.AutoString(), nullable=False, server_default=''),
+            sa.Column('org_id', sa.BigInteger(), nullable=False),
+            sa.Column('created_by_user_id', sa.Integer(), nullable=True),
+            sa.Column('revoked', sa.Boolean(), nullable=False, server_default=sa.false()),
+            sa.Column('creation_date', sqlmodel.sql.sqltypes.AutoString(), nullable=False, server_default=''),
+            sa.Column('update_date', sqlmodel.sql.sqltypes.AutoString(), nullable=False, server_default=''),
+            sa.ForeignKeyConstraint(['org_id'], ['organization.id'], ondelete='CASCADE'),
+        )
+        op.create_index('ix_mediasharetoken_token', 'mediasharetoken', ['token'])
+        op.create_index('ix_mediasharetoken_media_uuid', 'mediasharetoken', ['media_uuid'])
+        op.create_index('ix_mediasharetoken_org_id', 'mediasharetoken', ['org_id'])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = set(inspector.get_table_names())
+
+    if 'mediasharetoken' in tables:
+        op.drop_table('mediasharetoken')
+    if 'media' in tables:
+        cols = {c['name'] for c in inspector.get_columns('media')}
+        if 'storage_key' in cols:
+            op.drop_column('media', 'storage_key')

--- a/apps/api/migrations/versions/5e3a9c7f1b2d_secure_media_storage_and_share_tokens.py
+++ b/apps/api/migrations/versions/5e3a9c7f1b2d_secure_media_storage_and_share_tokens.py
@@ -5,7 +5,7 @@ Adds `media.storage_key` (randomized, server-only storage path for uploads) and 
 idempotent so re-running on partially-migrated DBs is safe.
 
 Revision ID: 5e3a9c7f1b2d
-Revises: d4e5f6a7b8c9
+Revises: f7a8b9c0d1e2
 Create Date: 2026-06-23
 
 """
@@ -18,7 +18,7 @@ import sqlmodel  # noqa: F401
 
 # revision identifiers, used by Alembic.
 revision: str = '5e3a9c7f1b2d'
-down_revision: Union[str, None] = 'd4e5f6a7b8c9'
+down_revision: Union[str, None] = 'f7a8b9c0d1e2'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/apps/api/migrations/versions/7f2b9d1c3e4a_merge_secure_media_and_drop_collections.py
+++ b/apps/api/migrations/versions/7f2b9d1c3e4a_merge_secure_media_and_drop_collections.py
@@ -1,0 +1,32 @@
+"""Merge the secure-media and drop-collections branches
+
+`5e3a9c7f1b2d` (secure media: storage_key + mediasharetoken) and `d4e5f6a7b8c9`
+(drop legacy collections) both branch off `f7a8b9c0d1e2`. This is a no-op merge
+node so the history has a single head.
+
+Why the split: the secure-media schema is decoupled from the *destructive*
+collections drop so production can apply ONLY the secure-media migration
+(`alembic upgrade 5e3a9c7f1b2d`) without dropping any collections. `alembic
+upgrade head` applies both plus this merge.
+
+Revision ID: 7f2b9d1c3e4a
+Revises: 5e3a9c7f1b2d, d4e5f6a7b8c9
+Create Date: 2026-06-23
+
+"""
+from typing import Sequence, Union
+
+
+# revision identifiers, used by Alembic.
+revision: str = '7f2b9d1c3e4a'
+down_revision: Union[str, Sequence[str], None] = ('5e3a9c7f1b2d', 'd4e5f6a7b8c9')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/apps/api/migrations/versions/d4e5f6a7b8c9_drop_collections_tables.py
+++ b/apps/api/migrations/versions/d4e5f6a7b8c9_drop_collections_tables.py
@@ -1,0 +1,75 @@
+"""Drop the legacy collection / collectioncourse tables
+
+Collections are fully replaced by the folders model (see f7a8b9c0d1e2). This
+migration removes the legacy tables for good. It is intentionally a separate,
+dedicated revision so the destructive drop is reviewed and deployed on its own,
+independently of the additive folders/media work.
+
+This also reconciles environments where f7a8b9c0d1e2 was stamped from an earlier
+build whose upgrade() never actually executed the drop (Alembic keys off the
+revision id, not file contents) — those DBs still have the collection tables and
+this revision is what removes them.
+
+Revision ID: d4e5f6a7b8c9
+Revises: f7a8b9c0d1e2
+Create Date: 2026-06-22
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel  # noqa: F401
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd4e5f6a7b8c9'
+down_revision: Union[str, None] = 'f7a8b9c0d1e2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = set(inspector.get_table_names())
+
+    # Child table first (FK collectioncourse.collection_id -> collection.id).
+    if 'collectioncourse' in tables:
+        op.drop_table('collectioncourse')
+    if 'collection' in tables:
+        op.drop_table('collection')
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = set(inspector.get_table_names())
+
+    # Recreate the legacy tables (minimal shape) so the drop is reversible.
+    if 'collection' not in tables:
+        op.create_table(
+            'collection',
+            sa.Column('id', sa.Integer(), primary_key=True, nullable=False),
+            sa.Column('org_id', sa.BigInteger(), nullable=False),
+            sa.Column('collection_uuid', sqlmodel.sql.sqltypes.AutoString(), nullable=False, server_default=''),
+            sa.Column('name', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+            sa.Column('public', sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column('description', sqlmodel.sql.sqltypes.AutoString(), nullable=True, server_default=''),
+            sa.Column('creation_date', sqlmodel.sql.sqltypes.AutoString(), nullable=False, server_default=''),
+            sa.Column('update_date', sqlmodel.sql.sqltypes.AutoString(), nullable=False, server_default=''),
+            sa.ForeignKeyConstraint(['org_id'], ['organization.id'], ondelete='CASCADE'),
+        )
+    if 'collectioncourse' not in tables:
+        op.create_table(
+            'collectioncourse',
+            sa.Column('id', sa.Integer(), primary_key=True, nullable=False),
+            sa.Column('collection_id', sa.Integer(), nullable=False),
+            sa.Column('course_id', sa.Integer(), nullable=False),
+            sa.Column('org_id', sa.Integer(), nullable=False),
+            sa.Column('creation_date', sqlmodel.sql.sqltypes.AutoString(), nullable=False, server_default=''),
+            sa.Column('update_date', sqlmodel.sql.sqltypes.AutoString(), nullable=False, server_default=''),
+            sa.ForeignKeyConstraint(['collection_id'], ['collection.id'], ondelete='CASCADE'),
+            sa.ForeignKeyConstraint(['course_id'], ['course.id'], ondelete='CASCADE'),
+            sa.ForeignKeyConstraint(['org_id'], ['organization.id'], ondelete='CASCADE'),
+        )

--- a/apps/api/src/db/media/media.py
+++ b/apps/api/src/db/media/media.py
@@ -30,6 +30,10 @@ class Media(MediaBase, table=True):
     media_uuid: str = Field(default="", index=True)
     # For UPLOAD — file metadata (mirrors BlockFile shape)
     file_id: Optional[str] = ""
+    # Randomized, server-only relative storage key (under content/). New uploads
+    # set this; it is NEVER returned to clients, so the storage path cannot be
+    # derived from public identifiers. Legacy rows leave it empty (reconstructed).
+    storage_key: Optional[str] = ""
     file_format: Optional[str] = ""
     file_size: Optional[int] = Field(default=None, sa_column=Column(Integer, nullable=True))
     file_mime: Optional[str] = ""
@@ -55,7 +59,10 @@ class MediaRead(MediaBase):
     id: int
     org_id: int
     media_uuid: str
-    file_id: Optional[str] = ""
+    # NOTE: the storage-locating fields (file_id / storage_key) are intentionally
+    # NOT exposed — clients load bytes via GET /media/{media_uuid}/file only, so
+    # the storage path is never derivable. file_format/size/mime are safe metadata
+    # the UI needs to pick the right preview.
     file_format: Optional[str] = ""
     file_size: Optional[int] = None
     file_mime: Optional[str] = ""

--- a/apps/api/src/db/media/media_share_token.py
+++ b/apps/api/src/db/media/media_share_token.py
@@ -1,0 +1,25 @@
+from typing import Optional
+
+from sqlalchemy import BigInteger, Column, ForeignKey
+from sqlmodel import Field, SQLModel
+
+
+class MediaShareToken(SQLModel, table=True):
+    """A random, opaque, revocable token for a copyable media share link.
+
+    Each "Copy link" mints a NEW row, so the link is unique every time and is not
+    derivable from the media_uuid. The token is NOT an access bypass — the resolve
+    endpoint still enforces the requesting user's access to the media.
+    """
+    id: Optional[int] = Field(default=None, primary_key=True)
+    token: str = Field(default="", index=True)
+    media_uuid: str = Field(default="", index=True)
+    org_id: int = Field(
+        sa_column=Column(
+            BigInteger, ForeignKey("organization.id", ondelete="CASCADE"), index=True
+        )
+    )
+    created_by_user_id: Optional[int] = None
+    revoked: bool = False
+    creation_date: str = ""
+    update_date: str = ""

--- a/apps/api/src/routers/content_files.py
+++ b/apps/api/src/routers/content_files.py
@@ -101,6 +101,7 @@ async def _check_content_access(
     file_path: str,
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
+    request: Request | None = None,
 ) -> None:
     """
     Check if the user has access to the requested content.
@@ -179,6 +180,20 @@ async def _check_content_access(
             raise HTTPException(status_code=403, detail="Access denied")
         return
 
+    # Library media content: enforce the media's (folder-aware) access. Closes
+    # the legacy hole where orgs/{}/media/... fell through to the public branch.
+    if len(parts) >= 4 and parts[0] == 'orgs' and parts[2] == 'media':
+        from src.security.rbac import check_resource_access, AccessAction
+        media_uuid = parts[3]  # legacy keys embed media_uuid as the directory
+        if media_uuid.startswith('media_'):
+            await check_resource_access(
+                request, db_session, current_user, media_uuid, AccessAction.READ
+            )
+            return
+        # Randomized keys don't embed the media_uuid → deny direct /content
+        # access (these are only served via /media/{uuid}/file).
+        raise HTTPException(status_code=403, detail="Access denied")
+
     # Course metadata (thumbnails, etc.) and org-level content — always public
     if len(parts) >= 2 and parts[0] == 'orgs':
         return
@@ -221,7 +236,7 @@ async def serve_content_file(
     if safe_path is None:
         raise HTTPException(status_code=400, detail="Invalid path")
 
-    await _check_content_access(safe_path, current_user, db_session)
+    await _check_content_access(safe_path, current_user, db_session, request=request)
 
     s3_key = f"content/{safe_path}"
     s3_client = get_storage_client()
@@ -350,6 +365,7 @@ async def serve_content_file(
     },
 )
 async def head_content_file(
+    request: Request,
     file_path: str,
     current_user: PublicUser | AnonymousUser | APITokenUser = Depends(get_current_user),
     db_session: AsyncSession = Depends(get_db_session),
@@ -359,7 +375,7 @@ async def head_content_file(
     if safe_path is None:
         raise HTTPException(status_code=400, detail="Invalid path")
 
-    await _check_content_access(safe_path, current_user, db_session)
+    await _check_content_access(safe_path, current_user, db_session, request=request)
 
     s3_key = f"content/{safe_path}"
     s3_client = get_storage_client()

--- a/apps/api/src/routers/local_content.py
+++ b/apps/api/src/routers/local_content.py
@@ -58,6 +58,7 @@ async def _check_content_access(
     file_path: str,
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
+    request: Request | None = None,
 ) -> None:
     """
     Check if the user has access to the requested content.
@@ -136,6 +137,20 @@ async def _check_content_access(
             raise HTTPException(status_code=403, detail="Access denied")
         return
 
+    # Library media content: enforce the media's (folder-aware) access. Closes
+    # the legacy hole where orgs/{}/media/... fell through to the public branch.
+    if len(parts) >= 4 and parts[0] == 'orgs' and parts[2] == 'media':
+        from src.security.rbac import check_resource_access, AccessAction
+        media_uuid = parts[3]  # legacy keys embed media_uuid as the directory
+        if media_uuid.startswith('media_'):
+            await check_resource_access(
+                request, db_session, current_user, media_uuid, AccessAction.READ
+            )
+            return
+        # Randomized keys don't embed the media_uuid → deny direct /content
+        # access (these are only served via /media/{uuid}/file).
+        raise HTTPException(status_code=403, detail="Access denied")
+
     # Course metadata (thumbnails, etc.) and org-level content — always public
     # These are displayed on listing pages to all users
     if len(parts) >= 2 and parts[0] == 'orgs':
@@ -203,7 +218,7 @@ async def serve_local_content(
     if resolved is None:
         raise HTTPException(status_code=400, detail="Invalid path")
 
-    await _check_content_access(file_path, current_user, db_session)
+    await _check_content_access(file_path, current_user, db_session, request=request)
 
     if not resolved.is_file():
         raise HTTPException(status_code=404, detail="File not found")
@@ -244,7 +259,7 @@ async def head_local_content(
     if resolved is None:
         raise HTTPException(status_code=400, detail="Invalid path")
 
-    await _check_content_access(file_path, current_user, db_session)
+    await _check_content_access(file_path, current_user, db_session, request=request)
 
     if not resolved.is_file():
         raise HTTPException(status_code=404, detail="File not found")

--- a/apps/api/src/routers/media/media.py
+++ b/apps/api/src/routers/media/media.py
@@ -10,10 +10,80 @@ from src.services.media.media import (
     get_media_list,
     update_media,
     delete_media,
+    authorize_media_file,
+    authorize_share_token,
+    create_media_share_link,
 )
+from src.services.media.media_serve import serve_media_file
 
 
 router = APIRouter()
+
+
+# --- File serving (the ONLY way the client loads media bytes) ----------------
+
+@router.get(
+    "/{media_uuid}/file",
+    summary="Serve a media file",
+    description="Streams the media file's bytes after enforcing access (folder-aware). The storage path is never exposed to the client. Supports Range requests.",
+)
+async def api_serve_media_file(
+    request: Request,
+    media_uuid: str,
+    current_user=Depends(get_current_user),
+    db_session=Depends(get_db_session),
+):
+    media, is_public = await authorize_media_file(request, media_uuid, current_user, db_session)
+    return await serve_media_file(request, media, db_session, is_public=is_public)
+
+
+@router.head("/{media_uuid}/file", summary="Media file metadata")
+async def api_head_media_file(
+    request: Request,
+    media_uuid: str,
+    current_user=Depends(get_current_user),
+    db_session=Depends(get_db_session),
+):
+    media, is_public = await authorize_media_file(request, media_uuid, current_user, db_session)
+    return await serve_media_file(request, media, db_session, is_public=is_public, head=True)
+
+
+# --- Shareable copy link (random + unique every call) ------------------------
+
+@router.post(
+    "/{media_uuid}/share-link",
+    summary="Create a media share link",
+    description="Mints a fresh random, revocable token each call. The link is NOT an access bypass — recipients still need access.",
+)
+async def api_create_media_share_link(
+    request: Request,
+    media_uuid: str,
+    current_user: PublicUser = Depends(get_current_user),
+    db_session=Depends(get_db_session),
+):
+    return await create_media_share_link(request, media_uuid, current_user, db_session)
+
+
+@router.get("/shared/{token}/file", summary="Serve a shared media file by token")
+async def api_serve_shared_media(
+    request: Request,
+    token: str,
+    current_user=Depends(get_current_user),
+    db_session=Depends(get_db_session),
+):
+    media, is_public = await authorize_share_token(request, token, current_user, db_session)
+    return await serve_media_file(request, media, db_session, is_public=is_public)
+
+
+@router.head("/shared/{token}/file", summary="Shared media file metadata by token")
+async def api_head_shared_media(
+    request: Request,
+    token: str,
+    current_user=Depends(get_current_user),
+    db_session=Depends(get_db_session),
+):
+    media, is_public = await authorize_share_token(request, token, current_user, db_session)
+    return await serve_media_file(request, media, db_session, is_public=is_public, head=True)
 
 
 @router.post(

--- a/apps/api/src/security/rbac/resource_access.py
+++ b/apps/api/src/security/rbac/resource_access.py
@@ -723,10 +723,22 @@ class ResourceAccessChecker:
         else:
             is_public = getattr(resource, 'public', False)
             is_published = getattr(resource, 'published', True) if config.has_published_field else True
+            # Media privacy is folder-aware: a file placed in ANY private folder
+            # is private even if its own `public` flag is True (most-restrictive
+            # wins). This makes a direct media read deny for a public media that
+            # lives inside a private folder, for every caller of check_access.
+            if is_public and config.resource_type == "media":
+                if await self._media_in_any_private_folder(resource_uuid):
+                    is_public = False
             result = (is_public, is_published)
 
         self._public_published_cache[resource_uuid] = result
         return result
+
+    async def _media_in_any_private_folder(self, media_uuid: str) -> bool:
+        """True if this media is placed in at least one non-public folder."""
+        from src.services.media.media_access import media_in_any_private_folder
+        return await media_in_any_private_folder(self.db_session, media_uuid)
 
     async def _is_resource_author(self, resource_uuid: str) -> bool:
         """Check if current user is the author of the resource."""

--- a/apps/api/src/services/media/media.py
+++ b/apps/api/src/services/media/media.py
@@ -1,3 +1,4 @@
+import secrets
 from datetime import datetime
 from typing import List, Optional
 from uuid import uuid4
@@ -20,8 +21,10 @@ from src.db.resource_authors import (
     ResourceAuthorshipEnum,
     ResourceAuthorshipStatusEnum,
 )
+from src.db.media.media_share_token import MediaShareToken
 from src.security.auth import resolve_acting_user_id
 from src.security.rbac import check_resource_access, AccessAction
+from src.services.media.media_access import media_in_any_private_folder
 from src.services.utils.upload_content import upload_file
 
 
@@ -76,9 +79,13 @@ async def create_media(
         if file is None:
             raise HTTPException(status_code=400, detail="A file is required for UPLOAD media")
         org_uuid = await _get_org_uuid(db_session, media_object.org_id)
+        # Randomize BOTH the directory and the filename so the storage path is
+        # not derivable from the media_uuid (which is returned in API responses).
+        rand_dir = secrets.token_urlsafe(16)
+        directory = f"media/{rand_dir}"
         filename = await upload_file(
             file=file,
-            directory=f"media/{media.media_uuid}",
+            directory=directory,
             type_of_dir="orgs",
             uuid=org_uuid,
             allowed_types=ALLOWED_MEDIA_TYPES,
@@ -86,6 +93,8 @@ async def create_media(
         )
         parts = filename.rsplit(".", 1)
         media.file_id = filename
+        # Server-only key (under content/), never returned to clients.
+        media.storage_key = f"orgs/{org_uuid}/{directory}/{filename}"
         media.file_format = parts[1] if len(parts) > 1 else ""
         media.file_mime = file.content_type or ""
         try:
@@ -224,6 +233,104 @@ async def get_media_list(
     statement = select(Media).where(Media.org_id == int(org_id))
     if anonymous:
         statement = statement.where(Media.public == True)  # noqa: E712
+        # Most-restrictive: also hide media that sit in any private folder.
+        from src.db.folders.folder_content import FolderContent
+        from src.db.folders.folders import Folder
+
+        private_media = (
+            select(FolderContent.resource_uuid)
+            .join(Folder, Folder.id == FolderContent.folder_id)
+            .where(Folder.public == False)  # noqa: E712
+        )
+        statement = statement.where(Media.media_uuid.not_in(private_media))
     statement = statement.offset((page - 1) * limit).limit(limit)
     media_items = (await db_session.execute(statement)).scalars().all()
     return [MediaRead.model_validate(m) for m in media_items]
+
+
+# ---------------------------------------------------------------------------
+# File serving + shareable links
+# ---------------------------------------------------------------------------
+
+async def authorize_media_file(
+    request: Request,
+    media_uuid: str,
+    current_user: PublicUser | AnonymousUser,
+    db_session: AsyncSession,
+):
+    """Load media and enforce (folder-aware) READ access. Returns (media, is_public)."""
+    media = (
+        await db_session.execute(select(Media).where(Media.media_uuid == media_uuid))
+    ).scalars().first()
+    if not media:
+        raise HTTPException(status_code=404, detail="Media not found")
+    await check_resource_access(
+        request, db_session, current_user, media.media_uuid, AccessAction.READ
+    )
+    is_public = bool(media.public) and not await media_in_any_private_folder(
+        db_session, media.media_uuid
+    )
+    return media, is_public
+
+
+async def create_media_share_link(
+    request: Request,
+    media_uuid: str,
+    current_user: PublicUser,
+    db_session: AsyncSession,
+) -> dict:
+    """Mint a NEW random token (unique every call) for a media the caller can read."""
+    media = (
+        await db_session.execute(select(Media).where(Media.media_uuid == media_uuid))
+    ).scalars().first()
+    if not media:
+        raise HTTPException(status_code=404, detail="Media not found")
+    await check_resource_access(
+        request, db_session, current_user, media.media_uuid, AccessAction.READ
+    )
+    token = secrets.token_urlsafe(32)
+    db_session.add(
+        MediaShareToken(
+            token=token,
+            media_uuid=media.media_uuid,
+            org_id=media.org_id,
+            created_by_user_id=resolve_acting_user_id(current_user) or None,
+            revoked=False,
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+    )
+    await db_session.commit()
+    return {"token": token}
+
+
+async def authorize_share_token(
+    request: Request,
+    token: str,
+    current_user: PublicUser | AnonymousUser,
+    db_session: AsyncSession,
+):
+    """Resolve a share token → media, then enforce the REQUESTING user's access.
+
+    The token is NOT an access bypass: an anonymous/unauthorized recipient is
+    still denied. Returns (media, is_public).
+    """
+    row = (
+        await db_session.execute(
+            select(MediaShareToken).where(MediaShareToken.token == token)
+        )
+    ).scalars().first()
+    if not row or row.revoked:
+        raise HTTPException(status_code=404, detail="Invalid or expired link")
+    media = (
+        await db_session.execute(select(Media).where(Media.media_uuid == row.media_uuid))
+    ).scalars().first()
+    if not media:
+        raise HTTPException(status_code=404, detail="Media not found")
+    await check_resource_access(
+        request, db_session, current_user, media.media_uuid, AccessAction.READ
+    )
+    is_public = bool(media.public) and not await media_in_any_private_folder(
+        db_session, media.media_uuid
+    )
+    return media, is_public

--- a/apps/api/src/services/media/media_access.py
+++ b/apps/api/src/services/media/media_access.py
@@ -1,0 +1,35 @@
+"""Shared media-access helpers (folder-aware privacy)."""
+
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+async def media_in_any_private_folder(db_session: AsyncSession, media_uuid: str) -> bool:
+    """True if this media is placed in at least one non-public folder.
+
+    Most-restrictive rule: a file inside any private folder is private even if its
+    own `public` flag is True. Root-level placements (folder_id NULL) impose no
+    constraint. Used both by the RBAC public-check and the file endpoint.
+    """
+    from src.db.folders.folder_content import FolderContent
+    from src.db.folders.folders import Folder
+
+    folder_ids = (
+        await db_session.execute(
+            select(FolderContent.folder_id).where(
+                FolderContent.resource_uuid == media_uuid,
+                FolderContent.folder_id.is_not(None),
+            )
+        )
+    ).scalars().all()
+    if not folder_ids:
+        return False
+    private = (
+        await db_session.execute(
+            select(Folder.id).where(
+                Folder.id.in_(folder_ids),
+                Folder.public == False,  # noqa: E712
+            )
+        )
+    ).scalars().first()
+    return private is not None

--- a/apps/api/src/services/media/media_serve.py
+++ b/apps/api/src/services/media/media_serve.py
@@ -1,0 +1,186 @@
+"""
+Authenticated serving of Library media file bytes.
+
+The client never receives a direct storage URL — media bytes are streamed
+through the API after an access check (see the /media/{uuid}/file endpoint).
+Handles both filesystem and s3/R2 delivery, with HTTP Range support.
+"""
+
+from pathlib import Path
+
+from botocore.exceptions import ClientError
+from fastapi import HTTPException, Request
+from fastapi.responses import FileResponse, Response, StreamingResponse
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.db.media.media import Media, MediaTypeEnum
+from src.db.organizations import Organization
+from src.services.courses.transfer.storage_utils import (
+    get_content_delivery_type,
+    get_s3_bucket_name,
+    get_storage_client,
+)
+
+CHUNK_SIZE = 1024 * 1024  # 1MB
+
+_MIME_TYPES = {
+    '.mp4': 'video/mp4', '.webm': 'video/webm', '.mov': 'video/quicktime',
+    '.mp3': 'audio/mpeg', '.wav': 'audio/wav', '.ogg': 'audio/ogg', '.m4a': 'audio/mp4',
+    '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.png': 'image/png', '.gif': 'image/gif',
+    '.webp': 'image/webp', '.pdf': 'application/pdf',
+    '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    '.doc': 'application/msword', '.xls': 'application/vnd.ms-excel',
+    '.ppt': 'application/vnd.ms-powerpoint', '.zip': 'application/zip',
+}
+
+
+def _mime_for(key: str) -> str:
+    return _MIME_TYPES.get(Path(key).suffix.lower(), 'application/octet-stream')
+
+
+async def _resolve_storage_key(db_session: AsyncSession, media: Media) -> str:
+    """Return the relative storage key (under `content/`), randomized for new
+    uploads (`media.storage_key`), or reconstructed for legacy rows."""
+    key = getattr(media, 'storage_key', None)
+    if key:
+        return key
+    if not media.file_id:
+        raise HTTPException(status_code=404, detail="File not found")
+    org = (
+        await db_session.execute(select(Organization).where(Organization.id == media.org_id))
+    ).scalars().first()
+    if not org:
+        raise HTTPException(status_code=404, detail="File not found")
+    return f"orgs/{org.org_uuid}/media/{media.media_uuid}/{media.file_id}"
+
+
+def _headers(mime: str, is_public: bool) -> dict:
+    cache = "public, max-age=86400" if is_public else "private, no-store"
+    return {
+        "Content-Type": mime,
+        "Accept-Ranges": "bytes",
+        "Cache-Control": cache,
+        "X-Content-Type-Options": "nosniff",
+    }
+
+
+def _parse_range(range_header: str, file_size: int):
+    spec = range_header.replace('bytes=', '')
+    if spec.startswith('-'):
+        start = max(0, file_size - int(spec[1:]))
+        end = file_size - 1
+    elif spec.endswith('-'):
+        start = int(spec[:-1])
+        end = file_size - 1
+    else:
+        a, _, b = spec.partition('-')
+        start = int(a)
+        end = int(b) if b else file_size - 1
+    start = max(0, min(start, file_size - 1))
+    end = max(start, min(end, file_size - 1))
+    return start, end
+
+
+async def serve_media_file(
+    request: Request,
+    media: Media,
+    db_session: AsyncSession,
+    *,
+    is_public: bool,
+    head: bool = False,
+) -> Response:
+    """Stream (or HEAD) a media file's bytes after the caller has already
+    authorized access. `is_public` only controls caching headers."""
+    if media.media_type != MediaTypeEnum.UPLOAD:
+        raise HTTPException(status_code=404, detail="This media has no file")
+
+    rel_key = await _resolve_storage_key(db_session, media)
+    mime = media.file_mime or _mime_for(rel_key)
+    headers = _headers(mime, is_public)
+    range_header = request.headers.get("range")
+
+    if get_content_delivery_type() == "s3api":
+        return _serve_s3(rel_key, mime, headers, range_header, head)
+    return _serve_fs(rel_key, mime, headers, range_header, head)
+
+
+def _serve_fs(rel_key, mime, headers, range_header, head):
+    path = Path("content") / rel_key
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+    file_size = path.stat().st_size
+    if head:
+        return Response(status_code=200, headers={**headers, "Content-Length": str(file_size)})
+    if range_header:
+        start, end = _parse_range(range_header, file_size)
+        length = end - start + 1
+
+        def stream():
+            with open(path, 'rb') as f:
+                f.seek(start)
+                remaining = length
+                while remaining > 0:
+                    data = f.read(min(CHUNK_SIZE, remaining))
+                    if not data:
+                        break
+                    remaining -= len(data)
+                    yield data
+
+        return StreamingResponse(
+            stream(), status_code=206, media_type=mime,
+            headers={**headers, "Content-Range": f"bytes {start}-{end}/{file_size}", "Content-Length": str(length)},
+        )
+    # Full file — FileResponse handles efficient sending.
+    return FileResponse(path=str(path), media_type=mime, headers=headers)
+
+
+def _serve_s3(rel_key, mime, headers, range_header, head):
+    s3 = get_storage_client()
+    bucket = get_s3_bucket_name()
+    if not s3:
+        raise HTTPException(status_code=500, detail="Storage not configured")
+    s3_key = f"content/{rel_key}"
+    try:
+        meta = s3.head_object(Bucket=bucket, Key=s3_key)
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code in ("NoSuchKey", "404"):
+            raise HTTPException(status_code=404, detail="File not found")
+        if code in ("AccessDenied", "403"):
+            raise HTTPException(status_code=403, detail="Access denied")
+        raise HTTPException(status_code=502, detail="Storage service error")
+    except Exception:
+        raise HTTPException(status_code=502, detail="Storage service error")
+
+    file_size = meta['ContentLength']
+    if head:
+        return Response(status_code=200, headers={**headers, "Content-Length": str(file_size)})
+
+    start, end = (0, file_size - 1)
+    status = 200
+    if range_header:
+        start, end = _parse_range(range_header, file_size)
+        status = 206
+        headers = {**headers, "Content-Range": f"bytes {start}-{end}/{file_size}"}
+    length = end - start + 1
+    headers = {**headers, "Content-Length": str(length)}
+
+    def stream():
+        pos, remaining = start, length
+        while remaining > 0:
+            chunk_end = min(pos + CHUNK_SIZE - 1, end)
+            resp = s3.get_object(Bucket=bucket, Key=s3_key, Range=f"bytes={pos}-{chunk_end}")
+            try:
+                data = resp['Body'].read()
+            finally:
+                resp['Body'].close()
+            if not data:
+                break
+            remaining -= len(data)
+            pos += len(data)
+            yield data
+
+    return StreamingResponse(stream(), status_code=status, media_type=mime, headers=headers)

--- a/apps/api/src/tests/routers/test_media_router.py
+++ b/apps/api/src/tests/routers/test_media_router.py
@@ -104,7 +104,9 @@ class TestMediaRouter:
             )
         assert res.status_code == 200, res.text
         body = res.json()
-        assert body["file_id"] == "abc_media.pdf"
+        # file_id / storage_key are intentionally NOT exposed to clients now.
+        assert "file_id" not in body
+        assert "storage_key" not in body
         assert body["file_format"] == "pdf"
 
     async def test_create_upload_without_file_400(self, client, org):

--- a/apps/api/src/tests/routers/test_media_serve_router.py
+++ b/apps/api/src/tests/routers/test_media_serve_router.py
@@ -194,3 +194,96 @@ class TestShareEndpoints:
     async def test_unknown_token_404(self, client):
         res = await client.get("/api/v1/media/shared/nope/file")
         assert res.status_code == 404
+
+
+class TestServeEdges:
+    async def test_range_suffix(self, client, db, org, fs_file):
+        m = await _mk_media(db, org, storage_key=fs_file, name="suffix")
+        res = await client.get(f"/api/v1/media/{m.media_uuid}/file", headers={"Range": "bytes=-100"})
+        assert res.status_code == 206
+        assert res.content == PDF_BYTES[-100:]
+
+    async def test_range_prefix_open_ended(self, client, db, org, fs_file):
+        m = await _mk_media(db, org, storage_key=fs_file, name="prefix")
+        start = len(PDF_BYTES) - 50
+        res = await client.get(f"/api/v1/media/{m.media_uuid}/file", headers={"Range": f"bytes={start}-"})
+        assert res.status_code == 206
+        assert res.content == PDF_BYTES[start:]
+
+    async def test_unknown_extension_uses_octet_stream(self, client, db, org):
+        rel = "orgs/org_test/media/randdir/blob.xyz"
+        path = Path("content") / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"raw bytes")
+        m = Media(
+            name="blob", media_type=MediaTypeEnum.UPLOAD, public=True, org_id=org.id,
+            media_uuid="media_blob", file_id="blob.xyz", storage_key=rel,
+            file_format="xyz", file_mime="",  # empty mime -> _mime_for fallback
+            creation_date=str(datetime.now()), update_date=str(datetime.now()),
+        )
+        db.add(m)
+        await db.commit()
+        try:
+            res = await client.get(f"/api/v1/media/{m.media_uuid}/file")
+            assert res.status_code == 200
+            assert res.headers["content-type"].startswith("application/octet-stream")
+        finally:
+            shutil.rmtree(Path("content") / "orgs" / "org_test", ignore_errors=True)
+
+    async def test_legacy_no_file_id_404(self, client, db, org):
+        m = Media(
+            name="nofile", media_type=MediaTypeEnum.UPLOAD, public=True, org_id=org.id,
+            media_uuid="media_nofile", file_id="", storage_key="",
+            creation_date=str(datetime.now()), update_date=str(datetime.now()),
+        )
+        db.add(m)
+        await db.commit()
+        res = await client.get(f"/api/v1/media/{m.media_uuid}/file")
+        assert res.status_code == 404
+
+    async def test_legacy_org_not_found_404(self, client, db, org):
+        m = Media(
+            name="noorg", media_type=MediaTypeEnum.UPLOAD, public=True, org_id=999999,
+            media_uuid="media_noorg", file_id="x.pdf", storage_key="",
+            creation_date=str(datetime.now()), update_date=str(datetime.now()),
+        )
+        db.add(m)
+        await db.commit()
+        res = await client.get(f"/api/v1/media/{m.media_uuid}/file")
+        assert res.status_code == 404
+
+
+class TestServeS3Errors:
+    async def _media(self, db, org):
+        m = await _mk_media(db, org, storage_key="orgs/x/media/r/f.pdf", name="s3err")
+        return m
+
+    async def test_no_storage_client_500(self, client, db, org):
+        m = await self._media(db, org)
+        with patch("src.services.media.media_serve.get_content_delivery_type", return_value="s3api"), \
+             patch("src.services.media.media_serve.get_storage_client", return_value=None), \
+             patch("src.services.media.media_serve.get_s3_bucket_name", return_value="b"):
+            res = await client.get(f"/api/v1/media/{m.media_uuid}/file")
+        assert res.status_code == 500
+
+    @pytest.mark.parametrize("code,expected", [("AccessDenied", 403), ("InternalError", 502)])
+    async def test_s3_client_errors(self, client, db, org, code, expected):
+        from botocore.exceptions import ClientError
+        m = await self._media(db, org)
+        s3 = MagicMock()
+        s3.head_object.side_effect = ClientError({"Error": {"Code": code}}, "HeadObject")
+        with patch("src.services.media.media_serve.get_content_delivery_type", return_value="s3api"), \
+             patch("src.services.media.media_serve.get_storage_client", return_value=s3), \
+             patch("src.services.media.media_serve.get_s3_bucket_name", return_value="b"):
+            res = await client.get(f"/api/v1/media/{m.media_uuid}/file")
+        assert res.status_code == expected
+
+    async def test_s3_unexpected_exception_502(self, client, db, org):
+        m = await self._media(db, org)
+        s3 = MagicMock()
+        s3.head_object.side_effect = RuntimeError("boom")
+        with patch("src.services.media.media_serve.get_content_delivery_type", return_value="s3api"), \
+             patch("src.services.media.media_serve.get_storage_client", return_value=s3), \
+             patch("src.services.media.media_serve.get_s3_bucket_name", return_value="b"):
+            res = await client.get(f"/api/v1/media/{m.media_uuid}/file")
+        assert res.status_code == 502

--- a/apps/api/src/tests/routers/test_media_serve_router.py
+++ b/apps/api/src/tests/routers/test_media_serve_router.py
@@ -1,0 +1,196 @@
+"""
+Router tests for media file serving (GET/HEAD /media/{uuid}/file, shared tokens).
+
+Exercises the actual byte-serving in src/services/media/media_serve.py for both
+filesystem (FileResponse / Range / HEAD) and s3 (boto3 stream, mocked), plus the
+share-link mint + resolve endpoints.
+"""
+
+import shutil
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.core.events.database import get_db_session
+from src.db.media.media import Media, MediaTypeEnum
+from src.security.auth import get_current_user
+from src.routers.media.media import router
+
+PDF_BYTES = b"%PDF-1.4 hello world this is a test file " * 50  # ~2KB
+
+
+@pytest.fixture
+def app(db, admin_user):
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1/media")
+    app.dependency_overrides[get_db_session] = lambda: db
+    app.dependency_overrides[get_current_user] = lambda: admin_user
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def client(app):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _bypass_rbac():
+    with patch("src.services.media.media.check_resource_access", new_callable=AsyncMock):
+        yield
+
+
+@pytest.fixture
+def fs_file():
+    """Create a real file under content/ for filesystem serving; clean up after."""
+    rel = "orgs/org_test/media/randdir/testfile.pdf"
+    path = Path("content") / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(PDF_BYTES)
+    yield rel
+    shutil.rmtree(Path("content") / "orgs" / "org_test", ignore_errors=True)
+
+
+async def _mk_media(db, org, storage_key="", public=True, media_type=MediaTypeEnum.UPLOAD, name="m"):
+    m = Media(
+        name=name, media_type=media_type, public=public, org_id=org.id,
+        media_uuid=f"media_{name}", file_id="testfile.pdf", storage_key=storage_key,
+        file_format="pdf", file_mime="application/pdf",
+        creation_date=str(datetime.now()), update_date=str(datetime.now()),
+    )
+    db.add(m)
+    await db.commit()
+    await db.refresh(m)
+    return m
+
+
+class TestServeFilesystem:
+    async def test_get_full_file(self, client, db, org, fs_file):
+        m = await _mk_media(db, org, storage_key=fs_file, name="fsfull")
+        res = await client.get(f"/api/v1/media/{m.media_uuid}/file")
+        assert res.status_code == 200, res.text
+        assert res.content == PDF_BYTES
+        assert res.headers["content-type"].startswith("application/pdf")
+        assert res.headers["cache-control"] == "public, max-age=86400"
+
+    async def test_head_file(self, client, db, org, fs_file):
+        m = await _mk_media(db, org, storage_key=fs_file, name="fshead")
+        res = await client.head(f"/api/v1/media/{m.media_uuid}/file")
+        assert res.status_code == 200, res.text
+        assert int(res.headers["content-length"]) == len(PDF_BYTES)
+
+    async def test_range_request(self, client, db, org, fs_file):
+        m = await _mk_media(db, org, storage_key=fs_file, name="fsrange")
+        res = await client.get(f"/api/v1/media/{m.media_uuid}/file", headers={"Range": "bytes=0-99"})
+        assert res.status_code == 206, res.text
+        assert res.headers["content-range"] == f"bytes 0-99/{len(PDF_BYTES)}"
+        assert res.content == PDF_BYTES[0:100]
+
+    async def test_non_public_media_is_no_store(self, client, db, org, fs_file):
+        m = await _mk_media(db, org, storage_key=fs_file, public=False, name="fspriv")
+        res = await client.get(f"/api/v1/media/{m.media_uuid}/file")
+        assert res.status_code == 200, res.text
+        assert res.headers["cache-control"] == "private, no-store"
+
+    async def test_missing_file_on_disk_404(self, client, db, org):
+        m = await _mk_media(db, org, storage_key="orgs/org_test/media/none/missing.pdf", name="fsmiss")
+        res = await client.get(f"/api/v1/media/{m.media_uuid}/file")
+        assert res.status_code == 404
+
+    async def test_embed_media_has_no_file(self, client, db, org):
+        m = await _mk_media(db, org, media_type=MediaTypeEnum.EMBED, name="embed")
+        res = await client.get(f"/api/v1/media/{m.media_uuid}/file")
+        assert res.status_code == 404
+
+    async def test_legacy_storage_key_reconstructed(self, client, db, org):
+        # No storage_key -> reconstruct orgs/{org_uuid}/media/{media_uuid}/{file_id}
+        m = await _mk_media(db, org, storage_key="", name="legacy")
+        rel = f"orgs/{org.org_uuid}/media/{m.media_uuid}/{m.file_id}"
+        path = Path("content") / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(PDF_BYTES)
+        try:
+            res = await client.get(f"/api/v1/media/{m.media_uuid}/file")
+            assert res.status_code == 200, res.text
+            assert res.content == PDF_BYTES
+        finally:
+            shutil.rmtree(Path("content") / "orgs" / org.org_uuid, ignore_errors=True)
+
+
+def _mock_s3(size):
+    s3 = MagicMock()
+    s3.head_object.return_value = {"ContentLength": size}
+
+    def _get_object(Bucket, Key, Range):
+        spec = Range.replace("bytes=", "")
+        a, _, b = spec.partition("-")
+        start, end = int(a), int(b)
+        body = MagicMock()
+        body.read.return_value = PDF_BYTES[start:end + 1]
+        body.close.return_value = None
+        return {"Body": body}
+
+    s3.get_object.side_effect = _get_object
+    return s3
+
+
+class TestServeS3:
+    @pytest.fixture(autouse=True)
+    def _s3_mode(self):
+        s3 = _mock_s3(len(PDF_BYTES))
+        with patch("src.services.media.media_serve.get_content_delivery_type", return_value="s3api"), \
+             patch("src.services.media.media_serve.get_storage_client", return_value=s3), \
+             patch("src.services.media.media_serve.get_s3_bucket_name", return_value="bucket"):
+            yield s3
+
+    async def test_get_streams_from_s3(self, client, db, org):
+        m = await _mk_media(db, org, storage_key="orgs/x/media/r/f.pdf", name="s3full")
+        res = await client.get(f"/api/v1/media/{m.media_uuid}/file")
+        assert res.status_code == 200, res.text
+        assert res.content == PDF_BYTES
+
+    async def test_head_s3(self, client, db, org):
+        m = await _mk_media(db, org, storage_key="orgs/x/media/r/f.pdf", name="s3head")
+        res = await client.head(f"/api/v1/media/{m.media_uuid}/file")
+        assert res.status_code == 200, res.text
+        assert int(res.headers["content-length"]) == len(PDF_BYTES)
+
+    async def test_range_s3(self, client, db, org):
+        m = await _mk_media(db, org, storage_key="orgs/x/media/r/f.pdf", name="s3range")
+        res = await client.get(f"/api/v1/media/{m.media_uuid}/file", headers={"Range": "bytes=10-49"})
+        assert res.status_code == 206, res.text
+        assert res.headers["content-range"] == f"bytes 10-49/{len(PDF_BYTES)}"
+        assert res.content == PDF_BYTES[10:50]
+
+    async def test_s3_missing_key_404(self, client, db, org, _s3_mode):
+        from botocore.exceptions import ClientError
+        _s3_mode.head_object.side_effect = ClientError({"Error": {"Code": "NoSuchKey"}}, "HeadObject")
+        m = await _mk_media(db, org, storage_key="orgs/x/media/r/gone.pdf", name="s3miss")
+        res = await client.get(f"/api/v1/media/{m.media_uuid}/file")
+        assert res.status_code == 404
+
+
+class TestShareEndpoints:
+    async def test_share_link_then_serve(self, client, db, org, fs_file):
+        m = await _mk_media(db, org, storage_key=fs_file, name="shareserve")
+        # mint a token
+        mk = await client.post(f"/api/v1/media/{m.media_uuid}/share-link")
+        assert mk.status_code == 200, mk.text
+        token = mk.json()["token"]
+        assert token
+        # serve via the token
+        res = await client.get(f"/api/v1/media/shared/{token}/file")
+        assert res.status_code == 200, res.text
+        assert res.content == PDF_BYTES
+        # HEAD via token
+        h = await client.head(f"/api/v1/media/shared/{token}/file")
+        assert h.status_code == 200
+
+    async def test_unknown_token_404(self, client):
+        res = await client.get("/api/v1/media/shared/nope/file")
+        assert res.status_code == 404

--- a/apps/api/src/tests/security/test_media_file_access.py
+++ b/apps/api/src/tests/security/test_media_file_access.py
@@ -1,0 +1,125 @@
+"""
+Security tests for media-file access (folder-aware) + random share links.
+
+Targets the access *decisions* (the security-critical part) via the service
+authorizers — not the byte streaming.
+"""
+
+from datetime import datetime
+
+import pytest
+from fastapi import HTTPException
+
+from src.db.folders.folders import Folder
+from src.db.folders.folder_content import FolderContent
+from src.db.media.media import Media, MediaTypeEnum
+from src.services.media.media import (
+    authorize_media_file,
+    authorize_share_token,
+    create_media_share_link,
+)
+
+
+async def _mk_media(db, org, public=True, name="m"):
+    m = Media(
+        name=name, media_type=MediaTypeEnum.UPLOAD, public=public, org_id=org.id,
+        media_uuid=f"media_{name}", file_id="x.pdf",
+        storage_key=f"orgs/{org.org_uuid}/media/rand/x.pdf", file_format="pdf",
+        creation_date=str(datetime.now()), update_date=str(datetime.now()),
+    )
+    db.add(m)
+    await db.commit()
+    await db.refresh(m)
+    return m
+
+
+async def _mk_folder(db, org, public, name):
+    f = Folder(
+        name=name, public=public, org_id=org.id, folder_uuid=f"folder_{name}",
+        creation_date=str(datetime.now()), update_date=str(datetime.now()),
+    )
+    db.add(f)
+    await db.commit()
+    await db.refresh(f)
+    return f
+
+
+async def _place(db, org, folder_id, media_uuid):
+    db.add(FolderContent(
+        folder_id=folder_id, resource_uuid=media_uuid, org_id=org.id, position=0,
+        creation_date=str(datetime.now()), update_date=str(datetime.now()),
+    ))
+    await db.commit()
+
+
+class TestMediaFileAccess:
+    @pytest.mark.asyncio
+    async def test_public_root_media_allowed_for_anon(self, db, org, anonymous_user, mock_request):
+        m = await _mk_media(db, org, public=True, name="rootpub")
+        media, is_public = await authorize_media_file(mock_request, m.media_uuid, anonymous_user, db)
+        assert media.media_uuid == m.media_uuid
+        assert is_public is True
+
+    @pytest.mark.asyncio
+    async def test_public_media_in_private_folder_denied_for_anon(self, db, org, anonymous_user, mock_request):
+        m = await _mk_media(db, org, public=True, name="inpriv")
+        priv = await _mk_folder(db, org, public=False, name="priv")
+        await _place(db, org, priv.id, m.media_uuid)
+        with pytest.raises(HTTPException) as exc:
+            await authorize_media_file(mock_request, m.media_uuid, anonymous_user, db)
+        assert exc.value.status_code in (401, 403)
+
+    @pytest.mark.asyncio
+    async def test_private_folder_media_allowed_for_org_admin(self, db, org, admin_user, mock_request):
+        m = await _mk_media(db, org, public=True, name="adminok")
+        priv = await _mk_folder(db, org, public=False, name="priv2")
+        await _place(db, org, priv.id, m.media_uuid)
+        media, is_public = await authorize_media_file(mock_request, m.media_uuid, admin_user, db)
+        assert media.media_uuid == m.media_uuid
+        assert is_public is False  # folder-private → cache as private
+
+    @pytest.mark.asyncio
+    async def test_non_public_media_denied_for_anon(self, db, org, anonymous_user, mock_request):
+        m = await _mk_media(db, org, public=False, name="secret")
+        with pytest.raises(HTTPException):
+            await authorize_media_file(mock_request, m.media_uuid, anonymous_user, db)
+
+    @pytest.mark.asyncio
+    async def test_missing_media_404(self, db, anonymous_user, mock_request):
+        with pytest.raises(HTTPException) as exc:
+            await authorize_media_file(mock_request, "media_nope", anonymous_user, db)
+        assert exc.value.status_code == 404
+
+
+class TestMediaShareLink:
+    @pytest.mark.asyncio
+    async def test_share_link_unique_every_call(self, db, org, admin_user, mock_request):
+        m = await _mk_media(db, org, public=True, name="share1")
+        a = await create_media_share_link(mock_request, m.media_uuid, admin_user, db)
+        b = await create_media_share_link(mock_request, m.media_uuid, admin_user, db)
+        assert a["token"] and b["token"]
+        assert a["token"] != b["token"]
+
+    @pytest.mark.asyncio
+    async def test_share_token_resolves_for_owner(self, db, org, admin_user, mock_request):
+        m = await _mk_media(db, org, public=True, name="share2")
+        tok = (await create_media_share_link(mock_request, m.media_uuid, admin_user, db))["token"]
+        media, _ = await authorize_share_token(mock_request, tok, admin_user, db)
+        assert media.media_uuid == m.media_uuid
+
+    @pytest.mark.asyncio
+    async def test_share_token_not_a_bypass_for_private(self, db, org, admin_user, anonymous_user, mock_request):
+        m = await _mk_media(db, org, public=True, name="share3")
+        priv = await _mk_folder(db, org, public=False, name="priv3")
+        await _place(db, org, priv.id, m.media_uuid)
+        tok = (await create_media_share_link(mock_request, m.media_uuid, admin_user, db))["token"]
+        # Anonymous recipient with the link is still denied.
+        with pytest.raises(HTTPException) as exc:
+            await authorize_share_token(mock_request, tok, anonymous_user, db)
+        assert exc.value.status_code in (401, 403)
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_404(self, db, anonymous_user, mock_request):
+        with pytest.raises(HTTPException) as exc:
+            await authorize_share_token(mock_request, "doesnotexist", anonymous_user, db)
+        assert exc.value.status_code == 404

--- a/apps/api/src/tests/security/test_media_file_access.py
+++ b/apps/api/src/tests/security/test_media_file_access.py
@@ -125,6 +125,24 @@ class TestMediaShareLink:
             await authorize_share_token(mock_request, "doesnotexist", anonymous_user, db)
         assert exc.value.status_code == 404
 
+    @pytest.mark.asyncio
+    async def test_share_link_missing_media_404(self, db, admin_user, mock_request):
+        with pytest.raises(HTTPException) as exc:
+            await create_media_share_link(mock_request, "media_nope", admin_user, db)
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_share_token_to_deleted_media_404(self, db, org, admin_user, mock_request):
+        from src.db.media.media_share_token import MediaShareToken
+        db.add(MediaShareToken(
+            token="danglingtok", media_uuid="media_deleted", org_id=org.id,
+            revoked=False, creation_date=str(datetime.now()), update_date=str(datetime.now()),
+        ))
+        await db.commit()
+        with pytest.raises(HTTPException) as exc:
+            await authorize_share_token(mock_request, "danglingtok", admin_user, db)
+        assert exc.value.status_code == 404
+
 
 class TestCheckContentAccessMediaBranch:
     """The legacy /content/...media... gate in both serving routers."""

--- a/apps/api/src/tests/security/test_media_file_access.py
+++ b/apps/api/src/tests/security/test_media_file_access.py
@@ -6,6 +6,7 @@ authorizers — not the byte streaming.
 """
 
 from datetime import datetime
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -123,3 +124,35 @@ class TestMediaShareLink:
         with pytest.raises(HTTPException) as exc:
             await authorize_share_token(mock_request, "doesnotexist", anonymous_user, db)
         assert exc.value.status_code == 404
+
+
+class TestCheckContentAccessMediaBranch:
+    """The legacy /content/...media... gate in both serving routers."""
+
+    @pytest.mark.parametrize("module", [
+        "src.routers.content_files",
+        "src.routers.local_content",
+    ])
+    @pytest.mark.asyncio
+    async def test_legacy_media_path_checks_access(self, db, org, admin_user, mock_request, module):
+        import importlib
+        mod = importlib.import_module(module)
+        m = await _mk_media(db, org, public=True, name="gated")
+        path = f"orgs/{org.org_uuid}/media/{m.media_uuid}/file.pdf"
+        with patch("src.security.rbac.check_resource_access", new_callable=AsyncMock) as chk:
+            await mod._check_content_access(path, admin_user, db, request=mock_request)
+            assert chk.await_count == 1  # media access was enforced
+
+    @pytest.mark.parametrize("module", [
+        "src.routers.content_files",
+        "src.routers.local_content",
+    ])
+    @pytest.mark.asyncio
+    async def test_randomized_media_key_denied(self, db, org, admin_user, mock_request, module):
+        import importlib
+        mod = importlib.import_module(module)
+        # A randomized storage dir (not 'media_...') is never resolvable by path → denied.
+        path = f"orgs/{org.org_uuid}/media/randomtoken123/file.pdf"
+        with pytest.raises(HTTPException) as exc:
+            await mod._check_content_access(path, admin_user, db, request=mock_request)
+        assert exc.value.status_code == 403

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/library/folder/[folderid]/page.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/library/folder/[folderid]/page.tsx
@@ -1,34 +1,60 @@
 import React from 'react'
+import { notFound } from 'next/navigation'
 import FolderClient from './FolderClient'
 import { Metadata } from 'next'
 import { getOrganizationContextInfo } from '@services/organizations/orgs'
+import { getFolderById } from '@services/folders/folders'
 import { getOrgThumbnailMediaDirectory, getOrgOgImageMediaDirectory } from '@services/media/media'
 import { getOrgSeoConfig, buildPageTitle } from '@/lib/seo/utils'
 import { getServerCanonicalUrl } from '@/lib/seo/utils.server'
+import { getServerSession } from '@/lib/auth/server'
 
 type MetadataProps = {
   params: Promise<{ orgslug: string; folderid: string }>
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }
 
+/** Fetch the folder as the current viewer (forwards their session). Returns null
+ * when the folder is private / the viewer has no access (the API denies). */
+async function fetchFolderForViewer(folderid: string) {
+  const session = await getServerSession()
+  const access_token = session?.tokens?.access_token
+  try {
+    const folder = await getFolderById(
+      `folder_${folderid}`,
+      access_token ?? undefined,
+      { revalidate: 0, tags: ['folders'] }
+    )
+    return folder && folder.folder_uuid ? folder : null
+  } catch {
+    return null
+  }
+}
+
 export async function generateMetadata(props: MetadataProps): Promise<Metadata> {
   const params = await props.params
-  const org = await getOrganizationContextInfo(params.orgslug, {
-    revalidate: 120,
-    tags: ['organizations'],
-  })
+  const [org, folder] = await Promise.all([
+    getOrganizationContextInfo(params.orgslug, { revalidate: 120, tags: ['organizations'] }),
+    fetchFolderForViewer(params.folderid),
+  ])
 
   const seoConfig = getOrgSeoConfig(org)
+
+  // Private / inaccessible folder: never index, never leak the folder name.
+  if (!folder) {
+    return {
+      title: buildPageTitle('Library', org.name, seoConfig),
+      robots: { index: false, follow: false, googleBot: { index: false, follow: false } },
+    }
+  }
+
   const ogImageUrl = seoConfig.default_og_image
     ? getOrgOgImageMediaDirectory(org?.org_uuid, seoConfig.default_og_image)
     : null
   const imageUrl = ogImageUrl || getOrgThumbnailMediaDirectory(org?.org_uuid, org?.thumbnail_image)
-  const canonical = await getServerCanonicalUrl(
-    params.orgslug,
-    `/library/folder/${params.folderid}`
-  )
-  const title = buildPageTitle('Library', org.name, seoConfig)
-  const description = org.description || seoConfig.default_meta_description || ''
+  const canonical = await getServerCanonicalUrl(params.orgslug, `/library/folder/${params.folderid}`)
+  const title = buildPageTitle(folder.name || 'Library', org.name, seoConfig)
+  const description = folder.description || org.description || seoConfig.default_meta_description || ''
 
   return {
     title,
@@ -37,27 +63,14 @@ export async function generateMetadata(props: MetadataProps): Promise<Metadata> 
       index: true,
       follow: true,
       nocache: true,
-      googleBot: {
-        index: true,
-        follow: true,
-        'max-image-preview': 'large',
-      },
+      googleBot: { index: true, follow: true, 'max-image-preview': 'large' },
     },
-    alternates: {
-      canonical,
-    },
+    alternates: { canonical },
     openGraph: {
       title,
       description,
       type: 'website',
-      images: [
-        {
-          url: imageUrl,
-          width: 800,
-          height: 600,
-          alt: org.name,
-        },
-      ],
+      images: [{ url: imageUrl, width: 800, height: 600, alt: org.name }],
     },
     twitter: {
       card: 'summary_large_image',
@@ -71,6 +84,12 @@ export async function generateMetadata(props: MetadataProps): Promise<Metadata> 
 
 const FolderPage = async (props: any) => {
   const params = await props.params
+  // Server-side access gate: a private folder (or one the viewer lacks rights
+  // to) returns a real 404 — no folder name/contents are rendered or indexed.
+  const folder = await fetchFolderForViewer(params.folderid)
+  if (!folder) {
+    notFound()
+  }
   return <FolderClient orgslug={params.orgslug} folderid={params.folderid} />
 }
 

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/library/library-cards.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/library/library-cards.tsx
@@ -122,7 +122,9 @@ export function LibraryItemCard({ item, orgslug }: { item: any; orgslug: string 
   let external = false
   let fileUrl: string | null = null
   if (type === 'media') {
-    if (resource.file_id) fileUrl = getMediaFileDirectory(org?.org_uuid, resource.media_uuid || item.resource_uuid, resource.file_id)
+    // file_id is no longer exposed; uploaded media is served via the authed
+    // /media/{uuid}/file endpoint keyed only by media_uuid.
+    if (resource.media_type !== 'EMBED') fileUrl = getMediaFileDirectory(org?.org_uuid, resource.media_uuid || item.resource_uuid)
     if (resource.media_type === 'EMBED' && resource.url) { href = safeExternalUrl(resource.url); external = !!href }
     else if (fileUrl) { href = fileUrl; external = true }
   } else {

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/library/library-cards.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/library/library-cards.tsx
@@ -11,6 +11,7 @@ import { getFolderThumbnailMediaDirectory } from '@services/media/media'
 import { getMediaFileDirectory } from '@services/media/media-resource'
 import { folderTone } from '@components/Dashboard/Library/LibraryToolbar'
 import { shareFolderLink } from '@components/Dashboard/Library/shareFolder'
+import { resourceHref, safeExternalUrl } from '@components/Dashboard/Library/resourceLink'
 import MediaPreview from '@components/Dashboard/Library/MediaPreview'
 import {
   FolderSimple,
@@ -120,12 +121,13 @@ export function LibraryItemCard({ item, orgslug }: { item: any; orgslug: string 
   let href: string | null = null
   let external = false
   let fileUrl: string | null = null
-  if (type === 'podcasts') {
-    href = getUriWithOrg(orgslug, `/podcasts`)
-  } else if (type === 'media') {
+  if (type === 'media') {
     if (resource.file_id) fileUrl = getMediaFileDirectory(org?.org_uuid, resource.media_uuid || item.resource_uuid, resource.file_id)
-    if (resource.media_type === 'EMBED' && resource.url) { href = resource.url; external = true }
+    if (resource.media_type === 'EMBED' && resource.url) { href = safeExternalUrl(resource.url); external = !!href }
     else if (fileUrl) { href = fileUrl; external = true }
+  } else {
+    // Podcasts, communities, boards, playgrounds → their own resource page.
+    href = resourceHref(type, resource, orgslug, 'public')
   }
   const isUpload = type === 'media' && resource.media_type !== 'EMBED'
 

--- a/apps/web/components/Dashboard/Library/LibraryItemCard.tsx
+++ b/apps/web/components/Dashboard/Library/LibraryItemCard.tsx
@@ -1,10 +1,14 @@
 'use client'
 import { useOrg } from '@components/Contexts/OrgContext'
+import { useLHSession } from '@components/Contexts/LHSessionContext'
 import ConfirmationModal from '@components/Objects/StyledElements/ConfirmationModal/ConfirmationModal'
 import Modal from '@components/Objects/StyledElements/Modal/Modal'
 import ManageAccessPopover from '@components/Dashboard/Library/ManageAccessPopover'
 import MediaPreview from '@components/Dashboard/Library/MediaPreview'
+import { resourceHref, safeExternalUrl } from '@components/Dashboard/Library/resourceLink'
+import { shareMediaLink } from '@components/Dashboard/Library/shareFolder'
 import { getMediaFileDirectory } from '@services/media/media-resource'
+import Link from 'next/link'
 import {
   MicrophoneStage,
   ChatsCircle,
@@ -71,6 +75,8 @@ type Props = {
 export default function LibraryItemCard({ item, orgslug, onRemove }: Props) {
   const { t } = useTranslation()
   const org = useOrg() as any
+  const session = useLHSession() as any
+  const access_token = session?.data?.tokens?.access_token
   const [isMenuOpen, setIsMenuOpen] = React.useState(false)
   const [accessOpen, setAccessOpen] = React.useState(false)
 
@@ -81,12 +87,18 @@ export default function LibraryItemCard({ item, orgslug, onRemove }: Props) {
   const Icon = typeIcon(type, resource)
   const isUploadMedia = type === 'media' && resource.media_type !== 'EMBED'
 
-  let href: string | null = null
+  let href: string | null = null          // external (media file / embed url)
+  let internalHref: string | null = null  // resource detail page (same-tab)
   let fileUrl: string | null = null
   if (type === 'media') {
-    if (resource.file_id) fileUrl = getMediaFileDirectory(org?.org_uuid, resource.media_uuid || item.resource_uuid, resource.file_id)
-    if (resource.media_type === 'EMBED' && resource.url) href = resource.url
+    // file_id is no longer exposed; uploaded media is served via the authed
+    // /media/{uuid}/file endpoint keyed only by media_uuid.
+    if (isUploadMedia) fileUrl = getMediaFileDirectory(org?.org_uuid, resource.media_uuid || item.resource_uuid)
+    if (resource.media_type === 'EMBED' && resource.url) href = safeExternalUrl(resource.url)
     else if (fileUrl) href = fileUrl
+  } else {
+    // Podcasts, communities, boards, playgrounds → their dashboard page.
+    internalHref = resourceHref(type, resource, orgslug, 'dashboard')
   }
   const typeLabel = t(`library.tabs.${type}`)
 
@@ -104,7 +116,7 @@ export default function LibraryItemCard({ item, orgslug, onRemove }: Props) {
         <h3 className="text-base font-bold text-gray-900 leading-tight line-clamp-1">{name}</h3>
         <div className="pt-1.5 flex items-center justify-between border-t border-gray-100">
           <span className="text-[10px] font-bold uppercase tracking-wider text-gray-400">{typeLabel}</span>
-          {href && (
+          {(href || internalHref) && (
             <span className="text-[10px] font-bold uppercase tracking-wider text-gray-400 inline-flex items-center gap-1">
               {isUploadMedia ? t('media.download') : t('library.open_resource')}
               {isUploadMedia ? <DownloadSimple size={11} /> : <ArrowSquareOut size={11} />}
@@ -130,6 +142,23 @@ export default function LibraryItemCard({ item, orgslug, onRemove }: Props) {
                 <a href={href} target="_blank" rel="noopener noreferrer" className="flex items-center cursor-pointer">
                   {isUploadMedia ? (<><DownloadSimple className="mr-2 h-4 w-4" /> {t('media.download')}</>) : (<><ArrowSquareOut className="mr-2 h-4 w-4" /> {t('library.open')}</>)}
                 </a>
+              </DropdownMenuItem>
+            )}
+            {isUploadMedia && (
+              <DropdownMenuItem asChild>
+                <button
+                  onClick={() =>
+                    shareMediaLink(
+                      resource.media_uuid || item.resource_uuid,
+                      access_token,
+                      t('library.link_copied'),
+                      t('library.link_copy_error'),
+                    )
+                  }
+                  className="w-full text-left flex items-center px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-50 rounded-md transition-colors"
+                >
+                  <LinkSimple className="mr-2 h-4 w-4" /> {t('library.copy_link')}
+                </button>
               </DropdownMenuItem>
             )}
             {type === 'media' && (
@@ -161,6 +190,10 @@ export default function LibraryItemCard({ item, orgslug, onRemove }: Props) {
         <a href={href} target="_blank" rel="noopener noreferrer" className="block">
           {body}
         </a>
+      ) : internalHref ? (
+        <Link href={internalHref} className="block">
+          {body}
+        </Link>
       ) : (
         <div>{body}</div>
       )}

--- a/apps/web/components/Dashboard/Library/ManageAccessPopover.tsx
+++ b/apps/web/components/Dashboard/Library/ManageAccessPopover.tsx
@@ -8,7 +8,7 @@ import {
   unLinkResourcesToUserGroup,
 } from '@services/usergroups/usergroups'
 import { updateFolder, getFolderById } from '@services/folders/folders'
-import { updateMedia } from '@services/media/media-resource'
+import { updateMedia, getMediaById } from '@services/media/media-resource'
 import { updateCourse, getCourse } from '@services/courses/courses'
 import { apiFetch } from '@services/utils/ts/requests'
 import { Check, Globe, Info, SquareUserRound, Users, X } from 'lucide-react'
@@ -196,6 +196,7 @@ function ManageAccessPopover({ resource_uuid, resourceType }: Props) {
     async () => {
       if (resourceType === 'folders') return getFolderById(resource_uuid, access_token)
       if (resourceType === 'courses') return getCourse(resource_uuid, null, access_token)
+      if (resourceType === 'media') return getMediaById(resource_uuid, access_token)
       return null
     }
   )

--- a/apps/web/components/Dashboard/Library/MediaPreview.tsx
+++ b/apps/web/components/Dashboard/Library/MediaPreview.tsx
@@ -218,12 +218,10 @@ export default function MediaPreview({
     return <EmbedPreview url={url} video={isVimeo(url)} />
   }
 
-  // UPLOAD: build the file url.
+  // UPLOAD: build the file url. file_id is no longer exposed by the API; the
+  // authed /media/{uuid}/file endpoint is keyed only by media_uuid.
   const mediaUuid = resource?.media_uuid || resourceUuid
-  const fileUrl =
-    resource?.file_id && orgUuid && mediaUuid
-      ? getMediaFileDirectory(orgUuid, mediaUuid, resource.file_id)
-      : null
+  const fileUrl = mediaUuid ? getMediaFileDirectory(orgUuid, mediaUuid) : null
   const fmt = (resource?.file_format || '').toLowerCase()
 
   if (fileUrl && IMAGE_FORMATS.includes(fmt)) {

--- a/apps/web/components/Dashboard/Library/PdfThumbnail.tsx
+++ b/apps/web/components/Dashboard/Library/PdfThumbnail.tsx
@@ -46,7 +46,9 @@ export default function PdfThumbnail({ url }: { url: string }) {
         const pdfjs = await loadPdfjs()
         if (cancelled) return
         // pdfjs v6 requires an options object; a bare url string is rejected.
-        const loadingTask = pdfjs.getDocument({ url })
+        // withCredentials so the session cookie is sent to the authenticated
+        // media endpoint (private PDFs are access-checked server-side).
+        const loadingTask = pdfjs.getDocument({ url, withCredentials: true })
         pdfDoc = await loadingTask.promise
         if (cancelled) return
         const page = await pdfDoc.getPage(1)

--- a/apps/web/components/Dashboard/Library/PdfThumbnail.tsx
+++ b/apps/web/components/Dashboard/Library/PdfThumbnail.tsx
@@ -90,32 +90,18 @@ export default function PdfThumbnail({ url }: { url: string }) {
   }, [url])
 
   if (state === 'error') {
-    // Page-1 render failed (unreachable file / blocked cross-origin fetch).
-    // Only offer a clickable link for http(s) URLs — never bind an untrusted
-    // scheme (e.g. javascript:) to href. Otherwise fall back to a plain tile.
-    const isHttp = /^https?:\/\//i.test(url)
-    if (!isHttp) {
-      return (
-        <div className="relative aspect-video flex items-center justify-center bg-amber-50 text-amber-500">
-          <FilePdf size={46} weight="fill" />
-        </div>
-      )
-    }
+    // Page-1 render failed (unreachable file / blocked fetch). The media card
+    // that wraps this thumbnail is ALREADY a link to the file, so render a
+    // non-interactive tile here — a nested <a> inside the card's <a> is invalid
+    // HTML and causes a hydration error.
     return (
-      <a
-        href={url}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={(e) => e.stopPropagation()}
-        title={t('media.open_pdf')}
-        className="group relative aspect-video flex flex-col items-center justify-center gap-1.5 bg-amber-50 text-amber-500 hover:bg-amber-100 transition-colors"
-      >
+      <div className="relative aspect-video flex flex-col items-center justify-center gap-1.5 bg-amber-50 text-amber-500">
         <FilePdf size={42} weight="fill" />
-        <span className="inline-flex items-center gap-1 text-[11px] font-semibold text-amber-600/80 group-hover:text-amber-700">
+        <span className="inline-flex items-center gap-1 text-[11px] font-semibold text-amber-600/80">
           {t('media.open_pdf')}
           <ArrowSquareOut size={11} weight="bold" />
         </span>
-      </a>
+      </div>
     )
   }
 

--- a/apps/web/components/Dashboard/Library/resourceLink.ts
+++ b/apps/web/components/Dashboard/Library/resourceLink.ts
@@ -1,0 +1,56 @@
+import { getUriWithOrg } from '@services/config/config'
+
+export type LibraryContext = 'dashboard' | 'public'
+
+/**
+ * Guard for binding an external URL to an anchor href: only allow http(s) so an
+ * untrusted scheme (e.g. javascript:) from a user-entered embed URL can't run.
+ */
+export function safeExternalUrl(url?: string | null): string | null {
+  if (!url) return null
+  return /^https?:\/\//i.test(url) ? url : null
+}
+
+/**
+ * Internal navigation URL for a resource placed in the library, by type.
+ * Mirrors each resource's canonical link (and uuid-prefix handling) used by its
+ * own card elsewhere in the app. Returns null for types handled separately
+ * (courses use CourseThumbnail; media links to its file/embed URL).
+ */
+export function resourceHref(
+  type: string,
+  resource: any,
+  orgslug: string,
+  ctx: LibraryContext
+): string | null {
+  if (!resource) return null
+  const dash = ctx === 'dashboard'
+  switch (type) {
+    case 'communities': {
+      const id = (resource.community_uuid || '').replace('community_', '')
+      return id
+        ? getUriWithOrg(orgslug, dash ? `/dash/communities/${id}/general` : `/community/${id}`)
+        : null
+    }
+    case 'boards': {
+      const id = (resource.board_uuid || '').replace('board_', '')
+      return id
+        ? getUriWithOrg(orgslug, dash ? `/dash/boards/${id}/general` : `/board/${id}`)
+        : null
+    }
+    case 'podcasts': {
+      const id = (resource.podcast_uuid || '').replace('podcast_', '')
+      return id
+        ? getUriWithOrg(orgslug, dash ? `/dash/podcasts/podcast/${id}/general` : `/podcast/${id}`)
+        : null
+    }
+    case 'playgrounds': {
+      // Playgrounds use the full prefixed uuid and have no separate dash route.
+      return resource.playground_uuid
+        ? getUriWithOrg(orgslug, `/playground/${resource.playground_uuid}`)
+        : null
+    }
+    default:
+      return null
+  }
+}

--- a/apps/web/components/Dashboard/Library/shareFolder.ts
+++ b/apps/web/components/Dashboard/Library/shareFolder.ts
@@ -1,6 +1,7 @@
 import toast from 'react-hot-toast'
 import { getUriWithOrg } from '@services/config/config'
 import { removeFolderPrefix } from '@services/folders/folders'
+import { createMediaShareLink, getMediaShareFileUrl } from '@services/media/media-resource'
 
 /**
  * Build the public, shareable URL for a folder.
@@ -39,6 +40,32 @@ export async function shareFolderLink(
     throw new Error('clipboard unavailable')
   } catch (e: any) {
     if (e?.name === 'AbortError') return // user dismissed the share sheet
+    toast.error(errorLabel)
+  }
+}
+
+/**
+ * Copy a media file's share link. Mints a FRESH random token on every call
+ * (the URL is unique each time) and copies the resulting access-checked URL.
+ */
+export async function shareMediaLink(
+  media_uuid: string,
+  access_token: string,
+  copiedLabel: string,
+  errorLabel: string,
+) {
+  try {
+    const res = await createMediaShareLink(media_uuid, access_token)
+    if (!res?.token) throw new Error('no token')
+    const url = getMediaShareFileUrl(res.token)
+    const nav: any = typeof navigator !== 'undefined' ? navigator : null
+    if (nav?.clipboard?.writeText) {
+      await nav.clipboard.writeText(url)
+      toast.success(copiedLabel)
+      return
+    }
+    throw new Error('clipboard unavailable')
+  } catch {
     toast.error(errorLabel)
   }
 }

--- a/apps/web/services/media/media-resource.ts
+++ b/apps/web/services/media/media-resource.ts
@@ -1,5 +1,4 @@
 import { getAPIUrl } from '@services/config/config'
-import { getBackendUrl, getConfig } from '@services/config/config'
 import {
   RequestBodyFormWithAuthHeader,
   RequestBodyWithAuthHeader,
@@ -15,26 +14,39 @@ import {
  not be overwritten. This file holds the Media resource API service.
 */
 
-function getMediaUrl() {
-  const mediaUrl = getConfig('NEXT_PUBLIC_LEARNHOUSE_MEDIA_URL')
-  if (mediaUrl) {
-    return mediaUrl
-  } else {
-    return getBackendUrl()
-  }
+/**
+ * Build the media file URL for an uploaded media resource.
+ *
+ * SECURITY: this now points at the authenticated, access-checked API endpoint
+ * (GET /api/v1/media/{uuid}/file) — NOT the public storage/CDN URL. The browser
+ * sends the session cookie (same-origin), so private-folder files are only
+ * served to authorized users, and the storage path is never exposed. The
+ * orgUuid/fileId params are kept for signature stability but unused.
+ */
+export function getMediaFileDirectory(
+  _orgUuid: string,
+  mediaUuid: string,
+  _fileId?: string
+) {
+  return `${getAPIUrl()}media/${mediaUuid}/file`
 }
 
 /**
- * Build the direct media file URL for an uploaded media resource.
- * Mirrors the thumbnail-directory helpers in services/media/media.ts.
+ * Create a fresh, random share link for a media file. Each call mints a NEW
+ * token (the URL is unique every time) and is revocable server-side. The link
+ * still enforces the recipient's access — it is not a public capability.
  */
-export function getMediaFileDirectory(
-  orgUuid: string,
-  mediaUuid: string,
-  fileId: string
-) {
-  let uri = `${getMediaUrl()}content/orgs/${orgUuid}/media/${mediaUuid}/${fileId}`
-  return uri
+export async function createMediaShareLink(media_uuid: string, access_token: string) {
+  const result = await fetch(
+    `${getAPIUrl()}media/${media_uuid}/share-link`,
+    RequestBodyWithAuthHeader('POST', {}, null, access_token)
+  )
+  return errorHandling(result) // { token }
+}
+
+/** Build the shareable, token-based file URL (random + unique every time). */
+export function getMediaShareFileUrl(token: string) {
+  return `${getAPIUrl()}media/shared/${token}/file`
 }
 
 export async function getOrgMedia(

--- a/apps/web/services/media/media-resource.ts
+++ b/apps/web/services/media/media-resource.ts
@@ -24,10 +24,12 @@ import {
  * orgUuid/fileId params are kept for signature stability but unused.
  */
 export function getMediaFileDirectory(
-  _orgUuid: string,
-  mediaUuid: string,
+  _orgUuid?: string,
+  mediaUuid?: string,
   _fileId?: string
 ) {
+  // _orgUuid/_fileId are accepted for backward-compatible call sites but no
+  // longer used: media is served via the authed endpoint keyed by media_uuid.
   return `${getAPIUrl()}media/${mediaUuid}/file`
 }
 


### PR DESCRIPTION
## Problem

In the new Library, a **direct link to a media file in a private folder** was fetchable by **anyone** (including logged-out users), because files were served from a public CDN via derivable URLs. Separately, **private folders** were viewable through the public UI and indexable by search engines.

## Fix (app-layer only — no bucket/infra changes)

**Media files**
- **Folder-aware privacy** — a file in *any* private folder is treated as private even if its own `public` flag is true (most-restrictive). Folded into the RBAC public-check so metadata reads and file reads agree.
- **Served only through an authenticated endpoint** — `GET/HEAD /media/{uuid}/file` access-checks then streams from storage (filesystem `FileResponse`, s3/R2 boto3 with Range). The client never receives the storage URL. The frontend points here instead of the CDN; `pdfjs` uses `withCredentials` so private PDF previews still render.
- **Randomized storage keys** — new uploads store under a random dir+filename, persisted server-side and **never returned** in API responses, so the path can't be derived from a known `media_uuid`.
- **Legacy `/content/...media...` gated** too (defense in depth + old URLs).

**Share links**
- "Copy link" mints a **fresh random, revocable token every time** (`POST /media/{uuid}/share-link` → `GET /media/shared/{token}/file`). The token is **not** an access bypass — recipients still need access.

**Private folders**
- The public folder page now does a **server-side access check** → real **404** for private/unauthorized folders (no name/contents leak) and **`robots: noindex`**; only public folders are indexable. Sitemap already lists public folders only.

## Notes
- Buckets stay **public** by design; protection is the authed API + randomized keys + streaming. (Accepted residual: a *leaked* random key on the public bucket is still fetchable — the app never emits one.)
- Adds `media.storage_key` + `mediasharetoken` (idempotent migration `5e3a9c7f1b2d`).
- Tests: new access-matrix + share-token tests; full API suite green (only pre-existing Ollama tests fail). Built/verified on an isolated worktree + dev install.
- Stacked on the folders PR (#882); retarget to `dev` once that merges.


---

### ℹ️ This PR now targets `dev` and also carries two already-merged-but-orphaned changes

`#882` (Folders) merged to `dev` first; then `#883` (drop legacy `collection`/`collectioncourse` tables) and `#884` (clickable community/board/playground/podcast cards) were merged into the **folders branch** *after* #882 had already closed — so their content never reached `dev`. Rather than reopen them, this PR (rebased onto current `dev`) bundles all three so everything lands together:

- **Secure private media files + private folders** (this PR's main change)
- **Drop legacy `collection` / `collectioncourse` tables** (migration `d4e5f6a7b8c9`) — ⚠️ destructive on prod (345 collections / 1,340 links); from #883
- **Clickable resource cards** (resourceLink helper) — from #884

Alembic chain on dev: `f7a8b9c0d1e2 → d4e5f6a7b8c9 → 5e3a9c7f1b2d` (single head). Merging this closes out the whole Library line on `dev`.
