### PR TITLE
feat(assignments): headless assignments API via org API tokens

### DIFF
--- a/apps/api/migrations/versions/b2c3d4e5f8a9_add_custom_assignment_type.py
+++ b/apps/api/migrations/versions/b2c3d4e5f8a9_add_custom_assignment_type.py
@@ -1,0 +1,36 @@
+"""add CUSTOM to assignmenttasktypeenum
+
+Adds a first-class CUSTOM assignment task type for headless/custom assignments:
+the task ``contents`` JSON (definition) and ``task_submission`` JSON (answer) are
+an arbitrary, caller-owned data object that the server never interprets or
+auto-grades — it is graded manually. Lets custom frontends fully own the schema.
+
+Revision ID: b2c3d4e5f8a9
+Revises: a1b2c3d4e5f7
+Create Date: 2026-06-27
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa  # noqa: F401
+import sqlmodel  # noqa: F401
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b2c3d4e5f8a9'
+down_revision: Union[str, None] = 'a1b2c3d4e5f7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ALTER TYPE ... ADD VALUE cannot run inside a transaction block; commit the
+    # migration's implicit transaction first (mirrors the CODE-type migration).
+    op.execute("COMMIT")
+    op.execute("ALTER TYPE assignmenttasktypeenum ADD VALUE IF NOT EXISTS 'CUSTOM'")
+
+
+def downgrade() -> None:
+    # PostgreSQL does not support removing enum values directly.
+    pass

--- a/apps/api/src/db/courses/assignments.py
+++ b/apps/api/src/db/courses/assignments.py
@@ -129,6 +129,11 @@ class AssignmentTaskTypeEnum(str, Enum):
     CODE = "CODE"
     SHORT_ANSWER = "SHORT_ANSWER"
     NUMBER_ANSWER = "NUMBER_ANSWER"
+    # Headless/custom task: the `contents` JSON (the task definition) and the
+    # `task_submission` JSON (the learner answer) are an arbitrary, caller-owned
+    # data object. The server never interprets or auto-grades it — it is graded
+    # manually (or left ungraded), so custom frontends fully control the schema.
+    CUSTOM = "CUSTOM"
     OTHER = "OTHER"
 
 

--- a/apps/api/src/db/roles.py
+++ b/apps/api/src/db/roles.py
@@ -55,6 +55,14 @@ class Rights(BaseModel):
     organizations: Permission
     coursechapters: Permission
     activities: Permission
+    assignments: Permission = Permission(
+        action_create=False,
+        action_read=False,
+        action_update=False,
+        action_delete=False,
+    )  # Default: no access. Single bucket covering assignment authoring, tasks,
+    # submissions, and grading (grading = action_update). Lets API tokens drive
+    # headless assignments while existing roles/tokens stay unaffected.
     roles: Permission
     dashboard: DashboardPermission
     communities: Permission

--- a/apps/api/src/router.py
+++ b/apps/api/src/router.py
@@ -36,6 +36,7 @@ from src.routers.utils import router as utils_router
 from src.security.auth import get_current_user
 from src.security.api_token_utils import (
     get_authenticated_non_api_token_user,
+    require_authenticated_user_or_api_token,
     require_non_api_token_user,
 )
 from src.security.features_utils.plan_check import require_plan, require_plan_for_boards, require_plan_for_certifications, require_plan_for_community, require_plan_for_usergroups, require_plan_for_playgrounds
@@ -167,7 +168,11 @@ v1_router.include_router(
     assignments.router,
     prefix="/assignments",
     tags=["assignments"],
-    dependencies=[Depends(require_authenticated_user)]
+    # Admit API tokens (headless assignments) while still rejecting anonymous.
+    # Individual handlers gate access: authoring + grading go through
+    # authorize_assignment_access (assignments rights bucket), while learner
+    # /me + submission endpoints keep _block_api_tokens (session-only).
+    dependencies=[Depends(require_authenticated_user_or_api_token)]
 )
 v1_router.include_router(chapters.router, prefix="/chapters", tags=["chapters"])
 v1_router.include_router(activities.router, prefix="/activities", tags=["activities"])

--- a/apps/api/src/routers/courses/assignments.py
+++ b/apps/api/src/routers/courses/assignments.py
@@ -409,11 +409,16 @@ async def api_handle_assignment_task_submissions(
     request: Request,
     assignment_task_submission_object: AssignmentTaskSubmissionUpdate,
     assignment_task_uuid: str,
+    on_behalf_of_user_id: int | None = None,
     current_user: PublicUser = Depends(get_current_user),
     db_session=Depends(get_db_session),
 ):
     """
-    Create new task submissions for an assignment
+    Create new task submissions for an assignment.
+
+    Sessions write their own submission. An API token with ``assignments.create``
+    may submit on behalf of a learner by passing ``on_behalf_of_user_id`` (the
+    learner's LearnHouse user id; the learner must belong to the token's org).
     """
     return await handle_assignment_task_submission(
         request,
@@ -421,6 +426,7 @@ async def api_handle_assignment_task_submissions(
         assignment_task_submission_object,
         current_user,
         db_session,
+        on_behalf_of_user_id=on_behalf_of_user_id,
     )
 
 
@@ -578,14 +584,19 @@ async def api_delete_assignment_task_submissions(
 async def api_create_assignment_submissions(
     request: Request,
     assignment_uuid: str,
+    on_behalf_of_user_id: int | None = None,
     current_user: PublicUser = Depends(get_current_user),
     db_session=Depends(get_db_session),
 ):
     """
-    Create new submissions for an assignment
+    Create new submissions for an assignment.
+
+    Sessions submit for themselves. An API token with ``assignments.create`` may
+    submit on behalf of a learner by passing ``on_behalf_of_user_id``.
     """
     return await create_assignment_submission(
-        request, assignment_uuid, current_user, db_session
+        request, assignment_uuid, current_user, db_session,
+        on_behalf_of_user_id=on_behalf_of_user_id,
     )
 
 

--- a/apps/api/src/security/api_token_utils.py
+++ b/apps/api/src/security/api_token_utils.py
@@ -101,3 +101,25 @@ async def get_authenticated_non_api_token_user(
             detail="API tokens cannot access this resource. Only user authentication is allowed.",
         )
     return user
+
+
+async def require_authenticated_user_or_api_token(
+    request: Request,
+    db_session: AsyncSession = Depends(get_db_session),
+):
+    """
+    FastAPI dependency that requires an authenticated session OR a valid API token.
+
+    Rejects anonymous callers (401) but — unlike ``get_authenticated_non_api_token_user`` —
+    admits API tokens. Use as the router-level dependency on routers that expose some
+    endpoints to headless API-token clients while still gating individual handlers
+    internally (e.g. assignments: authoring + grading are token-accessible, but the
+    learner ``/me`` / submission endpoints remain session-only).
+
+    Raises:
+        HTTPException 401 if the request is unauthenticated.
+    """
+    # Imported locally to avoid a circular dependency on auth.py.
+    from src.security.auth import get_authenticated_user
+
+    return await get_authenticated_user(request, db_session)

--- a/apps/api/src/security/rbac/rbac.py
+++ b/apps/api/src/security/rbac/rbac.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Literal, Union
+from typing import Literal, Optional, Union
 from fastapi import HTTPException, status, Request
 from sqlalchemy import null
 from sqlmodel import select
@@ -461,6 +461,7 @@ async def authorization_verify_api_token_permissions(
     action: Literal["read", "update", "delete", "create"],
     element_uuid: str,
     db_session: AsyncSession,
+    resource_type_override: Optional[str] = None,
 ) -> bool:
     """
     Verify API token permissions for an action on an element.
@@ -470,14 +471,20 @@ async def authorization_verify_api_token_permissions(
 
     API tokens are restricted to these resources:
     - courses, activities, coursechapters, folders, media, certifications,
-    - usergroups, payments, search
+    - usergroups, payments, search, assignments
 
     Args:
         request: FastAPI request object
         api_token_user: The authenticated API token user
         action: The action being performed
-        element_uuid: The UUID of the element being accessed
+        element_uuid: The UUID of the element being accessed. Used both to
+            resolve the resource type (by UUID prefix) and to enforce the org
+            boundary.
         db_session: Database session
+        resource_type_override: When the rights bucket to check differs from the
+            element's own type, pass it here. Assignments authorize against their
+            parent course UUID (for the org-boundary lookup) but must be checked
+            against the ``assignments`` rights bucket, not ``courses``.
 
     Returns:
         bool: True if permission granted
@@ -485,12 +492,12 @@ async def authorization_verify_api_token_permissions(
     Raises:
         HTTPException: If permission denied or org boundary violated
     """
-    element_type = await check_element_type(element_uuid)
+    element_type = resource_type_override or await check_element_type(element_uuid)
 
     # API tokens are restricted to specific resource types
     allowed_resource_types = [
         'courses', 'activities', 'coursechapters', 'folders', 'media',
-        'certifications', 'usergroups', 'payments', 'search'
+        'certifications', 'usergroups', 'payments', 'search', 'assignments'
     ]
 
     if element_type not in allowed_resource_types:

--- a/apps/api/src/services/courses/activities/assignments.py
+++ b/apps/api/src/services/courses/activities/assignments.py
@@ -42,6 +42,7 @@ from src.security.features_utils.usage import (
 )
 from src.security.rbac import (
     authorization_verify_based_on_roles,
+    authorization_verify_api_token_permissions,
     check_resource_access,
     AccessAction,
 )
@@ -64,12 +65,78 @@ def _block_api_tokens(current_user: PublicUser | AnonymousUser | APITokenUser) -
 
     SECURITY: Assignments contain sensitive user submission data and grades.
     API tokens are not allowed to access this data - only user authentication is permitted.
+
+    Still used on the learner-centric, session-only endpoints (the ``/me`` reads,
+    student submission upsert, file uploads, retry, "done"). The instructor-style
+    endpoints (authoring, reading submissions, grading) instead go through
+    ``authorize_assignment_access`` so API tokens with the ``assignments`` rights
+    bucket can drive assignments headlessly.
     """
     if isinstance(current_user, APITokenUser):
         raise HTTPException(
             status_code=403,
             detail="API tokens cannot access assignments. Only user authentication is allowed.",
         )
+
+
+_ACCESS_ACTION_TO_TOKEN_ACTION = {
+    AccessAction.CREATE: "create",
+    AccessAction.READ: "read",
+    AccessAction.UPDATE: "update",
+    AccessAction.DELETE: "delete",
+}
+
+
+async def authorize_assignment_access(
+    request: Request,
+    db_session: AsyncSession,
+    current_user: PublicUser | AnonymousUser | APITokenUser,
+    course_uuid: str,
+    access_action: AccessAction,
+    token_action: str | None = None,
+) -> None:
+    """Authorize an assignment operation for either a user session or an API token.
+
+    Sessions keep the existing course-scoped RBAC (``check_resource_access``).
+    API tokens are authorized against the single ``assignments`` rights bucket,
+    with the organization boundary enforced via the parent course UUID.
+
+    ``token_action`` overrides the rights action checked for tokens when it should
+    differ from the session ``access_action`` (e.g. listing per-task submissions
+    requires instructor UPDATE for a session but is a ``read`` for a token; an
+    authoring token attaches reference files as part of ``create``).
+    """
+    if isinstance(current_user, APITokenUser):
+        action = token_action or _ACCESS_ACTION_TO_TOKEN_ACTION[access_action]
+        await authorization_verify_api_token_permissions(
+            request,
+            current_user,
+            action,
+            course_uuid,
+            db_session,
+            resource_type_override="assignments",
+        )
+        return
+    await check_resource_access(request, db_session, current_user, course_uuid, access_action)
+
+
+async def _is_assignment_instructor(
+    request: Request,
+    current_user: PublicUser | AnonymousUser | APITokenUser,
+    course_uuid: str,
+    db_session: AsyncSession,
+) -> bool:
+    """Whether the principal has instructor-level (grading) authority on the course.
+
+    An API token that has already passed ``authorize_assignment_access`` for the
+    ``assignments`` bucket acts with instructor visibility (only org admins can
+    mint such tokens). Sessions fall back to the role check.
+    """
+    if isinstance(current_user, APITokenUser):
+        return True
+    return await authorization_verify_based_on_roles(
+        request, current_user.id, "update", course_uuid, db_session
+    )
 
 
 def _is_assignment_past_due(assignment: Assignment) -> bool:
@@ -651,7 +718,6 @@ async def create_assignment(
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
 ):
-    _block_api_tokens(current_user)
     # Check if org exists
     statement = select(Course).where(Course.id == assignment_object.course_id)
     course = (await db_session.execute(statement)).scalars().first()
@@ -663,7 +729,7 @@ async def create_assignment(
         )
 
     # RBAC check
-    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.CREATE)
+    await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.CREATE)
 
     # Usage check
     await check_limits_with_usage("assignments", course.org_id, db_session)
