### PR TITLE
fix(auth): always embed returnOrigin in Google OAuth state

### DIFF
--- a/apps/web/components/Contexts/AuthContext.tsx
+++ b/apps/web/components/Contexts/AuthContext.tsx
@@ -596,10 +596,14 @@ export function SessionProvider({
             timestamp: Date.now(),
           }
 
-          // For custom domains, embed returnOrigin so the main domain callback can bounce back
-          if (isCustomDomain()) {
-            stateData.returnOrigin = window.location.origin
-          }
+          // Always embed returnOrigin so the registered Google callback host can
+          // bounce the code+state back to the origin the user actually started on.
+          // Gating this on isCustomDomain() made recovery depend on the configured
+          // main domain: when that domain is stale (e.g. still .io while the app
+          // runs on .app), an app-domain user could be stranded on the callback
+          // host. When login starts on the registered host the origins match and
+          // the callback skips the bounce, so this is a no-op there.
+          stateData.returnOrigin = window.location.origin
 
           const state = btoa(JSON.stringify(stateData))
 
@@ -797,10 +801,10 @@ export async function signIn(
       timestamp: Date.now(),
     }
 
-    // For custom domains, embed returnOrigin so the main domain callback can bounce back
-    if (isCustomDomain()) {
-      stateData.returnOrigin = window.location.origin
-    }
+    // Always embed returnOrigin (see handleSignIn for rationale) so the callback
+    // can bounce the code+state back to the user's own origin regardless of the
+    // configured main domain. No-op when login starts on the registered host.
+    stateData.returnOrigin = window.location.origin
 
     const state = btoa(JSON.stringify(stateData))
 


### PR DESCRIPTION
## Problem

Google sign-in registers a **single** redirect URI built from the configured main domain (`getLEARNHOUSE_DOMAIN_VAL()`). To return the user to the host they actually started on, the flow embeds a `returnOrigin` in the OAuth `state`; the callback page bounces `code`+`state` to that origin.

That `returnOrigin` was only embedded **when `isCustomDomain()` was true**. So recovery depended on the configured main domain being correct. When the configured domain is stale relative to where the app is actually served, an app-domain user who signs in with Google can be **stranded on the callback host** instead of being returned to their own origin.

## Change

`apps/web/components/Contexts/AuthContext.tsx` — always embed `returnOrigin = window.location.origin` in the OAuth state, in both Google sign-in entry points (`handleSignIn` and the module-level `signIn`). The `isCustomDomain()` guard is dropped for this purpose (the function is still used for cookie scoping).

## Why it's safe

- When login starts **on the registered redirect host**, `returnOrigin === window.location.origin`, and the callback's bounce condition (`returnOrigin && returnOrigin !== window.location.origin`, `app/auth/callback/google/page.tsx`) is false — so it's a **no-op** there.
- OSS / self-hosted single-domain deploys: origins always match → no-op.
- For every other origin (org subdomains, custom domains) it guarantees the user is returned to where they began, **independent of the configured domain**.

## Test plan

- Local single-domain: Google sign-in completes, no bounce (origins match).
- Custom domain: returnOrigin embedded → callback bounces back → session set on the custom origin (unchanged behavior).
- Org subdomain: now also recovers unconditionally rather than depending on the configured main domain.

## Lint

`eslint components/Contexts/AuthContext.tsx` → 0 errors (only pre-existing `no-console` warnings).