### PR TITLE
fix(auth): correct platform signup verification link + auto sign-in on verify

### DIFF
--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -645,11 +645,17 @@ class VerifyEmailRequest(BaseModel):
 )
 async def api_verify_email(
     request: Request,
+    response: Response,
     body: VerifyEmailRequest,
     db_session: AsyncSession = Depends(get_db_session),
 ):
     """
     Verify user email with token.
+
+    On success the user is also signed in automatically: access/refresh cookies
+    are set (same as ``/login``) and the tokens are returned in the body so a
+    same-origin proxy can mirror them. This spares newly-verified users from
+    re-entering their password right after confirming their email.
     """
     # Rate limit: 5 attempts per 5 minutes. Key strictly on the stable
     # user_uuid (+ org_uuid) identity, NOT on the attacker-controllable
@@ -665,14 +671,33 @@ async def api_verify_email(
             detail=f"Too many verification attempts. Please try again in {retry_after // 60} minutes.",
         )
 
-    result = await verify_email_token(
+    # On invalid/expired/mismatched tokens this raises (4xx) and no session is
+    # issued — only a fresh, valid verification reaches the token-minting below.
+    user, message = await verify_email_token(
         request=request,
         db_session=db_session,
         token=body.token,
         user_uuid=body.user_uuid,
         org_uuid=body.org_uuid,
     )
-    return {"message": result}
+
+    # Auto sign-in: issue a session exactly like /login (sub = email).
+    access_token = create_access_token(
+        data={"sub": user.email},
+        expires_delta=JWT_ACCESS_TOKEN_EXPIRES,
+    )
+    refresh_token = create_refresh_token(data={"sub": user.email})
+    set_auth_cookies(response, access_token, refresh_token, request)
+
+    return {
+        "message": message,
+        "user": UserRead.model_validate(user),
+        "tokens": {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "expiry": get_token_expiry_ms(),
+        },
+    }
 
 
 class ResendVerificationRequest(BaseModel):

--- a/apps/api/src/services/email/utils.py
+++ b/apps/api/src/services/email/utils.py
@@ -159,18 +159,15 @@ async def _get_primary_verified_custom_domain(db_session, org_id: int) -> Option
         return None
 
 
-def get_base_url_from_request(request: Request) -> str:
+def get_trusted_base_url_from_request(request: Request) -> Optional[str]:
     """
-    Extract the base URL from a FastAPI request.
+    Return the request's Origin/Referer base URL **only if** it is an allowed
+    origin, otherwise None.
 
-    Uses the Origin or Referer header to determine the frontend URL,
-    but validates against allowed origins to prevent open redirect.
-
-    Args:
-        request: FastAPI Request object
-
-    Returns:
-        Base URL string (e.g., "https://myorg.example.com")
+    This is the "we actually know where the request came from" part of
+    ``get_base_url_from_request`` — callers that need to distinguish a trusted,
+    request-derived URL from the configured fallback (e.g. platform signups that
+    prefer the platform URL over ``frontend_domain``) use this directly.
     """
     # Try Origin header first
     origin = request.headers.get("origin")
@@ -188,6 +185,26 @@ def get_base_url_from_request(request: Request) -> str:
         if _is_allowed_base_url(candidate):
             return candidate
         logger.warning("Rejected untrusted Referer header for email URL: %s", candidate)
+
+    return None
+
+
+def get_base_url_from_request(request: Request) -> str:
+    """
+    Extract the base URL from a FastAPI request.
+
+    Uses the Origin or Referer header to determine the frontend URL,
+    but validates against allowed origins to prevent open redirect.
+
+    Args:
+        request: FastAPI Request object
+
+    Returns:
+        Base URL string (e.g., "https://myorg.example.com")
+    """
+    trusted = get_trusted_base_url_from_request(request)
+    if trusted:
+        return trusted
 
     # Fall back to configured frontend_domain (preferred over raw request URL
     # which would point to the API server, not the frontend)

--- a/apps/api/src/services/users/email_verification.py
+++ b/apps/api/src/services/users/email_verification.py
@@ -6,6 +6,7 @@ Supports both org-based and org-less (platform) signups.
 """
 from datetime import datetime, timezone
 import json
+import os
 import secrets
 import redis
 from fastapi import HTTPException, Request
@@ -18,7 +19,10 @@ from src.db.users import User, UserRead
 from config.config import get_learnhouse_config
 from src.services.orgs.orgs import get_org_default_language
 from src.services.users.emails import send_email_verification_email
-from src.services.email.utils import get_base_url_from_request
+from src.services.email.utils import (
+    get_base_url_from_request,
+    get_trusted_base_url_from_request,
+)
 from src.services.security.rate_limiting import check_verification_resend_rate_limit
 from src.services.webhooks.dispatch import dispatch_webhooks
 
@@ -119,8 +123,30 @@ async def send_verification_email(
     # Convert to Read model for email function
     user_read = UserRead.model_validate(user)
 
+    # Resolve the base URL for the verification link.
+    #
+    # Org-based signups always use the request-derived URL (the org's own
+    # host is what the user signed up on). Platform / org-less signups
+    # (org_id is None) frequently arrive without a trusted Origin/Referer, in
+    # which case the generic request fallback would land on the org app
+    # (frontend_domain), not the platform. So for org-less signups prefer, in
+    # order: a trusted request origin → the explicitly-configured platform URL
+    # (LEARNHOUSE_PLATFORM_URL) → the existing fallback. The platform-URL step
+    # only fires when the env var is set, so self-hosted deployments that don't
+    # set it keep their current behavior.
+    if org_id is None:
+        base_url = get_trusted_base_url_from_request(request)
+        if not base_url:
+            platform_url = os.environ.get("LEARNHOUSE_PLATFORM_URL")
+            base_url = (
+                platform_url.rstrip("/")
+                if platform_url
+                else get_base_url_from_request(request)
+            )
+    else:
+        base_url = get_base_url_from_request(request)
+
     # Send verification email
-    base_url = get_base_url_from_request(request)
     email_sent = send_email_verification_email(
         token=token,
         user=user_read,
@@ -145,7 +171,7 @@ async def verify_email_token(
     token: str,
     user_uuid: str,
     org_uuid: str,
-) -> str:
+) -> tuple[User, str]:
     """
     Verify an email verification token and mark email as verified.
 
@@ -157,7 +183,8 @@ async def verify_email_token(
         org_uuid: Organization UUID (or "none" for platform signups)
 
     Returns:
-        Success message
+        Tuple of (verified user, success message). The user is returned so the
+        caller can issue an authenticated session (auto sign-in) on success.
     """
     # Get Redis connection
     r = get_redis_connection()
@@ -204,7 +231,7 @@ async def verify_email_token(
     if user.email_verified:
         # Delete token and return success
         r.delete(redis_key)
-        return "Email already verified"
+        return user, "Email already verified"
 
     # Mark email as verified
     user.email_verified = True
@@ -231,7 +258,7 @@ async def verify_email_token(
                 },
             )
 
-    return "Email verified successfully"
+    return user, "Email verified successfully"
 
 
 async def resend_verification_email(

--- a/apps/api/src/tests/routers/test_auth_router.py
+++ b/apps/api/src/tests/routers/test_auth_router.py
@@ -494,8 +494,8 @@ class TestAuthRouter:
         ), patch(
             "src.routers.auth.verify_email_token",
             new_callable=AsyncMock,
-            return_value="Email verified",
-        ):
+            return_value=(auth_user, "Email verified"),
+        ), patch("src.routers.auth.set_auth_cookies") as verify_cookies_mock:
             response = await client.post(
                 "/api/v1/auth/verify-email",
                 json={
@@ -505,6 +505,12 @@ class TestAuthRouter:
                 },
             )
         assert response.status_code == 200
+        # Successful verification auto-signs-in: cookies set + tokens returned.
+        verify_cookies_mock.assert_called_once()
+        verify_body = response.json()
+        assert verify_body["message"] == "Email verified"
+        assert verify_body["tokens"]["access_token"]
+        assert verify_body["tokens"]["refresh_token"]
 
         with patch(
             "src.routers.auth.resend_verification_email",

--- a/apps/api/src/tests/services/test_email_verification_service.py
+++ b/apps/api/src/tests/services/test_email_verification_service.py
@@ -1,6 +1,7 @@
 """Tests for src/services/users/email_verification.py."""
 
 import json
+import os
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -180,6 +181,44 @@ class TestEmailVerificationService:
         assert send_exc.value.status_code == 500
 
     @pytest.mark.asyncio
+    async def test_send_verification_email_platform_uses_platform_url(
+        self, mock_request, db
+    ):
+        """Org-less (platform) signup without a trusted origin builds the link on
+        LEARNHOUSE_PLATFORM_URL, not the frontend_domain fallback."""
+        user = await _make_user(
+            db,
+            id=23,
+            username="platformuser",
+            email="platformuser@test.com",
+            user_uuid="user_platform",
+        )
+        fake_redis = Mock()
+        fake_redis.setex = Mock()
+
+        with patch.dict(
+            os.environ, {"LEARNHOUSE_PLATFORM_URL": "https://www.learnhouse.app"}
+        ), patch(
+            "src.services.users.email_verification.get_redis_connection",
+            return_value=fake_redis,
+        ), patch(
+            "src.services.users.email_verification.generate_verification_token",
+            return_value="verification-token",
+        ), patch(
+            "src.services.users.email_verification.get_base_url_from_request",
+            return_value="https://learnhouse.io",
+        ), patch(
+            "src.services.users.email_verification.send_email_verification_email",
+            return_value=True,
+        ) as mock_send:
+            result = await send_verification_email(mock_request, db, user, None)
+
+        assert result == "Verification email sent"
+        # mock_request has no Origin/Referer, so the trusted-origin step yields
+        # nothing and the platform URL must win over the (patched) fallback.
+        assert mock_send.call_args.kwargs["base_url"] == "https://www.learnhouse.app"
+
+    @pytest.mark.asyncio
     async def test_verify_email_token_paths(
         self, mock_request, db, org, regular_user
     ):
@@ -262,7 +301,7 @@ class TestEmailVerificationService:
             "src.services.users.email_verification.dispatch_webhooks",
             new_callable=AsyncMock,
         ) as mock_dispatch:
-            result = await verify_email_token(
+            returned_user, result = await verify_email_token(
                 mock_request,
                 db,
                 base_token,
@@ -270,6 +309,7 @@ class TestEmailVerificationService:
                 org.org_uuid,
             )
         assert result == "Email verified successfully"
+        assert returned_user.user_uuid == user.user_uuid
         mock_dispatch.assert_awaited_once()
         assert (await db.execute(
             select(User).where(User.user_uuid == user.user_uuid)
@@ -309,7 +349,7 @@ class TestEmailVerificationService:
             "src.services.users.email_verification.get_redis_connection",
             return_value=fake_redis,
         ):
-            already_verified = await verify_email_token(
+            already_verified_user, already_verified = await verify_email_token(
                 mock_request,
                 db,
                 token,
@@ -317,6 +357,7 @@ class TestEmailVerificationService:
                 org.org_uuid,
             )
         assert already_verified == "Email already verified"
+        assert already_verified_user.user_uuid == verified_user.user_uuid
         assert fake_redis.delete.called
 
         fake_redis.get.return_value = None
@@ -353,7 +394,7 @@ class TestEmailVerificationService:
             "src.services.users.email_verification.dispatch_webhooks",
             new_callable=AsyncMock,
         ) as mock_dispatch:
-            result = await verify_email_token(
+            _result_user, result = await verify_email_token(
                 mock_request,
                 db,
                 token,

--- a/apps/web/app/api/auth/[...path]/route.ts
+++ b/apps/web/app/api/auth/[...path]/route.ts
@@ -13,7 +13,9 @@ import {
 const BACKEND_URL = (getConfig('NEXT_PUBLIC_LEARNHOUSE_BACKEND_URL') || 'http://localhost:1338').replace(/\/+$/, '')
 
 // Paths that return tokens in response body (relative to /api/v1/auth/)
-const TOKEN_RESPONSE_PATHS = ['login', 'refresh', 'oauth', 'signup']
+// `verify-email` auto-signs-in the user on successful email verification, so
+// it returns tokens just like login/signup and its cookies must be mirrored.
+const TOKEN_RESPONSE_PATHS = ['login', 'refresh', 'oauth', 'signup', 'verify-email']
 
 function shouldExtractTokens(path: string): boolean {
   return TOKEN_RESPONSE_PATHS.some(p => path.startsWith(p))

--- a/apps/web/app/auth/verify-email/verify-email.tsx
+++ b/apps/web/app/auth/verify-email/verify-email.tsx
@@ -37,11 +37,17 @@ function VerifyEmailClient({ org }: VerifyEmailClientProps) {
                 if (res.success) {
                     setSuccess(true)
                     setShowMessage(true)
+                    // Verification also signs the user in (session cookies were
+                    // set via the auth proxy). Send them straight into the app —
+                    // a full navigation lets auth bootstrap from the new cookies.
+                    setTimeout(() => {
+                        window.location.assign('/')
+                    }, 1200)
                 } else {
                     setError(res.error || t('auth.verification_failed'))
                     setShowMessage(true)
                 }
-            } catch (err) {
+            } catch {
                 setError(t('auth.verification_failed'))
                 setShowMessage(true)
             } finally {
@@ -68,7 +74,7 @@ function VerifyEmailClient({ org }: VerifyEmailClientProps) {
                                 </span>
                                 {success && (
                                     <span className="text-sm ml-2">
-                                        · <Link href="/login" className="underline hover:no-underline">{t('auth.proceed_to_login')}</Link>
+                                        · <Link href="/" className="underline hover:no-underline">{t('auth.proceed_to_login')}</Link>
                                     </span>
                                 )}
                             </div>
@@ -140,7 +146,7 @@ function VerifyEmailClient({ org }: VerifyEmailClientProps) {
                                     </div>
                                 </div>
                                 <Link
-                                    href="/login"
+                                    href="/"
                                     className="block w-full bg-black text-white font-semibold text-center py-2.5 rounded-lg hover:bg-gray-800 transition-colors"
                                 >
                                     {t('auth.proceed_to_login')}

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -6,6 +6,20 @@ export default [
     js.configs.recommended,
     ...nextConfig,
     {
+        // DOM lib type-only names (used purely in TS type positions, with no
+        // runtime global counterpart) are otherwise reported as `no-undef`
+        // false positives. Declaring them keeps type annotations like
+        // `HeadersInit` / `RequestInit` lint-clean.
+        languageOptions: {
+            globals: {
+                HeadersInit: "readonly",
+                BodyInit: "readonly",
+                RequestInit: "readonly",
+                ResponseInit: "readonly",
+                RequestInfo: "readonly",
+                RequestCredentials: "readonly",
+            },
+        },
         plugins: {
             "unused-imports": unusedImports,
         },

--- a/apps/web/services/auth/auth.ts
+++ b/apps/web/services/auth/auth.ts
@@ -1,11 +1,6 @@
 import { getAPIUrl } from '@services/config/config'
 import { RequestBody, getResponseMetadata } from '@services/utils/ts/requests'
 
-interface LoginAndGetTokenResponse {
-  access_token: 'string'
-  token_type: 'string'
-}
-
 // ⚠️ mvp phase code
 // TODO : everything in this file need to be refactored including security issues fix
 
@@ -266,9 +261,12 @@ export async function verifyEmail(
         user_uuid: userUuid,
         org_uuid: orgUuid,
       }),
+      // Go through the same-origin auth proxy so the session cookies the
+      // backend returns on success are mirrored onto this origin (auto sign-in).
+      credentials: 'include',
     }
 
-    const response = await fetch(`${getAPIUrl()}auth/verify-email`, requestOptions)
+    const response = await fetch('/api/auth/verify-email', requestOptions)
     const data = await response.json()
 
     if (response.ok) {
@@ -279,7 +277,7 @@ export async function verifyEmail(
         error: data.detail || 'Verification failed',
       }
     }
-  } catch (error) {
+  } catch {
     return {
       success: false,
       error: 'An error occurred during verification',
@@ -314,7 +312,7 @@ export async function resendVerificationEmail(
         error: data.detail || 'Failed to resend verification email',
       }
     }
-  } catch (error) {
+  } catch {
     return {
       success: false,
       error: 'An error occurred',


### PR DESCRIPTION
## Problem

Users who sign up on the platform (org-less signup) get a verification email whose link points at the wrong host, and after verifying they're forced to log in again with their password. Both hurt conversion.

Two root causes:
1. For org-less signups the request often has no trusted `Origin`/`Referer`, so the link's base URL fell back to `frontend_domain` (the org app host) instead of the platform host.
2. The verify-email endpoint only set `email_verified = True` — it issued no session, and the page sent users to `/login`.

## Changes

**API**
- `services/email/utils.py`: extract `get_trusted_base_url_from_request()` (the "do we actually know the request origin" check). `get_base_url_from_request()` now delegates to it — behaviour unchanged.
- `services/users/email_verification.py`: for org-less signups, resolve the link base URL in priority order — trusted request origin → `LEARNHOUSE_PLATFORM_URL` (only when the env var is set) → existing fallback. Org-based signups keep their current path. `verify_email_token()` now returns `(user, message)`.
- `routers/auth.py`: on successful verification the endpoint now issues access/refresh cookies (reusing the `/login` cookie path) and returns a login-shaped `{message, user, tokens}` body so a same-origin proxy can mirror the session. Invalid/expired/mismatched tokens still return 4xx with **no** session.

**Web**
- `app/api/auth/[...path]/route.ts`: add `verify-email` to `TOKEN_RESPONSE_PATHS` so the proxy mirrors the returned session cookies.
- `services/auth/auth.ts`: `verifyEmail()` now goes through the same-origin `/api/auth/verify-email` proxy with credentials included.
- `app/auth/verify-email/verify-email.tsx`: on success, auto-redirect into the app (signed in) instead of linking to `/login`.

## Backwards compatibility / safety
- Org-based signups are untouched (same `get_base_url_from_request` path, already correct host).
- The platform-URL branch only fires when `LEARNHOUSE_PLATFORM_URL` is set, so self-hosted deployments that don't set it keep current behaviour.
- `send_verification_email` only runs in SaaS mode.
- Token stays single-use + 1h TTL; only a fresh valid verification issues a session.
- Verify response is additive (`message` preserved) and cookie scoping reuses the existing login helpers.

## Tests
- Updated existing tests for the `(user, message)` return.
- Added `test_send_verification_email_platform_uses_platform_url` and auto-sign-in assertions (cookies set + tokens returned) in the auth router test.
- `test_email_verification_service.py`, `test_auth_router.py` and the email/util suites pass locally.

## Follow-up
Activation switch: set `LEARNHOUSE_PLATFORM_URL` in the SaaS API env. The platform's `/verify-email` page must call this endpoint through a same-origin proxy so the returned cookies/tokens establish the session, then redirect to the dashboard/onboarding.