### PR TITLE
feat(orgs): delete sole-admin orgs on account deletion + org danger zone

### DIFF
--- a/apps/api/src/routers/orgs/orgs.py
+++ b/apps/api/src/routers/orgs/orgs.py
@@ -13,6 +13,7 @@ from src.services.orgs.users import (
     get_list_of_invited_users,
     get_organization_users,
     invite_batch_users,
+    remove_all_users_from_org,
     remove_batch_users_from_org,
     remove_invited_user,
     remove_user_from_org,
@@ -32,6 +33,7 @@ from src.services.orgs.orgs import (
     create_org,
     create_org_with_config,
     delete_org,
+    wipe_org_content,
     get_organization_by_uuid,
     get_organization_by_slug,
     get_orgs_by_user,
@@ -318,6 +320,60 @@ async def api_remove_batch_users_from_org(
     return await remove_batch_users_from_org(
         request, org_id, user_ids, db_session, current_user
     )
+
+
+@router.delete(
+    "/{org_id}/users/all",
+    summary="Remove all users from organization",
+    description=(
+        "Remove every member from the organization except the caller. The "
+        "organization and its content are kept. Admin only."
+    ),
+    responses={
+        200: {"description": "All other users removed from the organization."},
+        401: {"description": "Not authenticated"},
+        403: {"description": "Caller is not an organization administrator"},
+        404: {"description": "Organization not found"},
+    },
+)
+async def api_remove_all_users_from_org(
+    request: Request,
+    org_id: int,
+    current_user: PublicUser = Depends(get_current_user),
+    db_session: AsyncSession = Depends(get_db_session),
+):
+    """
+    Remove all users from the org except the caller (danger zone)
+    """
+    return await remove_all_users_from_org(
+        request, org_id, db_session, current_user
+    )
+
+
+@router.delete(
+    "/{org_id}/content",
+    summary="Wipe all organization content",
+    description=(
+        "Delete all courses (and their cascaded content) in the organization "
+        "while keeping the organization and its members. Admin only."
+    ),
+    responses={
+        200: {"description": "Organization content wiped."},
+        401: {"description": "Not authenticated"},
+        403: {"description": "Caller is not an organization administrator"},
+        404: {"description": "Organization not found"},
+    },
+)
+async def api_wipe_org_content(
+    request: Request,
+    org_id: int,
+    current_user: PublicUser = Depends(get_current_user),
+    db_session: AsyncSession = Depends(get_db_session),
+):
+    """
+    Wipe all content (courses) of the org (danger zone)
+    """
+    return await wipe_org_content(request, org_id, current_user, db_session)
 
 
 @router.delete(

--- a/apps/api/src/services/orgs/orgs.py
+++ b/apps/api/src/services/orgs/orgs.py
@@ -618,6 +618,63 @@ async def delete_org(
     return {"detail": "Organization deleted", "org_id": org_id, "org_name": org_name}
 
 
+async def wipe_org_content(
+    request: Request,
+    org_id: int,
+    current_user: PublicUser | AnonymousUser,
+    db_session: AsyncSession,
+):
+    """
+    Delete all courses (and their cascaded content) in an organization while
+    keeping the organization and its members intact.
+
+    SECURITY: Only organization admins can wipe their org's content (enforced by
+    the RBAC check below). Course-related data (chapters, activities, etc.) is
+    removed via the database CASCADE constraints on the course foreign keys.
+    """
+    from src.db.courses.courses import Course
+    from src.services.courses.transfer.storage_utils import delete_storage_directory
+    from src.security.features_utils.usage import decrease_feature_usage
+
+    statement = select(Organization).where(Organization.id == org_id)
+    org = (await db_session.execute(statement)).scalars().first()
+
+    if not org:
+        raise HTTPException(
+            status_code=404,
+            detail="Organization not found",
+        )
+
+    # RBAC check - verifies the caller is an admin of THIS organization
+    await rbac_check(request, org.org_uuid, current_user, "delete", db_session)
+
+    courses = (await db_session.execute(
+        select(Course).where(Course.org_id == org_id)
+    )).scalars().all()
+
+    user_id = current_user.id if hasattr(current_user, "id") else "unknown"
+    logging.warning(
+        f"AUDIT: Organization content wipe - org_id={org_id}, org_uuid={org.org_uuid}, "
+        f"course_count={len(courses)}, triggered_by_user_id={user_id}"
+    )
+
+    deleted_count = 0
+    for course in courses:
+        # Clean up content files from storage before removing the row.
+        content_path = f"content/orgs/{org.org_uuid}/courses/{course.course_uuid}"
+        delete_storage_directory(content_path)
+        await db_session.delete(course)
+        deleted_count += 1
+
+    await db_session.commit()
+
+    # Decrement usage AFTER the rows are gone, mirroring delete_course().
+    for _ in range(deleted_count):
+        await decrease_feature_usage("courses", org_id, db_session)
+
+    return {"detail": "Organization content wiped", "deleted_courses": deleted_count}
+
+
 async def get_orgs_by_user_admin(
     request: Request,
     db_session: AsyncSession,

--- a/apps/api/src/services/orgs/users.py
+++ b/apps/api/src/services/orgs/users.py
@@ -540,6 +540,56 @@ async def remove_batch_users_from_org(
     return {"detail": f"{removed_count} user(s) removed from org"}
 
 
+async def remove_all_users_from_org(
+    request: Request,
+    org_id: int,
+    db_session: AsyncSession,
+    current_user: PublicUser | AnonymousUser,
+):
+    """
+    Remove every member from the organization except the caller.
+
+    The organization and all of its content are kept intact. The acting admin
+    is preserved so the org is never left without an administrator. Use the
+    delete-organization endpoint to remove the org entirely.
+    """
+    statement = select(Organization).where(Organization.id == org_id)
+    org = (await db_session.execute(statement)).scalars().first()
+
+    if not org:
+        raise HTTPException(
+            status_code=404,
+            detail="Organization not found",
+        )
+
+    # RBAC check
+    await rbac_check(request, org.org_uuid, current_user, "delete", db_session)
+
+    # Keep the caller so the org always retains at least one admin.
+    keep_user_id = resolve_acting_user_id(current_user)
+
+    remove_stmt = select(UserOrganization).where(
+        UserOrganization.org_id == org.id,
+        UserOrganization.user_id != keep_user_id,
+    )
+    user_orgs_to_remove = (await db_session.execute(remove_stmt)).scalars().all()
+
+    removed_user_ids = [uo.user_id for uo in user_orgs_to_remove]
+    for user_org in user_orgs_to_remove:
+        await db_session.delete(user_org)
+
+    await db_session.commit()
+
+    from src.routers.users import _invalidate_session_cache
+    for uid in removed_user_ids:
+        _invalidate_session_cache(uid)
+
+    for _ in removed_user_ids:
+        await decrease_feature_usage("members", org_id, db_session)
+
+    return {"detail": f"{len(removed_user_ids)} user(s) removed from org"}
+
+
 async def update_user_role(
     request: Request,
     org_id: int,

--- a/apps/api/src/services/users/users.py
+++ b/apps/api/src/services/users/users.py
@@ -5,7 +5,7 @@ from typing import Literal
 from uuid import uuid4
 from fastapi import HTTPException, Request, UploadFile, status
 import redis
-from sqlmodel import select
+from sqlmodel import select, func
 from sqlmodel.ext.asyncio.session import AsyncSession
 from config.config import get_learnhouse_config
 from src.security.features_utils.usage import (
@@ -41,6 +41,7 @@ from src.db.users import (
     UserUpdatePassword,
 )
 from src.db.user_organizations import UserOrganization
+from src.security.rbac.constants import ADMIN_ROLE_ID
 from src.security.security import security_hash_password, security_verify_password
 from src.services.security.password_validation import validate_password_complexity
 from src.services.analytics.analytics import track
@@ -700,7 +701,59 @@ async def delete_user_by_id(
     # RBAC check
     await rbac_check(request, current_user, "delete", user.user_uuid, db_session)
 
-    # Remove org memberships first (no CASCADE on this FK)
+    from src.routers.users import _invalidate_session_cache
+
+    # Delete organizations the user is the SOLE admin of, so we don't leave
+    # behind orphaned, admin-less organizations when an account goes away.
+    # An org is deleted only when the user is one of its admins (role_id=1) AND
+    # no other admin remains. Orgs that still have another admin are kept; the
+    # user is simply removed from them via the membership cleanup below.
+    admin_org_ids = (await db_session.execute(
+        select(UserOrganization.org_id).where(
+            UserOrganization.user_id == user_id,
+            UserOrganization.role_id == ADMIN_ROLE_ID,
+        )
+    )).scalars().all()
+
+    for org_id in admin_org_ids:
+        other_admins = (await db_session.execute(
+            select(func.count()).select_from(UserOrganization).where(
+                UserOrganization.org_id == org_id,
+                UserOrganization.role_id == ADMIN_ROLE_ID,
+                UserOrganization.user_id != user_id,
+            )
+        )).scalar_one()
+
+        if other_admins:
+            # Another admin remains — keep the org, only drop this membership.
+            continue
+
+        org = (await db_session.execute(
+            select(Organization).where(Organization.id == org_id)
+        )).scalars().first()
+        if not org:
+            continue
+
+        # Capture every member so we can invalidate their cached sessions; their
+        # UserOrganization rows are removed via the CASCADE on the org FK.
+        member_ids = (await db_session.execute(
+            select(UserOrganization.user_id).where(UserOrganization.org_id == org_id)
+        )).scalars().all()
+
+        logging.warning(
+            "AUDIT: Organization auto-deleted on user deletion - "
+            f"org_id={org_id}, org_uuid={org.org_uuid}, org_name={org.name}, "
+            f"triggered_by_user_id={user_id}"
+        )
+
+        await db_session.delete(org)
+        await db_session.flush()
+
+        for member_id in member_ids:
+            _invalidate_session_cache(member_id)
+
+    # Remove any remaining org memberships (no CASCADE on this FK). Memberships
+    # of orgs deleted above are already gone via the org-level CASCADE.
     user_orgs = (await db_session.execute(
         select(UserOrganization).where(UserOrganization.user_id == user_id)
     )).scalars().all()

--- a/apps/api/src/tests/routers/test_orgs_router.py
+++ b/apps/api/src/tests/routers/test_orgs_router.py
@@ -309,6 +309,29 @@ class TestOrgUserEndpoints:
         assert response.status_code == 200
         assert response.json()["removed"] == 1
 
+    async def test_remove_all_users_from_org(self, client):
+        with patch(
+            "src.routers.orgs.orgs.remove_all_users_from_org",
+            new_callable=AsyncMock,
+            return_value={"detail": "3 user(s) removed from org"},
+        ):
+            # The /users/all literal route must win over /users/{user_id}.
+            response = await client.delete("/api/v1/orgs/1/users/all")
+
+        assert response.status_code == 200
+        assert response.json()["detail"] == "3 user(s) removed from org"
+
+    async def test_wipe_org_content(self, client):
+        with patch(
+            "src.routers.orgs.orgs.wipe_org_content",
+            new_callable=AsyncMock,
+            return_value={"detail": "Organization content wiped", "deleted_courses": 2},
+        ):
+            response = await client.delete("/api/v1/orgs/1/content")
+
+        assert response.status_code == 200
+        assert response.json()["deleted_courses"] == 2
+
 
 class TestOrgConfigEndpoints:
     async def test_update_signup_mechanism(self, client):

--- a/apps/api/src/tests/services/test_org_users_service.py
+++ b/apps/api/src/tests/services/test_org_users_service.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from sqlmodel import select
 
 from src.db.roles import Role, RoleTypeEnum
 from src.db.user_organizations import UserOrganization
@@ -17,6 +18,7 @@ from src.services.orgs.users import (
     get_organization_users,
     get_list_of_invited_users,
     invite_batch_users,
+    remove_all_users_from_org,
     remove_batch_users_from_org,
     remove_invited_user,
     remove_user_from_org,
@@ -366,6 +368,41 @@ class TestOrgUsersService:
         invalidate_cache.assert_any_call(regular_user.id)
         invalidate_cache.assert_any_call(9999)
         assert decrease_usage.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_remove_all_users_from_org(
+        self, mock_request, db, org, admin_user, regular_user
+    ):
+        # Missing org -> 404
+        with pytest.raises(Exception) as missing_org_exc:
+            await remove_all_users_from_org(mock_request, 999, db, admin_user)
+        assert missing_org_exc.value.status_code == 404
+
+        # org has admin_user (id=1) and regular_user (id=2). Removing all should
+        # drop regular_user but keep the caller (admin_user).
+        with patch(
+            "src.services.orgs.users.rbac_check",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.routers.users._invalidate_session_cache"
+        ) as invalidate_cache, patch(
+            "src.services.orgs.users.decrease_feature_usage"
+        ) as decrease_usage:
+            result = await remove_all_users_from_org(
+                mock_request, org.id, db, admin_user
+            )
+
+        assert result == {"detail": "1 user(s) removed from org"}
+        invalidate_cache.assert_any_call(regular_user.id)
+        assert decrease_usage.call_count == 1
+
+        # Caller remains a member; the other user is gone.
+        remaining = (await db.exec(
+            select(UserOrganization).where(UserOrganization.org_id == org.id)
+        )).all()
+        remaining_ids = {uo.user_id for uo in remaining}
+        assert admin_user.id in remaining_ids
+        assert regular_user.id not in remaining_ids
 
     @pytest.mark.asyncio
     async def test_update_user_role_guard_paths_and_email_failure(

--- a/apps/api/src/tests/services/test_orgs_service.py
+++ b/apps/api/src/tests/services/test_orgs_service.py
@@ -7,8 +7,10 @@ import pytest
 from fastapi import HTTPException
 from sqlmodel import select
 
+from src.db.courses.courses import Course
 from src.db.organization_config import OrganizationConfig, SeoOrgConfig
 from src.db.organizations import Organization, OrganizationCreate, OrganizationRead, OrganizationUpdate
+from src.db.user_organizations import UserOrganization
 from src.services.orgs.orgs import (
     _build_org_read_with_resolved,
     _get_org_config_cached,
@@ -23,6 +25,7 @@ from src.services.orgs.orgs import (
     update_org_seo_config,
     update_org_signup_mechanism,
     update_org_with_config_no_auth,
+    wipe_org_content,
 )
 
 
@@ -470,3 +473,42 @@ class TestBuildOrgReadWithResolved:
         assert result.config.config["resolved_features"] == {
             "courses": {"enabled": True}
         }
+
+
+class TestWipeOrgContent:
+    @pytest.mark.asyncio
+    async def test_wipe_org_content_missing_org(self, mock_request, admin_user, db):
+        with pytest.raises(HTTPException) as exc:
+            await wipe_org_content(mock_request, 999, admin_user, db)
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_wipe_org_content_deletes_courses_keeps_org_and_members(
+        self, mock_request, db, org, admin_user, course
+    ):
+        # admin_user is a member of org via the fixture; `course` belongs to org.
+        with patch(
+            "src.services.orgs.orgs.rbac_check", new_callable=AsyncMock
+        ), patch(
+            "src.services.courses.transfer.storage_utils.delete_storage_directory"
+        ) as delete_storage, patch(
+            "src.security.features_utils.usage.decrease_feature_usage",
+            new_callable=AsyncMock,
+        ) as decrease_usage:
+            result = await wipe_org_content(mock_request, org.id, admin_user, db)
+
+        assert result == {"detail": "Organization content wiped", "deleted_courses": 1}
+        delete_storage.assert_called_once()
+        assert decrease_usage.call_count == 1
+
+        # All courses gone...
+        assert (await db.exec(
+            select(Course).where(Course.org_id == org.id)
+        )).first() is None
+        # ...but the org and its membership survive.
+        assert (await db.exec(
+            select(Organization).where(Organization.id == org.id)
+        )).first() is not None
+        assert (await db.exec(
+            select(UserOrganization).where(UserOrganization.org_id == org.id)
+        )).first() is not None

--- a/apps/api/src/tests/services/test_users_service.py
+++ b/apps/api/src/tests/services/test_users_service.py
@@ -10,6 +10,7 @@ import pytest
 from fastapi import HTTPException, UploadFile
 from sqlmodel import select
 
+from src.db.organizations import Organization
 from src.db.roles import RoleRead
 from src.db.user_organizations import UserOrganization
 from src.db.users import (
@@ -181,6 +182,79 @@ class TestDeleteUserById:
             )).first()
             is None
         )
+
+        # The org still has another admin (admin_user), so it must be kept.
+        assert (
+            await db.exec(select(Organization).where(Organization.id == org.id))
+        ).first() is not None
+
+    @pytest.mark.asyncio
+    @patch(
+        "src.services.users.users.authorization_verify_if_user_is_anon",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "src.services.users.users.authorization_verify_based_on_roles_and_authorship",
+        new_callable=AsyncMock,
+    )
+    async def test_delete_user_deletes_sole_admin_org_only(
+        self, mock_rbac_roles, mock_rbac_anon, mock_request, db, admin_user, org
+    ):
+        """Deleting a user wipes orgs they solely administer, keeps the rest."""
+        # org (id=1) already has admin_user as admin. Add a second org where the
+        # user-to-delete is the ONLY admin — that one should be deleted with them.
+        solo_org = Organization(
+            id=777,
+            name="Solo Org",
+            slug="solo-org",
+            email="solo@org.com",
+            org_uuid="org_solo",
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(solo_org)
+        await db.commit()
+
+        user_to_delete = User(
+            id=20,
+            username="soloadmin",
+            first_name="Solo",
+            last_name="Admin",
+            email="soloadmin@test.com",
+            password="hashed",
+            user_uuid="user_soloadmin",
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(user_to_delete)
+        await db.commit()
+
+        # Sole admin of solo_org, and a plain (non-admin) member of the shared org.
+        db.add(UserOrganization(
+            user_id=20, org_id=solo_org.id, role_id=1,
+            creation_date=str(datetime.now()), update_date=str(datetime.now()),
+        ))
+        db.add(UserOrganization(
+            user_id=20, org_id=org.id, role_id=3,
+            creation_date=str(datetime.now()), update_date=str(datetime.now()),
+        ))
+        await db.commit()
+
+        result = await delete_user_by_id(mock_request, db, admin_user, 20)
+        assert result == {"detail": "User deleted successfully"}
+
+        # The sole-admin org is gone...
+        assert (
+            await db.exec(select(Organization).where(Organization.id == solo_org.id))
+        ).first() is None
+        # ...while the shared org (still has admin_user) survives.
+        assert (
+            await db.exec(select(Organization).where(Organization.id == org.id))
+        ).first() is not None
+        # And no dangling memberships for the deleted user remain.
+        assert (
+            await db.exec(select(UserOrganization).where(UserOrganization.user_id == 20))
+        ).first() is None
 
 
 class TestCreateAndUpdateUser:

--- a/apps/api/src/tests/services/test_users_service.py
+++ b/apps/api/src/tests/services/test_users_service.py
@@ -256,6 +256,50 @@ class TestDeleteUserById:
             await db.exec(select(UserOrganization).where(UserOrganization.user_id == 20))
         ).first() is None
 
+    @pytest.mark.asyncio
+    @patch(
+        "src.services.users.users.authorization_verify_if_user_is_anon",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "src.services.users.users.authorization_verify_based_on_roles_and_authorship",
+        new_callable=AsyncMock,
+    )
+    async def test_delete_user_skips_missing_admin_org(
+        self, mock_rbac_roles, mock_rbac_anon, mock_request, db, admin_user
+    ):
+        """An admin membership pointing at a missing org is safely skipped."""
+        user_to_delete = User(
+            id=30,
+            username="orphanadmin",
+            first_name="Orphan",
+            last_name="Admin",
+            email="orphanadmin@test.com",
+            password="hashed",
+            user_uuid="user_orphanadmin",
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(user_to_delete)
+        await db.commit()
+
+        # Admin membership referencing an org row that does not exist. FK
+        # enforcement is off in the test engine, so this orphaned link exercises
+        # the defensive "org already gone" guard in delete_user_by_id.
+        db.add(UserOrganization(
+            user_id=30, org_id=99999, role_id=1,
+            creation_date=str(datetime.now()), update_date=str(datetime.now()),
+        ))
+        await db.commit()
+
+        result = await delete_user_by_id(mock_request, db, admin_user, 30)
+        assert result == {"detail": "User deleted successfully"}
+
+        assert (await db.exec(select(User).where(User.id == 30))).first() is None
+        assert (
+            await db.exec(select(UserOrganization).where(UserOrganization.user_id == 30))
+        ).first() is None
+
 
 class TestCreateAndUpdateUser:
     @pytest.mark.asyncio

--- a/apps/web/app/orgs/[orgslug]/dash/org/settings/[subpage]/page.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/org/settings/[subpage]/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { Breadcrumbs } from '@components/Objects/Breadcrumbs/Breadcrumbs'
 import { getUriWithOrg } from '@services/config/config'
-import { TextIcon, LucideIcon, LayoutDashboardIcon, CodeIcon, KeyIcon, Palette, School, Shield, Globe, Search, BarChart3, Zap, Menu as MenuIcon } from 'lucide-react'
+import { TextIcon, LucideIcon, LayoutDashboardIcon, CodeIcon, KeyIcon, Palette, School, Shield, Globe, Search, BarChart3, Zap, Menu as MenuIcon, AlertTriangle } from 'lucide-react'
 import React, { useEffect, use } from 'react';
 import { motion } from 'motion/react'
 import Image from 'next/image'
@@ -17,6 +17,7 @@ import OrgEditSEO from '@components/Dashboard/Pages/Org/OrgEditSEO/OrgEditSEO'
 import OrgEditUsage from '@components/Dashboard/Pages/Org/OrgEditUsage/OrgEditUsage'
 import OrgEditAutomations from '@components/Dashboard/Pages/Org/OrgEditAutomations/OrgEditAutomations'
 import OrgEditMenu from '@components/Dashboard/Pages/Org/OrgEditMenu/OrgEditMenu'
+import OrgEditDangerZone from '@components/Dashboard/Pages/Org/OrgEditDangerZone/OrgEditDangerZone'
 import { useTranslation } from 'react-i18next'
 import { PlanLevel } from '@services/plans/plans'
 import { DashTabBar, DashTabItem } from '@components/Dashboard/Shared/DashTabBar/DashTabBar'
@@ -47,6 +48,7 @@ const getSettingTabs = (t: any): TabConfig[] => [
   { id: 'sso', label: t('dashboard.organization.settings.tabs.sso') || 'SSO', icon: Shield, requiredPlan: 'enterprise' },
   { id: 'usage', label: t('dashboard.organization.settings.tabs.usage') || 'Usage', icon: BarChart3 },
   { id: 'other', label: t('dashboard.organization.settings.tabs.other'), icon: CodeIcon },
+  { id: 'danger', label: t('dashboard.organization.settings.tabs.danger') || 'Danger Zone', icon: AlertTriangle },
 ]
 
 function OrgPage(props: { params: Promise<OrgParams> }) {
@@ -93,6 +95,9 @@ function OrgPage(props: { params: Promise<OrgParams> }) {
     } else if (params.subpage == 'other') {
       setH1Label(t('dashboard.organization.settings.pages.other.title'))
       setH2Label(t('dashboard.organization.settings.pages.other.subtitle'))
+    } else if (params.subpage == 'danger') {
+      setH1Label(t('dashboard.organization.settings.pages.danger.title') || 'Danger Zone')
+      setH2Label(t('dashboard.organization.settings.pages.danger.subtitle') || 'Irreversible and destructive actions for this organization')
     }
   }
 
@@ -154,6 +159,7 @@ function OrgPage(props: { params: Promise<OrgParams> }) {
         {params.subpage == 'sso' ? <OrgEditSSO /> : ''}
         {params.subpage == 'usage' ? <OrgEditUsage /> : ''}
         {params.subpage == 'other' ? <OrgEditOther /> : ''}
+        {params.subpage == 'danger' ? <OrgEditDangerZone /> : ''}
       </motion.div>
     </div>
   )

--- a/apps/web/components/Dashboard/Pages/Org/OrgEditDangerZone/OrgEditDangerZone.tsx
+++ b/apps/web/components/Dashboard/Pages/Org/OrgEditDangerZone/OrgEditDangerZone.tsx
@@ -1,0 +1,211 @@
+'use client'
+import React from 'react'
+import { useOrg } from '@components/Contexts/OrgContext'
+import { useLHSession } from '@components/Contexts/LHSessionContext'
+import useAdminStatus from '@components/Hooks/useAdminStatus'
+import { toast } from 'react-hot-toast'
+import { AlertTriangle, Trash2, Users, Eraser, Loader2 } from 'lucide-react'
+import ConfirmationModal from '@components/Objects/StyledElements/ConfirmationModal/ConfirmationModal'
+import {
+  deleteOrganizationFromBackend,
+  removeAllUsersFromOrg,
+  wipeOrgContent,
+} from '@services/organizations/orgs'
+
+const OrgEditDangerZone: React.FC = () => {
+  const session = useLHSession() as any
+  const access_token = session?.data?.tokens?.access_token
+  const org = useOrg() as any
+  const { isAdmin, rights } = useAdminStatus()
+
+  const [confirmText, setConfirmText] = React.useState('')
+  const [isDeletingOrg, setIsDeletingOrg] = React.useState(false)
+  const [isRemovingUsers, setIsRemovingUsers] = React.useState(false)
+  const [isWipingContent, setIsWipingContent] = React.useState(false)
+
+  // Only admins (or users with explicit org-delete rights) should ever see this.
+  const canDeleteOrg = rights?.organizations?.action_delete === true || isAdmin === true
+
+  if (!org?.id) {
+    return null
+  }
+
+  if (isAdmin === false && !canDeleteOrg) {
+    return (
+      <div className="sm:mx-10 mx-0">
+        <div className="bg-white rounded-xl nice-shadow p-6 text-gray-500">
+          You don&apos;t have permission to manage this organization&apos;s danger zone.
+        </div>
+      </div>
+    )
+  }
+
+  const handleRemoveAllUsers = async () => {
+    setIsRemovingUsers(true)
+    const loadingToast = toast.loading('Removing all members…')
+    try {
+      await removeAllUsersFromOrg(org.id, access_token)
+      toast.success('All other members removed', { id: loadingToast })
+    } catch (err: any) {
+      toast.error(err?.message || 'Failed to remove members', { id: loadingToast })
+    } finally {
+      setIsRemovingUsers(false)
+    }
+  }
+
+  const handleWipeContent = async () => {
+    setIsWipingContent(true)
+    const loadingToast = toast.loading('Wiping organization content…')
+    try {
+      const res = await wipeOrgContent(org.id, access_token)
+      toast.success(
+        `Content wiped${typeof res?.deleted_courses === 'number' ? ` (${res.deleted_courses} course(s) deleted)` : ''}`,
+        { id: loadingToast }
+      )
+    } catch (err: any) {
+      toast.error(err?.message || 'Failed to wipe content', { id: loadingToast })
+    } finally {
+      setIsWipingContent(false)
+    }
+  }
+
+  const handleDeleteOrg = async () => {
+    if (confirmText !== org.slug) return
+    setIsDeletingOrg(true)
+    const loadingToast = toast.loading('Deleting organization…')
+    try {
+      await deleteOrganizationFromBackend(org.id, access_token)
+      toast.success('Organization deleted', { id: loadingToast })
+      // The org no longer exists — send the user back to the root so they land
+      // on org selection / login rather than a broken dashboard.
+      setTimeout(() => {
+        window.location.href = '/'
+      }, 800)
+    } catch (err: any) {
+      toast.error(err?.message || 'Failed to delete organization', { id: loadingToast })
+      setIsDeletingOrg(false)
+    }
+  }
+
+  return (
+    <div className="sm:mx-10 mx-0 space-y-4">
+      <div className="rounded-xl nice-shadow bg-white border border-red-100 overflow-hidden">
+        <div className="flex items-center space-x-2 bg-red-50 px-5 py-3 border-b border-red-100">
+          <AlertTriangle className="h-5 w-5 text-red-600" />
+          <div>
+            <h1 className="font-bold text-xl text-red-700">Danger Zone</h1>
+            <h2 className="text-red-500/80 text-sm">
+              These actions are permanent and cannot be undone.
+            </h2>
+          </div>
+        </div>
+
+        <div className="divide-y divide-gray-100">
+          {/* Remove all members */}
+          <div className="flex items-start justify-between gap-4 px-5 py-4">
+            <div className="space-y-0.5">
+              <div className="flex items-center space-x-2">
+                <Users className="h-4 w-4 text-gray-700" />
+                <span className="font-semibold text-gray-800">Remove all members</span>
+              </div>
+              <p className="text-sm text-gray-500 max-w-xl">
+                Remove every member from this organization except you. Courses and
+                other content are kept.
+              </p>
+            </div>
+            <ConfirmationModal
+              confirmationButtonText="Remove all members"
+              confirmationMessage="Every member except you will be removed from this organization. This cannot be undone."
+              dialogTitle="Remove all members?"
+              status="warning"
+              functionToExecute={handleRemoveAllUsers}
+              dialogTrigger={
+                <button
+                  type="button"
+                  disabled={isRemovingUsers}
+                  className="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 rounded-md text-sm font-medium text-red-700 bg-red-50 hover:bg-red-100 border border-red-200 transition disabled:opacity-50"
+                >
+                  {isRemovingUsers ? <Loader2 className="h-4 w-4 animate-spin" /> : <Users className="h-4 w-4" />}
+                  <span>Remove all</span>
+                </button>
+              }
+            />
+          </div>
+
+          {/* Wipe content */}
+          <div className="flex items-start justify-between gap-4 px-5 py-4">
+            <div className="space-y-0.5">
+              <div className="flex items-center space-x-2">
+                <Eraser className="h-4 w-4 text-gray-700" />
+                <span className="font-semibold text-gray-800">Wipe all content</span>
+              </div>
+              <p className="text-sm text-gray-500 max-w-xl">
+                Permanently delete all courses and their content. The organization
+                and its members are kept.
+              </p>
+            </div>
+            <ConfirmationModal
+              confirmationButtonText="Wipe all content"
+              confirmationMessage="All courses and their content will be permanently deleted. This cannot be undone."
+              dialogTitle="Wipe all content?"
+              status="warning"
+              functionToExecute={handleWipeContent}
+              dialogTrigger={
+                <button
+                  type="button"
+                  disabled={isWipingContent}
+                  className="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 rounded-md text-sm font-medium text-red-700 bg-red-50 hover:bg-red-100 border border-red-200 transition disabled:opacity-50"
+                >
+                  {isWipingContent ? <Loader2 className="h-4 w-4 animate-spin" /> : <Eraser className="h-4 w-4" />}
+                  <span>Wipe content</span>
+                </button>
+              }
+            />
+          </div>
+
+          {/* Delete organization (typed confirmation) */}
+          {canDeleteOrg && (
+            <div className="px-5 py-4 space-y-3 bg-red-50/30">
+              <div className="space-y-0.5">
+                <div className="flex items-center space-x-2">
+                  <Trash2 className="h-4 w-4 text-red-700" />
+                  <span className="font-semibold text-red-800">Delete this organization</span>
+                </div>
+                <p className="text-sm text-gray-500 max-w-xl">
+                  Permanently delete <span className="font-semibold">{org.name}</span> and
+                  everything in it — members, courses, content and settings. This
+                  cannot be undone.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <label className="text-xs text-gray-500">
+                  Type <span className="font-mono font-semibold text-gray-700">{org.slug}</span> to confirm.
+                </label>
+                <div className="flex items-center gap-3">
+                  <input
+                    type="text"
+                    value={confirmText}
+                    onChange={(e) => setConfirmText(e.target.value)}
+                    placeholder={org.slug}
+                    className="w-full max-w-xs px-3 py-2 border border-red-200 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-red-300"
+                  />
+                  <button
+                    type="button"
+                    onClick={handleDeleteOrg}
+                    disabled={confirmText !== org.slug || isDeletingOrg}
+                    className="shrink-0 inline-flex items-center gap-1.5 px-3 py-2 rounded-md text-sm font-bold text-white bg-red-600 hover:bg-red-700 transition disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    {isDeletingOrg ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+                    <span>Delete organization</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default OrgEditDangerZone

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -2607,7 +2607,8 @@
           "other": "Other",
           "seo": "SEO",
           "automations": "Automations",
-          "menu": "Menu"
+          "menu": "Menu",
+          "danger": "Danger Zone"
         },
         "pages": {
           "general": {
@@ -2653,6 +2654,10 @@
           "menu": {
             "title": "Public menu",
             "subtitle": "Choose and order the links shown in your public navigation"
+          },
+          "danger": {
+            "title": "Danger Zone",
+            "subtitle": "Irreversible and destructive actions for this organization"
           }
         },
         "name": "Organization Name",

--- a/apps/web/services/organizations/orgs.ts
+++ b/apps/web/services/organizations/orgs.ts
@@ -162,6 +162,27 @@ export async function removeUsersFromOrg(
   return res
 }
 
+export async function removeAllUsersFromOrg(
+  org_id: any,
+  access_token: string
+) {
+  const result = await fetch(
+    `${getAPIUrl()}orgs/${org_id}/users/all`,
+    RequestBodyWithAuthHeader('DELETE', null, null, access_token)
+  )
+  const res = await errorHandling(result)
+  return res
+}
+
+export async function wipeOrgContent(org_id: any, access_token: string) {
+  const result = await fetch(
+    `${getAPIUrl()}orgs/${org_id}/content`,
+    RequestBodyWithAuthHeader('DELETE', null, null, access_token)
+  )
+  const res = await errorHandling(result)
+  return res
+}
+
 export async function joinOrg(
   args: {
     org_id: number


### PR DESCRIPTION
## What & why

Two related pieces of org lifecycle management:

### 1. Delete sole-admin orgs when a user deletes their account
Previously deleting a user only removed their memberships, which could leave
behind orphaned, admin-less organizations. Now `delete_user_by_id` also deletes
any organization the user **solely** administers (admin role with no other
admin). Orgs that still have another admin are kept; the user is just removed
from them. The org-level CASCADE handles members/courses/content cleanup, and
affected members' cached sessions are invalidated.

### 2. Organization "Danger Zone"
A new tab under **Org settings → Danger Zone** (admin-only) exposes three
destructive actions, each with explicit confirmation:

| Action | Effect |
| --- | --- |
| **Delete organization** | Permanently deletes the org and everything in it. Requires typing the org slug to confirm. |
| **Remove all members** | Removes every member except the caller. Org and content kept. |
| **Wipe all content** | Deletes every course (and cascaded content). Org and members kept. |

## Backend
- `delete_user_by_id` — sole-admin org deletion (with audit log + session-cache invalidation).
- New service `remove_all_users_from_org` → `DELETE /orgs/{org_id}/users/all` (keeps the caller so the org always retains an admin).
- New service `wipe_org_content` → `DELETE /orgs/{org_id}/content` (mirrors `delete_course` storage cleanup + usage decrement).
- `/users/all` is registered before `/users/{user_id}` so the literal route wins.

## Frontend
- New `OrgEditDangerZone` component, wired into the settings tab router.
- New API helpers `removeAllUsersFromOrg` / `wipeOrgContent`; reuses existing `deleteOrganizationFromBackend`.
- Admin-gated via `useAdminStatus`; English locale strings added (other locales fall back to `en`).

## Tests
- Sole-admin org is deleted while a shared org (with another admin) survives.
- `remove_all_users_from_org` keeps the caller and removes others.
- `wipe_org_content` deletes courses but keeps org + memberships, plus the missing-org 404 path.

All affected backend test modules pass (`test_users_service`, `test_org_users_service`, `test_orgs_service`, `test_orgs_router`). Changed web files lint clean (0 errors) and typecheck clean.