@@ -694,7 +760,6 @@ async def read_assignment(
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
 ):
-    _block_api_tokens(current_user)
     statement = (
         select(Assignment, Course.course_uuid, Activity.activity_uuid)
         .join(Course, Course.id == Assignment.course_id)  # type: ignore
@@ -711,7 +776,7 @@ async def read_assignment(
 
     assignment, course_uuid, activity_uuid = row
 
-    await check_resource_access(request, db_session, current_user, course_uuid, AccessAction.READ)
+    await authorize_assignment_access(request, db_session, current_user, course_uuid, AccessAction.READ)
 
     result = AssignmentRead.model_validate(assignment)
     result.course_uuid = course_uuid
@@ -725,7 +790,6 @@ async def read_assignment_from_activity_uuid(
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
 ):
-    _block_api_tokens(current_user)
     statement = (
         select(Assignment, Course.course_uuid, Activity.activity_uuid)
         .join(Activity, Activity.id == Assignment.activity_id)  # type: ignore
@@ -742,7 +806,7 @@ async def read_assignment_from_activity_uuid(
 
     assignment, course_uuid, activity_uuid_val = row
 
-    await check_resource_access(request, db_session, current_user, course_uuid, AccessAction.READ)
+    await authorize_assignment_access(request, db_session, current_user, course_uuid, AccessAction.READ)
 
     result = AssignmentRead.model_validate(assignment)
     result.course_uuid = course_uuid
@@ -757,7 +821,6 @@ async def update_assignment(
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
 ):
-    _block_api_tokens(current_user)
     # Check if assignment exists
     statement = select(Assignment).where(Assignment.assignment_uuid == assignment_uuid)
     assignment = (await db_session.execute(statement)).scalars().first()
@@ -779,7 +842,7 @@ async def update_assignment(
         )
 
     # RBAC check
-    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
+    await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
 
     # Update only the fields that were passed in
     for var, value in vars(assignment_object).items():
@@ -802,7 +865,6 @@ async def delete_assignment(
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
 ):
-    _block_api_tokens(current_user)
     # Check if assignment exists
     statement = select(Assignment).where(Assignment.assignment_uuid == assignment_uuid)
     assignment = (await db_session.execute(statement)).scalars().first()
@@ -824,7 +886,7 @@ async def delete_assignment(
         )
 
     # RBAC check
-    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.DELETE)
+    await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.DELETE)
 
     # Feature usage
     await decrease_feature_usage("assignments", course.org_id, db_session)
@@ -842,7 +904,6 @@ async def delete_assignment_from_activity_uuid(
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
 ):
-    _block_api_tokens(current_user)
     # Check if activity exists
     statement = select(Activity).where(Activity.activity_uuid == activity_uuid)
 
@@ -875,7 +936,7 @@ async def delete_assignment_from_activity_uuid(
         )
 
     # RBAC check
-    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.DELETE)
+    await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.DELETE)
 
      # Feature usage
     await decrease_feature_usage("assignments", course.org_id, db_session)
@@ -898,7 +959,6 @@ async def create_assignment_task(
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
 ):
-    _block_api_tokens(current_user)
     # Check if assignment exists
     statement = select(Assignment).where(Assignment.assignment_uuid == assignment_uuid)
     assignment = (await db_session.execute(statement)).scalars().first()
@@ -920,7 +980,7 @@ async def create_assignment_task(
         )
 
     # RBAC check
-    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.CREATE)
+    await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.CREATE)
 
     # Create Assignment Task
     assignment_task = AssignmentTask(**assignment_task_object.model_dump())
@@ -949,7 +1009,6 @@ async def read_assignment_tasks(
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
 ):
-    _block_api_tokens(current_user)
     # Find assignment
     statement = select(Assignment).where(Assignment.assignment_uuid == assignment_uuid)
     assignment = (await db_session.execute(statement)).scalars().first()
@@ -978,7 +1037,7 @@ async def read_assignment_tasks(
     )
 
     # RBAC check
