### PR TITLE
docs(guides): add Guides section — headless platform + custom features/webhooks

### DIFF
--- a/docs/components/GuideCards/GuideCards.jsx
+++ b/docs/components/GuideCards/GuideCards.jsx
@@ -1,0 +1,114 @@
+'use client'
+
+import Link from 'next/link'
+import {
+  Browser,
+  Robot,
+  Stack,
+  WebhooksLogo,
+  GraduationCap,
+  PlugsConnected,
+} from '@phosphor-icons/react/dist/ssr'
+
+// Card sets, keyed by the `set` prop. Icons live inside this client component
+// so MDX pages only need to pass a string.
+const SETS = {
+  // Guides section landing
+  index: [
+    {
+      href: '/guides/build-learning-platform',
+      icon: GraduationCap,
+      color: '#6366f1',
+      title: 'Build a learning platform',
+      desc: 'Ship your own headless learning platform with Next.js and the LearnHouse API — anonymous browsing first, then auth, enrollment and progress.',
+    },
+    {
+      href: '/guides/custom-features',
+      icon: PlugsConnected,
+      color: '#10b981',
+      title: 'Custom features & webhooks',
+      desc: 'Drive the API with tokens, automate with webhooks, and extend LearnHouse with your own integrations.',
+    },
+  ],
+  // build-learning-platform landing — the two paths
+  build: [
+    {
+      href: '/guides/build-learning-platform/do-it-yourself',
+      icon: Browser,
+      color: '#0ea5e9',
+      title: 'Do it yourself',
+      desc: 'A complete, tested step-by-step build. Start with a public catalogue, then layer on login, enrollment and progress.',
+    },
+    {
+      href: '/guides/build-learning-platform/with-an-agent',
+      icon: Robot,
+      color: '#8b5cf6',
+      title: 'Let an agent build it',
+      desc: 'Hand a coding agent (Claude Code, Cursor…) a ready-made spec and have it build the whole platform for you.',
+    },
+  ],
+  // custom-features landing
+  custom: [
+    {
+      href: '/guides/custom-features',
+      icon: Stack,
+      color: '#10b981',
+      title: 'Work with the API',
+      desc: 'API tokens, request conventions, and recipes for creating and querying content programmatically.',
+    },
+    {
+      href: '/guides/custom-features/webhooks',
+      icon: WebhooksLogo,
+      color: '#f97316',
+      title: 'Consume webhooks',
+      desc: 'Subscribe to dozens of events, verify signatures, and react to learning activity in real time.',
+    },
+  ],
+}
+
+export default function GuideCards({ set = 'index' }) {
+  const cards = SETS[set] || SETS.index
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 12, margin: '32px 0' }}>
+      {cards.map((card) => {
+        const Icon = card.icon
+        return (
+          <Link
+            key={card.href}
+            href={card.href}
+            className="nice-shadow"
+            style={{
+              display: 'flex', alignItems: 'flex-start', gap: 16,
+              padding: '22px 24px',
+              borderRadius: 16,
+              background: '#fff',
+              overflow: 'hidden',
+              position: 'relative',
+              textDecoration: 'none',
+              transition: 'transform 0.15s ease',
+            }}
+            onMouseEnter={e => e.currentTarget.style.transform = 'scale(1.02)'}
+            onMouseLeave={e => e.currentTarget.style.transform = 'scale(1)'}
+          >
+            <div
+              style={{
+                position: 'relative', zIndex: 1,
+                flexShrink: 0,
+                width: 42, height: 42,
+                borderRadius: 12,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                backgroundColor: card.color + '10',
+              }}
+            >
+              <Icon size={20} weight="duotone" style={{ color: card.color }} />
+            </div>
+            <div style={{ position: 'relative', zIndex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 15, fontWeight: 650, color: '#1a1a1a', lineHeight: 1.3, margin: 0 }}>{card.title}</div>
+              <div style={{ fontSize: 13, color: '#9ca3af', lineHeight: 1.45, margin: 0, marginTop: 3 }}>{card.desc}</div>
+            </div>
+          </Link>
+        )
+      })}
+    </div>
+  )
+}

--- a/docs/components/HomeCards/HomeCards.jsx
+++ b/docs/components/HomeCards/HomeCards.jsx
@@ -6,6 +6,7 @@ import {
   BookOpen,
   Cloud,
   Code,
+  GraduationCap,
 } from '@phosphor-icons/react/dist/ssr'
 
 const cards = [
@@ -44,6 +45,15 @@ const cards = [
     desc: 'Architecture, REST API, and contributing guide',
     pattern: 'repeating-linear-gradient(0deg, currentColor 0px, currentColor 1px, transparent 1px, transparent 6px)',
     patternSize: '6px 6px',
+  },
+  {
+    href: '/guides',
+    icon: GraduationCap,
+    color: '#0ea5e9',
+    title: 'Guides',
+    desc: 'Build your own learning platform and custom features',
+    pattern: 'radial-gradient(circle, currentColor 1px, transparent 1px)',
+    patternSize: '16px 16px',
   },
 ]
 

--- a/docs/components/Sidebar/Sidebar.jsx
+++ b/docs/components/Sidebar/Sidebar.jsx
@@ -65,6 +65,9 @@ import {
   IdentificationBadge,
   Package,
   Scroll,
+  Robot,
+  WebhooksLogo,
+  PlugsConnected,
 } from '@phosphor-icons/react/dist/ssr'
 
 const ICON_SIZE = 15