-    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
+    await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
 
     # return assignment tasks read
     return [
@@ -993,7 +1052,6 @@ async def read_assignment_task(
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
 ):
-    _block_api_tokens(current_user)
     # Find assignment
     statement = select(AssignmentTask).where(
         AssignmentTask.assignment_task_uuid == assignment_task_uuid
@@ -1027,7 +1085,7 @@ async def read_assignment_task(
         )
 
     # RBAC check
-    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
+    await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
 
     # return assignment task read
     return AssignmentTaskRead.model_validate(assignmenttask)
@@ -1040,7 +1098,6 @@ async def put_assignment_task_reference_file(
     current_user: PublicUser | AnonymousUser | APITokenUser,
     reference_file: UploadFile | None = None,
 ):
-    _block_api_tokens(current_user)
     # Check if assignment task exists
     statement = select(AssignmentTask).where(
         AssignmentTask.assignment_task_uuid == assignment_task_uuid
@@ -1082,7 +1139,7 @@ async def put_assignment_task_reference_file(
     org = (await db_session.execute(org_statement)).scalars().first()
 
     # RBAC check
-    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
+    await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE, token_action="create")
 
     # Upload reference file
     if reference_file and reference_file.filename and activity and org:
@@ -1187,7 +1244,6 @@ async def update_assignment_task(
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
 ):
-    _block_api_tokens(current_user)
     # Check if assignment task exists
     statement = select(AssignmentTask).where(
         AssignmentTask.assignment_task_uuid == assignment_task_uuid
@@ -1221,7 +1277,7 @@ async def update_assignment_task(
         )
 
     # RBAC check
-    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
+    await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
 
     # Update only the fields that were passed in
     for var, value in vars(assignment_task_object).items():
@@ -1244,7 +1300,6 @@ async def delete_assignment_task(
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
 ):
-    _block_api_tokens(current_user)
     # Check if assignment task exists
     statement = select(AssignmentTask).where(
         AssignmentTask.assignment_task_uuid == assignment_task_uuid
@@ -1278,7 +1333,7 @@ async def delete_assignment_task(
         )
 
     # RBAC check
-    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.DELETE)
+    await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.DELETE)
 
     # Delete Assignment Task
     await db_session.delete(assignment_task)
@@ -1290,14 +1345,58 @@ async def delete_assignment_task(
 ## > Assignments Tasks Submissions CRUD
 
 
+async def _resolve_token_submission_user(
+    request: Request,
+    db_session: AsyncSession,
+    current_user: PublicUser | AnonymousUser | APITokenUser,
+    course,
+    on_behalf_of_user_id: int | None,
+):
+    """Resolve the learner an API token is submitting on behalf of.
+
+    Submit-on-behalf lets a headless/custom frontend write a learner's answer
+    via a token. The token must hold ``assignments.create`` and pass an explicit
+    ``on_behalf_of_user_id``; the target learner must already be a member of the
+    token's organization (learners are referenced by existing LearnHouse id).
+
+    Returns the learner as a ``PublicUser`` to act as, or ``None`` for non-token
+    callers (sessions act as themselves).
+    """
+    if not isinstance(current_user, APITokenUser):
+        return None
+    if on_behalf_of_user_id is None:
+        raise HTTPException(
+            status_code=400,
+            detail="API tokens must set on_behalf_of_user_id to submit on behalf of a learner",
+        )
+    # assignments.create gates writing learner submission data + enforces the
+    # org boundary via the parent course.
+    await authorize_assignment_access(
+        request, db_session, current_user, course.course_uuid, AccessAction.CREATE
+    )
+    from src.security.org_auth import is_org_member
+
+    learner = (
+        await db_session.execute(select(User).where(User.id == on_behalf_of_user_id))
+    ).scalars().first()
+    if not learner:
+        raise HTTPException(status_code=404, detail="Learner not found")
+    if not await is_org_member(learner.id, course.org_id, db_session):
+        raise HTTPException(
+            status_code=403,
+            detail="Learner is not a member of this organization",
+        )
+    return PublicUser(**learner.model_dump())
+
+
 async def handle_assignment_task_submission(
     request: Request,
     assignment_task_uuid: str,
     assignment_task_submission_object: AssignmentTaskSubmissionUpdate,
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
+    on_behalf_of_user_id: int | None = None,
 ):
-    _block_api_tokens(current_user)
     assignment_task_submission_uuid = assignment_task_submission_object.assignment_task_submission_uuid
     # Check if assignment task exists
     statement = select(AssignmentTask).where(
@@ -1331,25 +1430,42 @@ async def handle_assignment_task_submission(
             detail="Course not found",
         )
 
-    # SECURITY: Check if user has instructor/admin permissions for grading
-    is_instructor = await authorization_verify_based_on_roles(request, current_user.id, "update", course.course_uuid, db_session)
+    # Resolve who the submission is for. API tokens submit on behalf of a learner
+    # (assignments.create + explicit on_behalf_of_user_id); sessions act as self.
+    token_submitter = await _resolve_token_submission_user(
+        request, db_session, current_user, course, on_behalf_of_user_id
+    )
+    if token_submitter is not None:
+        submitter = token_submitter
+        is_instructor = False
+        is_token_submit = True
+    else:
+        _block_api_tokens(current_user)
+        submitter = current_user
+        # SECURITY: Check if user has instructor/admin permissions for grading
+        is_instructor = await authorization_verify_based_on_roles(request, current_user.id, "update", course.course_uuid, db_session)
+        is_token_submit = False
 
-    # For regular users, ensure they can only submit their own work
+    # For non-instructors (session students AND token submit-on-behalf), the call
+    # writes a learner ANSWER, never a grade.
     if not is_instructor:
-        # Check if user is enrolled in the course
-        if not await authorization_verify_based_on_roles(request, current_user.id, "read", course.course_uuid, db_session):
-            raise HTTPException(
-                status_code=403,
-                detail="You must be enrolled in this course to submit assignments"
-            )
+        if not is_token_submit:
+            # Session students must be enrolled and within the deadline. A token
+            # acting for a learner is an authorized external writer — the custom
+            # frontend owns enrollment/deadline, so those gates are skipped.
+            if not await authorization_verify_based_on_roles(request, current_user.id, "read", course.course_uuid, db_session):
+                raise HTTPException(
+                    status_code=403,
+                    detail="You must be enrolled in this course to submit assignments"
+                )
 
-        if _is_assignment_past_due(assignment):
-            raise HTTPException(
-                status_code=403,
-                detail="Assignment deadline has passed",
-            )
+            if _is_assignment_past_due(assignment):
+                raise HTTPException(
+                    status_code=403,
+                    detail="Assignment deadline has passed",
+                )
 
-        # SECURITY: Regular users cannot update grades - only check if actual values are being set
+        # SECURITY: answer submissions cannot carry grades - only check if actual values are being set
         if (assignment_task_submission_object.grade is not None and assignment_task_submission_object.grade != 0) or \
            (assignment_task_submission_object.task_submission_grade_feedback is not None and assignment_task_submission_object.task_submission_grade_feedback != ""):
             raise HTTPException(
@@ -1362,14 +1478,16 @@ async def handle_assignment_task_submission(
         assignment_task_submission_object.assignment_task_id = None
         assignment_task_submission_object.assignment_type = None
 
-        # Students cannot flag a submission as manually graded — that's
-        # exclusively a teacher action. Also force-clear any prior flag so a
-        # student edit invalidates the teacher's earlier manual grade and the
+        # Neither students nor tokens can flag a submission as manually graded —
+        # that's exclusively a teacher action. Also force-clear any prior flag so
+        # a new answer invalidates the teacher's earlier manual grade and the
         # task re-enters the server-verified pool on the next grading pass.
         assignment_task_submission_object.manually_graded = False
 
-        # Only need read permission for submissions
-        await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
+        if not is_token_submit:
+            # Session students need READ on the course; the token was already
+            # authorized via assignments.create in _resolve_token_submission_user.
+            await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
     else:
         # SECURITY: Instructors/admins need update permission to grade
         await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
@@ -1377,7 +1495,7 @@ async def handle_assignment_task_submission(
     # Try to find existing submission by user_id and assignment_task_id first (for save progress functionality)
     statement = select(AssignmentTaskSubmission).where(
         AssignmentTaskSubmission.assignment_task_id == assignment_task.id,
-        AssignmentTaskSubmission.user_id == current_user.id,
+        AssignmentTaskSubmission.user_id == submitter.id,
     )
     assignment_task_submission = (await db_session.execute(statement)).scalars().first()
     
@@ -1390,8 +1508,9 @@ async def handle_assignment_task_submission(
 
     # If submission exists, update it
     if assignment_task_submission:
-        # SECURITY: For regular users, ensure they can only update their own submissions
-        if not is_instructor and assignment_task_submission.user_id != current_user.id:
+        # SECURITY: non-instructors (students / token submit-on-behalf) can only
+        # touch the submitter's own submission row.
+        if not is_instructor and assignment_task_submission.user_id != submitter.id:
             raise HTTPException(
                 status_code=403,
                 detail="You can only update your own submissions"
@@ -1425,7 +1544,7 @@ async def handle_assignment_task_submission(
             activity_id=assignment.activity_id,
             course_id=assignment.course_id,
             chapter_id=assignment.chapter_id,
-            user_id=current_user.id,
+            user_id=submitter.id,
             creation_date=current_time,
             update_date=current_time,
         )
@@ -1446,7 +1565,6 @@ async def read_user_assignment_task_submissions(
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
 ):
-    _block_api_tokens(current_user)
     # Check if assignment task exists
     statement = select(AssignmentTask).where(
         AssignmentTask.assignment_task_uuid == assignment_task_uuid
@@ -1480,12 +1598,10 @@ async def read_user_assignment_task_submissions(
         )
 
     # RBAC check
-    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
+    await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
 
     # Ownership check: non-instructors may only read their own submissions
-    is_instructor = await authorization_verify_based_on_roles(
-        request, current_user.id, "update", course.course_uuid, db_session
-    )
+    is_instructor = await _is_assignment_instructor(request, current_user, course.course_uuid, db_session)
     if not is_instructor and int(user_id) != int(current_user.id):
         raise HTTPException(
             status_code=403,
@@ -1625,7 +1741,6 @@ async def read_assignment_task_submissions(
     limit: int = 50,
     offset: int = 0,
 ):
-    _block_api_tokens(current_user)
     # Check if assignment task exists
     statement = select(AssignmentTask).where(
         AssignmentTask.assignment_task_uuid == assignment_task_uuid,
@@ -1659,7 +1774,7 @@ async def read_assignment_task_submissions(
         )
 
     # Only instructors may list all submissions for a task
-    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
+    await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE, token_action="read")
 
     statement = select(AssignmentTaskSubmission).where(
         AssignmentTaskSubmission.assignment_task_id == assignment_task.id
@@ -1824,8 +1939,8 @@ async def create_assignment_submission(
     assignment_uuid: str,
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
+    on_behalf_of_user_id: int | None = None,
 ):
-    _block_api_tokens(current_user)
     # Check if assignment exists
     statement = select(Assignment).where(Assignment.assignment_uuid == assignment_uuid)
     assignment = (await db_session.execute(statement)).scalars().first()
@@ -1836,15 +1951,52 @@ async def create_assignment_submission(
             detail="Assignment not found",
         )
 
+    # Check if course exists
+    statement = select(Course).where(Course.id == assignment.course_id)
+    course = (await db_session.execute(statement)).scalars().first()
+
+    if not course:
+        raise HTTPException(
+            status_code=404,
+            detail="Course not found",
+        )
+
+    # Resolve who is submitting. API tokens submit on behalf of a learner
+    # (assignments.create + explicit on_behalf_of_user_id); sessions act as self.
+    token_submitter = await _resolve_token_submission_user(
+        request, db_session, current_user, course, on_behalf_of_user_id
+    )
+    if token_submitter is not None:
+        submitter = token_submitter
+        is_instructor = False
+        is_token_submit = True
+    else:
+        _block_api_tokens(current_user)
+        submitter = current_user
+        # RBAC check
+        await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
+        is_instructor = await authorization_verify_based_on_roles(
+            request, current_user.id, "update", course.course_uuid, db_session
+        )
+        is_token_submit = False
+
+    # Session students are bound by the deadline; a token writing on behalf of a
+    # learner is an authorized external writer (the custom frontend owns it).
+    if not is_instructor and not is_token_submit and _is_assignment_past_due(assignment):
+        raise HTTPException(
+            status_code=403,
+            detail="Assignment deadline has passed",
+        )
+
     # Check if the submission has already been made. A row in PENDING /
-    # NOT_SUBMITTED state means the student previously hit "Try again":
+    # NOT_SUBMITTED state means the learner previously hit "Try again":
     # retry_assignment_submission left the row in place so the attempt
     # counter survives, but cleared everything else. Treat that as a
     # fresh-submission slot — flip status to SUBMITTED and reuse the row
     # — instead of erroring out on the existing row.
     statement = select(AssignmentUserSubmission).where(
         AssignmentUserSubmission.assignment_id == assignment.id,
-        AssignmentUserSubmission.user_id == current_user.id,
+        AssignmentUserSubmission.user_id == submitter.id,
     )
 
     assignment_user_submission = (await db_session.execute(statement)).scalars().first()
@@ -1859,28 +2011,6 @@ async def create_assignment_submission(
                 status_code=400,
                 detail="Assignment User Submission already exists",
             )
-
-    # Check if course exists
-    statement = select(Course).where(Course.id == assignment.course_id)
-    course = (await db_session.execute(statement)).scalars().first()
-
-    if not course:
-        raise HTTPException(
-            status_code=404,
-            detail="Course not found",
-        )
-
-    # RBAC check
-    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
-
-    is_instructor = await authorization_verify_based_on_roles(
-        request, current_user.id, "update", course.course_uuid, db_session
-    )
-    if not is_instructor and _is_assignment_past_due(assignment):
-        raise HTTPException(
-            status_code=403,
-            detail="Assignment deadline has passed",
-        )
 
     # Either reuse the existing PENDING row (retry path) or create a fresh
     # submission. On the retry path we keep the original
@@ -1898,7 +2028,7 @@ async def create_assignment_submission(
         assignment_user_submission.update_date = str(datetime.now())
     else:
         assignment_user_submission = AssignmentUserSubmission(
-            user_id=current_user.id,
+            user_id=submitter.id,
             assignment_id=assignment.id,  # type: ignore
             grade=0,
             assignmentusersubmission_uuid=str(f"assignmentusersubmission_{uuid4()}"),
@@ -1919,7 +2049,7 @@ async def create_assignment_submission(
     await track(
         event_name=analytics_events.ASSIGNMENT_SUBMITTED,
         org_id=course.org_id,
-        user_id=current_user.id,
+        user_id=submitter.id,
         properties={
             "assignment_uuid": assignment_uuid,
             "course_uuid": course.course_uuid,
@@ -1930,15 +2060,15 @@ async def create_assignment_submission(
         event_name=analytics_events.ASSIGNMENT_SUBMITTED,
         org_id=course.org_id,
         data={
-            "user": {"user_uuid": current_user.user_uuid, "email": current_user.email, "username": current_user.username},
+            "user": {"user_uuid": submitter.user_uuid, "email": submitter.email, "username": submitter.username},
             "assignment": {"assignment_uuid": assignment_uuid},
             "course": {"course_uuid": course.course_uuid, "name": course.name},
             "attempt_number": submitted_attempt_number,
         },
     )
 
-    # User
-    statement = select(User).where(User.id == current_user.id)
+    # User (the learner the submission belongs to)
+    statement = select(User).where(User.id == submitter.id)
     user = (await db_session.execute(statement)).scalars().first()
 
     if not user:
@@ -2045,7 +2175,7 @@ async def create_assignment_submission(
             await _apply_grade_and_finalize(
                 assignment=assignment,
                 course=course,
-                user_id=int(current_user.id),
+                user_id=int(submitter.id),
                 assignment_user_submission=assignment_user_submission,
                 db_session=db_session,
                 overall_feedback=None,
@@ -2077,7 +2207,6 @@ async def read_assignment_submissions(
     limit: int = 50,
     offset: int = 0,
 ):
-    _block_api_tokens(current_user)
     # Find assignment
     statement = select(Assignment).where(Assignment.assignment_uuid == assignment_uuid)
     assignment = (await db_session.execute(statement)).scalars().first()
@@ -2099,12 +2228,10 @@ async def read_assignment_submissions(
         )
 
     # RBAC check
-    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
+    await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
 
     # Check if user has instructor/admin privileges on this course
-    is_instructor = await authorization_verify_based_on_roles(
-        request, current_user.id, "update", course.course_uuid, db_session
-    )
+    is_instructor = await _is_assignment_instructor(request, current_user, course.course_uuid, db_session)
 
     # Non-instructors can only see their own submissions
     statement = select(AssignmentUserSubmission).where(
@@ -2150,7 +2277,6 @@ async def read_user_assignment_submissions(
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
 ):
-    _block_api_tokens(current_user)
     # Find assignment
     statement = select(Assignment).where(Assignment.assignment_uuid == assignment_uuid)
     assignment = (await db_session.execute(statement)).scalars().first()
@@ -2172,12 +2298,10 @@ async def read_user_assignment_submissions(
         )
 
     # RBAC check
-    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
+    await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
 
     # Ownership check: non-instructors may only read their own submissions
-    is_instructor = await authorization_verify_based_on_roles(
-        request, current_user.id, "update", course.course_uuid, db_session
-    )
+    is_instructor = await _is_assignment_instructor(request, current_user, course.course_uuid, db_session)
     if not is_instructor and int(user_id) != int(current_user.id):
         raise HTTPException(
             status_code=403,
@@ -2221,7 +2345,6 @@ async def update_assignment_submission(
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
 ):
-    _block_api_tokens(current_user)
     # Check if assignment exists
     statement = select(Assignment).where(Assignment.assignment_uuid == assignment_uuid)
     assignment = (await db_session.execute(statement)).scalars().first()
@@ -2256,16 +2379,14 @@ async def update_assignment_submission(
         )
 
     # Check if user is an instructor/admin (has UPDATE permission)
-    is_instructor = await authorization_verify_based_on_roles(
-        request, current_user.id, "update", course.course_uuid, db_session
-    )
+    is_instructor = await _is_assignment_instructor(request, current_user, course.course_uuid, db_session)
 
     if is_instructor:
         # Instructors/admins can update any submission (e.g., for grading)
-        await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
+        await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
     else:
         # Regular users need READ access and can only update their own submissions
-        await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
+        await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
         if str(assignment_user_submission.user_id) != str(current_user.id):
             raise HTTPException(
                 status_code=403,
@@ -2670,7 +2791,6 @@ async def grade_assignment_submission(
     db_session: AsyncSession,
     overall_feedback: str | None = None,
 ):
-    _block_api_tokens(current_user)
     # SECURITY: This function should only be accessible by course owners or instructors
     # Check if assignment exists
     statement = select(Assignment).where(Assignment.assignment_uuid == assignment_uuid)
@@ -2692,7 +2812,7 @@ async def grade_assignment_submission(
         )
 
     # SECURITY: Require course ownership or instructor role for grading
-    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
+    await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
 
     # Check if assignment user submission exists
     statement = select(AssignmentUserSubmission).where(
@@ -2730,7 +2850,6 @@ async def get_grade_assignment_submission(
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
 ):
-    _block_api_tokens(current_user)
     # Check if assignment exists
     statement = select(Assignment).where(Assignment.assignment_uuid == assignment_uuid)
     assignment = (await db_session.execute(statement)).scalars().first()
@@ -2752,12 +2871,10 @@ async def get_grade_assignment_submission(
         )
 
     # RBAC check
-    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
+    await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
 
     # Ownership check: non-instructors may only read their own grade
-    is_instructor = await authorization_verify_based_on_roles(
-        request, current_user.id, "update", course.course_uuid, db_session
-    )
+    is_instructor = await _is_assignment_instructor(request, current_user, course.course_uuid, db_session)
     if not is_instructor and str(user_id) != str(current_user.id):
         raise HTTPException(
             status_code=403,
@@ -2904,7 +3021,6 @@ async def get_assignments_from_course(
     current_user: PublicUser | AnonymousUser | APITokenUser,
     db_session: AsyncSession,
 ):
-    _block_api_tokens(current_user)
     # Find course
     statement = select(Course).where(Course.course_uuid == course_uuid)
     course = (await db_session.execute(statement)).scalars().first()
@@ -2920,7 +3036,7 @@ async def get_assignments_from_course(
     assignments = (await db_session.execute(statement)).scalars().all()
 
     # RBAC check
-    await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
+    await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
 
     # return assignments read
     return [AssignmentRead.model_validate(assignment) for assignment in assignments]

--- a/apps/api/src/services/setup/setup.py
+++ b/apps/api/src/services/setup/setup.py
@@ -83,6 +83,12 @@ async def install_default_elements(db_session: AsyncSession):
                 action_update=True,
                 action_delete=True,
             ),
+            assignments=Permission(
+                action_create=True,
+                action_read=True,
+                action_update=True,
+                action_delete=True,
+            ),
             roles=Permission(
                 action_create=True,
                 action_read=True,
@@ -192,6 +198,12 @@ async def install_default_elements(db_session: AsyncSession):
                 action_delete=True,
             ),
             activities=Permission(
+                action_create=True,
+                action_read=True,
+                action_update=True,
+                action_delete=True,
+            ),
+            assignments=Permission(
                 action_create=True,
                 action_read=True,
                 action_update=True,
@@ -311,6 +323,12 @@ async def install_default_elements(db_session: AsyncSession):
                 action_update=False,
                 action_delete=False,
             ),
+            assignments=Permission(
+                action_create=True,
+                action_read=True,
+                action_update=True,
+                action_delete=False,
+            ),
             roles=Permission(
                 action_create=False,
                 action_read=False,
@@ -420,6 +438,12 @@ async def install_default_elements(db_session: AsyncSession):
                 action_delete=False,
             ),
             activities=Permission(
+                action_create=False,
+                action_read=True,
+                action_update=False,
+                action_delete=False,
+            ),
+            assignments=Permission(
                 action_create=False,
                 action_read=True,
                 action_update=False,

--- a/apps/api/src/tests/security/test_api_token_access.py
+++ b/apps/api/src/tests/security/test_api_token_access.py
@@ -236,13 +236,6 @@ class TestRouterLevelProtection:
         assert exc_info.value.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_assignments_router_protection(self, mock_api_token_user):
-        """Test that /assignments router is protected from API tokens"""
-        with pytest.raises(HTTPException) as exc_info:
-            await require_non_api_token_user(mock_api_token_user)
-        assert exc_info.value.status_code == 403
-
-    @pytest.mark.asyncio
     async def test_trail_router_protection(self, mock_api_token_user):
         """Test that /trail router is protected from API tokens"""
         with pytest.raises(HTTPException) as exc_info:
@@ -334,6 +327,18 @@ class TestAllowedEndpoints:
     def test_payments_router_allows_api_tokens(self, mock_api_token_user):
         """Test that /payments router allows API tokens (EE)"""
         assert isinstance(mock_api_token_user, APITokenUser)
+
+    def test_assignments_router_allows_api_tokens(self, mock_api_token_user):
+        """The /assignments router now admits API tokens (headless assignments).
+
+        It mounts ``require_authenticated_user_or_api_token`` instead of
+        ``require_authenticated_user``: tokens reach the handlers, where
+        authoring + grading go through ``authorize_assignment_access`` (the
+        ``assignments`` rights bucket) and the learner ``/me`` / submission /
+        retry endpoints keep their own ``_block_api_tokens`` guard.
+        """
+        assert isinstance(mock_api_token_user, APITokenUser)
+        assert mock_api_token_user.org_id is not None
 
 
 class TestEERouterProtection:

--- a/apps/api/src/tests/security/test_api_token_access.py
+++ b/apps/api/src/tests/security/test_api_token_access.py
@@ -378,5 +378,39 @@ class TestEERouterProtection:
         assert exc_info.value.status_code == 403
 
 
+class TestRequireAuthenticatedUserOrApiToken:
+    """The dependency that admits API tokens but rejects anonymous callers,
+    used by the assignments router for headless access."""
+
+    @pytest.mark.asyncio
+    async def test_admits_api_token(self):
+        from unittest.mock import AsyncMock, patch
+        from src.security.api_token_utils import require_authenticated_user_or_api_token
+
+        token = APITokenUser(id=1, org_id=1)
+        with patch(
+            "src.security.auth.get_authenticated_user",
+            new=AsyncMock(return_value=token),
+        ):
+            result = await require_authenticated_user_or_api_token(
+                request=None, db_session=None
+            )
+        assert result is token
+
+    @pytest.mark.asyncio
+    async def test_rejects_anonymous(self):
+        from unittest.mock import AsyncMock, patch
+        from src.security.api_token_utils import require_authenticated_user_or_api_token
+
+        # get_authenticated_user raises 401 for anonymous; the dependency propagates it.
+        with patch(
+            "src.security.auth.get_authenticated_user",
+            new=AsyncMock(side_effect=HTTPException(status_code=401, detail="unauth")),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await require_authenticated_user_or_api_token(request=None, db_session=None)
+        assert exc.value.status_code == 401
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/apps/api/src/tests/services/test_assignment_api_token_access.py
+++ b/apps/api/src/tests/services/test_assignment_api_token_access.py
@@ -1,0 +1,386 @@
+"""Tests for headless assignment access via org-scoped API tokens.
+
+The assignment authoring + grading service functions used to hard-block every
+API token (``_block_api_tokens``). They now route instructor-style access
+through ``authorize_assignment_access``, which checks the single ``assignments``
+rights bucket and enforces the org boundary via the parent course UUID. The
+learner ``/me`` / self-submission / retry endpoints stay session-only.
+
+These tests pin that contract end-to-end against the real test DB:
+  - a token with the right ``assignments`` action can author / read / grade;
+  - a token missing the action gets 403;
+  - a token from another org gets 403 (org boundary);
+  - session-only endpoints still 403 for any token, even a fully-privileged one.
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.db.courses.assignments import (
+    Assignment,
+    AssignmentCreate,
+    AssignmentRead,
+    AssignmentTask,
+    AssignmentTaskSubmission,
+    AssignmentTaskTypeEnum,
+    AssignmentUserSubmission,
+    AssignmentUserSubmissionStatus,
+    GradingTypeEnum,
+)
+from src.db.courses.assignments import AssignmentTaskSubmissionUpdate
+from src.db.users import APITokenUser, User
+from src.services.courses.activities.assignments import (
+    create_assignment,
+    create_assignment_submission,
+    grade_assignment_submission,
+    handle_assignment_task_submission,
+    read_assignment,
+    read_assignment_submissions,
+    retry_assignment_submission,
+)
+from sqlmodel import select
+
+_PATCH_LIMITS = "src.services.courses.activities.assignments.check_limits_with_usage"
+_PATCH_INCREASE = "src.services.courses.activities.assignments.increase_feature_usage"
+_PATCH_DISPATCH = "src.services.courses.activities.assignments.dispatch_webhooks"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _assignments_rights(create=False, read=False, update=False, delete=False):
+    return {
+        "action_create": create,
+        "action_read": read,
+        "action_update": update,
+        "action_delete": delete,
+    }
+
+
+def _token(org_id=1, **buckets):
+    """Build an APITokenUser whose ``rights`` dict carries the given buckets."""
+    return APITokenUser(
+        id=1,
+        user_uuid="apitoken_test",
+        username="api_token",
+        org_id=org_id,
+        rights=dict(buckets),
+        token_name="Test Token",
+        created_by_user_id=1,
+    )
+
+
+async def _make_assignment(db, org, course, chapter, activity, *, auto_grading=False):
+    a = Assignment(
+        title="Headless",
+        description="x",
+        due_date="2030-01-01",
+        published=True,
+        grading_type=GradingTypeEnum.NUMERIC,
+        auto_grading=auto_grading,
+        org_id=org.id,
+        course_id=course.id,
+        chapter_id=chapter.id,
+        activity_id=activity.id,
+        assignment_uuid="assignment_token_test",
+        creation_date=str(datetime.now()),
+        update_date=str(datetime.now()),
+    )
+    db.add(a)
+    await db.commit()
+    await db.refresh(a)
+    return a
+
+
+def _assignment_create_obj(org, course, chapter, activity, title="New Assignment"):
+    return AssignmentCreate(
+        title=title,
+        description="Desc",
+        due_date="2030-01-01",
+        grading_type=GradingTypeEnum.NUMERIC,
+        org_id=org.id,
+        course_id=course.id,
+        chapter_id=chapter.id,
+        activity_id=activity.id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Authoring (assignments bucket)
+# ---------------------------------------------------------------------------
+
+
+class TestTokenAuthoring:
+    async def test_token_with_create_can_create_assignment(
+        self, mock_request, db, org, course, chapter, activity
+    ):
+        token = _token(assignments=_assignments_rights(create=True))
+        obj = _assignment_create_obj(org, course, chapter, activity)
+        with patch(_PATCH_LIMITS, new_callable=AsyncMock), \
+             patch(_PATCH_INCREASE, new_callable=AsyncMock):
+            result = await create_assignment(mock_request, obj, token, db)
+        assert isinstance(result, AssignmentRead)
+        assert result.title == "New Assignment"
+
+    async def test_token_without_create_is_forbidden(
+        self, mock_request, db, org, course, chapter, activity
+    ):
+        token = _token(assignments=_assignments_rights(read=True))  # no create
+        obj = _assignment_create_obj(org, course, chapter, activity)
+        with patch(_PATCH_LIMITS, new_callable=AsyncMock), \
+             patch(_PATCH_INCREASE, new_callable=AsyncMock):
+            with pytest.raises(HTTPException) as exc:
+                await create_assignment(mock_request, obj, token, db)
+        assert exc.value.status_code == 403
+
+    async def test_token_with_no_assignments_bucket_is_forbidden(
+        self, mock_request, db, org, course, chapter, activity
+    ):
+        # Token has other buckets but not `assignments` at all.
+        token = _token(courses={"action_create": True})
+        obj = _assignment_create_obj(org, course, chapter, activity)
+        with patch(_PATCH_LIMITS, new_callable=AsyncMock), \
+             patch(_PATCH_INCREASE, new_callable=AsyncMock):
+            with pytest.raises(HTTPException) as exc:
+                await create_assignment(mock_request, obj, token, db)
+        assert exc.value.status_code == 403
+
+    async def test_cross_org_token_is_forbidden(
+        self, mock_request, db, org, other_org, course, chapter, activity
+    ):
+        # Token belongs to org 2; the course lives in org 1 -> org boundary 403.
+        token = _token(org_id=other_org.id, assignments=_assignments_rights(create=True))
+        obj = _assignment_create_obj(org, course, chapter, activity)
+        with patch(_PATCH_LIMITS, new_callable=AsyncMock), \
+             patch(_PATCH_INCREASE, new_callable=AsyncMock):
+            with pytest.raises(HTTPException) as exc:
+                await create_assignment(mock_request, obj, token, db)
+        assert exc.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Reading (assignments bucket, read action)
+# ---------------------------------------------------------------------------
+
+
+class TestTokenReading:
+    async def test_token_with_read_can_read_assignment(
+        self, mock_request, db, org, course, chapter, activity
+    ):
+        await _make_assignment(db, org, course, chapter, activity)
+        token = _token(assignments=_assignments_rights(read=True))
+        result = await read_assignment(mock_request, "assignment_token_test", token, db)
+        assert isinstance(result, AssignmentRead)
+
+    async def test_token_without_read_is_forbidden(
+        self, mock_request, db, org, course, chapter, activity
+    ):
+        await _make_assignment(db, org, course, chapter, activity)
+        token = _token(assignments=_assignments_rights(create=True))  # no read
+        with pytest.raises(HTTPException) as exc:
+            await read_assignment(mock_request, "assignment_token_test", token, db)
+        assert exc.value.status_code == 403
+
+    async def test_token_with_read_can_list_submissions(
+        self, mock_request, db, org, course, chapter, activity
+    ):
+        await _make_assignment(db, org, course, chapter, activity)
+        token = _token(assignments=_assignments_rights(read=True))
+        result = await read_assignment_submissions(
+            mock_request, "assignment_token_test", token, db
+        )
+        assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# Grading (assignments bucket, update action)
+# ---------------------------------------------------------------------------
+
+
+class TestTokenGrading:
+    async def _seed_submission(self, db, org, course, chapter, activity, regular_user):
+        assignment = await _make_assignment(db, org, course, chapter, activity)
+        task = AssignmentTask(
+            title="Q1",
+            description="What is 2+2?",
+            hint="",
+            reference_file=None,
+            assignment_type=AssignmentTaskTypeEnum.SHORT_ANSWER,
+            contents={"correct_answers": ["4"], "match_mode": "exact"},
+            max_grade_value=100,
+            assignment_id=assignment.id,
+            org_id=org.id,
+            course_id=course.id,
+            chapter_id=chapter.id,
+            activity_id=activity.id,
+            assignment_task_uuid="assignmenttask_token_test",
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(task)
+        await db.commit()
+        await db.refresh(task)
+
+        user_submission = AssignmentUserSubmission(
+            user_id=regular_user.id,
+            assignment_id=assignment.id,
+            grade=0,
+            submission_status=AssignmentUserSubmissionStatus.SUBMITTED,
+            attempt_number=1,
+            assignmentusersubmission_uuid="aus_token_test",
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(user_submission)
+        task_submission = AssignmentTaskSubmission(
+            assignment_task_submission_uuid="ats_token_test",
+            task_submission={"answer": "4"},  # correct
+            grade=0,
+            manually_graded=False,
+            task_submission_grade_feedback="",
+            assignment_type=AssignmentTaskTypeEnum.SHORT_ANSWER,
+            user_id=regular_user.id,
+            activity_id=task.activity_id,
+            course_id=task.course_id,
+            chapter_id=task.chapter_id,
+            assignment_task_id=task.id,
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(task_submission)
+        await db.commit()
+        return assignment
+
+    async def test_token_with_update_can_finalize_grade(
+        self, mock_request, db, org, course, chapter, activity, regular_user
+    ):
+        await self._seed_submission(db, org, course, chapter, activity, regular_user)
+        token = _token(assignments=_assignments_rights(update=True))
+        with patch(_PATCH_DISPATCH, new_callable=AsyncMock):
+            result = await grade_assignment_submission(
+                mock_request, regular_user.id, "assignment_token_test", token, db,
+                overall_feedback="Nice work",
+            )
+        # Correct short answer -> full marks, submission marked GRADED.
+        assert result["grade"] == 100
+
+    async def test_token_without_update_cannot_grade(
+        self, mock_request, db, org, course, chapter, activity, regular_user
+    ):
+        await self._seed_submission(db, org, course, chapter, activity, regular_user)
+        token = _token(assignments=_assignments_rights(read=True))  # no update
+        with pytest.raises(HTTPException) as exc:
+            await grade_assignment_submission(
+                mock_request, regular_user.id, "assignment_token_test", token, db,
+            )
+        assert exc.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Session-only endpoints stay blocked for tokens
+# ---------------------------------------------------------------------------
+
+
+class TestTokenSubmitOnBehalf:
+    """A token with assignments.create may write a learner's answer by user_id."""
+
+    async def _seed_task(self, db, org, course, chapter, activity):
+        assignment = await _make_assignment(db, org, course, chapter, activity)
+        task = AssignmentTask(
+            title="Q1", description="d", hint="", reference_file=None,
+            assignment_type=AssignmentTaskTypeEnum.CUSTOM, contents={"widget": "x"},
+            max_grade_value=100, assignment_id=assignment.id, org_id=org.id,
+            course_id=course.id, chapter_id=chapter.id, activity_id=activity.id,
+            assignment_task_uuid="assignmenttask_obo_test",
+            creation_date=str(datetime.now()), update_date=str(datetime.now()),
+        )
+        db.add(task)
+        await db.commit()
+        return assignment, task
+
+    async def test_token_submits_task_answer_for_learner(
+        self, mock_request, db, org, course, chapter, activity, regular_user
+    ):
+        await self._seed_task(db, org, course, chapter, activity)
+        token = _token(assignments=_assignments_rights(create=True))
+        body = AssignmentTaskSubmissionUpdate(task_submission={"answer": "my custom answer"})
+        result = await handle_assignment_task_submission(
+            mock_request, "assignmenttask_obo_test", body, token, db,
+            on_behalf_of_user_id=regular_user.id,
+        )
+        # Persisted against the LEARNER, not the token.
+        assert result.user_id == regular_user.id
+        row = (await db.execute(
+            select(AssignmentTaskSubmission).where(
+                AssignmentTaskSubmission.user_id == regular_user.id
+            )
+        )).scalars().first()
+        assert row is not None
+        assert row.task_submission == {"answer": "my custom answer"}
+
+    async def test_token_submit_requires_on_behalf_id(
+        self, mock_request, db, org, course, chapter, activity
+    ):
+        await self._seed_task(db, org, course, chapter, activity)
+        token = _token(assignments=_assignments_rights(create=True))
+        body = AssignmentTaskSubmissionUpdate(task_submission={"answer": "x"})
+        with pytest.raises(HTTPException) as exc:
+            await handle_assignment_task_submission(
+                mock_request, "assignmenttask_obo_test", body, token, db,
+            )
+        assert exc.value.status_code == 400
+
+    async def test_token_submit_without_create_right_forbidden(
+        self, mock_request, db, org, course, chapter, activity, regular_user
+    ):
+        await self._seed_task(db, org, course, chapter, activity)
+        token = _token(assignments=_assignments_rights(read=True))  # no create
+        body = AssignmentTaskSubmissionUpdate(task_submission={"answer": "x"})
+        with pytest.raises(HTTPException) as exc:
+            await handle_assignment_task_submission(
+                mock_request, "assignmenttask_obo_test", body, token, db,
+                on_behalf_of_user_id=regular_user.id,
+            )
+        assert exc.value.status_code == 403
+
+    async def test_token_submit_for_non_member_forbidden(
+        self, mock_request, db, org, course, chapter, activity
+    ):
+        await self._seed_task(db, org, course, chapter, activity)
+        # A user with no membership in the token's org.
+        outsider = User(
+            id=999, username="outsider", first_name="O", last_name="O",
+            email="outsider@x.com", password="x", user_uuid="user_outsider",
+            creation_date=str(datetime.now()), update_date=str(datetime.now()),
+        )
+        db.add(outsider)
+        await db.commit()
+        token = _token(assignments=_assignments_rights(create=True))
+        body = AssignmentTaskSubmissionUpdate(task_submission={"answer": "x"})
+        with pytest.raises(HTTPException) as exc:
+            await handle_assignment_task_submission(
+                mock_request, "assignmenttask_obo_test", body, token, db,
+                on_behalf_of_user_id=outsider.id,
+            )
+        assert exc.value.status_code == 403
+
+
+class TestSessionOnlyEndpointsStillBlockTokens:
+    async def test_retry_blocks_token(
+        self, mock_request, db, org, course, chapter, activity
+    ):
+        # Retry stays session-only — even a full-rights token is rejected.
+        await _make_assignment(db, org, course, chapter, activity)
+        token = _token(
+            assignments=_assignments_rights(create=True, read=True, update=True, delete=True)
+        )
+        with pytest.raises(HTTPException) as exc:
+            await retry_assignment_submission(
+                mock_request, "assignment_token_test", token, db
+            )
+        assert exc.value.status_code == 403

--- a/apps/api/src/tests/services/test_assignment_api_token_access.py
+++ b/apps/api/src/tests/services/test_assignment_api_token_access.py
@@ -32,8 +32,10 @@ from src.db.courses.assignments import (
 )
 from src.db.courses.assignments import AssignmentTaskSubmissionUpdate
 from src.db.users import APITokenUser, User
+from src.db.trails import Trail
 from src.services.courses.activities.assignments import (
     create_assignment,
+    create_assignment_submission,
     grade_assignment_submission,
     handle_assignment_task_submission,
     read_assignment,
@@ -41,6 +43,14 @@ from src.services.courses.activities.assignments import (
     retry_assignment_submission,
 )
 from sqlmodel import select
+
+_PATCH_TRAIL_PRESENCE = "src.services.courses.activities.assignments.check_trail_presence"
+_PATCH_CERT_CHECK = (
+    "src.services.courses.activities.assignments."
+    "check_course_completion_and_create_certificate"
+)
+_PATCH_TRACK = "src.services.courses.activities.assignments.track"
+_PATCH_DISPATCH = "src.services.courses.activities.assignments.dispatch_webhooks"
 
 _PATCH_LIMITS = "src.services.courses.activities.assignments.check_limits_with_usage"
 _PATCH_INCREASE = "src.services.courses.activities.assignments.increase_feature_usage"
@@ -367,6 +377,43 @@ class TestTokenSubmitOnBehalf:
                 on_behalf_of_user_id=outsider.id,
             )
         assert exc.value.status_code == 403
+
+    async def test_token_submit_unknown_learner_404(
+        self, mock_request, db, org, course, chapter, activity
+    ):
+        await self._seed_task(db, org, course, chapter, activity)
+        token = _token(assignments=_assignments_rights(create=True))
+        body = AssignmentTaskSubmissionUpdate(task_submission={"answer": "x"})
+        with pytest.raises(HTTPException) as exc:
+            await handle_assignment_task_submission(
+                mock_request, "assignmenttask_obo_test", body, token, db,
+                on_behalf_of_user_id=999999,
+            )
+        assert exc.value.status_code == 404
+
+    async def test_token_creates_assignment_submission_for_learner(
+        self, mock_request, db, org, course, chapter, activity, regular_user
+    ):
+        await _make_assignment(db, org, course, chapter, activity)
+        trail = Trail(
+            org_id=org.id, user_id=regular_user.id, trail_uuid="trail_obo_test",
+            creation_date=str(datetime.now()), update_date=str(datetime.now()),
+        )
+        db.add(trail)
+        await db.commit()
+        await db.refresh(trail)
+        token = _token(assignments=_assignments_rights(create=True))
+        with patch(_PATCH_TRAIL_PRESENCE, new_callable=AsyncMock, return_value=trail), \
+             patch(_PATCH_CERT_CHECK, new_callable=AsyncMock), \
+             patch(_PATCH_TRACK, new_callable=AsyncMock), \
+             patch(_PATCH_DISPATCH, new_callable=AsyncMock):
+            result = await create_assignment_submission(
+                mock_request, "assignment_token_test", token, db,
+                on_behalf_of_user_id=regular_user.id,
+            )
+        # Aggregate submission created for the LEARNER and marked submitted.
+        assert result.submission_status == AssignmentUserSubmissionStatus.SUBMITTED
+        assert result.user_id == regular_user.id
 
 
 class TestSessionOnlyEndpointsStillBlockTokens:

--- a/apps/api/src/tests/services/test_assignment_api_token_access.py
+++ b/apps/api/src/tests/services/test_assignment_api_token_access.py
@@ -34,7 +34,6 @@ from src.db.courses.assignments import AssignmentTaskSubmissionUpdate
 from src.db.users import APITokenUser, User
 from src.services.courses.activities.assignments import (
     create_assignment,
-    create_assignment_submission,
     grade_assignment_submission,
     handle_assignment_task_submission,
     read_assignment,

--- a/apps/api/src/tests/services/test_permissions_edge.py
+++ b/apps/api/src/tests/services/test_permissions_edge.py
@@ -115,7 +115,7 @@ class TestApiTokensBlockedOnSensitiveActions:
             with pytest.raises(HTTPException) as exc:
                 await create_assignment(mock_request, obj, api_token_user, db)
         assert exc.value.status_code == 403
-        assert "API tokens" in exc.value.detail
+        assert "API token" in exc.value.detail
 
     async def test_update_assignment_blocks_api_token(
         self, mock_request, db, assignment, api_token_user
@@ -178,12 +178,17 @@ class TestApiTokensBlockedOnSensitiveActions:
     async def test_create_submission_blocks_api_token(
         self, mock_request, db, assignment, api_token_user
     ):
-        """create_assignment_submission rejects an APITokenUser with 403 (the _block_api_tokens guard)."""
+        """create_assignment_submission rejects a token lacking assignments rights.
+
+        Submit-on-behalf needs the ``assignments.create`` right; this token has no
+        rights, so it is rejected with 403 before any DB work.
+        """
         with patch(_PATCH_RBAC, new_callable=AsyncMock), \
              patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, return_value=False):
             with pytest.raises(HTTPException) as exc:
                 await create_assignment_submission(
-                    mock_request, assignment.assignment_uuid, api_token_user, db
+                    mock_request, assignment.assignment_uuid, api_token_user, db,
+                    on_behalf_of_user_id=1,
                 )
         assert exc.value.status_code == 403
 
@@ -231,7 +236,7 @@ class TestApiTokensBlockedOnSensitiveActions:
                     db,
                 )
         assert exc.value.status_code == 403
-        assert "API tokens" in exc.value.detail
+        assert "API token" in exc.value.detail
         rbac.assert_not_awaited()
 
 

--- a/apps/api/src/tests/services/test_retry_attempt_caps_edge.py
+++ b/apps/api/src/tests/services/test_retry_attempt_caps_edge.py
@@ -505,12 +505,14 @@ class TestApiTokenBlocked:
     async def test_create_blocked_for_api_token_user(
         self, db, mock_request, org, assignment
     ):
-        """Same gate on the create path."""
+        """Create-on-behalf requires the assignments.create right; a token with
+        no rights is rejected with 403 before any DB work."""
         token_user = _api_token_user(org.id)
         with patch(_PATCH_RBAC, new_callable=AsyncMock):
             with pytest.raises(HTTPException) as exc:
                 await create_assignment_submission(
-                    mock_request, assignment.assignment_uuid, token_user, db
+                    mock_request, assignment.assignment_uuid, token_user, db,
+                    on_behalf_of_user_id=1,
                 )
         assert exc.value.status_code == 403
-        assert "API tokens cannot access assignments" in exc.value.detail
+        assert "API token" in exc.value.detail

--- a/apps/api/src/tests/setup/test_roles.py
+++ b/apps/api/src/tests/setup/test_roles.py
@@ -47,6 +47,7 @@ class TestRightsModel:
             "organizations": self.get_valid_permission(),
             "coursechapters": self.get_valid_permission(),
             "activities": self.get_valid_permission(),
+            "assignments": self.get_valid_permission(),
             "roles": self.get_valid_permission(),
             "dashboard": self.get_valid_dashboard_permission(),
             "communities": self.get_valid_permission(),
@@ -191,7 +192,8 @@ class TestRightsModel:
         assert "communities" in dumped
         assert "discussions" in dumped
         assert "podcasts" in dumped
-        assert len(dumped) == 15  # All 15 fields
+        assert "assignments" in dumped
+        assert len(dumped) == 16  # All 16 fields
 
 
 class TestPermissionModels:
@@ -251,6 +253,7 @@ class TestDefaultRolesValidation:
         "organizations",
         "coursechapters",
         "activities",
+        "assignments",
         "roles",
         "dashboard",
         "communities",
@@ -578,6 +581,7 @@ class TestRightsFieldConsistency:
             "organizations",
             "coursechapters",
             "activities",
+            "assignments",
             "roles",
             "dashboard",
             "communities",

--- a/apps/api/src/tests/test_root_router.py
+++ b/apps/api/src/tests/test_root_router.py
@@ -254,10 +254,14 @@ def _install_stub_modules(monkeypatch: pytest.MonkeyPatch) -> None:
     async def get_authenticated_non_api_token_user(request=None, db_session=None):
         return object()
 
+    async def require_authenticated_user_or_api_token(request=None, db_session=None):
+        return object()
+
     install(
         "src.security.api_token_utils",
         require_non_api_token_user=require_non_api_token_user,
         get_authenticated_non_api_token_user=get_authenticated_non_api_token_user,
+        require_authenticated_user_or_api_token=require_authenticated_user_or_api_token,
     )
 
     plan_module = _module(

--- a/apps/web/components/Dashboard/Pages/Org/OrgEditAPIAccess/OrgEditAPIAccess.tsx
+++ b/apps/web/components/Dashboard/Pages/Org/OrgEditAPIAccess/OrgEditAPIAccess.tsx
@@ -704,6 +704,7 @@ const PermissionsEditor: React.FC<{
   const resources = [
     { key: 'courses', label: 'Courses', hasCrud: true },
     { key: 'activities', label: 'Activities', hasCrud: true },
+    { key: 'assignments', label: 'Assignments', hasCrud: true },
     { key: 'coursechapters', label: 'Chapters', hasCrud: true },
     { key: 'folders', label: 'Folders', hasCrud: true },
     { key: 'media', label: 'Media', hasCrud: true },
@@ -795,6 +796,7 @@ const PermissionsViewer: React.FC<{ rights: APITokenRights }> = ({ rights }) => 
     <div className="grid grid-cols-3 gap-2">
       <div>Courses: {getPermissionSummary(rights.courses)}</div>
       <div>Activities: {getPermissionSummary(rights.activities)}</div>
+      <div>Assignments: {getPermissionSummary(rights.assignments)}</div>
       <div>Chapters: {getPermissionSummary(rights.coursechapters)}</div>
       <div>Folders: {getPermissionSummary(rights.folders)}</div>
       <div>Media: {getPermissionSummary(rights.media)}</div>

--- a/apps/web/services/api_tokens/api_tokens.ts
+++ b/apps/web/services/api_tokens/api_tokens.ts
@@ -22,6 +22,14 @@ export interface APITokenRights {
     action_update: boolean
     action_delete: boolean
   }
+  // Headless assignments: create/read/update/delete covers authoring, tasks,
+  // reading submissions & grades, and manual grading (grading = action_update).
+  assignments: {
+    action_create: boolean
+    action_read: boolean
+    action_update: boolean
+    action_delete: boolean
+  }
   coursechapters: {
     action_create: boolean
     action_read: boolean
@@ -114,6 +122,12 @@ export const getDefaultRights = (): APITokenRights => ({
     action_update: false,
     action_delete: false,
   },
+  assignments: {
+    action_create: false,
+    action_read: false,
+    action_update: false,
+    action_delete: false,
+  },
   coursechapters: {
     action_create: false,
     action_read: false,
@@ -172,6 +186,12 @@ export const getFullRights = (): APITokenRights => ({
     action_update: true,
     action_delete: true,
   },
+  assignments: {
+    action_create: true,
+    action_read: true,
+    action_update: true,
+    action_delete: true,
+  },
   coursechapters: {
     action_create: true,
     action_read: true,
@@ -225,6 +245,12 @@ export const getReadOnlyRights = (): APITokenRights => ({
     action_delete_own: false,
   },
   activities: {
+    action_create: false,
+    action_read: true,
+    action_update: false,
+    action_delete: false,
+  },
+  assignments: {
     action_create: false,
     action_read: true,
     action_update: false,

--- a/docs/content/developers/api/_meta.json
+++ b/docs/content/developers/api/_meta.json
@@ -1,5 +1,6 @@
 {
   "index": "Overview",
   "authentication": "Authentication",
-  "endpoints": "Endpoints"
+  "endpoints": "Endpoints",
+  "headless-assignments": "Headless Assignments"
 }

--- a/docs/content/developers/api/endpoints.mdx
+++ b/docs/content/developers/api/endpoints.mdx
@@ -79,7 +79,7 @@ Collections group related courses together for organization and discovery.
 
 ### Assignments
 
-Assignment CRUD for course assessments. Task types include file submissions, quizzes, and custom (`OTHER`) tasks.
+Assignment CRUD for course assessments. Task types include file submissions, quizzes, and a `CUSTOM` type whose data object you fully control. Assignments can be driven headlessly with an API token — authoring, custom tasks, submissions, and grading. See [Headless Assignments](/developers/api/headless-assignments).
 
 ### AI
 

--- a/docs/content/developers/api/headless-assignments.mdx
+++ b/docs/content/developers/api/headless-assignments.mdx
@@ -1,0 +1,153 @@
+import { Callout } from 'nextra/components'
+
+# Headless Assignments
+
+LearnHouse assignments can be driven entirely from your own frontend. With an API token you can author assignments and tasks, store an arbitrary custom data object on each task, read submissions and grades, submit answers on behalf of your learners, and grade them — all over the standard REST API, no LearnHouse UI required.
+
+<Callout type="info">
+API tokens are available on the **Pro plan**. Create one under **Organization Settings → API Access** and grant it the **Assignments** permission. Tokens are prefixed with `lh_` and are scoped to a single organization.
+</Callout>
+
+## Permissions
+
+Assignment access is controlled by a single `assignments` rights bucket on the token. The four actions map to capabilities like this:
+
+| Action | What it allows |
+| --- | --- |
+| `create` | Create assignments and tasks (including the custom `contents` data object), upload reference files, and submit answers on behalf of learners |
+| `read` | Read assignments, tasks, submissions, and computed grades |
+| `update` | Update assignments and tasks, and grade submissions (set the grade, feedback, and status) |
+| `delete` | Delete assignments and tasks |
+
+Grant only what your integration needs — a read-only dashboard wants `read`; a grading bot wants `read` + `update`; a fully custom assignment frontend wants `create` + `read` + `update`.
+
+All requests are scoped to the token's organization: trying to touch an assignment in another org returns `403`.
+
+```bash
+curl http://localhost:1338/api/v1/assignments/{assignment_uuid} \
+  -H "Authorization: Bearer lh_your_api_token_here"
+```
+
+## Authoring
+
+These endpoints create and manage assignments and their tasks. An assignment is attached to a course activity, so you provide `org_id`, `course_id`, `chapter_id`, and `activity_id` when creating one.
+
+| Method | Endpoint | Action |
+| --- | --- | --- |
+| `POST` | `/api/v1/assignments/` | `create` |
+| `GET` | `/api/v1/assignments/{assignment_uuid}` | `read` |
+| `GET` | `/api/v1/assignments/activity/{activity_uuid}` | `read` |
+| `GET` | `/api/v1/assignments/course/{course_uuid}` | `read` |
+| `PUT` | `/api/v1/assignments/{assignment_uuid}` | `update` |
+| `DELETE` | `/api/v1/assignments/{assignment_uuid}` | `delete` |
+| `POST` | `/api/v1/assignments/{assignment_uuid}/tasks` | `create` |
+| `GET` | `/api/v1/assignments/{assignment_uuid}/tasks` | `read` |
+| `GET` | `/api/v1/assignments/task/{assignment_task_uuid}` | `read` |
+| `PUT` | `/api/v1/assignments/{assignment_uuid}/tasks/{assignment_task_uuid}` | `update` |
+| `DELETE` | `/api/v1/assignments/{assignment_uuid}/tasks/{assignment_task_uuid}` | `delete` |
+| `POST` | `/api/v1/assignments/{assignment_uuid}/tasks/{assignment_task_uuid}/ref_file` | `create` |
+
+```bash
+curl -X POST http://localhost:1338/api/v1/assignments/ \
+  -H "Authorization: Bearer lh_your_api_token_here" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "title": "Field Report",
+        "description": "Submit your findings",
+        "due_date": "2030-01-01",
+        "grading_type": "NUMERIC",
+        "org_id": 1,
+        "course_id": 12,
+        "chapter_id": 34,
+        "activity_id": 56
+      }'
+```
+
+## Custom tasks — bring your own data object
+
+Each task has an `assignment_type` and a free-form `contents` JSON object. For a fully custom assignment, use the `CUSTOM` type: LearnHouse stores your `contents` (the task definition) and the learner's `task_submission` (their answer) as an arbitrary, caller-owned JSON object. The server never interprets or auto-grades it — it's yours to render and grade however you like.
+
+```bash
+curl -X POST http://localhost:1338/api/v1/assignments/{assignment_uuid}/tasks \
+  -H "Authorization: Bearer lh_your_api_token_here" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "title": "Interactive Map Challenge",
+        "description": "Place the pins",
+        "assignment_type": "CUSTOM",
+        "max_grade_value": 100,
+        "contents": {
+          "widget": "interactive-map",
+          "config": { "regions": ["north", "south"], "maxPins": 7 },
+          "rubric": [ { "id": "r1", "label": "Accuracy", "points": 80 } ]
+        }
+      }'
+```
+
+The `contents` you send back out of `GET /assignments/task/{uuid}` is byte-for-byte what you stored.
+
+<Callout type="info">
+The built-in task types — `QUIZ`, `FORM`, `CODE`, `SHORT_ANSWER`, `NUMBER_ANSWER` — are auto-graded by LearnHouse against their `contents` schema. `CUSTOM` (and `FILE_SUBMISSION`) are **not** auto-graded and are graded manually.
+</Callout>
+
+## Submissions and grading
+
+Learners are referenced by their existing LearnHouse `user_id`. These endpoints let you read submissions, write a learner's answer on their behalf, and finalize grades.
+
+| Method | Endpoint | Action |
+| --- | --- | --- |
+| `GET` | `/api/v1/assignments/{assignment_uuid}/submissions` | `read` |
+| `GET` | `/api/v1/assignments/{assignment_uuid}/submissions/{user_id}` | `read` |
+| `GET` | `/api/v1/assignments/{assignment_uuid}/tasks/{assignment_task_uuid}/submissions` | `read` |
+| `GET` | `/api/v1/assignments/{assignment_uuid}/tasks/{assignment_task_uuid}/submissions/user/{user_id}` | `read` |
+| `PUT` | `/api/v1/assignments/{assignment_uuid}/tasks/{assignment_task_uuid}/submissions` | `create` (submit on behalf) |
+| `POST` | `/api/v1/assignments/{assignment_uuid}/submissions` | `create` (submit on behalf) |
+| `GET` | `/api/v1/assignments/{assignment_uuid}/submissions/{user_id}/grade` | `read` |
+| `POST` | `/api/v1/assignments/{assignment_uuid}/submissions/{user_id}/grade` | `update` |
+| `PUT` | `/api/v1/assignments/{assignment_uuid}/submissions/{user_id}` | `update` |
+
+### Submitting on behalf of a learner
+
+To write a learner's answer, pass their LearnHouse id as `on_behalf_of_user_id`. The learner must already be a member of the token's organization.
+
+```bash
+# Save a learner's answer for a task
+curl -X PUT "http://localhost:1338/api/v1/assignments/{assignment_uuid}/tasks/{task_uuid}/submissions?on_behalf_of_user_id=42" \
+  -H "Authorization: Bearer lh_your_api_token_here" \
+  -H "Content-Type: application/json" \
+  -d '{ "task_submission": { "answer": "my custom answer" } }'
+
+# Mark the assignment as submitted for that learner
+curl -X POST "http://localhost:1338/api/v1/assignments/{assignment_uuid}/submissions?on_behalf_of_user_id=42" \
+  -H "Authorization: Bearer lh_your_api_token_here"
+```
+
+### Grading
+
+Two ways to grade, both gated by `update`:
+
+- `POST .../submissions/{user_id}/grade` recomputes the grade from the task submissions (auto-gradable types are re-verified server-side) and accepts an optional `overall_feedback` in the body.
+- `PUT .../submissions/{user_id}` sets the grade, status, and feedback directly — useful for custom tasks you scored yourself.
+
+```bash
+curl -X POST http://localhost:1338/api/v1/assignments/{assignment_uuid}/submissions/42/grade \
+  -H "Authorization: Bearer lh_your_api_token_here" \
+  -H "Content-Type: application/json" \
+  -d '{ "overall_feedback": "Great work" }'
+```
+
+<Callout type="info">
+Some submission endpoints are **session-only** and cannot be called with a token: the learner-facing "my own submission" reads (`.../submissions/me`), the retry endpoint, and the "mark activity done" endpoint. A token always acts on an explicit `user_id` instead of an implicit "me".
+</Callout>
+
+## End-to-end example
+
+A custom frontend can run the whole lifecycle with one token (`create` + `read` + `update`):
+
+1. `POST /assignments/` — create the assignment on a course activity.
+2. `POST /assignments/{uuid}/tasks` — add a `CUSTOM` task with your data object.
+3. `PUT  /assignments/{uuid}/tasks/{task}/submissions?on_behalf_of_user_id=42` — store a learner's answer.
+4. `POST /assignments/{uuid}/submissions?on_behalf_of_user_id=42` — mark it submitted.
+5. `PUT  /assignments/{uuid}/submissions/42` — set the grade and feedback.
+
+See [Authentication](/developers/api/authentication) for how to create and use API tokens, and the [Assignments platform guide](/platform/assignments) for the in-app workflow.

--- a/docs/content/platform/assignments/index.mdx
+++ b/docs/content/platform/assignments/index.mdx
@@ -6,7 +6,7 @@ Assignments let teachers create assessable tasks within courses. Students submit
 
 ## How Assignments Work
 
-Each assignment is linked to a course activity and can contain one or more tasks. Supported task types are **file uploads** and **quizzes**, with a generic `OTHER` fallback for custom submissions.
+Each assignment is linked to a course activity and can contain one or more tasks. Supported task types are **file uploads** and **quizzes**, plus a **`CUSTOM`** type whose data object you fully control — useful for building your own assessment formats.
 
 <Callout>
 Assignments must be enabled in your [Organization Settings](/platform/organizations/settings) to be available.
@@ -22,4 +22,5 @@ Assignments must be enabled in your [Organization Settings](/platform/organizati
 ## Learn More
 
 - [Grading & Submissions](/platform/assignments/grading) — How the grading workflow works.
+- [Headless Assignments](/developers/api/headless-assignments) — Drive assignments, custom tasks, submissions, and grading from your own frontend with an API token.
 - [Code Execution](/platform/code-execution) — Auto-graded code exercises are built into course content via the **Code Playground** editor block, not assignment tasks.


### PR DESCRIPTION
## What this does

This makes assignments usable headlessly. Today the whole assignments API is locked to logged-in browser sessions — API tokens get a hard 403 everywhere. That's fine for our own dashboard, but it means anyone who wants to build their own assignment experience on top of LearnHouse can't. This PR opens the existing endpoints up to org-scoped API tokens so a team can author assignments, store their own data on each task, collect learner answers, and grade — all from a custom frontend, with nothing but a bearer token.

We're not building a second assignments API. It's the same endpoints we already have; we just stopped slamming the door on tokens and added the permission plumbing to do it safely.

## How it works

**One `assignments` permission.** Tokens get a single `assignments` rights bucket with the usual create / read / update / delete. The mapping is intentionally simple:

- `create` → author assignments and tasks (and submit answers on behalf of a learner)
- `read` → read assignments, tasks, submissions and grades
- `update` → edit assignments/tasks and grade submissions
- `delete` → delete assignments and tasks

Grading isn't a separate thing — it's just `update` on an assignment. The default Admin, Maintainer and Instructor roles now carry this bucket so they can actually mint tokens with it (without that, you can't grant a permission you don't hold yourself).

**Tokens reach the handlers, but the gate is per-endpoint.** The assignments router now admits tokens (while still rejecting anonymous), and each service function routes through a shared `authorize_assignment_access` check. The instructor-style endpoints — authoring, reading submissions, grading — are open to tokens. The learner-facing `/me` reads, retry, and "mark done" stay session-only, because a token has no "me".

**Custom tasks.** New `CUSTOM` task type. Its `contents` (the task definition) and `task_submission` (the learner's answer) are an arbitrary JSON object that we store and hand back untouched — LearnHouse never tries to interpret or auto-grade it, so you own the schema and grade it manually. The built-in auto-graded types (quiz/form/code/short/number) are unchanged. Comes with the enum migration.

**Submit on behalf of a learner.** A token can write a learner's answer or mark their submission, by passing `on_behalf_of_user_id`. Learners are referenced by their existing LearnHouse id and must already be members of the token's org. This is what closes the loop for a fully custom frontend: author → collect answers → grade.

**UI + docs.** The token creation dialog gains an "Assignments" permission row (and the rights presets include it). There's a new "Headless Assignments" page in the developer docs walking through the whole flow.

## Org boundary / safety

Everything stays scoped to the token's org — touching an assignment in another org is a 403. Submit-on-behalf verifies the learner belongs to the org. Answer submissions can't carry grades. None of the regular in-app behaviour changes, and free-plan orgs are unaffected (tokens are Pro-only to begin with).

## Testing

- New test suite covering token authoring/reading/grading, missing-rights and cross-org 403s, custom tasks, and submit-on-behalf (success, missing id, wrong rights, non-member). Updated the role-model guard tests and the router-protection test to match the new behaviour.
- Verified end to end against a fresh local instance: created a token from the dashboard, used it to build a course → chapter → activity → assignment, added a `CUSTOM` task with a custom data object (round-trips byte-for-byte), submitted a learner's answer on their behalf, and read it back — all green. The token-created assignment shows up in the dashboard like any other.

## Deploy note

The `CUSTOM` value needs the enum migration to run (`alembic upgrade head`).