@@ -77,6 +80,7 @@ const iconMap = {
   '/enterprise': Briefcase,
   '/self-hosting': Cloud,
   '/developers': Code,
+  '/guides': GraduationCap,
 
   // Getting Started
   '/getting-started/quickstart': Lightning,
@@ -209,6 +213,18 @@ const iconMap = {
   '/developers/migration/programmatic': Code,
   '/developers/migration/activity-types': Stack,
   '/developers/migration/assisted': Brain,
+
+  // Guides
+  '/guides/build-learning-platform': Browser,
+  '/guides/custom-features': PlugsConnected,
+
+  // Guides > Build a Learning Platform
+  '/guides/build-learning-platform/do-it-yourself': Wrench,
+  '/guides/build-learning-platform/with-an-agent': Robot,
+  '/guides/build-learning-platform/agent-spec': ClipboardText,
+
+  // Guides > Custom Features
+  '/guides/custom-features/webhooks': WebhooksLogo,
 }
 
 function getIcon(route) {
@@ -217,7 +233,34 @@ function getIcon(route) {
   return <Icon size={ICON_SIZE} weight="fill" />
 }
 
-function SidebarItem({ item, depth = 0, onNavigate }) {
+// Explicit sidebar label overrides (the page map auto-titleizes folder names,
+// which drops articles like "a" and can't express "&"). Keyed by route.
+const labelMap = {
+  '/guides/build-learning-platform': 'Build a Learning Platform',
+  '/guides/custom-features': 'Custom Features & Webhooks',
+}
+
+// Explicit child ordering for folders whose pages shouldn't be alphabetical.
+const childOrder = {
+  '/guides/build-learning-platform': [
+    '/guides/build-learning-platform',
+    '/guides/build-learning-platform/do-it-yourself',
+    '/guides/build-learning-platform/with-an-agent',
+    '/guides/build-learning-platform/agent-spec',
+  ],
+}
+
+function orderedChildren(item) {
+  const order = childOrder[item.route]
+  if (!order) return item.children
+  return [...item.children].sort((a, b) => {
+    const ai = order.indexOf(a.route)
+    const bi = order.indexOf(b.route)
+    return (ai === -1 ? 99 : ai) - (bi === -1 ? 99 : bi)
+  })
+}
+
+function SidebarItem({ item, depth = 0, parentRoute = null, onNavigate }) {
   const pathname = usePathname()
   const isActive = pathname === item.route
   const hasChildren = item.children && item.children.length > 0
@@ -240,11 +283,12 @@ function SidebarItem({ item, depth = 0, onNavigate }) {
 
   if (item.display === 'hidden') return null
 
-  const title = typeof item.title === 'string'
-    ? item.title
-    : typeof item.title === 'object' && item.title
-      ? item.title
-      : item.name
+  // Resolve the display label: explicit override → "Overview" for a folder's
+  // own index child → page map title → name.
+  const isIndexChild = parentRoute && item.route === parentRoute && !hasChildren
+  const title = (isIndexChild && item.route?.startsWith('/guides') ? 'Overview' : null)
+    ?? labelMap[item.route]
+    ?? (typeof item.title === 'string' ? item.title : item.name)
 
   const icon = getIcon(item.route)
 
@@ -276,8 +320,8 @@ function SidebarItem({ item, depth = 0, onNavigate }) {
         </button>
         {open && (
           <div className="lh-sidebar-children">
-            {item.children.map((child, i) => (
-              <SidebarItem key={child.route || i} item={child} depth={depth + 1} onNavigate={onNavigate} />
+            {orderedChildren(item).map((child, i) => (
+              <SidebarItem key={child.route || i} item={child} depth={depth + 1} parentRoute={item.route} onNavigate={onNavigate} />
             ))}
           </div>
         )}

--- a/docs/components/diagrams/AuthFlowDiagram.jsx
+++ b/docs/components/diagrams/AuthFlowDiagram.jsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { Browser, Stack, SignIn, Cookie } from '@phosphor-icons/react/dist/ssr'
+import FlowDiagram from './FlowDiagram'
+
+// The BFF login flow: the browser talks only to your Next.js server, which
+// holds the LearnHouse tokens in its own httpOnly cookie.
+const nodes = [
+  { label: 'Browser', sub: 'Login form', icon: Browser, color: '#6366f1', bg: '#eef2ff', border: '#c7d2fe',
+    edge: { label: 'email + password' } },
+  { label: 'Next.js Route Handler', sub: 'Your BFF', icon: Stack, color: '#0ea5e9', bg: '#e0f2fe', border: '#bae6fd',
+    edge: { label: 'form POST' } },
+  { label: 'POST /auth/login', sub: 'Returns access + refresh tokens', icon: SignIn, color: '#10b981', bg: '#ecfdf5', border: '#a7f3d0',
+    edge: { label: 'tokens in body', dashed: true } },
+  { label: 'httpOnly session cookie', sub: 'Tokens stay server-side', icon: Cookie, color: '#f59e0b', bg: '#fffbeb', border: '#fde68a' },
+]
+
+export default function AuthFlowDiagram() {
+  return (
+    <FlowDiagram
+      nodes={nodes}
+      caption="The browser only ever holds your app's own session cookie — never the LearnHouse tokens. To refresh, your server re-sends the stored refresh token to GET /auth/refresh as a Cookie: LH_refresh=… header (the endpoint reads it only from that cookie)."
+    />
+  )
+}

--- a/docs/components/diagrams/FlowDiagram.jsx
+++ b/docs/components/diagrams/FlowDiagram.jsx
@@ -1,0 +1,96 @@
+'use client'
+
+// A clean, predictable horizontal flow diagram: a row of labelled cards
+// connected by labelled arrows. Wraps/scrolls on narrow screens. Used for the
+// linear pipelines (architecture, auth, webhooks) — no floating-edge guesswork.
+
+function Arrow({ label, dashed }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 4,
+        flexShrink: 0,
+        minWidth: 64,
+        padding: '0 4px',
+      }}
+    >
+      {label && (
+        <span style={{ fontSize: 10.5, color: '#64748b', whiteSpace: 'nowrap', textAlign: 'center', lineHeight: 1.2 }}>
+          {label}
+        </span>
+      )}
+      <svg width="100%" height="14" viewBox="0 0 64 14" preserveAspectRatio="none" style={{ display: 'block' }}>
+        <line
+          x1="2" y1="7" x2="54" y2="7"
+          stroke="#cbd5e1" strokeWidth="2"
+          strokeDasharray={dashed ? '4 4' : undefined}
+        />
+        <path d="M52 2 L62 7 L52 12" fill="none" stroke="#94a3b8" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </div>
+  )
+}
+
+function Node({ node }) {
+  const Icon = node.icon
+  return (
+    <div
+      style={{
+        flex: '1 1 0',
+        minWidth: 130,
+        background: node.bg || '#f8fafc',
+        border: `1px solid ${node.border || '#e2e8f0'}`,
+        borderRadius: 14,
+        padding: '14px 16px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+    >
+      <div
+        style={{
+          width: 30, height: 30, borderRadius: 9,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          background: '#fff',
+          border: `1px solid ${node.border || '#e2e8f0'}`,
+        }}
+      >
+        {Icon && <Icon size={17} weight="duotone" color={node.color || '#475569'} />}
+      </div>
+      <div>
+        <div style={{ fontSize: 12.5, fontWeight: 650, color: '#1e293b', lineHeight: 1.25 }}>{node.label}</div>
+        {node.sub && <div style={{ fontSize: 10.5, color: '#64748b', lineHeight: 1.3, marginTop: 2 }}>{node.sub}</div>}
+      </div>
+    </div>
+  )
+}
+
+export default function FlowDiagram({ nodes, caption }) {
+  return (
+    <div
+      style={{
+        border: '1px solid #e5e7eb',
+        borderRadius: 16,
+        background: '#fafafa',
+        padding: 20,
+        margin: '24px 0',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'stretch', overflowX: 'auto', paddingBottom: 2 }}>
+        {nodes.map((node, i) => (
+          <div key={node.label} style={{ display: 'contents' }}>
+            <Node node={node} />
+            {i < nodes.length - 1 && <Arrow label={node.edge?.label} dashed={node.edge?.dashed} />}
+          </div>
+        ))}
+      </div>
+      {caption && (
+        <p style={{ fontSize: 12, color: '#64748b', margin: '14px 2px 0', lineHeight: 1.5 }}>{caption}</p>
+      )}
+    </div>
+  )
+}

--- a/docs/components/diagrams/HeadlessArchitecture.jsx
+++ b/docs/components/diagrams/HeadlessArchitecture.jsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { Browser, Stack, Cube } from '@phosphor-icons/react/dist/ssr'
+import FlowDiagram from './FlowDiagram'
+
+// Browser → your Next.js app (BFF) → LearnHouse API. Media streams straight
+// from the API's content-delivery endpoint.
+const nodes = [
+  { label: 'Browser', sub: 'Your learners', icon: Browser, color: '#6366f1', bg: '#eef2ff', border: '#c7d2fe',
+    edge: { label: 'HTTP' } },
+  { label: 'Your Next.js app', sub: 'Server Components + BFF Route Handlers', icon: Stack, color: '#0ea5e9', bg: '#e0f2fe', border: '#bae6fd',
+    edge: { label: 'REST + Bearer' } },
+  { label: 'LearnHouse API', sub: '/api/v1', icon: Cube, color: '#10b981', bg: '#ecfdf5', border: '#a7f3d0' },
+]
+
+export default function HeadlessArchitecture() {
+  return (
+    <FlowDiagram
+      nodes={nodes}
+      caption="Reads happen in Server Components; anything with a token goes through a Route Handler acting as a Backend-for-Frontend, so tokens never reach the browser. Media (thumbnails, video, files) streams directly from the backend's content-delivery endpoint at /content/… (served at the root, not under /api/v1)."
+    />
+  )
+}

--- a/docs/components/diagrams/ResourceModelDiagram.jsx
+++ b/docs/components/diagrams/ResourceModelDiagram.jsx
@@ -1,0 +1,94 @@
+'use client'
+
+import {
+  Buildings, BookOpen, Stack, Article,
+  User, Path, Flag, CheckCircle,
+} from '@phosphor-icons/react/dist/ssr'
+
+// Two parallel chains: the content tree you read, and the progress tree you
+// write. Cross-links (Run↔Course, Step↔Activity) are described in the caption
+// rather than drawn, which keeps the picture clean.
+
+function Card({ node }) {
+  const Icon = node.icon
+  return (
+    <div
+      style={{
+        flex: '1 1 0', minWidth: 116,
+        background: node.bg, border: `1px solid ${node.border}`,
+        borderRadius: 14, padding: '12px 14px',
+        display: 'flex', flexDirection: 'column', gap: 7,
+      }}
+    >
+      <div
+        style={{
+          width: 28, height: 28, borderRadius: 8,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          background: '#fff', border: `1px solid ${node.border}`,
+        }}
+      >
+        <Icon size={16} weight="duotone" color={node.color} />
+      </div>
+      <div>
+        <div style={{ fontSize: 12.5, fontWeight: 650, color: '#1e293b', lineHeight: 1.2 }}>{node.label}</div>
+        {node.sub && <div style={{ fontSize: 10, color: '#64748b', lineHeight: 1.25, marginTop: 2 }}>{node.sub}</div>}
+      </div>
+    </div>
+  )
+}
+
+function Arrow({ label }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 3, flexShrink: 0, minWidth: 58 }}>
+      <span style={{ fontSize: 9.5, color: '#94a3b8', whiteSpace: 'nowrap' }}>{label}</span>
+      <svg width="100%" height="12" viewBox="0 0 58 12" preserveAspectRatio="none">
+        <line x1="2" y1="6" x2="48" y2="6" stroke="#cbd5e1" strokeWidth="2" />
+        <path d="M46 2 L56 6 L46 10" fill="none" stroke="#94a3b8" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </div>
+  )
+}
+
+function Chain({ title, nodes }) {
+  return (
+    <div>
+      <div style={{ fontSize: 11, fontWeight: 700, color: '#64748b', textTransform: 'uppercase', letterSpacing: 0.4, marginBottom: 8 }}>
+        {title}
+      </div>
+      <div style={{ display: 'flex', alignItems: 'stretch', overflowX: 'auto', paddingBottom: 2 }}>
+        {nodes.map((node, i) => (
+          <div key={node.label} style={{ display: 'contents' }}>
+            <Card node={node} />
+            {i < nodes.length - 1 && <Arrow label="has many" />}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+const content = [
+  { label: 'Organization', sub: 'org_slug', icon: Buildings, color: '#6366f1', bg: '#eef2ff', border: '#c7d2fe' },
+  { label: 'Course', sub: 'course_uuid', icon: BookOpen, color: '#0ea5e9', bg: '#e0f2fe', border: '#bae6fd' },
+  { label: 'Chapter', sub: 'ordered', icon: Stack, color: '#8b5cf6', bg: '#f5f3ff', border: '#ddd6fe' },
+  { label: 'Activity', sub: 'video · doc · page', icon: Article, color: '#db2777', bg: '#fdf2f8', border: '#fbcfe8' },
+]
+
+const progress = [
+  { label: 'User', sub: 'learner', icon: User, color: '#10b981', bg: '#ecfdf5', border: '#a7f3d0' },
+  { label: 'Trail', sub: 'one per user, per org', icon: Path, color: '#0d9488', bg: '#f0fdfa', border: '#99f6e4' },
+  { label: 'Run', sub: 'one per enrolled course', icon: Flag, color: '#f59e0b', bg: '#fffbeb', border: '#fde68a' },
+  { label: 'Step', sub: 'one per completed activity', icon: CheckCircle, color: '#16a34a', bg: '#f0fdf4', border: '#bbf7d0' },
+]
+
+export default function ResourceModelDiagram() {
+  return (
+    <div style={{ border: '1px solid #e5e7eb', borderRadius: 16, background: '#fafafa', padding: 20, margin: '24px 0', display: 'flex', flexDirection: 'column', gap: 20 }}>
+      <Chain title="Content you read" nodes={content} />
+      <Chain title="Progress you write" nodes={progress} />
+      <p style={{ fontSize: 12, color: '#64748b', margin: '0 2px', lineHeight: 1.5 }}>
+        The two chains connect through enrollment: a <strong>Run</strong> records a learner&apos;s enrollment in a <strong>Course</strong>, and each <strong>Step</strong> records completion of an <strong>Activity</strong>.
+      </p>
+    </div>
+  )
+}

--- a/docs/components/diagrams/WebhookFlowDiagram.jsx
+++ b/docs/components/diagrams/WebhookFlowDiagram.jsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { Lightning, Cube, ShieldCheck, CheckCircle } from '@phosphor-icons/react/dist/ssr'
+import FlowDiagram from './FlowDiagram'
+
+// How a webhook reaches your receiver and is verified.
+const nodes = [
+  { label: 'Event happens', sub: 'e.g. course_completed', icon: Lightning, color: '#f59e0b', bg: '#fffbeb', border: '#fde68a',
+    edge: { label: 'signs payload' } },
+  { label: 'LearnHouse API', sub: 'HMAC-SHA256 over body', icon: Cube, color: '#10b981', bg: '#ecfdf5', border: '#a7f3d0',
+    edge: { label: 'signed POST' } },
+  { label: 'Your endpoint', sub: 'Verify X-Webhook-Signature', icon: ShieldCheck, color: '#0ea5e9', bg: '#e0f2fe', border: '#bae6fd',
+    edge: { label: 'valid → handle' } },
+  { label: 'Return 2xx', sub: 'Delivery logged', icon: CheckCircle, color: '#16a34a', bg: '#f0fdf4', border: '#bbf7d0' },
+]
+
+export default function WebhookFlowDiagram() {
+  return (
+    <FlowDiagram
+      nodes={nodes}
+      caption="Recompute the HMAC-SHA256 of the raw request body with your endpoint secret and compare it to X-Webhook-Signature before trusting the payload. If your endpoint doesn't return a 2xx, LearnHouse retries — up to 3 attempts, waiting 1s then 4s between them."
+    />
+  )
+}

--- a/docs/content/_meta.json
+++ b/docs/content/_meta.json
@@ -12,6 +12,7 @@
   "platform": "Platform",
   "self-hosting": "Self Hosting",
   "developers": "Developers",
+  "guides": "Guides",
   "cli": "CLI",
   "enterprise": "Enterprise Edition"
 }

--- a/docs/content/guides/_meta.json
+++ b/docs/content/guides/_meta.json
@@ -1,0 +1,5 @@
+{
+  "index": "Overview",
+  "build-learning-platform": "Build a Learning Platform",
+  "custom-features": "Custom Features & Webhooks"
+}

--- a/docs/content/guides/build-learning-platform/_meta.json
+++ b/docs/content/guides/build-learning-platform/_meta.json
@@ -1,0 +1,6 @@
+{
+  "index": "Overview",
+  "do-it-yourself": "Do It Yourself",
+  "with-an-agent": "Let an Agent Build It",
+  "agent-spec": "Agent Spec"
+}

--- a/docs/content/guides/build-learning-platform/agent-spec.mdx
+++ b/docs/content/guides/build-learning-platform/agent-spec.mdx
@@ -1,0 +1,161 @@
+---
+title: Agent Spec
+description: A self-contained, copy-paste specification a coding agent can follow to build a headless LearnHouse learning platform with Next.js, including the exact API contract and acceptance criteria.
+---
+
+import { Callout } from 'nextra/components'
+
+# Agent Spec
+
+Copy everything in the block below, fill in the **Configuration** values at the top, and paste it into your coding agent (see [Let an Agent Build It](/guides/build-learning-platform/with-an-agent) for the workflow). It's written *for the model* and contains the real LearnHouse API contract, so the agent builds against the API that actually exists.
+
+<Callout type="info">
+This spec mirrors the [Do It Yourself](/guides/build-learning-platform/do-it-yourself) build exactly. If you want to understand what the agent is doing, read that page alongside the generated code.
+</Callout>
+
+````markdown
+# SPEC: Build a headless learning platform on the LearnHouse API
+
+## Configuration (fill these in before starting)
+- API_BASE = http://localhost:1338/api/v1     # your LearnHouse API base URL
+- ORG_SLUG = your-org-slug                     # your organization slug
+- TEST_EMAIL = you@example.com                 # optional, for verifying auth
+- TEST_PASSWORD = ********                      # optional
+
+## Goal
+Build a web learning platform with Next.js (App Router + TypeScript + Tailwind)
+that reads courses and content from the LearnHouse REST API and supports user
+signup, login, enrollment, and progress tracking. Build it in two stages:
+Stage 1 is fully anonymous (no tokens); Stage 2 adds authentication on top
+without rewriting Stage 1.
+
+## Hard rules
+- LearnHouse access/refresh tokens MUST NEVER reach the browser. Do all
+  authenticated calls from the server (Route Handlers / Server Actions) and
+  store tokens in the Next.js app's own httpOnly cookie (a "BFF" pattern).
+- Read the API base and org slug from environment variables; never hardcode.
+- All API responses must be treated as uncacheable (cache: 'no-store').
+- Surface API errors: error bodies are JSON shaped { "detail": "..." }.
+
+## API contract (use these exactly; all paths are relative to API_BASE)
+Anonymous reads (no Authorization header needed for public, published content):
+- GET  /orgs/slug/{ORG_SLUG}
+    -> organization object incl. numeric `id`.
+- GET  /courses/org_slug/{ORG_SLUG}/page/{page}/limit/{limit}
+    -> JSON ARRAY of courses. Each: { course_uuid, name, description,
+       thumbnail_image, public, published }. `course_uuid` already includes a
+       "course_" prefix — use it verbatim in URLs.
+- GET  /courses/{course_uuid}/meta
+    -> course + { org_id, chapters: [ { chapter_uuid, name, description,
+       activities: [ { id, activity_uuid, name, activity_type,
+       activity_sub_type, content, published } ] } ] }.
+       Each activity has BOTH a numeric `id` and a string `activity_uuid`.
+       Match progress with the numeric `id` (step.activity_id === activity.id);
+       use `activity_uuid` for routing/fetching.
+- GET  /activities/{activity_uuid}
+    -> a single activity { id, activity_uuid, name, activity_type,
+       activity_sub_type, content, published }.
+       activity_type is one of: TYPE_VIDEO, TYPE_DOCUMENT, TYPE_DYNAMIC,
+       TYPE_ASSIGNMENT, TYPE_CUSTOM, TYPE_SCORM.
+
+Media: served from the backend ROOT (NOT under /api/v1) — derive a media base
+by stripping "/api/v1" from API_BASE. Stored media values are BARE filenames,
+not paths, so build org/course-scoped URLs:
+  - course thumbnail: {MEDIA_BASE}/content/orgs/{org_uuid}/courses/{course_uuid}/thumbnails/{thumbnail_image}
+  - hosted video:     {MEDIA_BASE}/content/orgs/{org_uuid}/courses/{course_uuid}/activities/{activity_uuid}/video/{fileId}
+  - document (pdf):    {MEDIA_BASE}/content/orgs/{org_uuid}/courses/{course_uuid}/activities/{activity_uuid}/documentpdf/{fileId}
+  org_uuid comes from GET /orgs/slug/{ORG_SLUG} or the /meta response (the
+  course LIST does not include org_uuid). Values starting with http(s) are full
+  S3 URLs — use as-is.
+
+Auth (Stage 2):
+- POST /auth/login   Content-Type: application/x-www-form-urlencoded
+    body: username={email}&password={password}
+    -> { user: { user_uuid, username, email, ... },
+         tokens: { access_token, refresh_token, expiry } }
+    (It also sets httpOnly cookies, but rely on the body for a headless client.)
+- POST /users/{org_id}   Content-Type: application/json
+    body: { email, password, username, first_name, last_name }  -> creates a user.
+    (Resolve org_id via GET /orgs/slug/{ORG_SLUG}.)
+- GET  /auth/refresh
+    Reads the refresh token ONLY from the `LH_refresh` cookie — NOT a header or
+    body. To refresh from the server, send header: Cookie: LH_refresh={value}.
+    -> { access_token, refresh_token, expiry }. The refresh token ROTATES: you
+    MUST persist the returned refresh_token (and access_token) back into your
+    session, or the next refresh is rejected as a replay (401).
+- DELETE /auth/logout   Authorization: Bearer {access_token}  -> revokes session.
+- Authenticated calls: send header Authorization: Bearer {access_token}.
+
+Enrollment & progress (Stage 2, authenticated):
+- A Trail (one per user per org) must EXIST before a course can be added, or
+  add_course returns 404. Reading the trail creates it lazily, so call
+  GET /trail/org/{org_id}/trail once before POST /trail/add_course.
+- GET    /trail/org/{org_id}/trail            lazily creates the trail; returns
+         { runs: [ { course, steps:[{activity_id, complete, ...}],
+         course_total_steps, ... } ] } (one run per enrolled course).
+- POST   /trail/add_course/{course_uuid}      enroll the current user (trail must exist).
+- POST   /trail/add_activity/{activity_uuid}  mark an activity done (creates trail/run if needed).
+
+## Required pages / files
+- src/lib/learnhouse.ts   : API_BASE/ORG_SLUG consts, `lhFetch` (public reads,
+                            optional token), media-URL helpers that build the
+                            backend-root org/course-scoped paths (see Media
+                            above), shared types.
+- src/lib/session.ts      : httpOnly-cookie session (get/set/clear) + `authedFetch`
+                            that retries once on 401 by refreshing (refresh token
+                            sent as a Cookie: LH_refresh header), persisting the
+                            rotated access+refresh tokens back to the session
+                            before retrying — see contract.
+- src/app/page.tsx        : course catalogue (anonymous).
+- src/app/courses/[uuid]/page.tsx           : course detail from /meta (anonymous).
+- src/app/courses/[uuid]/[activityUuid]/page.tsx : activity viewer, switch on
+                            activity_type (video / document / dynamic).
+- src/app/api/auth/login/route.ts   : POST -> /auth/login, store session.
+- src/app/api/auth/signup/route.ts  : POST -> resolve org id, /users/{org_id}.
+- src/app/api/auth/logout/route.ts  : POST -> /auth/logout, clear session.
+- src/app/login/page.tsx            : client login form posting to /api/auth/login.
+- src/app/courses/[uuid]/actions.ts : Server Actions `enroll` and
+                            `markActivityDone` using authedFetch.
+- Enroll button on the course page (link to /login if no session); progress
+  ticks derived from GET /trail/org/{org_id}/trail.
+
+## Environment
+Create .env.local:
+  NEXT_PUBLIC_LEARNHOUSE_API_URL=<API_BASE>
+  NEXT_PUBLIC_LEARNHOUSE_ORG_SLUG=<ORG_SLUG>
+
+## Build order
+1. Scaffold: npx create-next-app@latest . --typescript --app --tailwind --eslint --src-dir --use-npm
+2. Stage 1: lib/learnhouse.ts -> catalogue -> course page -> activity viewer.
+   STOP and verify the public site renders before continuing.
+3. Stage 2: session.ts -> auth route handlers + login form -> authedFetch ->
+   enroll action -> progress display.
+
+## Acceptance criteria (verify against the live instance)
+1. Catalogue lists the org's public courses with thumbnails.
+2. A course page lists chapters and their published activities.
+3. At least one activity renders (video, document, or dynamic page).
+4. A new user can sign up (TEST_EMAIL) and log in.
+5. A logged-in user can enroll in a course and see at least one progress tick
+   after marking an activity done.
+Report which criteria pass and show the commands/URLs you used to check.
+
+## Known adjustment points (don't guess — inspect, then adapt)
+- Activity `content` keys vary by activity_sub_type and editor version. Inspect a
+  real GET /activities/{uuid} and adapt the viewer's field names. Dynamic pages
+  are a structured block document; rendering raw JSON is an acceptable v1.
+- Media is served from the backend ROOT (not /api/v1) at org/course-scoped
+  paths (see the Media section). If images 404, confirm the base has no /api/v1
+  and that you built the full orgs/{org}/courses/{course}/... path; S3 values
+  are absolute URLs.
+- On SaaS instances, login may require email verification first. On local
+  self-hosted instances this is usually disabled.
+````
+
+<Callout type="warning">
+The agent can build the structure and the happy path, but it can't see your instance's exact `content` shapes or storage config. Plan to review the **activity viewer** and **media URLs** — the spec flags both as the likely places to adjust.
+</Callout>
+
+## After it runs
+
+Click through the acceptance criteria yourself, then continue with the same next steps as the manual build: real block rendering for dynamic activities, [webhooks](/guides/custom-features/webhooks), and the full [API Reference](/developers/api). Compare your result with [`learnhouse/headless-examples`](https://github.com/learnhouse/headless-examples).

--- a/docs/content/guides/build-learning-platform/do-it-yourself.mdx
+++ b/docs/content/guides/build-learning-platform/do-it-yourself.mdx
@@ -1,0 +1,767 @@
+---
+title: Build It Yourself
+description: A complete, tested, step-by-step guide to building a headless learning platform with Next.js and the LearnHouse API — public catalogue first, then authentication, enrollment, and progress tracking.
+---
+
+import { Callout, Tabs } from 'nextra/components'
+import AuthFlowDiagram from '../../../components/diagrams/AuthFlowDiagram'
+
+# Build It Yourself
+
+This is the full build. By the end you'll have a Next.js app that browses your courses, plays their content, signs learners in, enrolls them, and tracks progress — all on top of the LearnHouse API.
+
+It's split into two parts. **Part 1 is completely anonymous** — no login, no tokens, just public reads — and gets you a working public site. **Part 2 layers authentication on top** without rewriting anything from Part 1.
+
+<Callout type="info">
+**Prerequisites** (from the [overview](/guides/build-learning-platform)): Node 18+, a running LearnHouse instance at `http://localhost:1338`, your **org slug**, and at least one **public, published course** with content. Everything reads the API base from one env var, so adjust it if your instance is elsewhere.
+</Callout>
+
+---
+
+# Part 1 — A public learning site (no auth)
+
+## Step 1 — Scaffold the app
+
+Create a new Next.js app with the App Router, TypeScript, and Tailwind:
+
+```bash
+npx create-next-app@latest my-learning-platform \
+  --typescript --app --tailwind --eslint --src-dir --use-npm
+cd my-learning-platform
+```
+
+Add a `.env.local` with your API base and organization slug. Both are safe to expose to the browser (the org slug is public and reads are anonymous), so we prefix them with `NEXT_PUBLIC_`:
+
+```bash filename=".env.local"
+NEXT_PUBLIC_LEARNHOUSE_API_URL=http://localhost:1338/api/v1
+NEXT_PUBLIC_LEARNHOUSE_ORG_SLUG=your-org-slug
+```
+
+<Callout type="warning">
+Replace `your-org-slug` with your real slug. You can confirm it resolves by opening `http://localhost:1338/api/v1/orgs/slug/your-org-slug` in your browser — you should get the organization JSON back.
+</Callout>
+
+## Step 2 — A tiny API client
+
+Every call to LearnHouse goes through one small helper. Create `src/lib/learnhouse.ts`. This mirrors the pattern the official frontend uses in `apps/web/services/utils/ts/requests.ts` — a thin `fetch` wrapper that surfaces the API's `{ "detail": "..." }` error shape.
+
+```ts filename="src/lib/learnhouse.ts"
+export const API_URL = process.env.NEXT_PUBLIC_LEARNHOUSE_API_URL!
+export const ORG_SLUG = process.env.NEXT_PUBLIC_LEARNHOUSE_ORG_SLUG!
+
+/**
+ * Fetch JSON from the LearnHouse API.
+ * Pass an access token to authenticate (Part 2); omit it for public reads.
+ */
+export async function lhFetch<T = any>(
+  path: string,
+  { token, ...init }: RequestInit & { token?: string } = {}
+): Promise<T> {
+  const res = await fetch(`${API_URL}/${path.replace(/^\//, '')}`, {
+    ...init,
+    headers: {
+      Accept: 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...init.headers,
+    },
+    // Access state can change at any time, so never cache API responses.
+    cache: 'no-store',
+  })
+
+  if (!res.ok) {
+    let detail = res.statusText
+    try {
+      detail = (await res.json()).detail ?? detail
+    } catch {
+      /* non-JSON error body */
+    }
+    throw new Error(`LearnHouse API ${res.status}: ${detail}`)
+  }
+  return res.json()
+}
+
+// Media is served from the backend ROOT (not under /api/v1), at org/course-
+// scoped paths. Derive the backend base by stripping the /api/v1 suffix.
+export const BACKEND_URL = API_URL.replace(/\/api\/v1\/?$/, '')
+
+/**
+ * URL for a course thumbnail. The API stores `thumbnail_image` as a bare
+ * filename, so the full path is org/course-scoped. Absolute URLs (S3) are
+ * returned as-is.
+ */
+export function courseThumbnail(orgUuid: string, course: Course): string | null {
+  const file = course.thumbnail_image
+  if (!file) return null
+  if (/^https?:\/\//.test(file)) return file
+  return `${BACKEND_URL}/content/orgs/${orgUuid}/courses/${course.course_uuid}/thumbnails/${file}`
+}
+
+/**
+ * URL for hosted activity media (kind = 'video' | 'documentpdf'). `fileId` is
+ * the stored filename from the activity's `content`.
+ */
+export function activityMedia(
+  orgUuid: string,
+  courseUuid: string,
+  activityUuid: string,
+  kind: 'video' | 'documentpdf',
+  fileId: string
+): string {
+  return `${BACKEND_URL}/content/orgs/${orgUuid}/courses/${courseUuid}/activities/${activityUuid}/${kind}/${fileId}`
+}
+```
+
+<Callout type="info">
+The content-delivery endpoint lives at the backend **root** (`http://localhost:1338/content/…`), *not* under `/api/v1`. And `thumbnail_image` is just a filename — the real path is `content/orgs/{org_uuid}/courses/{course_uuid}/thumbnails/{filename}`. This mirrors the official frontend's media service.
+</Callout>
+
+It also defines a few types you'll reuse. Add them to the same file:
+
+```ts filename="src/lib/learnhouse.ts (continued)"
+export type Course = {
+  course_uuid: string
+  name: string
+  description: string
+  thumbnail_image?: string
+  public: boolean
+  published: boolean
+}
+
+export type Activity = {
+  id: number                 // numeric id — progress steps are keyed by this
+  activity_uuid: string
+  name: string
+  activity_type: string      // TYPE_VIDEO | TYPE_DOCUMENT | TYPE_DYNAMIC | ...
+  activity_sub_type: string
+  content: any
+  published: boolean
+}
+
+export type Chapter = {
+  chapter_uuid: string
+  name: string
+  description?: string
+  activities: Activity[]
+}
+
+export type CourseMeta = Course & {
+  org_id: number
+  chapters: Chapter[]
+}
+```
+
+## Step 3 — The course catalogue
+
+The list endpoint returns a plain JSON array of courses for an organization, **and it works anonymously** for public courses — no token required. Replace `src/app/page.tsx`:
+
+```tsx filename="src/app/page.tsx"
+import Link from 'next/link'
+import { lhFetch, courseThumbnail, ORG_SLUG, type Course } from '@/lib/learnhouse'
+
+export default async function CataloguePage() {
+  // Fetch the org (for its org_uuid, needed to build thumbnail URLs) and the
+  // course list together. Both are anonymous reads.
+  const [org, courses] = await Promise.all([
+    lhFetch<{ org_uuid: string }>(`orgs/slug/${ORG_SLUG}`),
+    lhFetch<Course[]>(`courses/org_slug/${ORG_SLUG}/page/1/limit/50`),
+  ])
+
+  return (
+    <main className="mx-auto max-w-5xl p-8">
+      <h1 className="mb-8 text-3xl font-bold">Courses</h1>
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {courses.map((course) => {
+          const thumb = courseThumbnail(org.org_uuid, course)
+          return (
+            <Link
+              key={course.course_uuid}
+              href={`/courses/${course.course_uuid}`}
+              className="overflow-hidden rounded-xl border transition hover:shadow-lg"
+            >
+              {thumb && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={thumb} alt={course.name} className="h-40 w-full object-cover" />
+              )}
+              <div className="p-4">
+                <h2 className="font-semibold">{course.name}</h2>
+                <p className="mt-1 line-clamp-2 text-sm text-gray-500">
+                  {course.description}
+                </p>
+              </div>
+            </Link>
+          )
+        })}
+      </div>
+    </main>
+  )
+}
+```
+
+Start the dev server:
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) and you'll see your courses. (If LearnHouse is also on `:3000`, run the API on its usual port and Next will pick `:3001` — or set `PORT`.)
+
+<Callout type="info">
+The path segment after `courses/` is the **full** `course_uuid` exactly as returned by the list — it already includes the `course_` prefix (e.g. `course_3f2a…`). Pass it through verbatim; don't add or strip anything.
+</Callout>
+
+## Step 4 — The course page
+
+`GET /api/v1/courses/{course_uuid}/meta` returns the whole content tree in one call: the course plus its `chapters`, each with its `activities`. Create `src/app/courses/[uuid]/page.tsx`:
+
+```tsx filename="src/app/courses/[uuid]/page.tsx"
+import Link from 'next/link'
+import { lhFetch, type CourseMeta } from '@/lib/learnhouse'
+
+export default async function CoursePage({
+  params,
+}: {
+  params: Promise<{ uuid: string }>
+}) {
+  const { uuid } = await params
+  const course = await lhFetch<CourseMeta>(`courses/${uuid}/meta`)
+
+  return (
+    <main className="mx-auto max-w-3xl p-8">
+      <Link href="/" className="text-sm text-gray-500">← All courses</Link>
+      <h1 className="mt-4 text-3xl font-bold">{course.name}</h1>
+      <p className="mt-2 text-gray-600">{course.description}</p>
+
+      <div className="mt-8 space-y-6">
+        {course.chapters.map((chapter) => (
+          <section key={chapter.chapter_uuid}>
+            <h2 className="mb-2 text-lg font-semibold">{chapter.name}</h2>
+            <ul className="space-y-1">
+              {chapter.activities
+                .filter((a) => a.published)
+                .map((activity) => (
+                  <li key={activity.activity_uuid}>
+                    <Link
+                      href={`/courses/${uuid}/${activity.activity_uuid}`}
+                      className="text-blue-600 hover:underline"
+                    >
+                      {activity.name}
+                    </Link>
+                  </li>
+                ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </main>
+  )
+}
+```
+
+<Callout type="info">
+`meta` accepts a `with_unpublished_activities` query flag, but that only returns drafts to a user with edit permission. For a public site, leave it off and filter on `activity.published` as above.
+</Callout>
+
+## Step 5 — The activity viewer
+
+Each activity carries an `activity_type` and a `content` object. Render per type. Create `src/app/courses/[uuid]/[activityUuid]/page.tsx`:
+
+```tsx filename="src/app/courses/[uuid]/[activityUuid]/page.tsx"
+import { lhFetch, activityMedia, ORG_SLUG, type Activity } from '@/lib/learnhouse'
+
+export default async function ActivityPage({
+  params,
+}: {
+  params: Promise<{ uuid: string; activityUuid: string }>
+}) {
+  const { uuid, activityUuid } = await params
+  // Hosted media is org/course/activity-scoped, so we need the org_uuid too.
+  const [org, activity] = await Promise.all([
+    lhFetch<{ org_uuid: string }>(`orgs/slug/${ORG_SLUG}`),
+    lhFetch<Activity>(`activities/${activityUuid}`),
+  ])
+
+  return (
+    <main className="mx-auto max-w-3xl p-8">
+      <h1 className="mb-6 text-2xl font-bold">{activity.name}</h1>
+      <ActivityBody activity={activity} orgUuid={org.org_uuid} courseUuid={uuid} activityUuid={activityUuid} />
+    </main>
+  )
+}
+
+function ActivityBody({
+  activity, orgUuid, courseUuid, activityUuid,
+}: {
+  activity: Activity; orgUuid: string; courseUuid: string; activityUuid: string
+}) {
+  switch (activity.activity_type) {
+    case 'TYPE_VIDEO': {
+      // YouTube videos store a watch URL; hosted videos store a filename in content.
+      const c = activity.content ?? {}
+      if (activity.activity_sub_type === 'SUBTYPE_VIDEO_YOUTUBE' && c.uri) {
+        const id = new URL(c.uri).searchParams.get('v') ?? c.uri.split('/').pop()
+        return (
+          <div className="aspect-video">
+            <iframe
+              className="h-full w-full rounded-lg"
+              src={`https://www.youtube.com/embed/${id}`}
+              allowFullScreen
+            />
+          </div>
+        )
+      }
+      const fileId = c.filename // inspect your activity's `content` for the real key
+      return fileId
+        ? <video controls src={activityMedia(orgUuid, courseUuid, activityUuid, 'video', fileId)} className="w-full rounded-lg" />
+        : <Unsupported />
+    }
+    case 'TYPE_DOCUMENT': {
+      const fileId = activity.content?.filename
+      return fileId
+        ? <iframe src={activityMedia(orgUuid, courseUuid, activityUuid, 'documentpdf', fileId)} className="h-[80vh] w-full rounded-lg border" />
+        : <Unsupported />
+    }
+    case 'TYPE_DYNAMIC':
+      // Dynamic pages are a structured block document (see /platform/editor).
+      // Render your own block components here; for now show the raw structure.
+      return (
+        <pre className="overflow-auto rounded-lg bg-gray-50 p-4 text-xs">
+          {JSON.stringify(activity.content, null, 2)}
+        </pre>
+      )
+    default:
+      return <Unsupported />
+  }
+}
+
+function Unsupported() {
+  return <p className="text-gray-500">This activity type isn’t rendered yet.</p>
+}
+```
+
+<Callout type="warning">
+The exact keys inside `content` depend on the activity sub-type and your editor version. Inspect a real activity (`GET /api/v1/activities/{activity_uuid}`) on your instance and adjust the field names above to match. Dynamic pages in particular are a rich block document — see the [Editor docs](/platform/editor) for the block model.
+</Callout>
+
+### ✅ Checkpoint
+
+You now have a **fully browsable public learning site** — catalogue, course pages, and an activity viewer — with **zero authentication**. This is already useful for any course you've marked public. Everything from here is additive.
+
+---
+
+# Part 2 — Authentication, enrollment & progress
+
+Now we add accounts. The golden rule: **LearnHouse tokens never reach the browser.** Your Next.js app logs in on the server, stores the tokens in its *own* httpOnly cookie, and attaches them when calling the API. This is the Backend-for-Frontend (BFF) pattern.
+
+<AuthFlowDiagram />
+
+<Callout type="warning">
+**The refresh gotcha.** `POST /api/v1/auth/login` returns `access_token` **and** `refresh_token` in the JSON body. But `GET /api/v1/auth/refresh` reads the refresh token **only from the `LH_refresh` cookie** — not a header and not the body. So when your server refreshes, it must send the stored refresh token *as the `LH_refresh` cookie*. We handle this in `lib/session.ts` below.
+</Callout>
+
+## Step 6 — A server-side session
+
+Create `src/lib/session.ts` to read and write the session cookie. It stores the LearnHouse tokens, encrypted-at-rest concerns aside, in an httpOnly cookie that the browser can't read from JavaScript.
+
+```ts filename="src/lib/session.ts"
+import { cookies } from 'next/headers'
+
+const SESSION_COOKIE = 'lh_session'
+
+export type Session = {
+  access_token: string
+  refresh_token: string
+  user: { user_uuid: string; username: string; email: string }
+}
+
+export async function getSession(): Promise<Session | null> {
+  const raw = (await cookies()).get(SESSION_COOKIE)?.value
+  return raw ? (JSON.parse(raw) as Session) : null
+}
+
+export async function setSession(session: Session) {
+  ;(await cookies()).set(SESSION_COOKIE, JSON.stringify(session), {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 60 * 60 * 24 * 30, // 30 days, matches the refresh-token lifetime
+  })
+}
+
+export async function clearSession() {
+  ;(await cookies()).delete(SESSION_COOKIE)
+}
+```
+
+## Step 7 — Signup & login Route Handlers (the BFF)
+
+The login endpoint expects **form-encoded** fields `username` (the email) and `password`. Create `src/app/api/auth/login/route.ts`:
+
+```ts filename="src/app/api/auth/login/route.ts"
+import { NextRequest, NextResponse } from 'next/server'
+import { API_URL } from '@/lib/learnhouse'
+import { setSession } from '@/lib/session'
+
+export async function POST(req: NextRequest) {
+  const { email, password } = await req.json()
+
+  const form = new URLSearchParams({ username: email, password })
+  const res = await fetch(`${API_URL}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: form,
+  })
+
+  if (!res.ok) {
+    const { detail } = await res.json().catch(() => ({ detail: 'Login failed' }))
+    return NextResponse.json({ error: detail }, { status: res.status })
+  }
+
+  const { user, tokens } = await res.json()
+  await setSession({
+    access_token: tokens.access_token,
+    refresh_token: tokens.refresh_token,
+    user,
+  })
+  return NextResponse.json({ ok: true })
+}
+```
+
+Signup creates a user in your organization with `POST /api/v1/users/{org_id}` (JSON body). Create `src/app/api/auth/signup/route.ts`:
+
+```ts filename="src/app/api/auth/signup/route.ts"
+import { NextRequest, NextResponse } from 'next/server'
+import { API_URL, lhFetch, ORG_SLUG } from '@/lib/learnhouse'
+
+export async function POST(req: NextRequest) {
+  const body = await req.json() // { email, password, username, first_name, last_name }
+
+  // Resolve the org slug to its numeric id (the create-user route is keyed by id).
+  const org = await lhFetch<{ id: number }>(`orgs/slug/${ORG_SLUG}`)
+
+  const res = await fetch(`${API_URL}/users/${org.id}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+  if (!res.ok) {
+    const { detail } = await res.json().catch(() => ({ detail: 'Signup failed' }))
+    return NextResponse.json({ error: detail }, { status: res.status })
+  }
+  return NextResponse.json({ ok: true })
+}
+```
+
+<Callout type="info">
+On SaaS deployments, new accounts must verify their email before they can log in. On a local self-hosted instance this is usually disabled, so signup → login works immediately. See [Authentication](/developers/api/authentication) for the verification endpoints.
+</Callout>
+
+A logout handler clears the cookie — `src/app/api/auth/logout/route.ts`:
+
+```ts filename="src/app/api/auth/logout/route.ts"
+import { NextResponse } from 'next/server'
+import { API_URL } from '@/lib/learnhouse'
+import { getSession, clearSession } from '@/lib/session'
+
+export async function POST() {
+  const session = await getSession()
+  if (session) {
+    // Best-effort server-side revocation.
+    await fetch(`${API_URL}/auth/logout`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${session.access_token}` },
+    }).catch(() => {})
+  }
+  await clearSession()
+  return NextResponse.json({ ok: true })
+}
+```
+
+### A login form
+
+A minimal client form that posts to your BFF — `src/app/login/page.tsx`:
+
+```tsx filename="src/app/login/page.tsx"
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function LoginPage() {
+  const router = useRouter()
+  const [error, setError] = useState('')
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const data = Object.fromEntries(new FormData(e.currentTarget))
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (res.ok) router.push('/')
+    else setError((await res.json()).error ?? 'Login failed')
+  }
+
+  return (
+    <main className="mx-auto max-w-sm p-8">
+      <h1 className="mb-6 text-2xl font-bold">Log in</h1>
+      <form onSubmit={onSubmit} className="space-y-4">
+        <input name="email" type="email" placeholder="Email" required className="w-full rounded border p-2" />
+        <input name="password" type="password" placeholder="Password" required className="w-full rounded border p-2" />
+        <button className="w-full rounded bg-blue-600 p-2 text-white">Log in</button>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+      </form>
+      <p className="mt-4 text-sm text-gray-500">
+        No account? <a href="/signup" className="text-blue-600">Sign up</a>.
+      </p>
+    </main>
+  )
+}
+```
+
+### A signup form
+
+Signup collects a few more fields and posts to the signup handler, then logs in. Create `src/app/signup/page.tsx`:
+
+```tsx filename="src/app/signup/page.tsx"
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function SignupPage() {
+  const router = useRouter()
+  const [error, setError] = useState('')
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const data = Object.fromEntries(new FormData(e.currentTarget))
+
+    const signup = await fetch('/api/auth/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (!signup.ok) return setError((await signup.json()).error ?? 'Signup failed')
+
+    // Log straight in with the same credentials.
+    const login = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: data.email, password: data.password }),
+    })
+    if (login.ok) router.push('/')
+    else router.push('/login') // e.g. email verification required
+  }
+
+  return (
+    <main className="mx-auto max-w-sm p-8">
+      <h1 className="mb-6 text-2xl font-bold">Create an account</h1>
+      <form onSubmit={onSubmit} className="space-y-4">
+        <input name="first_name" placeholder="First name" required className="w-full rounded border p-2" />
+        <input name="last_name" placeholder="Last name" required className="w-full rounded border p-2" />
+        <input name="username" placeholder="Username" required className="w-full rounded border p-2" />
+        <input name="email" type="email" placeholder="Email" required className="w-full rounded border p-2" />
+        <input name="password" type="password" placeholder="Password" required className="w-full rounded border p-2" />
+        <button className="w-full rounded bg-blue-600 p-2 text-white">Sign up</button>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+      </form>
+    </main>
+  )
+}
+```
+
+## Step 8 — Authenticated requests & refresh
+
+Add a helper that pulls the token from the session and refreshes it when it has expired. Append to `src/lib/session.ts`:
+
+```ts filename="src/lib/session.ts (continued)"
+import { API_URL } from '@/lib/learnhouse'
+
+/**
+ * Run an API call as the logged-in user. On a 401, transparently refresh the
+ * token and retry once. Returns null if there is no session.
+ */
+export async function authedFetch<T = any>(
+  path: string,
+  init: RequestInit = {}
+): Promise<T | null> {
+  const session = await getSession()
+  if (!session) return null
+
+  const call = (token: string) =>
+    fetch(`${API_URL}/${path.replace(/^\//, '')}`, {
+      ...init,
+      headers: { Accept: 'application/json', Authorization: `Bearer ${token}`, ...init.headers },
+      cache: 'no-store',
+    })
+
+  let res = await call(session.access_token)
+
+  if (res.status === 401) {
+    // /auth/refresh reads the refresh token from the LH_refresh *cookie*,
+    // so send it as one (not as a header or body).
+    const refreshed = await fetch(`${API_URL}/auth/refresh`, {
+      headers: { Cookie: `LH_refresh=${session.refresh_token}` },
+    })
+    if (refreshed.ok) {
+      const tokens = await refreshed.json()
+      await setSession({ ...session, access_token: tokens.access_token, refresh_token: tokens.refresh_token })
+      res = await call(tokens.access_token)
+    }
+  }
+
+  if (!res.ok) throw new Error(`LearnHouse API ${res.status}`)
+  return res.json()
+}
+```
+
+## Step 9 — Enrollment
+
+A learner's enrollments and progress live on a **Trail** (one per user per organization). Adding a course to the trail is `POST /api/v1/trail/add_course/{course_uuid}` — but the trail must **exist first**, or you'll get a `404 Trail not found`. The simplest way to guarantee it: read the trail once (`GET /api/v1/trail/org/{org_id}/trail` creates it lazily) right before enrolling.
+
+Add a Server Action and wire it to a button. Create `src/app/courses/[uuid]/actions.ts`:
+
+```ts filename="src/app/courses/[uuid]/actions.ts"
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { authedFetch } from '@/lib/session'
+
+export async function enroll(courseUuid: string, orgId: number) {
+  // Reading the trail creates it if it doesn't exist yet — required before a
+  // course can be added. orgId comes from the course `meta` response.
+  await authedFetch(`trail/org/${orgId}/trail`)
+  await authedFetch(`trail/add_course/${courseUuid}`, { method: 'POST' })
+  revalidatePath(`/courses/${courseUuid}`)
+}
+
+export async function markActivityDone(courseUuid: string, activityUuid: string) {
+  // add_activity creates the trail/run on the fly, so no pre-step is needed here.
+  await authedFetch(`trail/add_activity/${activityUuid}`, { method: 'POST' })
+  revalidatePath(`/courses/${courseUuid}`)
+}
+```
+
+Now a small client component for the button. It calls the Server Action and shows a pending state. Create `src/app/courses/[uuid]/EnrollButton.tsx`:
+
+```tsx filename="src/app/courses/[uuid]/EnrollButton.tsx"
+'use client'
+
+import { useTransition } from 'react'
+import { enroll } from './actions'
+
+export default function EnrollButton({
+  courseUuid,
+  orgId,
+  loggedIn,
+}: {
+  courseUuid: string
+  orgId: number
+  loggedIn: boolean
+}) {
+  const [pending, start] = useTransition()
+
+  if (!loggedIn) {
+    return <a href="/login" className="rounded bg-blue-600 px-4 py-2 text-white">Log in to enroll</a>
+  }
+
+  return (
+    <button
+      disabled={pending}
+      onClick={() => start(() => enroll(courseUuid, orgId))}
+      className="rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50"
+    >
+      {pending ? 'Enrolling…' : 'Enroll'}
+    </button>
+  )
+}
+```
+
+## Step 10 — Progress
+
+A learner's progress lives on their **Trail**. Fetch it for the current org with `GET /api/v1/trail/org/{org_id}/trail`; it returns a `runs` array (one per enrolled course), each with `steps` (one per completed activity, keyed by numeric `activity_id`) and a `course_total_steps` count.
+
+Now wire it all together. Update the course page from Step 4 to fetch the trail for a logged-in user, show the **Enroll** button, and render a ✓ next to completed activities:
+
+```tsx filename="src/app/courses/[uuid]/page.tsx (updated)"
+import Link from 'next/link'
+import { lhFetch, type CourseMeta } from '@/lib/learnhouse'
+import { getSession, authedFetch } from '@/lib/session'
+import EnrollButton from './EnrollButton'
+
+export default async function CoursePage({
+  params,
+}: {
+  params: Promise<{ uuid: string }>
+}) {
+  const { uuid } = await params
+  const course = await lhFetch<CourseMeta>(`courses/${uuid}/meta`)
+
+  // Logged-in extras: enrollment + completed activities.
+  const session = await getSession()
+  let completed = new Set<number>()
+  if (session) {
+    const trail = await authedFetch<{ runs: any[] }>(`trail/org/${course.org_id}/trail`)
+    const run = trail?.runs.find((r) => r.course?.course_uuid === course.course_uuid)
+    completed = new Set(run?.steps?.map((s: any) => s.activity_id) ?? [])
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl p-8">
+      <Link href="/" className="text-sm text-gray-500">← All courses</Link>
+      <div className="mt-4 flex items-center justify-between gap-4">
+        <h1 className="text-3xl font-bold">{course.name}</h1>
+        <EnrollButton courseUuid={course.course_uuid} orgId={course.org_id} loggedIn={!!session} />
+      </div>
+      <p className="mt-2 text-gray-600">{course.description}</p>
+
+      <div className="mt-8 space-y-6">
+        {course.chapters.map((chapter) => (
+          <section key={chapter.chapter_uuid}>
+            <h2 className="mb-2 text-lg font-semibold">{chapter.name}</h2>
+            <ul className="space-y-1">
+              {chapter.activities
+                .filter((a) => a.published)
+                .map((activity) => (
+                  <li key={activity.activity_uuid} className="flex items-center gap-2">
+                    <span>{completed.has(activity.id) ? '✓' : '○'}</span>
+                    <Link
+                      href={`/courses/${uuid}/${activity.activity_uuid}`}
+                      className="text-blue-600 hover:underline"
+                    >
+                      {activity.name}
+                    </Link>
+                  </li>
+                ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </main>
+  )
+}
+```
+
+Finally, call `markActivityDone(course_uuid, activity_uuid)` from the activity viewer when a learner finishes — e.g. a "Mark as complete" button (a client component using the same `useTransition` pattern as `EnrollButton`).
+
+<Callout type="info">
+`steps` are keyed by the activity's numeric `id`, so the completed-set check uses `activity.id`. The `meta` response includes both `id` and `activity_uuid` on each activity — `id` for matching progress, `activity_uuid` for routing.
+</Callout>
+
+### ✅ Checkpoint
+
+You now have the full loop: **browse → sign up → log in → enroll → learn → track progress**, all on your own Next.js frontend, with tokens safely server-side.
+
+---
+
+## Where to go next
+
+- **Make it yours** — swap in real block rendering for dynamic activities ([Editor model](/platform/editor)), add search (`GET /api/v1/courses/org_slug/{slug}/search?query=…`), and collections.
+- **React to events** — add [webhooks](/guides/custom-features/webhooks) so your platform (or an external tool) reacts when a learner completes a course.
+- **Go deeper on the API** — the [API Reference](/developers/api) and the interactive Swagger UI at `http://localhost:1338/docs` (dev mode) list every endpoint and schema.
+- **Compare with the reference** — see [`learnhouse/headless-examples`](https://github.com/learnhouse/headless-examples) for a complete project.
+
+Prefer to skip the typing? **[Let an agent build all of this](/guides/build-learning-platform/with-an-agent)** from a ready-made spec.

--- a/docs/content/guides/build-learning-platform/index.mdx
+++ b/docs/content/guides/build-learning-platform/index.mdx
@@ -1,0 +1,77 @@
+---
+title: Build a Learning Platform
+description: Build your own headless learning platform on the web with Next.js and the LearnHouse API. Start with an anonymous public catalogue, then add authentication, enrollment, and progress tracking.
+---
+
+import { Callout, Tabs } from 'nextra/components'
+import GuideCards from '../../../components/GuideCards/GuideCards'
+import HeadlessArchitecture from '../../../components/diagrams/HeadlessArchitecture'
+import ResourceModelDiagram from '../../../components/diagrams/ResourceModelDiagram'
+
+# Build a Learning Platform
+
+LearnHouse is **API-first**. The official web app is just one client of a public REST API — which means you can build your *own* learning platform on top of the same API, with your own design, your own routing, and your own brand.
+
+This guide takes you from an empty folder to a working **headless learning platform**: a Next.js app that lists your courses, plays your content, signs users in, enrolls them, and tracks their progress — all powered by the LearnHouse API. It's the kind of result you'll find in the [`learnhouse/headless-examples`](https://github.com/learnhouse/headless-examples) repository.
+
+## Pick your path
+
+<GuideCards set="build" />
+
+- **[Do it yourself](/guides/build-learning-platform/do-it-yourself)** — Follow the build step by step. Every command and file is provided, and the whole thing is tested end to end. This is the best way to actually understand how the API fits together.
+- **[Let an agent build it](/guides/build-learning-platform/with-an-agent)** — Hand a coding agent (Claude Code, Cursor, etc.) a self-contained [spec](/guides/build-learning-platform/agent-spec) and let it generate the app for you, then review and run it.
+
+## What you'll build
+
+A learning platform you reach in two stages — **anonymous first, authenticated second**. You'll have a working public site before you touch a single token.
+
+<Tabs items={['Stage 1 — Anonymous', 'Stage 2 — Authenticated']}>
+  <Tabs.Tab>
+    No login, no tokens. Public content only:
+    - A **course catalogue** listing every public course in your organization.
+    - A **course page** showing chapters and activities.
+    - An **activity viewer** that renders dynamic pages, videos, and documents.
+  </Tabs.Tab>
+  <Tabs.Tab>
+    Layered on top of stage 1, without rewriting it:
+    - **Signup & login** with the LearnHouse auth endpoints.
+    - **Enrollment** — learners join a course.
+    - **Progress tracking** — mark activities complete and show how far a learner has come.
+  </Tabs.Tab>
+</Tabs>
+
+## Architecture
+
+Your Next.js app is a thin, fast client in front of the LearnHouse API. Reads happen in **Server Components**; anything involving a token goes through a **Route Handler acting as a Backend-for-Frontend (BFF)**, so LearnHouse tokens never reach the browser. Media is streamed straight from the API's content-delivery endpoint.
+
+<HeadlessArchitecture />
+
+<Callout type="info">
+Using a server-side BFF isn't just for security — it also sidesteps CORS entirely. Your browser only ever talks to your own Next.js origin, and your server talks to LearnHouse.
+</Callout>
+
+## The resources you'll touch
+
+Everything in LearnHouse hangs off an **Organization**. Content is a tree of **Course → Chapter → Activity**. A learner's progress is a separate tree: each **User** has a **Trail**, which holds a **Run** per enrolled course, which holds a **Step** per completed activity.
+
+<ResourceModelDiagram />
+
+| Resource | What it is | Key endpoint |
+| --- | --- | --- |
+| Organization | Top-level tenant, addressed by `org_slug` | `GET /api/v1/orgs/slug/{org_slug}` |
+| Course | A course, addressed by `course_uuid` | `GET /api/v1/courses/org_slug/{org_slug}/page/{page}/limit/{limit}` |
+| Chapter + Activity | The course's content tree | `GET /api/v1/courses/{course_uuid}/meta` |
+| Trail / Run / Step | A learner's enrollment & progress | `GET /api/v1/trail/org/{org_id}/trail` |
+
+## Prerequisites
+
+- **Node.js 18+** and a package manager (`npm`, `pnpm`, or `bun`).
+- **A running LearnHouse instance.** Spin one up locally with the [Quickstart](/getting-started/quickstart) or [self-hosting guide](/self-hosting), or use [LearnHouse Cloud](https://learnhouse.app). The examples assume the API is at `http://localhost:1338`.
+- **Your organization slug** and **at least one public, published course** with some content. Create one in the dashboard if you don't have it yet.
+- Basic familiarity with the [API Reference](/developers/api).
+
+<Callout type="warning">
+Throughout this guide the API base URL is `http://localhost:1338/api/v1`. If your instance lives elsewhere (a custom port, a domain, or Cloud), substitute your own base URL — every example reads it from a single environment variable.
+</Callout>
+
+Ready? Head to **[Do It Yourself](/guides/build-learning-platform/do-it-yourself)** to start building, or **[Let an Agent Build It](/guides/build-learning-platform/with-an-agent)** to delegate.

--- a/docs/content/guides/build-learning-platform/with-an-agent.mdx
+++ b/docs/content/guides/build-learning-platform/with-an-agent.mdx
@@ -1,0 +1,79 @@
+---
+title: Let an Agent Build It
+description: Have a coding agent like Claude Code or Cursor build your headless LearnHouse platform for you, using a ready-made, self-contained specification.
+---
+
+import { Callout, Steps } from 'nextra/components'
+
+# Let an Agent Build It
+
+If you'd rather not type out every file, hand the work to a coding agent. This page explains how to drive an agent (Claude Code, Cursor, Windsurf, Copilot, etc.) to build the same headless learning platform described in [Do It Yourself](/guides/build-learning-platform/do-it-yourself), using the self-contained **[Agent Spec](/guides/build-learning-platform/agent-spec)**.
+
+The spec is written *for the model*: it states the goal, the exact API contract taken from the LearnHouse codebase, the file layout, the auth rules, and clear acceptance criteria. You supply three facts about your instance and let the agent do the rest.
+
+<Callout type="info">
+This still produces **your** code on **your** machine — the agent is just doing the typing. Review the result the same way you'd review a teammate's PR.
+</Callout>
+
+## What you'll need
+
+- A coding agent with file-writing and terminal access (e.g. **Claude Code**).
+- A running LearnHouse instance and its API base URL (e.g. `http://localhost:1338/api/v1`).
+- Your **organization slug** and at least one **public, published course**.
+- Test credentials (an email + password you can sign up with) if you want the agent to verify the authenticated flow.
+
+## How to do it
+
+<Steps>
+
+### Open the Agent Spec
+
+Go to the **[Agent Spec](/guides/build-learning-platform/agent-spec)** page and copy the entire specification block.
+
+### Fill in the three blanks
+
+At the top of the spec there's a short **Configuration** section. Replace the placeholders with your values:
+
+- `API_BASE` — your API base URL (e.g. `http://localhost:1338/api/v1`)
+- `ORG_SLUG` — your organization slug
+- `TEST_EMAIL` / `TEST_PASSWORD` — optional, for verifying login/enrollment
+
+### Paste it into your agent
+
+Start a new agent session in an empty directory and paste the filled-in spec as your first message. A good kickoff prompt:
+
+> Build the project described in the specification below. Work in this directory, create all files, install dependencies, and run the dev server when done. Ask me before doing anything destructive.
+>
+> _(paste the spec here)_
+
+### Review and run
+
+When the agent finishes, it should have scaffolded the app, written the files, and started `npm run dev`. Open the URL it reports and click through: catalogue → course → activity → sign up → log in → enroll → progress.
+
+### Iterate
+
+If something's off (a media URL that won't load, an activity type that isn't rendered), tell the agent what you saw. The spec includes the troubleshooting notes it needs to fix the common cases.
+
+</Steps>
+
+## What "done" looks like
+
+The spec's acceptance criteria ask the agent to confirm:
+
+1. The catalogue lists your public courses.
+2. A course page shows chapters and activities.
+3. An activity renders (video, document, or dynamic page).
+4. A new user can sign up and log in.
+5. A logged-in user can enroll and see progress update.
+
+If your agent can check those boxes against your live instance, you're done.
+
+<Callout type="warning">
+Agents are good at the scaffolding and the happy path, but they can't see your specific `content` field shapes or storage config. Expect to nudge it on the **activity viewer** (the keys inside `content` vary by sub-type) and **media URLs** (filesystem vs S3). The spec calls both out as the likely spots to adjust.
+</Callout>
+
+## Why a spec instead of "build me an LMS"?
+
+A vague prompt makes the agent invent an API. The [spec](/guides/build-learning-platform/agent-spec) pins down the **real** endpoints, response shapes, and the auth/refresh quirk — all lifted from this codebase — so the agent builds against the API that actually exists, not one it hallucinated. That's the difference between an app that runs and an app that 404s on every call.
+
+Ready? **[Open the Agent Spec →](/guides/build-learning-platform/agent-spec)**

--- a/docs/content/guides/custom-features/_meta.json
+++ b/docs/content/guides/custom-features/_meta.json
@@ -1,0 +1,4 @@
+{
+  "index": "Overview",
+  "webhooks": "Webhooks"
+}

--- a/docs/content/guides/custom-features/index.mdx
+++ b/docs/content/guides/custom-features/index.mdx
@@ -1,0 +1,138 @@
+---
+title: Custom Features & Webhooks
+description: Extend LearnHouse beyond the official frontend — authenticate with API tokens, create and query content programmatically, and react to events with webhooks.
+---
+
+import { Callout } from 'nextra/components'
+import GuideCards from '../../../components/GuideCards/GuideCards'
+
+# Custom Features & Webhooks
+
+The [build guide](/guides/build-learning-platform) showed how to *read* the API as a frontend. This guide is about going further: driving LearnHouse **programmatically** — creating and managing content from your own scripts and services, and reacting to what happens inside LearnHouse with **webhooks**.
+
+<GuideCards set="custom" />
+
+## Two ways to authenticate
+
+| | User session (JWT) | API token |
+| --- | --- | --- |
+| **For** | Acting *as a logged-in user* (a frontend) | Server-to-server automation, scripts, integrations |
+| **How** | `POST /api/v1/auth/login` → bearer token | A long-lived token created in org settings |
+| **Prefix** | a JWT | `lh_…` |
+| **Plan** | any | **Pro** |
+
+For everything in this guide, use an **API token**. It's a single bearer credential you attach to every request:
+
+```bash
+curl "http://localhost:1338/api/v1/courses/org_slug/{org_slug}/page/1/limit/10" \
+  -H "Authorization: Bearer lh_your_api_token_here"
+```
+
+<Callout type="warning">
+API tokens work on resource routes (courses, chapters, activities, collections…) but **not** on routes that require a real user session — `/users/*`, `/orgs/*`, `/roles/*`, and **webhook management** all reject `lh_` tokens with `403`. Use a courses read to smoke-test a token.
+</Callout>
+
+### Creating an API token
+
+API tokens are a **Pro** feature. Create one in your organization settings, or via the API itself (with a user session that has `roles` permissions):
+
+```bash
+curl -X POST "http://localhost:1338/api/v1/orgs/{org_id}/api-tokens" \
+  -H "Authorization: Bearer <user_jwt>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "My integration",
+    "description": "Server-side automation",
+    "expires_at": null
+  }'
+```
+
+The response includes the **full token exactly once** — store it securely, it can't be retrieved again:
+
+```json
+{
+  "token": "lh_8f3c…the only time you'll see this…",
+  "token_uuid": "apitoken_…",
+  "name": "My integration",
+  "token_prefix": "lh_8f3c4d2a",
+  "org_id": 1
+}
+```
+
+<Callout type="info">
+Tokens support fine-grained permissions via a `rights` object (per-resource read/write scopes) and an optional `expires_at`. Set `rights` to grant a token only the access it needs. The full schema is on the interactive Swagger UI at `http://localhost:1338/docs` (development mode). List, revoke, and regenerate tokens under `/api/v1/orgs/{org_id}/api-tokens`.
+</Callout>
+
+## Request conventions
+
+A few things that are true across the whole API:
+
+- **Base path** — every endpoint is under `/api/v1/`.
+- **Auth** — `Authorization: Bearer <token>` (JWT or `lh_` token).
+- **Reads are JSON** — `GET` returns JSON; lists are plain arrays unless documented otherwise.
+- **Writes are often multipart** — create/update endpoints that can take a file (courses, activities, avatars) accept `multipart/form-data`, not JSON. Endpoints without files (collections, trails, users) take JSON.
+- **Errors** — non-2xx responses are `{ "detail": "..." }`. Always read `detail`.
+- **UUIDs vs ids** — resources expose a stable `{resource}_uuid` (e.g. `course_…`, `activity_…`); numeric `id`s are used by a few routes (notably `org_id`).
+
+## Recipe: create a course programmatically
+
+Courses are created with multipart form data (so a thumbnail can ride along). `org_id` is a query parameter:
+
+```bash
+curl -X POST "http://localhost:1338/api/v1/courses/?org_id=1" \
+  -H "Authorization: Bearer lh_your_api_token" \
+  -F 'name=Introduction to Python' \
+  -F 'description=A beginner-friendly Python course' \
+  -F 'about=Learn Python from scratch.' \
+  -F 'public=true'
+```
+
+<Callout type="info">
+`name`, `description`, and `about` are all required on course creation — omitting `about` returns `422`. Creating courses, chapters, and activities requires a role with create permission (Admin / Maintainer / Instructor), not a plain member account.
+</Callout>
+
+Then add structure — a chapter (JSON), then activities inside it:
+
+```bash
+# Create a chapter
+curl -X POST "http://localhost:1338/api/v1/chapters/" \
+  -H "Authorization: Bearer lh_your_api_token" \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "Getting started", "org_id": 1, "course_id": 42 }'
+```
+
+<Callout type="info">
+For bulk or AI-assisted course creation from existing media, see the [Migration](/developers/migration) guides — there's a three-call flow that builds an entire course tree in one transaction.
+</Callout>
+
+## Recipe: search and list content
+
+```bash
+# Paginated list of courses
+curl "http://localhost:1338/api/v1/courses/org_slug/{org_slug}/page/1/limit/20" \
+  -H "Authorization: Bearer lh_your_api_token"
+
+# Full-text search (max 50 per page)
+curl "http://localhost:1338/api/v1/courses/org_slug/{org_slug}/search?query=python&page=1&limit=10" \
+  -H "Authorization: Bearer lh_your_api_token"
+```
+
+## Discoverability: the OpenAPI spec
+
+Because the API is built with FastAPI, a complete machine-readable spec is available:
+
+- **OpenAPI JSON** — `http://localhost:1338/openapi.json` (served on all instances)
+- **Swagger UI** — `http://localhost:1338/docs` (development mode only)
+- **ReDoc** — `http://localhost:1338/redoc` (development mode only)
+
+Point a client generator at `openapi.json` to produce a typed SDK in your language of choice.
+
+<Callout type="info">
+The interactive HTML docs (`/docs` and `/redoc`) are served in **development mode only**. The raw `/openapi.json` spec is generated by FastAPI and available on all instances.
+</Callout>
+
+## Next: react to events
+
+Polling the API to find out "did anyone finish a course?" is wasteful. **Webhooks** push those events to you the moment they happen — enrollment, completion, signups, and dozens more.
+
+→ **[Consume webhooks](/guides/custom-features/webhooks)**

--- a/docs/content/guides/custom-features/webhooks.mdx
+++ b/docs/content/guides/custom-features/webhooks.mdx
@@ -1,0 +1,187 @@
+---
+title: Webhooks
+description: Subscribe to LearnHouse events, verify HMAC-SHA256 signatures, and react to learning activity in real time with a Next.js webhook receiver.
+---
+
+import { Callout } from 'nextra/components'
+import WebhookFlowDiagram from '../../../components/diagrams/WebhookFlowDiagram'
+
+# Webhooks
+
+Webhooks let LearnHouse **push events to your application** the moment they happen — a learner enrolls, completes a course, submits an assignment, signs up — so you can react without polling. Use them to sync a CRM, send custom emails, update a dashboard, or kick off any workflow.
+
+<WebhookFlowDiagram />
+
+<Callout type="info">
+Webhooks are a **Pro** feature. They're managed by an authenticated user under organization settings or the webhook API below.
+</Callout>
+
+## How it works
+
+1. You register an **endpoint** (a public HTTPS URL) and choose which events to subscribe to.
+2. When a subscribed event fires, LearnHouse sends a `POST` to your URL with a JSON body, **signed** with a per-endpoint secret.
+3. Your receiver **verifies the signature**, then handles the event.
+4. If your endpoint doesn't return a `2xx`, LearnHouse **retries** — up to 3 attempts, waiting 1s then 4s between them — and logs every delivery.
+
+## Managing endpoints
+
+All webhook endpoints live under `/api/v1/orgs/{org_id}/webhooks`.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/orgs/{org_id}/webhooks/events` | List every event type and its payload schema |
+| `POST` | `/orgs/{org_id}/webhooks` | Create an endpoint |
+| `GET` | `/orgs/{org_id}/webhooks` | List your endpoints |
+| `GET` | `/orgs/{org_id}/webhooks/{webhook_uuid}` | Get one endpoint |
+| `PUT` | `/orgs/{org_id}/webhooks/{webhook_uuid}` | Update URL / events / active state |
+| `DELETE` | `/orgs/{org_id}/webhooks/{webhook_uuid}` | Delete an endpoint |
+| `POST` | `/orgs/{org_id}/webhooks/{webhook_uuid}/regenerate-secret` | Rotate the signing secret |
+| `POST` | `/orgs/{org_id}/webhooks/{webhook_uuid}/test` | Send a `ping` test event |
+| `GET` | `/orgs/{org_id}/webhooks/{webhook_uuid}/deliveries` | Recent delivery logs |
+
+### Create an endpoint
+
+```bash
+curl -X POST "http://localhost:1338/api/v1/orgs/1/webhooks" \
+  -H "Authorization: Bearer <user_jwt>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://your-app.com/api/webhooks/learnhouse",
+    "events": ["course_completed", "course_enrolled", "user_signed_up"]
+  }'
+```
+
+The response contains the **signing secret exactly once** (prefixed `whsec_`). Store it — you'll need it to verify signatures, and it can't be retrieved again (only rotated). It also returns the usual metadata (`created_by_user_id`, `creation_date`, …):
+
+```json
+{
+  "webhook_uuid": "webhook_…",
+  "url": "https://your-app.com/api/webhooks/learnhouse",
+  "events": ["course_completed", "course_enrolled", "user_signed_up"],
+  "secret": "whsec_…store me…",
+  "is_active": true
+}
+```
+
+<Callout type="info">
+Use `POST …/test` to send yourself a `ping` event while building your receiver, and `GET …/deliveries` to inspect what was sent and how your endpoint responded.
+</Callout>
+
+## The payload
+
+Every delivery is a JSON envelope. The `data` field is event-specific:
+
+```json
+{
+  "event": "course_completed",
+  "delivery_id": "dlv_1a2b3c4d5e6f7081",
+  "timestamp": "2026-06-22T12:00:00Z",
+  "org_id": 1,
+  "data": {
+    "user": { "user_uuid": "user_…", "email": "learner@example.com", "username": "learner" },
+    "course": { "course_uuid": "course_…", "name": "Introduction to Python" }
+  }
+}
+```
+
+Each request also carries these headers:
+
+| Header | Value |
+| --- | --- |
+| `X-Webhook-Event` | The event name, e.g. `course_completed` |
+| `X-Webhook-Delivery` | Unique delivery id, e.g. `dlv_…` (use it for idempotency) |
+| `X-Webhook-Signature` | `sha256=<hmac-hex>` — HMAC-SHA256 of the **raw request body** |
+| `User-Agent` | `LearnHouse-Webhooks/1.0` |
+
+## Verifying the signature
+
+The signature is `sha256=` followed by the hex HMAC-SHA256 of the **exact raw body bytes**, keyed by your endpoint secret. You must compute the HMAC over the **unparsed** body — re-serializing the JSON will change the bytes and break verification.
+
+Here's a complete receiver as a Next.js Route Handler:
+
+```ts filename="src/app/api/webhooks/learnhouse/route.ts"
+import { NextRequest, NextResponse } from 'next/server'
+import crypto from 'node:crypto'
+
+const SECRET = process.env.LEARNHOUSE_WEBHOOK_SECRET! // the whsec_… value
+
+export async function POST(req: NextRequest) {
+  // 1. Read the RAW body — do not use req.json() first.
+  const raw = await req.text()
+  const signature = req.headers.get('x-webhook-signature') ?? ''
+
+  // 2. Recompute the HMAC and compare in constant time.
+  const expected =
+    'sha256=' + crypto.createHmac('sha256', SECRET).update(raw).digest('hex')
+
+  const valid =
+    signature.length === expected.length &&
+    crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected))
+
+  if (!valid) {
+    return NextResponse.json({ error: 'invalid signature' }, { status: 401 })
+  }
+
+  // 3. Now it's safe to parse and handle.
+  const payload = JSON.parse(raw)
+  switch (payload.event) {
+    case 'course_completed':
+      console.log(`${payload.data.user.email} finished ${payload.data.course.name}`)
+      // …send a certificate email, update your CRM, etc.
+      break
+    case 'user_signed_up':
+      // …add to your mailing list
+      break
+  }
+
+  // 4. Return 2xx quickly so LearnHouse marks the delivery successful.
+  return NextResponse.json({ received: true })
+}
+```
+
+The same check in raw Node.js / Express:
+
+```js
+const crypto = require('node:crypto')
+
+function verify(rawBody, signatureHeader, secret) {
+  const expected = 'sha256=' + crypto.createHmac('sha256', secret).update(rawBody).digest('hex')
+  const a = Buffer.from(signatureHeader ?? '')
+  const b = Buffer.from(expected)
+  // timingSafeEqual throws if lengths differ, so guard first.
+  return a.length === b.length && crypto.timingSafeEqual(a, b)
+}
+```
+
+<Callout type="warning">
+**Always verify before trusting a payload**, and treat deliveries as **at-least-once** — the same `delivery_id` can arrive more than once after a retry. Make your handler idempotent (e.g. record processed `delivery_id`s).
+</Callout>
+
+## Event catalogue
+
+A webhook can subscribe to any of these events. The shape of each event's `data` field is returned live by `GET /api/v1/orgs/{org_id}/webhooks/events`, so your tooling never has to hardcode it.
+
+| Category | Events |
+| --- | --- |
+| **System** | `ping` |
+| **Learning Progress** | `course_completed`, `course_enrolled`, `activity_completed`, `assignment_submitted`, `assignment_graded`, `certificate_claimed` |
+| **User & Access** | `user_signed_up`, `user_email_verified`, `user_role_changed`, `user_invited_to_org`, `user_removed_from_org` |
+| **Course Lifecycle** | `course_created`, `course_published`, `course_deleted`, `course_update_published` |
+| **Content Management** | `activity_version_created`, `activity_version_restored`, `course_contributor_added`, `course_contributor_removed`, `collection_created`, `podcast_episode_created` |
+| **Collaboration** | `board_created`, `board_member_added`, `playground_created` |
+| **Community** | `discussion_posted`, `comment_created`, `discussion_pinned`, `discussion_locked`, `discussion_vote_cast` |
+| **Groups** | `usergroup_created`, `usergroup_deleted`, `usergroup_users_added`, `usergroup_resources_added` |
+| **Subscriptions** | `pack_activated`, `pack_deactivated` |
+| **Organization** | `org_signup_method_changed`, `org_ai_config_changed`, `org_payments_config_changed` |
+
+## Security notes
+
+- **Secrets** are stored encrypted at rest and are shown to you only at creation and on rotation.
+- **Signatures** use HMAC-SHA256 over the raw body — the same convention as GitHub and Stripe.
+- **Outbound requests are SSRF-protected**: LearnHouse validates the target URL and the resolved IP before every delivery, so endpoints must be publicly reachable — `localhost` and private/reserved IP ranges are always rejected (in every environment).
+
+## See also
+
+- [Custom features overview](/guides/custom-features) — API tokens and programmatic content.
+- [Build a learning platform](/guides/build-learning-platform) — the frontend side of the API.
+- [API Reference](/developers/api) — every endpoint and schema.

--- a/docs/content/guides/index.mdx
+++ b/docs/content/guides/index.mdx
@@ -1,0 +1,32 @@
+---
+title: Guides
+description: Hands-on, end-to-end guides for building with LearnHouse — ship your own headless learning platform with Next.js, drive the API, and react to events with webhooks.
+---
+
+import { Callout } from 'nextra/components'
+import GuideCards from '../../components/GuideCards/GuideCards'
+
+# Guides
+
+The rest of the docs explain *what* LearnHouse is and *how each feature works*. **Guides** are different: each one walks you all the way through **building something real** with LearnHouse, end to end.
+
+Every guide is written to be followed top to bottom, with copy-paste commands and code, and is tested against a real LearnHouse instance. Where there's a faster path, you'll get a choice: do it yourself, or hand the work to a coding agent.
+
+<GuideCards set="index" />
+
+## What you'll find here
+
+- **[Build a learning platform](/guides/build-learning-platform)** — Create your own web learning platform on top of the LearnHouse API with Next.js. You start with a fully anonymous public catalogue, then layer on authentication, enrollment, and progress tracking. Pick the **do-it-yourself** path or have an **agent** build it from a ready-made spec.
+- **[Custom features & webhooks](/guides/custom-features)** — Go beyond the official frontend: authenticate with API tokens, create and query content programmatically, and subscribe to webhooks to react to learning activity in real time.
+
+<Callout type="info">
+New to LearnHouse? Start with the [Quickstart](/getting-started/quickstart) to get an instance running, then come back here to build on top of it. The guides assume you have an organization and at least one course.
+</Callout>
+
+## Before you start
+
+These guides interact with the LearnHouse REST API, documented in the [Developers → API Reference](/developers/api). You'll get the most out of them if you're comfortable with:
+
+- **HTTP & REST** — the API is a standard JSON REST API under `/api/v1/`.
+- **A running LearnHouse instance** — local ([self-hosting](/self-hosting)) or [Cloud](https://learnhouse.app). The examples use `http://localhost:1338` as the API base.
+- **JavaScript / TypeScript** — the build guide uses Next.js, but the API calls are framework-agnostic.

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -48,3 +48,7 @@ New to LearnHouse? Start with the [Quickstart guide](/getting-started/quickstart
 - [Architecture Overview](/developers/architecture) — How the system fits together
 - [API Reference](/developers/api) — REST endpoints, authentication, and examples
 - [Contributing](/developers/contributing) — Dev environment setup and guidelines
+
+### For Builders
+- [Build a Learning Platform](/guides/build-learning-platform) — Ship your own headless platform with Next.js and the API
+- [Custom Features & Webhooks](/guides/custom-features) — Drive the API with tokens and react to events in real time


### PR DESCRIPTION
## What

Adds a new top-level **Guides** section to the docs (after **Developers**) with two complete, end-to-end tutorials for building on top of the LearnHouse API.

### Build a Learning Platform (Next.js + the API)
A headless platform built **progressively** — fully **anonymous** first (catalogue → course → activity viewer, no tokens), then **authenticated** features layered on (signup/login via a server-side BFF, enrollment, progress tracking). Two paths:
- **Do It Yourself** — the full step-by-step build.
- **Let an Agent Build It** — a self-contained, copy-paste **Agent Spec** a coding agent can follow.

### Custom Features & Webhooks
API tokens, request conventions, programmatic recipes, the webhook event catalogue, payload/headers, and a verified HMAC-SHA256 signature receiver.

### Supporting changes
- Reusable CSS flow + resource diagrams and guide cards (Phosphor icons).
- Sidebar label/order overrides + icons for the new routes; a home-page Guides card.

## Verification
Every documented endpoint, response shape, auth/refresh rule, enrollment flow, and media path was checked against the running API and the source. The guide was followed end-to-end: a Next.js app built from it (signup → login → enroll → progress, with thumbnails loading) runs with zero errors. Two multi-agent review sweeps (20 + 12 agents) confirmed the claims against `apps/api`; all real findings are fixed — notably the content-delivery URL (served at the backend root `/content/…`, not under `/api/v1`, with org/course-scoped paths).

## Notes
- Docs-only change under `docs/`. Build with `cd docs && bun run dev`.