### PR TITLE
Improve Video streaming and Experience

### DIFF
--- a/.github/workflows/api-tests.yaml
+++ b/.github/workflows/api-tests.yaml
@@ -26,6 +26,11 @@ jobs:
         with:
           version: latest
 
+      - name: Install ffmpeg
+        # Required by the video faststart / HLS transcode tests (they skip
+        # without it, which would leave that code uncovered).
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg
+
       - name: Install dependencies
         run: uv sync
         working-directory: apps/api

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3.14.3-slim-bookworm
 
-# Install curl and netcat for health checks and service waiting
-RUN apt-get update && apt-get install -y --no-install-recommends curl netcat-openbsd build-essential && rm -rf /var/lib/apt/lists/*
+# Install curl and netcat for health checks and service waiting, plus ffmpeg
+# for video faststart remuxing (moves the MP4 moov atom to the front so long
+# videos stream smoothly).
+RUN apt-get update && apt-get install -y --no-install-recommends curl netcat-openbsd build-essential ffmpeg && rm -rf /var/lib/apt/lists/*
 
 COPY --from=ghcr.io/astral-sh/uv:0.10.7 /uv /uvx /bin/
 

--- a/apps/api/cli.py
+++ b/apps/api/cli.py
@@ -182,6 +182,135 @@ async def _install_async(short: bool) -> None:
 
 
 @cli.command()
+def backfill_faststart(
+    prefix: Annotated[str, typer.Option(help="S3 key prefix to scan")] = "content/",
+    dry_run: Annotated[bool, typer.Option(help="Only report what would change")] = False,
+    limit: Annotated[int, typer.Option(help="Max files to process (0 = no limit)")] = 0,
+):
+    """Rewrite already-uploaded MP4 videos so their moov atom is at the front.
+
+    Streams the first 2MB of each MP4 to detect whether it is already faststart;
+    only non-faststart files are downloaded in full, remuxed with ffmpeg
+    (-c copy, lossless), and re-uploaded. Safe to re-run — faststart files are
+    skipped.
+    """
+    import tempfile
+    from src.services.courses.transfer.storage_utils import (
+        is_s3_enabled,
+        get_storage_client,
+        get_s3_bucket_name,
+    )
+    from src.services.utils.video_processing import (
+        ensure_faststart,
+        is_faststart,
+        _FASTSTART_EXTENSIONS,
+    )
+
+    if not is_s3_enabled():
+        print("❌ S3/R2 is not enabled; nothing to backfill.")
+        raise typer.Exit(code=1)
+
+    s3 = get_storage_client()
+    bucket = get_s3_bucket_name()
+    if not s3:
+        print("❌ Could not build storage client.")
+        raise typer.Exit(code=1)
+
+    bounded = limit if limit and limit > 0 else 0  # negative/0 → no limit
+    scanned = processed = skipped = failed = attempted = 0
+    stop = False
+    try:
+        paginator = s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                if os.path.splitext(key)[1].lower() not in _FASTSTART_EXTENSIONS:
+                    continue
+                scanned += 1
+
+                # Cheap check: fetch just the head and look for moov before mdat.
+                try:
+                    head = s3.get_object(Bucket=bucket, Key=key, Range="bytes=0-2097151")
+                    body = head["Body"]
+                    try:
+                        head_bytes = body.read()
+                    finally:
+                        body.close()  # always release the connection back to the pool
+                except Exception as e:
+                    print(f"  ⚠️  {key}: could not read head ({e})")
+                    failed += 1
+                    continue
+                moov, mdat = head_bytes.find(b"moov"), head_bytes.find(b"mdat")
+                if moov != -1 and (mdat == -1 or moov < mdat):
+                    skipped += 1
+                    continue
+
+                # This file needs work — counts toward the --limit budget whether
+                # or not the remux ultimately succeeds (bounds real download/CPU).
+                attempted += 1
+                print(f"  → needs faststart: {key} ({obj['Size'] / 1e6:.0f} MB)")
+                if dry_run:
+                    processed += 1
+                else:
+                    with tempfile.TemporaryDirectory() as td:
+                        local = os.path.join(td, os.path.basename(key))
+                        try:
+                            s3.download_file(bucket, key, local)
+                            if ensure_faststart(local) and is_faststart(local):
+                                s3.upload_file(local, bucket, key)
+                                print(f"    ✅ remuxed & re-uploaded {key}")
+                                processed += 1
+                            else:
+                                print(f"    ⚠️  remux skipped/failed for {key}")
+                                failed += 1
+                        except Exception as e:
+                            print(f"    ❌ error on {key}: {e}")
+                            failed += 1
+
+                if bounded and attempted >= bounded:
+                    print("Reached --limit; stopping.")
+                    stop = True
+                    break
+            if stop:
+                break
+    except Exception as e:
+        # A pagination/list error must not lose the summary of work already done.
+        print(f"⚠️  scan aborted early: {e}")
+
+    verb = "would remux" if dry_run else "remuxed"
+    print(
+        f"\nDone. scanned={scanned} attempted={attempted} {verb}={processed} "
+        f"already-faststart={skipped} failed={failed}"
+    )
+
+
+@cli.command()
+def transcode_backfill(
+    limit: Annotated[int, typer.Option(help="Max activities to process (0 = all)")] = 0,
+    inline: Annotated[bool, typer.Option(help="Transcode inline now instead of enqueuing")] = False,
+):
+    """Queue existing not-yet-ready hosted videos for HLS transcoding.
+
+    Default: enqueue them to Redis — the running API's in-app background consumer
+    transcodes them (no worker process needed); returns immediately. Use --inline
+    to transcode synchronously here (e.g. a one-off box with ffmpeg + creds)."""
+    from src.services.utils.hls_jobs import backfill, enqueue_pending
+    if inline:
+        result = asyncio.run(backfill(limit=limit))
+        print(
+            f"HLS backfill (inline) done. total={result['total']} "
+            f"done={result['done']} failed={result['failed']}"
+        )
+    else:
+        result = asyncio.run(enqueue_pending(limit=limit))
+        print(
+            f"HLS enqueue done. pending={result['pending']} "
+            f"enqueued={result.get('enqueued', 0)} "
+            f"(the API's in-app consumer will transcode them)"
+        )
+
+
+@cli.command()
 def main():
     cli()
 

--- a/apps/api/src/core/events/events.py
+++ b/apps/api/src/core/events/events.py
@@ -64,6 +64,16 @@ def startup_app(app: FastAPI) -> Callable:
         global _cleanup_task
         _cleanup_task = asyncio.create_task(_periodic_migration_cleanup())
 
+        # Start the in-app HLS transcoding consumer (drains the Redis queue as a
+        # background task; no separate worker). No-op unless LEARNHOUSE_HLS_ENABLED.
+        from src.services.utils.hls_jobs import start_consumer
+        start_consumer()
+
+        # Start the in-app AI captions consumer (no-op without Redis; idle until an
+        # instructor enables captions on a video).
+        from src.services.utils.caption_jobs import start_consumer as start_captions_consumer
+        start_captions_consumer()
+
         # Start Enterprise Edition Startup tasks if available
         run_ee_startup(app)
 
@@ -78,6 +88,12 @@ def shutdown_app(app: FastAPI) -> Callable:
                 await _cleanup_task
             except asyncio.CancelledError:
                 pass
+        # Stop the in-app HLS consumer and wait for in-flight transcodes.
+        from src.services.utils.hls_jobs import stop_consumer
+        await stop_consumer()
+        # Stop the in-app captions consumer.
+        from src.services.utils.caption_jobs import stop_consumer as stop_captions_consumer
+        await stop_captions_consumer()
         # Wait for in-flight webhook deliveries before closing the HTTP client
         from src.services.webhooks.dispatch import close_webhook_client, _background_tasks as _webhook_tasks
         if _webhook_tasks:  # pragma: no cover

--- a/apps/api/src/routers/courses/activities/activities.py
+++ b/apps/api/src/routers/courses/activities/activities.py
@@ -28,7 +28,9 @@ from src.services.courses.activities.pdf import (
     update_documentpdf_activity,
 )
 from src.services.courses.activities.video import (
+    CaptionsConfigIn,
     ExternalVideo,
+    configure_captions,
     create_external_video_activity,
     create_video_activity,
     update_video_activity,
@@ -528,6 +530,26 @@ async def api_update_video_activity(
     return await update_video_activity(
         request, activity_uuid, current_user, db_session, name, video_file, details_str
     )
+
+
+@router.post(
+    "/video/{activity_uuid}/captions",
+    summary="Configure AI closed captions for a hosted video activity",
+    description=(
+        "Enable/disable AI-generated captions and choose the target languages "
+        "(any of the platform's languages, or custom BCP-47 codes). When enabled, "
+        "queues generation on the AI captions pipeline (metered against the org's "
+        "AI credits). Returns the stored captions metadata."
+    ),
+)
+async def api_configure_video_captions(
+    request: Request,
+    activity_uuid: str,
+    config: CaptionsConfigIn,
+    current_user: PublicUser = Depends(get_current_user),
+    db_session=Depends(get_db_session),
+) -> dict:
+    return await configure_captions(request, activity_uuid, current_user, db_session, config)
 
 
 @router.put(

--- a/apps/api/src/routers/stream.py
+++ b/apps/api/src/routers/stream.py
@@ -8,8 +8,12 @@ SECURITY: All streaming endpoints validate resource access using the RBAC system
 Anonymous users can only stream content from public+published resources.
 """
 
+import asyncio
+import os
+import re
+
 from fastapi import APIRouter, Depends, HTTPException, Request, Path
-from fastapi.responses import StreamingResponse, Response
+from fastapi.responses import StreamingResponse, Response, RedirectResponse
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -21,18 +25,87 @@ from src.db.users import AnonymousUser, PublicUser, APITokenUser
 from src.core.events.database import get_db_session
 from src.security.auth import get_current_user
 from src.security.rbac.resource_access import ResourceAccessChecker, AccessAction, AccessContext
+from src.services.courses.transfer.storage_utils import (
+    is_s3_enabled,
+    generate_presigned_get_url,
+    read_file_content,
+)
 from src.services.utils.video_streaming import (
     stream_video_file,
     parse_range_header,
+    is_range_unsatisfiable,
     get_file_info,
     validate_video_path,
     CHUNK_SIZE,
 )
+from src.services.utils.hls_playlist import rewrite_playlist
 
 router = APIRouter()
 
 # Base content directory
 CONTENT_DIR = "content"
+
+# HLS MIME types (not covered by the generic media maps). Includes the
+# hover-preview sprite (.jpg, served like a segment) and the AES-128 key (.key,
+# served ONLY server-side after RBAC — never presigned/redirected).
+_HLS_MIME = {
+    ".m3u8": "application/vnd.apple.mpegurl",
+    ".ts": "video/mp2t",
+    ".m4s": "video/iso.segment",
+    ".jpg": "image/jpeg",
+    ".key": "application/octet-stream",
+}
+
+
+def _safe_hls_relpath(hls_path: str) -> str | None:
+    """Validate the client-supplied HLS sub-path (playlist or segment).
+
+    Only bare filenames and single-level rendition dirs (e.g. `master.m3u8`,
+    `v720p/index.m3u8`, `v720p/seg_0003.ts`) are allowed. Rejects traversal,
+    absolute paths, and unexpected extensions.
+    """
+    if not hls_path or "\x00" in hls_path or hls_path.startswith("/"):
+        return None
+    parts = hls_path.split("/")
+    if any(p in ("", ".", "..") for p in parts):
+        return None
+    if os.path.splitext(parts[-1])[1].lower() not in _HLS_MIME:
+        return None
+    return "/".join(parts)
+
+# The 302 to the presigned URL is cacheable for a bounded window. This is
+# critical for smooth playback: without it (no-store) the browser re-resolves
+# the redirect — re-running RBAC + presign (~0.3–1.3s) — on every seek and
+# reconnect, starving the buffer and causing periodic stalls. Caching lets the
+# browser resolve once and reuse the same R2 URL for all Range requests. The
+# 6h window stays well under the 24h presign TTL so a cached 302 never points
+# at an expired URL. "private" keeps shared caches (Cloudflare) from storing a
+# user-scoped signed URL.
+_PRESIGNED_REDIRECT_HEADERS = {"Cache-Control": "private, max-age=21600"}
+
+
+def _redirect_to_storage(file_path: str) -> RedirectResponse | None:
+    """
+    When S3/R2 is enabled, build a 302 redirect to a presigned URL so the
+    browser streams media directly from object storage (native Range support,
+    full edge throughput) instead of proxying every byte through this API.
+
+    Returns None when S3 isn't enabled or signing fails, so the caller falls
+    back to streaming the file through the API.
+
+    SECURITY: callers MUST run their RBAC check before calling this — the
+    presigned URL grants temporary unauthenticated read access to the object.
+    """
+    if not is_s3_enabled():
+        return None
+    presigned = generate_presigned_get_url(file_path)
+    if not presigned:
+        return None
+    return RedirectResponse(
+        url=presigned,
+        status_code=302,
+        headers=_PRESIGNED_REDIRECT_HEADERS,
+    )
 
 
 async def _verify_course_activity_access(
@@ -158,14 +231,28 @@ async def stream_activity_video(
     if not file_path:
         raise HTTPException(status_code=404, detail="Video not found")
 
-    # Get file info
-    file_size, mime_type, exists = get_file_info(file_path)
+    # Confirm the object exists first (offloaded head_object) so a missing file
+    # returns 404 consistently for GET and HEAD instead of redirecting to a dead
+    # presigned URL. The 302 is cached, so this runs ~once per viewing session.
+    file_size, mime_type, exists = await asyncio.to_thread(get_file_info, file_path)
 
     if not exists:
         raise HTTPException(status_code=404, detail="Video not found")
 
+    # S3/R2: redirect to object storage so the browser streams directly. RBAC
+    # was already enforced above, so the short-lived presigned URL is safe.
+    redirect = _redirect_to_storage(file_path)
+    if redirect:
+        return redirect
+
     # Parse Range header if present
     range_header = request.headers.get("range")
+    if range_header and is_range_unsatisfiable(range_header, file_size):
+        # RFC 7233: unsatisfiable range (empty file / start past EOF) → 416.
+        return Response(
+            status_code=416,
+            headers={"Content-Range": f"bytes */{file_size}", "Accept-Ranges": "bytes"},
+        )
     start, end = parse_range_header(range_header, file_size)
 
     # Calculate content length for this range
@@ -200,6 +287,151 @@ async def stream_activity_video(
             headers=headers,
             media_type=mime_type,
         )
+
+
+@router.get(
+    "/hls/{org_uuid}/{course_uuid}/{activity_uuid}/{hls_path:path}",
+    summary="Serve an HLS playlist or segment for an activity video",
+    description=(
+        "Serves the adaptive-bitrate HLS assets for a hosted video activity. "
+        "Playlists (.m3u8) are returned after an RBAC check with every segment "
+        "URL rewritten to a presigned R2 URL, so the player fetches segments "
+        "directly from object storage. Segments are only served here in local "
+        "filesystem mode."
+    ),
+    responses={
+        200: {"description": "Playlist or segment returned"},
+        302: {"description": "Redirect to a presigned segment URL (S3/R2 mode)"},
+        403: {"description": "User is not permitted to read this course"},
+        404: {"description": "Activity, course, or HLS asset not found"},
+    },
+)
+async def stream_activity_hls(
+    request: Request,
+    org_uuid: str = Path(..., description="Organization UUID"),
+    course_uuid: str = Path(..., description="Course UUID"),
+    activity_uuid: str = Path(..., description="Activity UUID"),
+    hls_path: str = Path(..., description="HLS asset path (e.g. master.m3u8)"),
+    current_user: PublicUser | AnonymousUser | APITokenUser = Depends(get_current_user),
+    db_session: AsyncSession = Depends(get_db_session),
+):
+    """
+    Serve HLS playlists (rewriting segment URLs to presigned R2 URLs) and, in
+    local mode, the segments themselves.
+
+    SECURITY: RBAC runs before any content is read or any URL is signed.
+    """
+    await _verify_course_activity_access(request, course_uuid, activity_uuid, current_user, db_session)
+
+    rel = _safe_hls_relpath(hls_path)
+    if rel is None:
+        raise HTTPException(status_code=404, detail="HLS asset not found")
+
+    # S3 keys use forward slashes; the on-disk layout mirrors it.
+    base_key = f"{CONTENT_DIR}/orgs/{org_uuid}/courses/{course_uuid}/activities/{activity_uuid}/video/hls"
+    asset_key = f"{base_key}/{rel}"
+    ext = os.path.splitext(rel)[1].lower()
+
+    if ext == ".m3u8":
+        raw = await asyncio.to_thread(read_file_content, asset_key)
+        if raw is None:
+            raise HTTPException(status_code=404, detail="Playlist not found")
+        playlist_dir_key = asset_key.rsplit("/", 1)[0]
+        # In S3 mode generate_presigned_get_url signs each segment; in local
+        # mode it returns None, so segment refs stay relative and come back here.
+        body = rewrite_playlist(
+            raw.decode("utf-8", errors="replace"),
+            playlist_dir_key,
+            generate_presigned_get_url,
+        )
+        return Response(
+            content=body,
+            media_type=_HLS_MIME[".m3u8"],
+            headers={
+                # Shorter than the presign TTL so cached playlists never carry
+                # expired segment URLs.
+                "Cache-Control": "private, max-age=300",
+                "X-Content-Type-Options": "nosniff",
+            },
+        )
+
+    if ext == ".key":
+        # AES-128 decryption key: served ONLY through this authed endpoint,
+        # never presigned/redirected, and never cached, so it stays gated by RBAC.
+        raw = await asyncio.to_thread(read_file_content, asset_key)
+        if raw is None:
+            raise HTTPException(status_code=404, detail="Key not found")
+        return Response(
+            content=raw,
+            media_type=_HLS_MIME[".key"],
+            headers={"Cache-Control": "private, no-store"},
+        )
+
+    # Segment request. In S3 mode the player uses presigned URLs directly, so
+    # this is only hit in local mode — but redirect defensively if S3 is on.
+    redirect = _redirect_to_storage(asset_key)
+    if redirect:
+        return redirect
+    raw = await asyncio.to_thread(read_file_content, asset_key)
+    if raw is None:
+        raise HTTPException(status_code=404, detail="Segment not found")
+    return Response(
+        content=raw,
+        media_type=_HLS_MIME.get(ext, "application/octet-stream"),
+        headers={
+            "Cache-Control": "public, max-age=86400",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
+
+
+# Caption language codes are bare BCP-47-ish tokens (letters/digits/hyphen). This
+# rejects path traversal, slashes, and dots so it can't escape the captions dir.
+_CAPTION_LANG_RE = re.compile(r"^[A-Za-z0-9-]{2,20}$")
+
+
+@router.get(
+    "/captions/{org_uuid}/{course_uuid}/{activity_uuid}/{lang}.vtt",
+    summary="Serve a WebVTT caption track for an activity video",
+    description=(
+        "Returns the WebVTT subtitle track for the given language after an RBAC "
+        "check (same access as the video). Served inline so the player can attach "
+        "it as a text track."
+    ),
+    responses={
+        200: {"description": "WebVTT track returned"},
+        403: {"description": "User is not permitted to read this course"},
+        404: {"description": "Caption track not found"},
+    },
+)
+async def stream_activity_captions(
+    request: Request,
+    org_uuid: str = Path(..., description="Organization UUID"),
+    course_uuid: str = Path(..., description="Course UUID"),
+    activity_uuid: str = Path(..., description="Activity UUID"),
+    lang: str = Path(..., description="Caption language code (e.g. en, fr, es-419)"),
+    current_user: PublicUser | AnonymousUser | APITokenUser = Depends(get_current_user),
+    db_session: AsyncSession = Depends(get_db_session),
+):
+    """Serve a WebVTT caption track. RBAC runs before any content is read."""
+    await _verify_course_activity_access(request, course_uuid, activity_uuid, current_user, db_session)
+    if not _CAPTION_LANG_RE.match(lang):
+        raise HTTPException(status_code=404, detail="Caption track not found")
+    asset_key = (
+        f"{CONTENT_DIR}/orgs/{org_uuid}/courses/{course_uuid}"
+        f"/activities/{activity_uuid}/video/captions/{lang}.vtt"
+    )
+    raw = await asyncio.to_thread(read_file_content, asset_key)
+    if raw is None:
+        raise HTTPException(status_code=404, detail="Caption track not found")
+    return Response(
+        content=raw,
+        media_type="text/vtt; charset=utf-8",
+        headers={
+            "Cache-Control": "private, max-age=300",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
 
 
 @router.get(
@@ -250,14 +482,28 @@ async def stream_block_audio(
     if not file_path:
         raise HTTPException(status_code=404, detail="Audio not found")
 
-    # Get file info
-    file_size, mime_type, exists = get_file_info(file_path)
+    # Confirm the object exists first (offloaded head_object) so a missing file
+    # returns 404 consistently for GET and HEAD instead of redirecting to a dead
+    # presigned URL. The 302 is cached, so this runs ~once per viewing session.
+    file_size, mime_type, exists = await asyncio.to_thread(get_file_info, file_path)
 
     if not exists:
         raise HTTPException(status_code=404, detail="Audio not found")
 
+    # S3/R2: redirect to object storage so the browser streams directly. RBAC
+    # was already enforced above, so the short-lived presigned URL is safe.
+    redirect = _redirect_to_storage(file_path)
+    if redirect:
+        return redirect
+
     # Parse Range header if present
     range_header = request.headers.get("range")
+    if range_header and is_range_unsatisfiable(range_header, file_size):
+        # RFC 7233: unsatisfiable range (empty file / start past EOF) → 416.
+        return Response(
+            status_code=416,
+            headers={"Content-Range": f"bytes */{file_size}", "Accept-Ranges": "bytes"},
+        )
     start, end = parse_range_header(range_header, file_size)
 
     # Calculate content length for this range
@@ -407,14 +653,28 @@ async def stream_block_video(
     if not file_path:
         raise HTTPException(status_code=404, detail="Video not found")
 
-    # Get file info
-    file_size, mime_type, exists = get_file_info(file_path)
+    # Confirm the object exists first (offloaded head_object) so a missing file
+    # returns 404 consistently for GET and HEAD instead of redirecting to a dead
+    # presigned URL. The 302 is cached, so this runs ~once per viewing session.
+    file_size, mime_type, exists = await asyncio.to_thread(get_file_info, file_path)
 
     if not exists:
         raise HTTPException(status_code=404, detail="Video not found")
 
+    # S3/R2: redirect to object storage so the browser streams directly. RBAC
+    # was already enforced above, so the short-lived presigned URL is safe.
+    redirect = _redirect_to_storage(file_path)
+    if redirect:
+        return redirect
+
     # Parse Range header if present
     range_header = request.headers.get("range")
+    if range_header and is_range_unsatisfiable(range_header, file_size):
+        # RFC 7233: unsatisfiable range (empty file / start past EOF) → 416.
+        return Response(
+            status_code=416,
+            headers={"Content-Range": f"bytes */{file_size}", "Accept-Ranges": "bytes"},
+        )
     start, end = parse_range_header(range_header, file_size)
 
     # Calculate content length for this range
@@ -627,14 +887,28 @@ async def stream_podcast_audio(
     if not file_path:
         raise HTTPException(status_code=404, detail="Audio not found")
 
-    # Get file info
-    file_size, mime_type, exists = get_file_info(file_path)
+    # Confirm the object exists first (offloaded head_object) so a missing file
+    # returns 404 consistently for GET and HEAD instead of redirecting to a dead
+    # presigned URL. The 302 is cached, so this runs ~once per viewing session.
+    file_size, mime_type, exists = await asyncio.to_thread(get_file_info, file_path)
 
     if not exists:
         raise HTTPException(status_code=404, detail="Audio not found")
 
+    # S3/R2: redirect to object storage so the browser streams directly. RBAC
+    # was already enforced above, so the short-lived presigned URL is safe.
+    redirect = _redirect_to_storage(file_path)
+    if redirect:
+        return redirect
+
     # Parse Range header if present
     range_header = request.headers.get("range")
+    if range_header and is_range_unsatisfiable(range_header, file_size):
+        # RFC 7233: unsatisfiable range (empty file / start past EOF) → 416.
+        return Response(
+            status_code=416,
+            headers={"Content-Range": f"bytes */{file_size}", "Accept-Ranges": "bytes"},
+        )
     start, end = parse_range_header(range_header, file_size)
 
     # Calculate content length for this range

--- a/apps/api/src/services/ai/captions.py
+++ b/apps/api/src/services/ai/captions.py
@@ -1,0 +1,277 @@
+"""AI closed-caption engine: audio → WebVTT (transcription) and VTT → VTT (translation).
+
+Uses the provider-agnostic LLM layer (`src.services.ai.llm.generate`), so it follows
+the org's configured provider (Gemini by default) and its multimodal support. Long audio
+is segmented, transcribed per chunk, and stitched back with time offsets so a two-hour
+lecture works the same as a two-minute clip.
+
+This module is pure/orchestration-only: no DB, no Redis, no storage. `caption_jobs`
+wires it to the video pipeline, R2, and org credit metering.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import subprocess
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Segment length for transcription. Kept well under provider audio limits and short
+# enough that one slow chunk can't stall the whole job for too long.
+CHUNK_SECONDS = 600  # 10 min
+AUDIO_EXTRACT_TIMEOUT_S = 30 * 60
+TRANSCRIBE_TIMEOUT_S = 8 * 60
+TRANSLATE_TIMEOUT_S = 5 * 60
+# Guard rails so a single job can't consume unbounded provider quota/time.
+MAX_CHUNKS = 60  # up to 10h of audio
+
+# WebVTT timestamps: the hours field is OPTIONAL. Models (Gemini) commonly emit
+# MM:SS.mmm (e.g. "00:01.800"); the spec also allows HH:MM:SS.mmm. Accept both —
+# requiring hours made every real transcript match zero cues.
+_TS = r"(?:\d+:)?\d{1,2}:\d{2}[.,]\d{3}"
+_CUE_TIME_RE = re.compile(rf"({_TS})\s*-->\s*({_TS})")
+
+
+# --------------------------------------------------------------------------
+# ffmpeg audio extraction
+# --------------------------------------------------------------------------
+
+def _run(args: list[str], timeout: int) -> tuple[int, bytes, bytes]:
+    """Blocking subprocess.run (call via asyncio.to_thread). Same rationale as
+    hls_transcode._run_subprocess: never spawn subprocesses on the server loop."""
+    try:
+        p = subprocess.run(args, capture_output=True, timeout=timeout)
+        return p.returncode, p.stdout or b"", p.stderr or b""
+    except subprocess.TimeoutExpired as e:
+        return -1, (e.stdout or b""), (e.stderr or b"")
+
+
+def _ffmpeg() -> str:
+    return os.environ.get("LEARNHOUSE_FFMPEG_PATH", "ffmpeg")
+
+
+def _ffprobe() -> str:
+    return os.environ.get("LEARNHOUSE_FFPROBE_PATH", "ffprobe")
+
+
+async def probe_duration(src_path: str) -> float:
+    """Media duration in seconds (0.0 if it can't be determined)."""
+    rc, out, _ = await asyncio.to_thread(
+        _run,
+        [_ffprobe(), "-v", "error", "-show_entries", "format=duration",
+         "-of", "default=nw=1:nk=1", src_path],
+        60,
+    )
+    if rc != 0:
+        return 0.0
+    try:
+        return max(0.0, float(out.decode().strip() or 0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+async def extract_audio_chunks(src_path: str, out_dir: str) -> list[str]:
+    """Extract mono 16 kHz MP3 audio and split it into CHUNK_SECONDS segments.
+
+    Returns the ordered list of chunk file paths (chunk N covers
+    [N*CHUNK_SECONDS, (N+1)*CHUNK_SECONDS)). Empty list on failure.
+    """
+    pattern = os.path.join(out_dir, "chunk_%04d.mp3")
+    rc, _, stderr = await asyncio.to_thread(
+        _run,
+        [_ffmpeg(), "-y", "-loglevel", "error", "-i", src_path,
+         "-vn", "-ac", "1", "-ar", "16000", "-b:a", "64k",
+         "-f", "segment", "-segment_time", str(CHUNK_SECONDS), pattern],
+        AUDIO_EXTRACT_TIMEOUT_S,
+    )
+    if rc != 0:
+        logger.error("Caption audio extraction failed (rc=%s): %s", rc, (stderr or b"").decode()[:400])
+        return []
+    chunks = sorted(
+        os.path.join(out_dir, f) for f in os.listdir(out_dir)
+        if f.startswith("chunk_") and f.endswith(".mp3")
+    )
+    return chunks[:MAX_CHUNKS]
+
+
+# --------------------------------------------------------------------------
+# WebVTT helpers
+# --------------------------------------------------------------------------
+
+def _parse_ts(ts: str) -> float:
+    """Parse a WebVTT/SRT timestamp (MM:SS.mmm or HH:MM:SS.mmm) to seconds."""
+    parts = ts.strip().replace(",", ".").split(":")
+    try:
+        nums = [float(p) for p in parts]
+    except ValueError:
+        return 0.0
+    if len(nums) == 3:
+        h, m, s = nums
+    elif len(nums) == 2:
+        h, m, s = 0.0, nums[0], nums[1]
+    else:
+        return 0.0
+    return h * 3600 + m * 60 + s
+
+
+def _seconds_to_ts(total: float) -> str:
+    if total < 0:
+        total = 0.0
+    ms = int(round((total - int(total)) * 1000))
+    total = int(total)
+    h, rem = divmod(total, 3600)
+    m, s = divmod(rem, 60)
+    return f"{h:02d}:{m:02d}:{s:02d}.{ms:03d}"
+
+
+def sanitize_vtt(text: str) -> str:
+    """Coerce model output into a valid WebVTT body.
+
+    Models sometimes wrap output in ```markdown fences``` or omit the required
+    `WEBVTT` header, or use ',' millisecond separators (SRT style). Normalize all
+    of that so players accept it.
+    """
+    if not text:
+        return "WEBVTT\n"
+    t = text.strip()
+    # Strip code fences.
+    if t.startswith("```"):
+        t = re.sub(r"^```[a-zA-Z]*\n?", "", t)
+        t = re.sub(r"\n?```$", "", t).strip()
+    # SRT-style comma milliseconds -> dot (MM:SS,mmm or HH:MM:SS,mmm).
+    t = re.sub(r"(\d{1,2}:\d{2}(?::\d{2})?),(\d{3})", r"\1.\2", t)
+    if not t.upper().startswith("WEBVTT"):
+        t = "WEBVTT\n\n" + t
+    if not t.endswith("\n"):
+        t += "\n"
+    return t
+
+
+def shift_vtt(text: str, offset_seconds: float) -> str:
+    """Add offset_seconds to every cue timestamp (for stitching chunk transcripts)."""
+    if not offset_seconds:
+        return text
+
+    def _shift(m: re.Match) -> str:
+        start = _parse_ts(m.group(1)) + offset_seconds
+        end = _parse_ts(m.group(2)) + offset_seconds
+        return f"{_seconds_to_ts(start)} --> {_seconds_to_ts(end)}"
+
+    return _CUE_TIME_RE.sub(_shift, text)
+
+
+def _cue_body(text: str) -> str:
+    """Everything after the WEBVTT header (the cues), for merging."""
+    t = text.strip()
+    if t.upper().startswith("WEBVTT"):
+        t = t.split("\n", 1)[1] if "\n" in t else ""
+    return t.strip()
+
+
+def merge_vtt_chunks(chunk_vtts: list[str]) -> str:
+    """Merge already-offset chunk VTTs into one document with a single header."""
+    bodies = [_cue_body(sanitize_vtt(c)) for c in chunk_vtts if c and c.strip()]
+    bodies = [b for b in bodies if b]
+    return "WEBVTT\n\n" + "\n\n".join(bodies) + "\n"
+
+
+def has_cues(text: str) -> bool:
+    return bool(_CUE_TIME_RE.search(text or ""))
+
+
+# --------------------------------------------------------------------------
+# Transcription + translation (LLM)
+# --------------------------------------------------------------------------
+
+_TRANSCRIBE_SYSTEM = (
+    "You are a precise speech-to-text captioning engine. You transcribe audio into "
+    "WebVTT subtitles. Rules: output ONLY valid WebVTT (start with 'WEBVTT'); use "
+    "cue timestamps in HH:MM:SS.mmm format; keep each cue short (max ~7 seconds and "
+    "~2 lines); transcribe in the ORIGINAL spoken language; do not translate; do not "
+    "add commentary, speaker labels, or code fences."
+)
+
+
+async def _transcribe_chunk(audio_path: str, model_name: str, source_language: Optional[str]) -> str:
+    from pydantic_ai import BinaryContent  # local import: heavy dep, keeps module import cheap
+
+    from src.services.ai.llm import generate
+
+    with open(audio_path, "rb") as f:
+        audio = f.read()
+    lang_hint = (
+        f"The spoken language is '{source_language}'. " if source_language and source_language != "auto" else ""
+    )
+    prompt = [
+        f"{lang_hint}Transcribe this audio into WebVTT subtitles following the rules.",
+        BinaryContent(data=audio, media_type="audio/mpeg"),
+    ]
+    out = await generate(
+        model_name=model_name,
+        user_prompt=prompt,
+        system_prompt=_TRANSCRIBE_SYSTEM,
+        output_type=str,
+        temperature=0.0,
+        timeout=float(TRANSCRIBE_TIMEOUT_S),
+    )
+    return sanitize_vtt(out or "")
+
+
+async def transcribe_to_vtt(
+    audio_chunks: list[str], model_name: str, source_language: Optional[str] = None
+) -> str:
+    """Transcribe ordered audio chunks and stitch into one WebVTT document.
+
+    Chunk N's timestamps are offset by N*CHUNK_SECONDS. Raises ValueError if the
+    result has no cues (nothing usable transcribed).
+    """
+    if not audio_chunks:
+        raise ValueError("no audio to transcribe")
+    pieces: list[str] = []
+    for i, path in enumerate(audio_chunks):
+        vtt = await _transcribe_chunk(path, model_name, source_language)
+        pieces.append(shift_vtt(vtt, i * CHUNK_SECONDS))
+    merged = merge_vtt_chunks(pieces)
+    if not has_cues(merged):
+        raise ValueError("transcription produced no cues")
+    return merged
+
+
+_TRANSLATE_SYSTEM = (
+    "You are a subtitle translation engine. You translate WebVTT captions. Rules: "
+    "output ONLY valid WebVTT (start with 'WEBVTT'); keep EVERY cue and its exact "
+    "timestamps unchanged; translate ONLY the spoken text of each cue into the target "
+    "language; preserve line breaks and cue order; do not add commentary or code fences."
+)
+
+
+async def translate_vtt(vtt_text: str, target_language_label: str, model_name: str) -> str:
+    """Translate a WebVTT document's cue text into `target_language_label`
+    (a human-readable language name, e.g. 'French'). Timestamps are preserved."""
+    from src.services.ai.llm import generate
+
+    out = await generate(
+        model_name=model_name,
+        user_prompt=(
+            f"Translate the caption text of the following WebVTT into {target_language_label}. "
+            f"Keep all timestamps and cue structure identical.\n\n{vtt_text}"
+        ),
+        system_prompt=_TRANSLATE_SYSTEM,
+        output_type=str,
+        temperature=0.2,
+        timeout=float(TRANSLATE_TIMEOUT_S),
+    )
+    result = sanitize_vtt(out or "")
+    if not has_cues(result):
+        raise ValueError(f"translation to {target_language_label} produced no cues")
+    return result
+
+
+def estimate_credits(duration_seconds: float, num_translations: int) -> int:
+    """AI credits for a caption job: 1 per (started) 10-min transcription chunk plus
+    1 per translation language. Minimum 1."""
+    chunks = max(1, -(-int(duration_seconds) // CHUNK_SECONDS))  # ceil
+    return max(1, chunks + max(0, num_translations))

--- a/apps/api/src/services/courses/activities/video.py
+++ b/apps/api/src/services/courses/activities/video.py
@@ -1,5 +1,7 @@
 from typing import Literal, Optional
 import json
+import logging
+import re
 from src.db.courses.courses import Course
 from src.db.organizations import Organization
 
@@ -21,6 +23,8 @@ from fastapi import HTTPException, status, UploadFile, Request
 from uuid import uuid4
 from datetime import datetime
 from src.security.rbac import check_resource_access, AccessAction
+
+logger = logging.getLogger(__name__)
 
 
 async def create_video_activity(
@@ -153,6 +157,14 @@ async def create_video_activity(
     db_session.add(chapter_activity_object)
     await db_session.commit()
     await db_session.refresh(chapter_activity_object)
+
+    # Kick off HLS transcoding (no-op unless LEARNHOUSE_HLS_ENABLED). The MP4 is
+    # served as the fallback until HLS is ready.
+    try:
+        from src.services.utils.hls_jobs import enqueue as enqueue_hls
+        enqueue_hls(activity.activity_uuid)
+    except Exception:
+        logger.exception("Failed to enqueue HLS transcode for %s", activity.activity_uuid)
 
     return ActivityRead.model_validate(activity)
 
@@ -329,6 +341,119 @@ async def update_video_activity(
     await db_session.refresh(activity)
 
     return ActivityRead.model_validate(activity)
+
+
+# --------------------------------------------------------------------------
+# AI closed captions
+# --------------------------------------------------------------------------
+
+_CAPTION_LANG_RE = re.compile(r"^[A-Za-z0-9-]{2,20}$")
+MAX_CAPTION_LANGUAGES = 15
+
+
+class CaptionLanguageIn(BaseModel):
+    code: str
+    label: Optional[str] = None
+
+
+class CaptionsConfigIn(BaseModel):
+    enabled: bool = True
+    # "auto" = let the model detect the spoken language, or a specific code.
+    source_language: str = "auto"
+    languages: list[CaptionLanguageIn] = []
+
+
+async def configure_captions(
+    request: Request,
+    activity_uuid: str,
+    current_user: PublicUser | AnonymousUser,
+    db_session: AsyncSession,
+    config: CaptionsConfigIn,
+) -> dict:
+    """Persist AI-caption settings on a hosted-video activity and (when enabled)
+    enqueue generation. Instructor must have UPDATE rights on the course.
+
+    Languages may be any of the platform's available languages OR custom
+    additions — any well-formed BCP-47-ish code is accepted (the model can
+    translate to it). Returns the stored `captions` metadata block.
+    """
+    activity = (
+        await db_session.execute(select(Activity).where(Activity.activity_uuid == activity_uuid))
+    ).scalars().first()
+    if not activity:
+        raise HTTPException(status_code=404, detail="Activity not found")
+    if activity.activity_sub_type != ActivitySubTypeEnum.SUBTYPE_VIDEO_HOSTED:
+        raise HTTPException(status_code=400, detail="Captions are only available for hosted videos")
+
+    course = (
+        await db_session.execute(select(Course).where(Course.id == activity.course_id))
+    ).scalars().first()
+    if not course:
+        raise HTTPException(status_code=404, detail="Course not found")
+    await check_resource_access(
+        request, db_session, current_user, course.course_uuid, AccessAction.UPDATE
+    )
+
+    # Validate + dedupe target languages.
+    seen: set[str] = set()
+    langs: list[dict] = []
+    for lang in config.languages:
+        code = (lang.code or "").strip()
+        if not _CAPTION_LANG_RE.match(code):
+            raise HTTPException(status_code=400, detail=f"Invalid language code: {lang.code!r}")
+        if code in seen:
+            continue
+        seen.add(code)
+        langs.append({"code": code, "label": (lang.label or code).strip(), "status": "queued"})
+    if len(langs) > MAX_CAPTION_LANGUAGES:
+        raise HTTPException(status_code=400, detail=f"At most {MAX_CAPTION_LANGUAGES} languages")
+    src = (config.source_language or "auto").strip()
+    if src != "auto" and not _CAPTION_LANG_RE.match(src):
+        raise HTTPException(status_code=400, detail="Invalid source language code")
+    if config.enabled and not langs:
+        raise HTTPException(status_code=400, detail="Choose at least one caption language")
+
+    # Feature + credit pre-check for immediate feedback (the job re-checks + meters).
+    if config.enabled:
+        from src.security.features_utils.usage import (
+            check_feature_enabled,
+            get_ai_credits_summary,
+        )
+        await check_feature_enabled("ai", activity.org_id, db_session)
+        summary = await get_ai_credits_summary(activity.org_id, db_session)
+        remaining = summary.get("remaining_credits")
+        if isinstance(remaining, (int, float)) and remaining != -1 and remaining <= 0:
+            raise HTTPException(status_code=402, detail="No AI credits remaining")
+
+    from sqlalchemy.orm.attributes import flag_modified
+
+    meta = dict(activity.extra_metadata or {})
+    captions = dict(meta.get("captions") or {})
+    captions.update({
+        "enabled": config.enabled,
+        "auto_generate": True,
+        "source_language": src,
+        "languages": langs,
+        "status": "queued" if (config.enabled and langs) else "idle",
+        "error": None,
+        "updated_at": str(datetime.now()),
+    })
+    meta["captions"] = captions
+    activity.extra_metadata = meta
+    flag_modified(activity, "extra_metadata")
+    db_session.add(activity)
+    await db_session.commit()
+
+    if config.enabled and langs:
+        try:
+            from src.services.utils.caption_jobs import enqueue as enqueue_captions
+            enqueue_captions(activity_uuid)
+        except Exception:
+            logging.getLogger(__name__).exception(
+                "Failed to enqueue captions for %s", activity_uuid
+            )
+
+    return captions
 
 
 async def update_external_video_activity(

--- a/apps/api/src/services/courses/transfer/storage_utils.py
+++ b/apps/api/src/services/courses/transfer/storage_utils.py
@@ -52,7 +52,9 @@ def _validate_local_path(file_path: str) -> Optional[str]:
     except ValueError:
         return None
 
-    return file_path
+    # Return the canonicalized, containment-checked path (not the original
+    # tainted string) so callers open the validated path.
+    return full_real
 
 
 @functools.cache
@@ -78,10 +80,22 @@ def get_storage_client():
         if _s3_client is not None:
             return _s3_client
         learnhouse_config = get_learnhouse_config()
+        # Cloudflare R2 requires SigV4 and the "auto" region; without this,
+        # botocore falls back to SigV2 for presigned URLs (the legacy
+        # AWSAccessKeyId/Signature/Expires form), which R2 rejects with 401.
+        # Overridable via LEARNHOUSE_S3_API_REGION for real AWS S3 / MinIO, which
+        # validate the region against the endpoint.
+        region = os.environ.get("LEARNHOUSE_S3_API_REGION") or "auto"
         _s3_client = boto3.client(
             "s3",
             endpoint_url=learnhouse_config.hosting_config.content_delivery.s3api.endpoint_url,
-            config=botocore.config.Config(connect_timeout=10, read_timeout=60, retries={"max_attempts": 2}),
+            region_name=region,
+            config=botocore.config.Config(
+                signature_version="s3v4",
+                connect_timeout=10,
+                read_timeout=60,
+                retries={"max_attempts": 2},
+            ),
         )
         return _s3_client
 
@@ -97,6 +111,41 @@ def get_s3_bucket_name() -> str:
 def is_s3_enabled() -> bool:
     """Check if S3 storage is enabled (cached)."""
     return get_content_delivery_type() == "s3api"
+
+
+# Presigned-URL lifetime (24h). Must stay comfortably longer than the redirect
+# Cache-Control window (see stream.py) so a browser-cached 302 never points at
+# an already-expired URL. 24h TTL + 6h cache leaves ≥18h of validity margin.
+PRESIGNED_URL_TTL_SECONDS = 24 * 60 * 60
+
+
+def generate_presigned_get_url(
+    s3_key: str, expires_in: int = PRESIGNED_URL_TTL_SECONDS
+) -> Optional[str]:
+    """
+    Generate a presigned GET URL for an object so the browser can fetch it
+    directly from S3/R2 (with native HTTP Range support) instead of proxying
+    every byte through the API.
+
+    Returns None when S3 is not enabled, the client is unavailable, or signing
+    fails — callers fall back to streaming the file through the API.
+    """
+    if not is_s3_enabled():
+        return None
+
+    s3_client = get_storage_client()
+    if not s3_client:
+        return None
+
+    try:
+        return s3_client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": get_s3_bucket_name(), "Key": s3_key},
+            ExpiresIn=expires_in,
+        )
+    except Exception as e:
+        logger.error("Failed to presign URL for %s: %s", s3_key, e)
+        return None
 
 
 def read_file_content(file_path: str) -> Optional[bytes]:
@@ -348,6 +397,9 @@ MIME_TYPES_BY_EXT = {
     ".webp": "image/webp",
     ".mp3": "audio/mpeg",
     ".wav": "audio/wav",
+    ".m3u8": "application/vnd.apple.mpegurl",
+    ".ts": "video/mp2t",
+    ".m4s": "video/iso.segment",
 }
 
 

--- a/apps/api/src/services/utils/caption_jobs.py
+++ b/apps/api/src/services/utils/caption_jobs.py
@@ -1,0 +1,419 @@
+"""AI closed-captions background pipeline.
+
+Mirrors the hardened HLS consumer (LPOP + reaper + per-job timeout + shutdown
+re-enqueue) but for caption generation: resolve the hosted video → extract audio
+→ meter the org's AI credits → transcribe (Gemini) → translate per target language
+→ upload WebVTT to R2 → record per-language status in
+``activity.extra_metadata['captions']``.
+
+Design mirrors ``hls_jobs`` deliberately so both pipelines behave identically under
+pod churn. Reuses the AI layer (``src.services.ai.llm``) and org credit metering
+(``reserve_ai_credit``/``refund_ai_credit``).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import HTTPException
+from sqlalchemy.orm.attributes import flag_modified
+from sqlmodel import select
+
+from src.core.events.database import _async_session_factory
+from src.core.redis import get_redis_client
+from src.db.courses.activities import Activity, ActivitySubTypeEnum
+from src.db.courses.courses import Course
+from src.db.organizations import Organization
+from src.services.ai import captions as cap
+from src.services.courses.transfer.storage_utils import (
+    is_s3_enabled,
+    upload_directory_to_s3,
+)
+from src.services.utils.hls_jobs import _fetch_source  # reuse the R2 download helper
+
+logger = logging.getLogger(__name__)
+
+REDIS_QUEUE_KEY = "learnhouse:captions:queue"
+JOB_TIMEOUT_SECONDS = 40 * 60
+CONSUMER_POLL_SECONDS = 2
+STALE_PROCESSING_SECONDS = 20 * 60
+REAPER_INTERVAL_SECONDS = 5 * 60
+
+_consumer_task: Optional["asyncio.Task"] = None
+_reaper_task: Optional["asyncio.Task"] = None
+_children: set = set()
+_inflight: set = set()
+
+
+def concurrency() -> int:
+    try:
+        return max(1, int(os.environ.get("LEARNHOUSE_CAPTIONS_CONCURRENCY", "1")))
+    except (TypeError, ValueError):
+        return 1
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# --------------------------------------------------------------------------
+# Status writes (activity.extra_metadata['captions'])
+# --------------------------------------------------------------------------
+
+async def _patch_captions(activity_uuid: str, **patch) -> None:
+    """Shallow-merge `patch` into extra_metadata['captions'] (creating it if absent)."""
+    async with _async_session_factory() as db:
+        activity = (
+            await db.execute(select(Activity).where(Activity.activity_uuid == activity_uuid))
+        ).scalars().first()
+        if not activity:
+            return
+        meta = dict(activity.extra_metadata or {})
+        captions = dict(meta.get("captions") or {})
+        captions.update(patch)
+        captions["updated_at"] = _now()
+        meta["captions"] = captions
+        activity.extra_metadata = meta
+        flag_modified(activity, "extra_metadata")
+        db.add(activity)
+        await db.commit()
+
+
+async def _set_lang_status(activity_uuid: str, code: str, status: str) -> None:
+    """Update one target language's status in-place (keeps the rest untouched)."""
+    async with _async_session_factory() as db:
+        activity = (
+            await db.execute(select(Activity).where(Activity.activity_uuid == activity_uuid))
+        ).scalars().first()
+        if not activity:
+            return
+        meta = dict(activity.extra_metadata or {})
+        captions = dict(meta.get("captions") or {})
+        langs = [dict(x) for x in (captions.get("languages") or [])]
+        for lang in langs:
+            if lang.get("code") == code:
+                lang["status"] = status
+        captions["languages"] = langs
+        captions["updated_at"] = _now()
+        meta["captions"] = captions
+        activity.extra_metadata = meta
+        flag_modified(activity, "extra_metadata")
+        db.add(activity)
+        await db.commit()
+
+
+# --------------------------------------------------------------------------
+# enqueue
+# --------------------------------------------------------------------------
+
+def enqueue(activity_uuid: str) -> None:
+    """Queue an activity for caption generation (fire-and-forget). Callers gate on
+    the org's AI feature + credits before enqueuing."""
+    client = get_redis_client()
+    if not client:
+        logger.warning("Captions: no Redis; cannot enqueue %s", activity_uuid)
+        return
+    try:
+        client.rpush(REDIS_QUEUE_KEY, activity_uuid)
+    except Exception as e:
+        logger.warning("Captions: could not enqueue %s: %s", activity_uuid, e)
+
+
+# --------------------------------------------------------------------------
+# The job
+# --------------------------------------------------------------------------
+
+async def _resolve(activity_uuid: str) -> Optional[dict]:
+    """Return {org_id, org_uuid, course_uuid, filename, captions} for a hosted video."""
+    async with _async_session_factory() as db:
+        a = (
+            await db.execute(select(Activity).where(Activity.activity_uuid == activity_uuid))
+        ).scalars().first()
+        if not a or a.activity_sub_type != ActivitySubTypeEnum.SUBTYPE_VIDEO_HOSTED:
+            return None
+        filename = (a.content or {}).get("filename")
+        captions = (a.extra_metadata or {}).get("captions") or {}
+        if not filename or not captions.get("enabled"):
+            return None
+        org = (await db.execute(select(Organization).where(Organization.id == a.org_id))).scalars().first()
+        course = (await db.execute(select(Course).where(Course.id == a.course_id))).scalars().first()
+        if not org or not course:
+            return None
+        return {
+            "org_id": a.org_id,
+            "org_uuid": org.org_uuid,
+            "course_uuid": course.course_uuid,
+            "filename": filename,
+            "captions": captions,
+        }
+
+
+async def generate_activity_captions(activity_uuid: str) -> bool:
+    """Full caption job: transcribe + translate + upload. Returns True on (partial)
+    success. Never raises for expected failures — records status instead."""
+    info = await _resolve(activity_uuid)
+    if not info:
+        logger.warning("Captions: nothing to generate for %s", activity_uuid)
+        return False
+
+    org_id = info["org_id"]
+    base = (
+        f"content/orgs/{info['org_uuid']}/courses/{info['course_uuid']}"
+        f"/activities/{activity_uuid}/video"
+    )
+    src_key = f"{base}/{info['filename']}"
+    captions_prefix = f"{base}/captions"
+    cfg = info["captions"]
+    source_language = cfg.get("source_language") or "auto"
+    targets = [dict(x) for x in (cfg.get("languages") or []) if x.get("code")]
+    if not targets:
+        await _patch_captions(activity_uuid, status="failed", error="no_languages")
+        return False
+
+    await _patch_captions(activity_uuid, status="processing", error=None)
+
+    # Credit metering + generation are deferred to the LLM layer; import lazily.
+    from src.security.features_utils.usage import (
+        check_feature_enabled,
+        refund_ai_credit,
+        reserve_ai_credit,
+    )
+    from src.services.ai.llm import model_for_tier
+
+    model_name = model_for_tier("standard")
+    reserved = 0
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            # 1. Download source video + extract audio.
+            local_src = os.path.join(td, os.path.basename(info["filename"]))
+            if not await asyncio.to_thread(_fetch_source, src_key, local_src):
+                await _patch_captions(activity_uuid, status="failed", error="source_unavailable")
+                return False
+            audio_dir = os.path.join(td, "audio")
+            os.makedirs(audio_dir, exist_ok=True)
+            chunks = await cap.extract_audio_chunks(local_src, audio_dir)
+            if not chunks:
+                await _patch_captions(activity_uuid, status="failed", error="audio_extract_failed")
+                return False
+            duration = await cap.probe_duration(local_src)
+
+            # 2. Credit gate (feature + atomic reserve). Cost scales with duration
+            #    + number of languages that need a real translation.
+            need_translation = [
+                t for t in targets
+                if not (source_language != "auto" and t["code"] == source_language)
+            ]
+            cost = cap.estimate_credits(duration, len(need_translation))
+            async with _async_session_factory() as db:
+                await check_feature_enabled("ai", org_id, db)
+                await reserve_ai_credit(org_id, db, amount=cost)
+            reserved = cost
+
+            # 3. Transcribe once (source language).
+            source_vtt = await cap.transcribe_to_vtt(chunks, model_name, source_language)
+
+            # 4. Produce a VTT per target language (translate unless it IS the source).
+            out_dir = os.path.join(td, "captions")
+            os.makedirs(out_dir, exist_ok=True)
+            done = 0
+            for t in targets:
+                code = t["code"]
+                await _set_lang_status(activity_uuid, code, "processing")
+                try:
+                    if source_language != "auto" and code == source_language:
+                        vtt = source_vtt
+                    else:
+                        vtt = await cap.translate_vtt(source_vtt, t.get("label") or code, model_name)
+                    with open(os.path.join(out_dir, f"{code}.vtt"), "w", encoding="utf-8") as f:
+                        f.write(vtt)
+                    await _set_lang_status(activity_uuid, code, "ready")
+                    done += 1
+                except Exception as e:  # one language failing must not sink the rest
+                    logger.error("Captions: %s lang %s failed: %s", activity_uuid, code, e)
+                    await _set_lang_status(activity_uuid, code, "failed")
+
+            if done == 0:
+                await _patch_captions(activity_uuid, status="failed", error="all_languages_failed")
+                if reserved:
+                    refund_ai_credit(org_id, amount=reserved)
+                return False
+
+            # 5. Upload the produced VTTs to R2 (or copy locally in filesystem mode).
+            if is_s3_enabled():
+                ok = await asyncio.to_thread(upload_directory_to_s3, out_dir, captions_prefix)
+            else:
+                import shutil
+                await asyncio.to_thread(shutil.copytree, out_dir, captions_prefix, dirs_exist_ok=True)
+                ok = True
+            if not ok:
+                await _patch_captions(activity_uuid, status="failed", error="upload_failed")
+                if reserved:
+                    refund_ai_credit(org_id, amount=reserved)
+                return False
+
+        await _patch_captions(
+            activity_uuid,
+            status="ready" if done == len(targets) else "partial",
+            error=None,
+        )
+        logger.info("Captions ready for %s (%s/%s langs)", activity_uuid, done, len(targets))
+        return True
+    except HTTPException as e:
+        # e.g. AI disabled or quota exceeded (reserve raises 403) — do NOT refund
+        # (nothing was reserved on a 403), record a clear status.
+        detail = getattr(e, "detail", "ai_error")
+        await _patch_captions(activity_uuid, status="failed", error=str(detail)[:200])
+        return False
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.error("Captions job crashed for %s: %s", activity_uuid, e)
+        await _patch_captions(activity_uuid, status="failed", error="exception")
+        if reserved:
+            refund_ai_credit(org_id, amount=reserved)
+        return False
+
+
+# --------------------------------------------------------------------------
+# In-app consumer + reaper (mirrors hls_jobs)
+# --------------------------------------------------------------------------
+
+async def _consumer_loop(poll_seconds: int = CONSUMER_POLL_SECONDS) -> None:
+    client = get_redis_client()
+    if not client:
+        logger.warning("Captions consumer: Redis unavailable; not started")
+        return
+    sem = asyncio.Semaphore(concurrency())
+    logger.info("Captions in-app consumer started (concurrency=%s)", concurrency())
+
+    async def _run(uuid: str) -> None:
+        _inflight.add(uuid)
+        try:
+            await asyncio.wait_for(generate_activity_captions(uuid), timeout=JOB_TIMEOUT_SECONDS)
+        except asyncio.TimeoutError:
+            logger.error("Captions: job %s exceeded %ss — marking failed", uuid, JOB_TIMEOUT_SECONDS)
+            try:
+                await _patch_captions(uuid, status="failed", error="timeout")
+            except Exception:
+                pass
+        except asyncio.CancelledError:
+            try:
+                client.rpush(REDIS_QUEUE_KEY, uuid)
+            except Exception:
+                pass
+            raise
+        except Exception as e:
+            logger.error("Captions consumer: job %s failed: %s", uuid, e)
+        finally:
+            _inflight.discard(uuid)
+            sem.release()
+
+    while True:
+        await sem.acquire()
+        try:
+            item = await asyncio.to_thread(client.lpop, REDIS_QUEUE_KEY)
+        except asyncio.CancelledError:
+            sem.release()
+            raise
+        except Exception as e:
+            logger.error("Captions consumer: poll error: %s", e)
+            sem.release()
+            await asyncio.sleep(poll_seconds)
+            continue
+        if not item:
+            sem.release()
+            await asyncio.sleep(poll_seconds)
+            continue
+        activity_uuid = item.decode() if isinstance(item, (bytes, bytearray)) else item
+        task = asyncio.create_task(_run(activity_uuid))
+        _children.add(task)
+        task.add_done_callback(_children.discard)
+
+
+async def _requeue_stale_processing(stale_after: int = STALE_PROCESSING_SECONDS) -> int:
+    client = get_redis_client()
+    if not client:
+        return 0
+    now = datetime.now(timezone.utc)
+    requeued = 0
+    async with _async_session_factory() as db:
+        rows = (await db.execute(
+            select(Activity).where(
+                Activity.activity_sub_type == ActivitySubTypeEnum.SUBTYPE_VIDEO_HOSTED
+            )
+        )).scalars().all()
+        for a in rows:
+            captions = (a.extra_metadata or {}).get("captions") or {}
+            if captions.get("status") != "processing":
+                continue
+            ts = captions.get("updated_at")
+            try:
+                age = (now - datetime.fromisoformat(ts)).total_seconds() if ts else 1e9
+            except (TypeError, ValueError):
+                age = 1e9
+            if age >= stale_after:
+                meta = dict(a.extra_metadata or {})
+                meta["captions"] = {**captions, "status": "queued", "updated_at": now.isoformat()}
+                a.extra_metadata = meta
+                flag_modified(a, "extra_metadata")
+                db.add(a)
+                await db.commit()
+                try:
+                    client.rpush(REDIS_QUEUE_KEY, a.activity_uuid)
+                    requeued += 1
+                except Exception:
+                    pass
+    if requeued:
+        logger.info("Captions reaper: re-enqueued %s stale job(s)", requeued)
+    return requeued
+
+
+async def _reaper_loop(interval: int = REAPER_INTERVAL_SECONDS) -> None:
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            await _requeue_stale_processing()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error("Captions reaper error: %s", e)
+
+
+def start_consumer() -> None:
+    """Start the captions consumer + reaper (call from app startup). No-op when
+    Redis is unavailable; otherwise idle (cheap poll) until an instructor enables
+    captions on a video. Work is only ever created via the AI-gated config
+    endpoint, so no separate feature flag is needed."""
+    global _consumer_task, _reaper_task
+    if not get_redis_client():
+        return
+    if not (_consumer_task and not _consumer_task.done()):
+        _consumer_task = asyncio.create_task(_consumer_loop())
+    if not (_reaper_task and not _reaper_task.done()):
+        _reaper_task = asyncio.create_task(_reaper_loop())
+
+
+async def stop_consumer() -> None:
+    global _consumer_task, _reaper_task
+    client = get_redis_client()
+    if client and _inflight:
+        for uuid in list(_inflight):
+            try:
+                client.rpush(REDIS_QUEUE_KEY, uuid)
+            except Exception:
+                pass
+    for t in (_consumer_task, _reaper_task):
+        if t:
+            t.cancel()
+            try:
+                await t
+            except asyncio.CancelledError:
+                pass
+    _consumer_task = None
+    _reaper_task = None
+    if _children:
+        await asyncio.gather(*list(_children), return_exceptions=True)

--- a/apps/api/src/services/utils/hls_jobs.py
+++ b/apps/api/src/services/utils/hls_jobs.py
@@ -1,0 +1,433 @@
+"""
+HLS transcoding jobs.
+
+Ties the transcoder to activities and storage: resolve an activity's source
+video, transcode it to an HLS ladder, upload the output next to the original,
+and record status on `activity.extra_metadata["hls"]`.
+
+Execution models (no dedicated worker infra exists yet):
+- A `transcode-worker` CLI drains a Redis queue — the recommended prod path so
+  heavy ffmpeg runs off the API pods.
+- An in-process consumer (`LEARNHOUSE_HLS_INPROCESS_WORKER=true`, default off,
+  Semaphore(1)) for dev/self-host.
+
+Everything is gated by `LEARNHOUSE_HLS_ENABLED` (default off). Until a video is
+`ready`, callers keep using the optimized MP4 fallback.
+"""
+
+import asyncio
+import logging
+import os
+import shutil
+import tempfile
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlmodel import select
+
+from src.core.events.database import _async_session_factory
+from src.core.redis import get_redis_client
+from src.db.courses.activities import Activity, ActivitySubTypeEnum
+from src.db.courses.courses import Course
+from src.db.organizations import Organization
+from src.services.courses.transfer.storage_utils import (
+    is_s3_enabled,
+    get_storage_client,
+    get_s3_bucket_name,
+    upload_directory_to_s3,
+)
+from src.services.utils.hls_transcode import transcode_source_to_hls
+
+logger = logging.getLogger(__name__)
+
+REDIS_QUEUE_KEY = "learnhouse:hls:queue"
+
+# In-app background consumer state. Transcoding runs INSIDE the API process as
+# an asyncio background task that drains the Redis queue — no separate worker
+# deployment. ffmpeg runs as an async subprocess and S3 I/O is offloaded to a
+# thread, so the event loop is never blocked; a semaphore caps how many
+# transcodes run at once per pod.
+_consumer_task: Optional["asyncio.Task"] = None
+_reaper_task: Optional["asyncio.Task"] = None
+_consumer_children: set = set()
+# UUIDs currently transcoding on THIS pod — re-enqueued on shutdown so a pod
+# termination (deploy/autoscale) never leaves a job stuck at "processing".
+_inflight: set = set()
+
+# A job left in "processing" longer than this (no heartbeat) is considered
+# orphaned (its pod died) and re-enqueued by the reaper.
+STALE_PROCESSING_SECONDS = 20 * 60
+REAPER_INTERVAL_SECONDS = 5 * 60
+CONSUMER_POLL_SECONDS = 2
+# Hard ceiling for a single transcode job; bounds any hang so the consumer slot
+# always frees (the reaper re-queues anything left stale).
+JOB_TIMEOUT_SECONDS = 40 * 60
+
+
+def _flag(name: str) -> bool:
+    return os.environ.get(name, "false").strip().lower() == "true"
+
+
+def hls_enabled() -> bool:
+    return _flag("LEARNHOUSE_HLS_ENABLED")
+
+
+def hls_concurrency() -> int:
+    """Max concurrent transcodes per API pod (LEARNHOUSE_HLS_CONCURRENCY, default 1)."""
+    try:
+        return max(1, int(os.environ.get("LEARNHOUSE_HLS_CONCURRENCY", "1")))
+    except (TypeError, ValueError):
+        return 1
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+async def _set_status(activity_uuid: str, status: str, **extra) -> None:
+    """Write {status, updated_at, **extra} to activity.extra_metadata['hls']."""
+    async with _async_session_factory() as db:
+        activity = (
+            await db.execute(select(Activity).where(Activity.activity_uuid == activity_uuid))
+        ).scalars().first()
+        if not activity:
+            return
+        meta = dict(activity.extra_metadata or {})
+        meta["hls"] = {"status": status, "updated_at": _now(), **extra}
+        # Reassign so SQLAlchemy detects the JSONB change.
+        activity.extra_metadata = meta
+        db.add(activity)
+        await db.commit()
+
+
+async def _resolve_source(activity_uuid: str) -> Optional[dict]:
+    """Return {org_uuid, course_uuid, filename} for a hosted-video activity."""
+    async with _async_session_factory() as db:
+        activity = (
+            await db.execute(select(Activity).where(Activity.activity_uuid == activity_uuid))
+        ).scalars().first()
+        if not activity or activity.activity_sub_type != ActivitySubTypeEnum.SUBTYPE_VIDEO_HOSTED:
+            return None
+        filename = (activity.content or {}).get("filename")
+        if not filename or not _safe_filename(filename):
+            return None
+        org = (await db.execute(select(Organization).where(Organization.id == activity.org_id))).scalars().first()
+        course = (await db.execute(select(Course).where(Course.id == activity.course_id))).scalars().first()
+        if not org or not course:
+            return None
+        return {"org_uuid": org.org_uuid, "course_uuid": course.course_uuid, "filename": filename}
+
+
+def _safe_filename(filename: str) -> bool:
+    """A stored filename must be a bare name — reject path separators, traversal,
+    NUL, and absolute paths so it can't escape the activity's key/dir on join."""
+    if not filename or "\x00" in filename:
+        return False
+    if "/" in filename or "\\" in filename:
+        return False
+    if filename in (".", "..") or filename.startswith("."):
+        return False
+    return True
+
+
+def _fetch_source(src_key: str, local_path: str) -> bool:
+    """Copy the source video to local_path (stream-download from R2, or local copy)."""
+    if is_s3_enabled():
+        client = get_storage_client()
+        if not client:
+            return False
+        try:
+            client.download_file(get_s3_bucket_name(), src_key, local_path)
+            return True
+        except Exception as e:
+            logger.error("HLS: failed to download source %s: %s", src_key, e)
+            return False
+    # Local filesystem: the source lives at the content-relative key.
+    if os.path.isfile(src_key):
+        shutil.copyfile(src_key, local_path)
+        return True
+    logger.error("HLS: local source missing %s", src_key)
+    return False
+
+
+async def transcode_activity(activity_uuid: str) -> bool:
+    """Full job: resolve → download → transcode → upload → mark ready/failed."""
+    info = await _resolve_source(activity_uuid)
+    if not info:
+        logger.warning("HLS: no transcodable source for activity %s", activity_uuid)
+        return False
+
+    org_uuid, course_uuid, filename = info["org_uuid"], info["course_uuid"], info["filename"]
+    base = f"content/orgs/{org_uuid}/courses/{course_uuid}/activities/{activity_uuid}/video"
+    src_key = f"{base}/{filename}"
+    hls_prefix = f"{base}/hls"
+
+    await _set_status(activity_uuid, "processing")
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            # basename() is defensive belt-and-suspenders on top of _safe_filename.
+            local_src = os.path.join(td, os.path.basename(filename))
+            # Blocking I/O off the event loop (matters for the in-process worker).
+            if not await asyncio.to_thread(_fetch_source, src_key, local_src):
+                await _set_status(activity_uuid, "failed", error="source_unavailable")
+                return False
+
+            out_dir = os.path.join(td, "hls")
+            result = await transcode_source_to_hls(local_src, out_dir)
+            if not result:
+                await _set_status(activity_uuid, "failed", error="transcode_failed")
+                return False
+
+            if is_s3_enabled():
+                ok = await asyncio.to_thread(upload_directory_to_s3, out_dir, hls_prefix)
+            else:
+                await asyncio.to_thread(shutil.copytree, out_dir, hls_prefix, dirs_exist_ok=True)
+                ok = True
+            if not ok:
+                await _set_status(activity_uuid, "failed", error="upload_failed")
+                return False
+
+        await _set_status(
+            activity_uuid, "ready",
+            master=result["master"], renditions=result["renditions"],
+            thumbnails=result.get("thumbnails"),
+        )
+        logger.info("HLS ready for activity %s (%s)", activity_uuid, ",".join(result["renditions"]))
+        return True
+    except Exception as e:
+        logger.error("HLS job crashed for %s: %s", activity_uuid, e)
+        await _set_status(activity_uuid, "failed", error="exception")
+        return False
+
+
+def enqueue(activity_uuid: str) -> None:
+    """Queue an activity for HLS transcoding (fire-and-forget, never raises).
+
+    Just pushes to the Redis queue; the in-app background consumer (started at
+    app startup) drains and transcodes it. No-op when HLS is disabled.
+    """
+    if not hls_enabled():
+        return
+    client = get_redis_client()
+    if not client:
+        logger.warning("HLS enabled but no Redis; cannot enqueue %s", activity_uuid)
+        return
+    try:
+        client.rpush(REDIS_QUEUE_KEY, activity_uuid)
+    except Exception as e:
+        logger.warning("HLS: could not enqueue %s to Redis: %s", activity_uuid, e)
+
+
+# ---------------------------------------------------------------------------
+# In-app background consumer (Redis queue → asyncio background tasks; no worker)
+# ---------------------------------------------------------------------------
+
+async def _consumer_loop(poll_seconds: int = CONSUMER_POLL_SECONDS) -> None:
+    """Drain the Redis queue and transcode, capped at hls_concurrency() jobs.
+
+    Uses non-blocking LPOP + sleep (NOT BLPOP) so it never collides with the
+    Redis client's socket_timeout (which turned every idle poll into an error
+    and could drop a job popped server-side). Acquires a permit before pulling,
+    so at most `concurrency` transcodes run at once and the queue is never
+    drained into memory.
+    """
+    client = get_redis_client()
+    if not client:
+        logger.warning("HLS consumer: Redis unavailable; not started")
+        return
+    sem = asyncio.Semaphore(hls_concurrency())
+    logger.info("HLS in-app consumer started (concurrency=%s)", hls_concurrency())
+
+    async def _run(uuid: str) -> None:
+        _inflight.add(uuid)
+        try:
+            # Hard overall cap so NO single job can occupy a slot indefinitely
+            # (e.g. a subprocess spawn that hangs before its own timeout applies).
+            await asyncio.wait_for(transcode_activity(uuid), timeout=JOB_TIMEOUT_SECONDS)
+        except asyncio.TimeoutError:
+            logger.error("HLS: job %s exceeded %ss — marking failed", uuid, JOB_TIMEOUT_SECONDS)
+            try:
+                await _set_status(uuid, "failed", error="timeout")
+            except Exception:
+                pass
+        except asyncio.CancelledError:
+            # Interrupted (pod shutting down) — re-queue so another pod finishes it.
+            try:
+                client.rpush(REDIS_QUEUE_KEY, uuid)
+            except Exception:
+                pass
+            raise
+        except Exception as e:
+            logger.error("HLS consumer: job %s failed: %s", uuid, e)
+        finally:
+            _inflight.discard(uuid)
+            sem.release()
+
+    while True:
+        await sem.acquire()
+        try:
+            item = await asyncio.to_thread(client.lpop, REDIS_QUEUE_KEY)
+        except asyncio.CancelledError:
+            sem.release()
+            raise
+        except Exception as e:
+            logger.error("HLS consumer: poll error: %s", e)
+            sem.release()
+            await asyncio.sleep(poll_seconds)
+            continue
+        if not item:
+            sem.release()
+            await asyncio.sleep(poll_seconds)
+            continue
+        activity_uuid = item.decode() if isinstance(item, (bytes, bytearray)) else item
+        task = asyncio.create_task(_run(activity_uuid))  # releases the permit when done
+        _consumer_children.add(task)
+        task.add_done_callback(_consumer_children.discard)
+
+
+async def _requeue_stale_processing(stale_after: int = STALE_PROCESSING_SECONDS) -> int:
+    """Re-enqueue hosted videos stuck in 'processing' longer than `stale_after`
+    (their pod died mid-transcode). Idempotent: transcode overwrites the output."""
+    from datetime import datetime, timezone
+    client = get_redis_client()
+    if not client:
+        return 0
+    now = datetime.now(timezone.utc)
+    requeued = 0
+    async with _async_session_factory() as db:
+        rows = (await db.execute(
+            select(Activity).where(
+                Activity.activity_sub_type == ActivitySubTypeEnum.SUBTYPE_VIDEO_HOSTED
+            )
+        )).scalars().all()
+        for a in rows:
+            hls = (a.extra_metadata or {}).get("hls") or {}
+            if hls.get("status") != "processing":
+                continue
+            ts = hls.get("updated_at")
+            try:
+                age = (now - datetime.fromisoformat(ts)).total_seconds() if ts else 1e9
+            except (TypeError, ValueError):
+                age = 1e9
+            if age >= stale_after:
+                # Mark queued (fresh timestamp) so other pods' reapers don't also
+                # grab it, then push to the queue.
+                meta = dict(a.extra_metadata or {})
+                meta["hls"] = {**hls, "status": "queued", "updated_at": now.isoformat()}
+                a.extra_metadata = meta
+                db.add(a)
+                await db.commit()
+                try:
+                    client.rpush(REDIS_QUEUE_KEY, a.activity_uuid)
+                    requeued += 1
+                except Exception:
+                    pass
+    if requeued:
+        logger.info("HLS reaper: re-enqueued %s stale 'processing' job(s)", requeued)
+    return requeued
+
+
+async def _reaper_loop(interval: int = REAPER_INTERVAL_SECONDS) -> None:
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            await _requeue_stale_processing()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error("HLS reaper error: %s", e)
+
+
+def start_consumer() -> None:
+    """Start the in-app HLS consumer + stale-job reaper (call from app startup).
+    Idempotent no-op when HLS is disabled or Redis is unavailable."""
+    global _consumer_task, _reaper_task
+    if not hls_enabled():
+        return
+    if not get_redis_client():
+        logger.warning("HLS enabled but no Redis; in-app consumer not started")
+        return
+    if not (_consumer_task and not _consumer_task.done()):
+        _consumer_task = asyncio.create_task(_consumer_loop())
+    if not (_reaper_task and not _reaper_task.done()):
+        _reaper_task = asyncio.create_task(_reaper_loop())
+
+
+async def stop_consumer() -> None:
+    """Cancel the consumer/reaper and re-enqueue in-flight jobs so a pod
+    shutdown (deploy/autoscale) never orphans a transcode (call from shutdown)."""
+    global _consumer_task, _reaper_task
+    # Re-enqueue in-flight jobs FIRST so they survive this pod's termination.
+    client = get_redis_client()
+    if client and _inflight:
+        for uuid in list(_inflight):
+            try:
+                client.rpush(REDIS_QUEUE_KEY, uuid)
+            except Exception:
+                pass
+    for t in (_consumer_task, _reaper_task):
+        if t:
+            t.cancel()
+            try:
+                await t
+            except asyncio.CancelledError:
+                pass
+    _consumer_task = None
+    _reaper_task = None
+    if _consumer_children:
+        await asyncio.gather(*list(_consumer_children), return_exceptions=True)
+
+
+async def _pending_targets(limit: int = 0) -> list[str]:
+    """UUIDs of hosted-video activities that aren't `ready` and have a file."""
+    async with _async_session_factory() as db:
+        activities = (
+            await db.execute(
+                select(Activity).where(
+                    Activity.activity_sub_type == ActivitySubTypeEnum.SUBTYPE_VIDEO_HOSTED
+                )
+            )
+        ).scalars().all()
+        # ((... or {}).get("hls") or {}) guards against extra_metadata={"hls": None}.
+        targets = [
+            a.activity_uuid
+            for a in activities
+            if ((a.extra_metadata or {}).get("hls") or {}).get("status") != "ready"
+            and (a.content or {}).get("filename")
+        ]
+    if limit and limit > 0:
+        targets = targets[:limit]
+    return targets
+
+
+async def enqueue_pending(limit: int = 0) -> dict:
+    """Enqueue every not-yet-ready hosted video for HLS. The in-app consumer
+    transcodes them in the background — this returns immediately."""
+    targets = await _pending_targets(limit)
+    client = get_redis_client()
+    if not client:
+        return {"pending": len(targets), "enqueued": 0, "error": "no_redis"}
+    enqueued = 0
+    for uuid in targets:
+        try:
+            client.rpush(REDIS_QUEUE_KEY, uuid)
+            enqueued += 1
+        except Exception as e:
+            logger.warning("HLS: could not enqueue %s: %s", uuid, e)
+    return {"pending": len(targets), "enqueued": enqueued}
+
+
+async def backfill(limit: int = 0) -> dict:
+    """Transcode existing not-ready hosted videos INLINE (sequential).
+
+    Kept for one-off CLI use / tests. The normal path is enqueue_pending(), which
+    hands work to the in-app background consumer instead of blocking here.
+    """
+    targets = await _pending_targets(limit)
+    done = failed = 0
+    for uuid in targets:
+        if await transcode_activity(uuid):
+            done += 1
+        else:
+            failed += 1
+    return {"total": len(targets), "done": done, "failed": failed}

--- a/apps/api/src/services/utils/hls_jobs.py
+++ b/apps/api/src/services/utils/hls_jobs.py
@@ -54,14 +54,48 @@ _consumer_children: set = set()
 # termination (deploy/autoscale) never leaves a job stuck at "processing".
 _inflight: set = set()
 
-# A job left in "processing" longer than this (no heartbeat) is considered
-# orphaned (its pod died) and re-enqueued by the reaper.
-STALE_PROCESSING_SECONDS = 20 * 60
 REAPER_INTERVAL_SECONDS = 5 * 60
 CONSUMER_POLL_SECONDS = 2
 # Hard ceiling for a single transcode job; bounds any hang so the consumer slot
-# always frees (the reaper re-queues anything left stale).
+# always frees (the reconciler re-queues anything left unfinished).
 JOB_TIMEOUT_SECONDS = 40 * 60
+
+# Reconciliation: a running transcode holds a heartbeated Redis "lease" so the
+# reconciler can tell active work from an interrupted job WITHOUT relying on
+# stale timestamps (a slow 1-thread encode can outlive any fixed staleness
+# window). The lease expires shortly after a pod dies, so its job is re-queued
+# fast. Retries are capped so a genuinely broken video can't loop forever.
+LEASE_TTL_SECONDS = 180
+LEASE_HEARTBEAT_SECONDS = 60
+
+
+def hls_max_retries() -> int:
+    """Max auto-retries per video before the reconciler gives up
+    (LEARNHOUSE_HLS_MAX_RETRIES, default 6)."""
+    try:
+        return max(1, int(os.environ.get("LEARNHOUSE_HLS_MAX_RETRIES", "6")))
+    except (TypeError, ValueError):
+        return 6
+
+
+def _lease_key(activity_uuid: str) -> str:
+    return f"learnhouse:hls:lease:{activity_uuid}"
+
+
+def _retries_key(activity_uuid: str) -> str:
+    return f"learnhouse:hls:retries:{activity_uuid}"
+
+
+async def _lease_heartbeat(client, key: str) -> None:
+    """Refresh the processing lease's TTL until cancelled."""
+    try:
+        while True:
+            await asyncio.sleep(LEASE_HEARTBEAT_SECONDS)
+            await asyncio.to_thread(client.expire, key, LEASE_TTL_SECONDS)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        pass
 
 
 def _flag(name: str) -> bool:
@@ -162,6 +196,18 @@ async def transcode_activity(activity_uuid: str) -> bool:
     src_key = f"{base}/{filename}"
     hls_prefix = f"{base}/hls"
 
+    # Hold a heartbeated lease so the reconciler knows this job is actively
+    # running; it expires shortly after this pod dies, prompting a fast retry.
+    client = get_redis_client()
+    lease = _lease_key(activity_uuid)
+    heartbeat = None
+    if client:
+        try:
+            client.set(lease, "1", ex=LEASE_TTL_SECONDS)
+            heartbeat = asyncio.create_task(_lease_heartbeat(client, lease))
+        except Exception:
+            heartbeat = None
+
     await _set_status(activity_uuid, "processing")
     try:
         with tempfile.TemporaryDirectory() as td:
@@ -192,12 +238,25 @@ async def transcode_activity(activity_uuid: str) -> bool:
             master=result["master"], renditions=result["renditions"],
             thumbnails=result.get("thumbnails"),
         )
+        if client:
+            try:
+                client.delete(_retries_key(activity_uuid))  # success clears the retry count
+            except Exception:
+                pass
         logger.info("HLS ready for activity %s (%s)", activity_uuid, ",".join(result["renditions"]))
         return True
     except Exception as e:
         logger.error("HLS job crashed for %s: %s", activity_uuid, e)
         await _set_status(activity_uuid, "failed", error="exception")
         return False
+    finally:
+        if heartbeat:
+            heartbeat.cancel()
+        if client:
+            try:
+                client.delete(lease)
+            except Exception:
+                pass
 
 
 def enqueue(activity_uuid: str) -> None:
@@ -285,15 +344,34 @@ async def _consumer_loop(poll_seconds: int = CONSUMER_POLL_SECONDS) -> None:
         task.add_done_callback(_consumer_children.discard)
 
 
-async def _requeue_stale_processing(stale_after: int = STALE_PROCESSING_SECONDS) -> int:
-    """Re-enqueue hosted videos stuck in 'processing' longer than `stale_after`
-    (their pod died mid-transcode). Idempotent: transcode overwrites the output."""
-    from datetime import datetime, timezone
+async def reconcile_unfinished(max_retries: Optional[int] = None) -> dict:
+    """Re-poll for hosted videos whose HLS isn't `ready` and (re)queue them —
+    the clean auto-retry system that replaces manual re-triggering.
+
+    Per video it:
+      * skips ones that are `ready`, already queued, or actively transcoding
+        (a live heartbeated processing lease exists);
+      * otherwise (re)queues it — interrupted `processing`, `failed`, a lost
+        `queued`, or never-started (no hls) — bumping a Redis retry counter;
+      * gives up after `max_retries` so a genuinely broken file can't loop
+        forever (a successful transcode clears that video's counter).
+
+    Returns {requeued, skipped, gaveup}.
+    """
+    if max_retries is None:
+        max_retries = hls_max_retries()
     client = get_redis_client()
     if not client:
-        return 0
+        return {"requeued": 0, "skipped": 0, "gaveup": 0, "error": "no_redis"}
     now = datetime.now(timezone.utc)
-    requeued = 0
+    # Snapshot what's already waiting so we never double-queue an item.
+    try:
+        raw = client.lrange(REDIS_QUEUE_KEY, 0, -1)
+        pending = {(x.decode() if isinstance(x, (bytes, bytearray)) else x) for x in raw}
+    except Exception:
+        pending = set()
+
+    requeued = skipped = gaveup = 0
     async with _async_session_factory() as db:
         rows = (await db.execute(
             select(Activity).where(
@@ -301,41 +379,59 @@ async def _requeue_stale_processing(stale_after: int = STALE_PROCESSING_SECONDS)
             )
         )).scalars().all()
         for a in rows:
-            hls = (a.extra_metadata or {}).get("hls") or {}
-            if hls.get("status") != "processing":
+            if not (a.content or {}).get("filename"):
                 continue
-            ts = hls.get("updated_at")
+            hls = (a.extra_metadata or {}).get("hls") or {}
+            if hls.get("status") == "ready":
+                continue
+            uuid = a.activity_uuid
+            if uuid in pending:
+                skipped += 1
+                continue
             try:
-                age = (now - datetime.fromisoformat(ts)).total_seconds() if ts else 1e9
-            except (TypeError, ValueError):
-                age = 1e9
-            if age >= stale_after:
-                # Mark queued (fresh timestamp) so other pods' reapers don't also
-                # grab it, then push to the queue.
-                meta = dict(a.extra_metadata or {})
-                meta["hls"] = {**hls, "status": "queued", "updated_at": now.isoformat()}
-                a.extra_metadata = meta
-                db.add(a)
-                await db.commit()
-                try:
-                    client.rpush(REDIS_QUEUE_KEY, a.activity_uuid)
-                    requeued += 1
-                except Exception:
-                    pass
-    if requeued:
-        logger.info("HLS reaper: re-enqueued %s stale 'processing' job(s)", requeued)
-    return requeued
+                if client.exists(_lease_key(uuid)):  # actively transcoding somewhere
+                    skipped += 1
+                    continue
+            except Exception:
+                pass
+            # Retry cap, tracked in Redis so status writes can't clobber it.
+            rkey = _retries_key(uuid)
+            try:
+                retries = int(client.get(rkey) or 0)
+            except Exception:
+                retries = 0
+            if retries >= max_retries:
+                gaveup += 1
+                continue
+            try:
+                client.incr(rkey)
+                client.expire(rkey, 7 * 24 * 3600)
+            except Exception:
+                pass
+            meta = dict(a.extra_metadata or {})
+            meta["hls"] = {**hls, "status": "queued", "updated_at": now.isoformat()}
+            a.extra_metadata = meta  # reassign so SQLAlchemy detects the JSONB change
+            db.add(a)
+            await db.commit()
+            try:
+                client.rpush(REDIS_QUEUE_KEY, uuid)
+                requeued += 1
+            except Exception:
+                pass
+    if requeued or gaveup:
+        logger.info("HLS reconcile: requeued=%s gaveup=%s skipped=%s", requeued, gaveup, skipped)
+    return {"requeued": requeued, "skipped": skipped, "gaveup": gaveup}
 
 
-async def _reaper_loop(interval: int = REAPER_INTERVAL_SECONDS) -> None:
+async def _reconcile_loop(interval: int = REAPER_INTERVAL_SECONDS) -> None:
     while True:
         await asyncio.sleep(interval)
         try:
-            await _requeue_stale_processing()
+            await reconcile_unfinished()
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            logger.error("HLS reaper error: %s", e)
+            logger.error("HLS reconcile error: %s", e)
 
 
 def start_consumer() -> None:
@@ -350,7 +446,7 @@ def start_consumer() -> None:
     if not (_consumer_task and not _consumer_task.done()):
         _consumer_task = asyncio.create_task(_consumer_loop())
     if not (_reaper_task and not _reaper_task.done()):
-        _reaper_task = asyncio.create_task(_reaper_loop())
+        _reaper_task = asyncio.create_task(_reconcile_loop())
 
 
 async def stop_consumer() -> None:

--- a/apps/api/src/services/utils/hls_playlist.py
+++ b/apps/api/src/services/utils/hls_playlist.py
@@ -1,0 +1,121 @@
+"""
+HLS playlist rewriting for auth-preserving delivery.
+
+The API serves `.m3u8` playlists after an RBAC check; segments are streamed
+directly from R2 via presigned URLs. To make that work we rewrite each playlist:
+
+- A segment reference (`.ts` / `.m4s`) → a presigned R2 URL, so the player pulls
+  segments straight from R2 with no per-segment API round-trip.
+- A nested playlist reference (`.m3u8`, i.e. master → rendition) → left relative,
+  so it re-enters the API endpoint and gets its own RBAC + presign pass.
+- Comments (`#...`), blank lines, and absolute URLs are passed through untouched.
+
+Segment/playlist paths are relative to the *directory of the playlist being
+served*, mirroring the on-disk/R2 layout.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+_SEGMENT_SUFFIXES = (".ts", ".m4s", ".mp4")
+_PLAYLIST_SUFFIXES = (".m3u8",)
+
+
+def rewrite_playlist(
+    text: str,
+    playlist_dir_key: str,
+    presign: Callable[[str], str | None],
+) -> str:
+    """
+    Rewrite a playlist's URIs.
+
+    Args:
+        text: raw .m3u8 contents.
+        playlist_dir_key: R2 key of the directory containing this playlist
+            (no trailing slash), e.g. "content/orgs/.../video/hls/v720p".
+        presign: maps an absolute R2 key → presigned URL (or None on failure).
+
+    Returns the rewritten playlist. Lines whose segment fails to presign are
+    left as-is (the player will simply fail that segment rather than the load).
+    """
+    base = playlist_dir_key.rstrip("/")
+    # Containment root: nothing a playlist references may resolve above the
+    # activity's HLS dir (defense-in-depth against a tampered playlist using ../
+    # to presign cross-tenant objects).
+    idx = base.rfind("/hls")
+    root = base[: idx + len("/hls")] if idx != -1 else base
+
+    def _sign_relative(uri: str) -> str | None:
+        key = _resolve_key(base, uri, root)
+        return presign(key) if key else None
+
+    out_lines: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            out_lines.append(line)
+            continue
+        if stripped.startswith("#"):
+            # Defense: fMP4 init segments live in an #EXT-X-MAP:URI="..." tag.
+            # (We emit TS, so this normally never fires — future-proofing.)
+            if stripped.upper().startswith("#EXT-X-MAP:"):
+                out_lines.append(_rewrite_map_tag(line, _sign_relative))
+            else:
+                out_lines.append(line)
+            continue
+        # Absolute or protocol-relative URLs pass through untouched.
+        low = stripped.lower()
+        if low.startswith("http://") or low.startswith("https://") or stripped.startswith("//"):
+            out_lines.append(line)
+            continue
+
+        # Extension test ignores any ?query/#fragment on the URI.
+        path_part = stripped.split("?", 1)[0].split("#", 1)[0].lower()
+        if path_part.endswith(_SEGMENT_SUFFIXES):
+            signed = _sign_relative(stripped)
+            out_lines.append(signed if signed else line)
+        else:
+            # Nested playlists (.m3u8) and anything else stay relative so they
+            # re-enter the API endpoint.
+            out_lines.append(line)
+    return "\n".join(out_lines) + "\n"
+
+
+def _rewrite_map_tag(line: str, sign_relative) -> str:
+    """Presign the URI="..." of an #EXT-X-MAP tag, leaving the rest intact."""
+    import re
+    m = re.search(r'URI="([^"]+)"', line)
+    if not m:
+        return line
+    uri = m.group(1)
+    low = uri.lower()
+    if low.startswith("http://") or low.startswith("https://") or uri.startswith("//"):
+        return line
+    signed = sign_relative(uri)
+    if not signed:
+        return line
+    return line[: m.start(1)] + signed + line[m.end(1):]
+
+
+def _resolve_key(base_dir_key: str, relative: str, root: str | None = None) -> str | None:
+    """Join a relative URI onto a base key, resolving ./ and ../ segments.
+
+    Returns None if the result escapes `root` (when given) — callers treat that
+    like a failed presign and leave the line unchanged.
+    """
+    # Drop any query/fragment before resolving.
+    relative = relative.split("?", 1)[0].split("#", 1)[0]
+    parts = base_dir_key.split("/")
+    for part in relative.split("/"):
+        if part in ("", "."):
+            continue
+        if part == "..":
+            if parts:
+                parts.pop()
+            continue
+        parts.append(part)
+    resolved = "/".join(parts)
+    if root is not None and not (resolved == root or resolved.startswith(root + "/")):
+        return None
+    return resolved

--- a/apps/api/src/services/utils/hls_transcode.py
+++ b/apps/api/src/services/utils/hls_transcode.py
@@ -1,0 +1,374 @@
+"""
+HLS transcoding.
+
+Turns a source video into an adaptive HLS ladder: a master playlist plus one
+rendition (index playlist + .ts segments) per quality level, so the player can
+switch quality to match live bandwidth instead of stalling.
+
+Everything here is CPU-heavy and slow — it is meant to run in a worker/CLI, not
+in a request. The ladder is *source-capped*: we never upscale, and the top rung
+never exceeds the source resolution.
+"""
+
+import asyncio
+import json
+import subprocess
+import logging
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Rung:
+    name: str          # e.g. "720p" → rendition dir "v720p"
+    height: int
+    v_bitrate: str     # target video bitrate
+    v_maxrate: str
+    v_bufsize: str
+
+
+# Standard 16:9 ladder. Widths are derived by ffmpeg (scale=-2:h) so non-16:9
+# sources keep their aspect ratio.
+_LADDER: tuple[Rung, ...] = (
+    Rung("1080p", 1080, "5000k", "5350k", "7500k"),
+    Rung("720p", 720, "2800k", "3000k", "4200k"),
+    Rung("480p", 480, "1400k", "1500k", "2100k"),
+    Rung("360p", 360, "800k", "856k", "1200k"),
+)
+
+HLS_SEGMENT_SECONDS = 6
+MASTER_PLAYLIST_NAME = "master.m3u8"
+
+# Hover-scrub preview sprite (a grid of small frames the player shows when the
+# user scrubs the progress bar, YouTube-style).
+THUMBS_DIR = "thumbnails"
+THUMBS_SPRITE = "sprite.jpg"
+THUMB_INTERVAL_SECONDS = 10
+THUMB_WIDTH = 160
+THUMB_HEIGHT = 90
+THUMB_COLUMNS = 10
+
+# AES-128 segment encryption. The key lives in the private bucket and is only
+# handed out by the authed key endpoint — a deterrent against casual segment
+# stitching (not DRM). The URI is relative so it resolves back to our API from
+# a rendition playlist at v{name}/index.m3u8.
+ENC_KEY_NAME = "enc.key"
+ENC_KEY_URI = f"../{ENC_KEY_NAME}"
+
+
+def encryption_enabled() -> bool:
+    return os.environ.get("LEARNHOUSE_HLS_ENCRYPT", "true").strip().lower() == "true"
+
+
+# Subprocess timeouts so a malformed/hostile source can never hang the worker.
+PROBE_TIMEOUT_S = 120
+SPRITE_TIMEOUT_S = 30 * 60
+TRANSCODE_TIMEOUT_S = 6 * 60 * 60
+
+
+async def _run_subprocess(args, timeout: int):
+    """Run a subprocess and return (returncode, stdout, stderr).
+
+    Uses a blocking `subprocess.run` on a worker thread rather than
+    `asyncio.create_subprocess_exec`: the async variant can hang indefinitely
+    when spawned from a server (uvicorn) event loop whose child watcher isn't
+    reliably attached — which stalled every in-app transcode before ffmpeg even
+    started. Running in a thread keeps the event loop free AND sidesteps asyncio's
+    subprocess machinery entirely. On timeout the process is killed and the
+    return code is -1.
+    """
+    def _run():
+        try:
+            p = subprocess.run(args, capture_output=True, timeout=timeout)
+            return p.returncode, p.stdout or b"", p.stderr or b""
+        except subprocess.TimeoutExpired as e:
+            return -1, (e.stdout or b""), (e.stderr or b"")
+
+    return await asyncio.to_thread(_run)
+
+
+def _ffmpeg() -> Optional[str]:
+    return shutil.which("ffmpeg")
+
+
+def _ffprobe() -> Optional[str]:
+    return shutil.which("ffprobe")
+
+
+def select_ladder(source_height: int) -> list[Rung]:
+    """Pick rungs no taller than the source; always keep at least the lowest.
+
+    A 1080p source yields all four rungs; a 540p source yields 480p+360p; a tiny
+    source yields just the smallest rung (never upscaled).
+    """
+    rungs = [r for r in _LADDER if r.height <= source_height]
+    if not rungs:
+        rungs = [_LADDER[-1]]  # smallest, for very small sources
+    return rungs
+
+
+def ffmpeg_threads() -> str:
+    """ffmpeg `-threads` value (LEARNHOUSE_HLS_FFMPEG_THREADS, default '1').
+
+    Kept as a string for the arg list; sanitized to a small non-negative int
+    ('0' means ffmpeg auto = all cores)."""
+    raw = os.environ.get("LEARNHOUSE_HLS_FFMPEG_THREADS", "1")
+    try:
+        return str(max(0, int(raw)))
+    except (TypeError, ValueError):
+        return "1"
+
+
+def build_ffmpeg_args(
+    src_path: str, out_dir: str, rungs: list[Rung], has_audio: bool,
+    key_info_file: Optional[str] = None,
+) -> list[str]:
+    """Build the single-invocation ffmpeg command for the whole ladder.
+
+    Output layout under out_dir: master.m3u8, v{name}/index.m3u8, v{name}/seg_*.ts
+    (relative refs — master → rendition playlists, rendition → segments).
+
+    When key_info_file is given, segments are AES-128 encrypted and the playlists
+    carry an #EXT-X-KEY pointing at the (authed) key URI from that file.
+    """
+    n = len(rungs)
+    split_labels = "".join(f"[v{i}]" for i in range(n))
+    filters = [f"[0:v]split={n}{split_labels}"]
+    for i, r in enumerate(rungs):
+        # -2 keeps width even and aspect ratio intact.
+        filters.append(f"[v{i}]scale=-2:{r.height}[v{i}out]")
+    filter_complex = ";".join(filters)
+
+    args = [_ffmpeg() or "ffmpeg", "-y", "-loglevel", "error", "-i", src_path,
+            "-filter_complex", filter_complex]
+    # Cap CPU so a transcode doesn't peg the whole pod (which spikes the API
+    # autoscaler). Default 1 thread ≈ ~1 core instead of ~all cores; raise via
+    # LEARNHOUSE_HLS_FFMPEG_THREADS if you have headroom and want faster encodes.
+    args += ["-threads", ffmpeg_threads()]
+
+    for i, r in enumerate(rungs):
+        args += [
+            "-map", f"[v{i}out]",
+            f"-c:v:{i}", "libx264", "-preset", "veryfast",
+            f"-b:v:{i}", r.v_bitrate, f"-maxrate:v:{i}", r.v_maxrate,
+            f"-bufsize:v:{i}", r.v_bufsize,
+            f"-g:v:{i}", "48", f"-keyint_min:v:{i}", "48",
+            f"-sc_threshold:v:{i}", "0",
+        ]
+
+    var_parts = []
+    if has_audio:
+        for i in range(n):
+            args += ["-map", "a:0"]
+        args += ["-c:a", "aac", "-b:a", "128k", "-ac", "2"]
+        var_parts = [f"v:{i},a:{i},name:{r.name}" for i, r in enumerate(rungs)]
+    else:
+        var_parts = [f"v:{i},name:{r.name}" for i, r in enumerate(rungs)]
+
+    args += [
+        "-f", "hls",
+        "-hls_time", str(HLS_SEGMENT_SECONDS),
+        "-hls_playlist_type", "vod",
+        "-hls_flags", "independent_segments",
+        "-master_pl_name", MASTER_PLAYLIST_NAME,
+        "-hls_segment_filename", os.path.join(out_dir, "v%v", "seg_%04d.ts"),
+        "-var_stream_map", " ".join(var_parts),
+    ]
+    if key_info_file:
+        args += ["-hls_key_info_file", key_info_file]
+    args.append(os.path.join(out_dir, "v%v", "index.m3u8"))
+    return args
+
+
+async def _probe(src_path: str) -> tuple[int, bool, float]:
+    """Return (height, has_audio, duration_s).
+
+    On any probe failure returns (0, False, 0.0): height 0 → a single lowest
+    rung (never upscale a source we can't measure), and has_audio False → no
+    audio maps (so a silent source can't fail the transcode with a bad a:0 map).
+    """
+    probe = _ffprobe()
+    if not probe:
+        return 0, False, 0.0
+    try:
+        rc, out, _ = await _run_subprocess(
+            [probe, "-v", "error", "-show_streams", "-show_format", "-of", "json", src_path],
+            PROBE_TIMEOUT_S,
+        )
+        if rc != 0:
+            return 0, False, 0.0
+    except Exception:
+        return 0, False, 0.0
+    try:
+        data = json.loads(out.decode() or "{}")
+    except json.JSONDecodeError:
+        return 0, False, 0.0
+    streams = data.get("streams", [])
+    height = 0
+    has_audio = False
+    for s in streams:
+        if s.get("codec_type") == "video":
+            height = max(height, int(s.get("height") or 0))
+        elif s.get("codec_type") == "audio":
+            has_audio = True
+    try:
+        duration = float(data.get("format", {}).get("duration") or 0.0)
+    except (TypeError, ValueError):
+        duration = 0.0
+    return height, has_audio, duration
+
+
+# Cap the sprite at a sane cell count so a multi-hour video can't produce a
+# gigantic JPEG shipped to every scrubbing viewer.
+MAX_THUMBNAILS = 400
+
+
+def thumbnails_grid(duration_s: float, interval: int = THUMB_INTERVAL_SECONDS,
+                    columns: int = THUMB_COLUMNS) -> tuple[int, int]:
+    """Return (columns, rows) for a sprite covering the whole duration.
+
+    Guards against interval/columns <= 0 (fall back to 1) so callers can't hit a
+    ZeroDivisionError.
+    """
+    import math
+    interval = max(1, int(interval))
+    columns = max(1, int(columns))
+    frames = max(1, math.ceil(max(duration_s, 0.0) / interval)) if duration_s else 1
+    rows = max(1, math.ceil(frames / columns))
+    return columns, rows
+
+
+def _sprite_interval(duration_s: float, interval: int, columns: int) -> int:
+    """Pick a sprite interval: shrink for short clips (so fps yields frames),
+    grow for very long clips so the sprite stays under MAX_THUMBNAILS cells."""
+    import math
+    interval = max(1, int(interval))
+    if duration_s and duration_s < interval:
+        return max(1, int(duration_s // 2) or 1)
+    if duration_s:
+        frames = math.ceil(duration_s / interval)
+        if frames > MAX_THUMBNAILS:
+            interval = max(interval, math.ceil(duration_s / MAX_THUMBNAILS))
+    return interval
+
+
+async def generate_sprite_thumbnails(
+    src_path: str, out_dir: str, duration_s: float,
+    interval: int = THUMB_INTERVAL_SECONDS,
+    width: int = THUMB_WIDTH, height: int = THUMB_HEIGHT,
+    columns: int = THUMB_COLUMNS,
+) -> Optional[dict]:
+    """
+    Build a single sprite sheet of evenly-spaced frames for progress-bar hover
+    previews. Returns the videojs-sprite-thumbnails config (relative url,
+    interval, width, height, columns, rows) or None on failure. Never raises.
+    """
+    if not _ffmpeg():
+        return None
+    # Shrink for short clips (fps must yield ≥1 frame) and grow for very long
+    # ones (keep the sprite under MAX_THUMBNAILS cells).
+    interval = _sprite_interval(duration_s, interval, columns)
+    cols, rows = thumbnails_grid(duration_s, interval, columns)
+    dest_dir = os.path.join(out_dir, THUMBS_DIR)
+    os.makedirs(dest_dir, exist_ok=True)
+    sprite_path = os.path.join(dest_dir, THUMBS_SPRITE)
+    # One frame per `interval`s, letterboxed into uniform WxH cells, tiled to a
+    # grid. `format=yuvj420p` gives the mjpeg encoder the full-range YUV it needs
+    # (avoids "Non full-range YUV is non-standard" failures on some sources).
+    vf = (
+        f"fps=1/{interval},"
+        f"scale={width}:{height}:force_original_aspect_ratio=decrease,"
+        f"pad={width}:{height}:(ow-iw)/2:(oh-ih)/2,"
+        f"tile={cols}x{rows},"
+        f"format=yuvj420p"
+    )
+    try:
+        rc, _, stderr = await _run_subprocess(
+            [_ffmpeg(), "-y", "-loglevel", "error", "-i", src_path,
+             "-vf", vf, "-frames:v", "1", "-an", sprite_path],
+            SPRITE_TIMEOUT_S,
+        )
+        if rc != 0 or not os.path.isfile(sprite_path):
+            logger.warning("Sprite thumbnail generation failed (rc=%s): %s",
+                           rc, (stderr or b"").decode()[:500])
+            return None
+    except Exception as e:
+        logger.warning("Sprite thumbnail error for %s: %s", src_path, e)
+        return None
+    return {
+        "url": f"{THUMBS_DIR}/{THUMBS_SPRITE}",
+        "interval": interval, "width": width, "height": height,
+        "columns": cols, "rows": rows,
+    }
+
+
+async def transcode_source_to_hls(src_path: str, out_dir: str) -> Optional[dict]:
+    """
+    Transcode src_path into an HLS ladder under out_dir.
+
+    Returns {"master": "master.m3u8", "renditions": ["720p", ...]} on success,
+    or None on failure (caller keeps the MP4 fallback). Never raises.
+    """
+    if not _ffmpeg():
+        logger.error("ffmpeg not available; cannot transcode %s", src_path)
+        return None
+    if not os.path.isfile(src_path):
+        logger.error("HLS source missing: %s", src_path)
+        return None
+
+    height, has_audio, duration = await _probe(src_path)
+    rungs = select_ladder(height)
+    os.makedirs(out_dir, exist_ok=True)
+    for r in rungs:
+        os.makedirs(os.path.join(out_dir, f"v{r.name}"), exist_ok=True)
+
+    # Optional AES-128 encryption: write a random key into out_dir (uploaded to
+    # the private bucket, served only via the authed key endpoint) and a keyinfo
+    # file (kept out of out_dir so it isn't uploaded).
+    keyinfo_path = None
+    if encryption_enabled():
+        key_path = os.path.join(out_dir, ENC_KEY_NAME)
+        with open(key_path, "wb") as kf:
+            kf.write(os.urandom(16))
+        fd, keyinfo_path = tempfile.mkstemp(suffix=".keyinfo")
+        with os.fdopen(fd, "w") as info:
+            info.write(f"{ENC_KEY_URI}\n{key_path}\n")
+
+    args = build_ffmpeg_args(src_path, out_dir, rungs, has_audio, key_info_file=keyinfo_path)
+    logger.info("Transcoding %s → HLS %s (%s%s)", src_path, out_dir,
+                ",".join(r.name for r in rungs),
+                ", encrypted" if keyinfo_path else "")
+    try:
+        rc, _, stderr = await _run_subprocess(args, TRANSCODE_TIMEOUT_S)
+        if rc != 0:
+            logger.error("ffmpeg HLS transcode failed (rc=%s): %s",
+                         rc, (stderr or b"").decode()[:1000])
+            return None
+    except Exception as e:
+        logger.error("HLS transcode error for %s: %s", src_path, e)
+        return None
+    finally:
+        if keyinfo_path and os.path.exists(keyinfo_path):
+            try:
+                os.remove(keyinfo_path)
+            except OSError:
+                pass
+
+    master = os.path.join(out_dir, MASTER_PLAYLIST_NAME)
+    if not os.path.isfile(master):
+        logger.error("HLS transcode produced no master playlist for %s", src_path)
+        return None
+
+    # Best-effort hover-preview sprite; playback works fine without it.
+    thumbnails = await generate_sprite_thumbnails(src_path, out_dir, duration)
+
+    return {
+        "master": MASTER_PLAYLIST_NAME,
+        "renditions": [r.name for r in rungs],
+        "thumbnails": thumbnails,
+    }

--- a/apps/api/src/services/utils/upload_content.py
+++ b/apps/api/src/services/utils/upload_content.py
@@ -1,14 +1,37 @@
+import asyncio
 import logging
 from typing import Literal, Optional
 import boto3
 import botocore.config
-from botocore.exceptions import ClientError
+from botocore.exceptions import BotoCoreError, ClientError
 import os
 from fastapi import HTTPException, UploadFile
 from config.config import get_learnhouse_config
 from src.security.file_validation import validate_upload
+from src.services.utils.video_processing import ensure_faststart
 
 logger = logging.getLogger(__name__)
+
+
+_CONTENT_ROOT = "content"
+
+
+def _safe_content_path(*parts: str) -> str:
+    """Build a path under the content root and confirm (via realpath +
+    commonpath) that user-supplied parts can't escape it. Returns the
+    canonicalized absolute path; raises HTTP 400 on any traversal attempt."""
+    for part in parts:
+        if part is None or "\x00" in part or ".." in str(part).replace("\\", "/").split("/"):
+            raise HTTPException(status_code=400, detail="Invalid file path")
+    base_real = os.path.realpath(_CONTENT_ROOT)
+    full_real = os.path.realpath(os.path.join(_CONTENT_ROOT, *parts))
+    try:
+        contained = full_real == base_real or os.path.commonpath([base_real, full_real]) == base_real
+    except ValueError:
+        contained = False
+    if not contained:
+        raise HTTPException(status_code=400, detail="Invalid file path")
+    return full_real
 
 
 def ensure_directory_exists(directory: str):
@@ -87,16 +110,21 @@ async def upload_content(
                 detail=f"File format {file_format} not allowed",
             )
 
-    ensure_directory_exists(f"content/{type_of_dir}/{uuid}/{directory}")
+    # Canonicalize + containment-check the destination so a crafted filename or
+    # directory can't escape the content root (prevents path traversal).
+    safe_dir = _safe_content_path(type_of_dir, uuid, directory)
+    ensure_directory_exists(safe_dir)
+    safe_path = _safe_content_path(type_of_dir, uuid, directory, file_and_format)
 
     if content_delivery == "filesystem":
         # upload file to server
-        with open(
-            f"content/{type_of_dir}/{uuid}/{directory}/{file_and_format}",
-            "wb",
-        ) as f:
+        with open(safe_path, "wb") as f:
             f.write(file_binary)
             f.close()
+        # Move the MP4 index atom to the front so long videos stream/seek
+        # smoothly over HTTP (no-op for non-MP4 and when ffmpeg is absent).
+        # Runs in a thread — the ffmpeg subprocess must not block the event loop.
+        await asyncio.to_thread(ensure_faststart, safe_path)
 
     elif content_delivery == "s3api":
         s3 = boto3.client(
@@ -106,18 +134,25 @@ async def upload_content(
         )
 
         bucket_name = learnhouse_config.hosting_config.content_delivery.s3api.bucket_name or "learnhouse-media"
-        local_path = f"content/{type_of_dir}/{uuid}/{directory}/{file_and_format}"
-        s3_key = local_path
+        local_path = safe_path
+        # The S3 key stays a clean relative content path.
+        s3_key = f"content/{type_of_dir}/{uuid}/{directory}/{file_and_format}"
 
         # Write to local temp file for S3 upload
         with open(local_path, "wb") as f:
             f.write(file_binary)
 
+        # Move the MP4 index atom to the front before uploading so long videos
+        # stream/seek smoothly from R2 (no-op for non-MP4 and when ffmpeg is
+        # absent). Done on the temp file so the uploaded object is faststart.
+        # Threaded — the ffmpeg subprocess must not block the event loop.
+        await asyncio.to_thread(ensure_faststart, local_path)
+
         try:
-            s3.upload_file(local_path, bucket_name, s3_key)
-            s3.head_object(Bucket=bucket_name, Key=s3_key)
+            await asyncio.to_thread(s3.upload_file, local_path, bucket_name, s3_key)
+            await asyncio.to_thread(s3.head_object, Bucket=bucket_name, Key=s3_key)
             logger.debug("S3 upload successful: %s", s3_key)
-        except ClientError as e:
+        except (ClientError, BotoCoreError) as e:
             logger.error("S3 upload failed: %s", e)
             raise HTTPException(status_code=500, detail="File upload to storage failed")
         finally:

--- a/apps/api/src/services/utils/video_processing.py
+++ b/apps/api/src/services/utils/video_processing.py
@@ -1,0 +1,112 @@
+"""
+Video processing helpers.
+
+The main job here is "faststart": moving the MP4 `moov` atom (the index the
+player needs before it can decode/seek) from the end of the file to the front.
+Without it, a browser streaming a large MP4 over HTTP has to hunt for the index
+in a multi-hundred-MB/GB file before it can start or seek, producing long
+startup delays and stutter. `ffmpeg -c copy -movflags +faststart` rewrites the
+container losslessly (no re-encode) to fix this.
+
+Everything degrades gracefully: if ffmpeg is missing or the remux fails, the
+original file is left untouched so uploads never break because of it.
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Only MP4-family containers have a movable `moov` atom. WebM/Ogg/MKV stream
+# fine as-is and are left untouched.
+_FASTSTART_EXTENSIONS = {".mp4", ".mov", ".m4v", ".m4a"}
+
+# Read window used to detect whether `moov` already precedes `mdat`.
+_ATOM_SCAN_BYTES = 2 * 1024 * 1024  # 2MB
+
+
+def _ffmpeg_available() -> bool:
+    return shutil.which("ffmpeg") is not None
+
+
+def is_faststart(path: str) -> bool:
+    """
+    Best-effort check for whether an MP4's `moov` atom is already near the
+    front (i.e. before `mdat`). Reads only the first couple of MB. On any error
+    we return False so the caller attempts a remux rather than skipping.
+    """
+    try:
+        with open(path, "rb") as f:
+            head = f.read(_ATOM_SCAN_BYTES)
+    except OSError:
+        return False
+    moov = head.find(b"moov")
+    mdat = head.find(b"mdat")
+    # moov seen before mdat (or mdat not in the head window yet) → faststart.
+    return moov != -1 and (mdat == -1 or moov < mdat)
+
+
+def ensure_faststart(path: str) -> bool:
+    """
+    Rewrite an MP4-family file in place so the `moov` atom is at the front.
+
+    Returns True if the file is faststart afterwards (either already was, or we
+    remuxed it), False if it was left as-is (unsupported type, ffmpeg missing,
+    or remux failed). Never raises — callers treat this as best-effort.
+    """
+    ext = Path(path).suffix.lower()
+    if ext not in _FASTSTART_EXTENSIONS:
+        return False
+
+    if not os.path.isfile(path):
+        return False
+
+    if is_faststart(path):
+        return True
+
+    if not _ffmpeg_available():
+        logger.warning(
+            "ffmpeg not available; serving %s without faststart (may stream slowly)",
+            path,
+        )
+        return False
+
+    tmp_path = f"{path}.faststart{ext}"
+    try:
+        result = subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-loglevel", "error",
+                "-i", path,
+                "-c", "copy",
+                "-map", "0",
+                "-movflags", "+faststart",
+                tmp_path,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60 * 30,  # 30 min ceiling for very large files
+        )
+        if result.returncode == 0 and os.path.isfile(tmp_path) and os.path.getsize(tmp_path) > 0:
+            os.replace(tmp_path, path)
+            logger.info("Applied faststart to %s", path)
+            return True
+        logger.warning(
+            "faststart remux failed for %s (rc=%s): %s",
+            path, result.returncode, (result.stderr or "").strip()[:500],
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning("faststart remux timed out for %s", path)
+    except Exception as e:
+        logger.warning("faststart remux error for %s: %s", path, e)
+    finally:
+        if os.path.exists(tmp_path):
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+    return False

--- a/apps/api/src/services/utils/video_streaming.py
+++ b/apps/api/src/services/utils/video_streaming.py
@@ -50,6 +50,28 @@ def get_video_mime_type(file_path: str) -> str:
     return mime_types.get(extension, 'video/mp4')
 
 
+def is_range_unsatisfiable(range_header: Optional[str], file_size: int) -> bool:
+    """
+    Whether a Range request cannot be satisfied per RFC 7233 → caller returns 416.
+
+    Unsatisfiable when: the resource is empty (a Range over 0 bytes), or the
+    requested start is at/after EOF. Suffix ranges (bytes=-N) and malformed
+    headers are treated as satisfiable (fall through to normal handling / 200).
+    """
+    if not range_header:
+        return False
+    if file_size <= 0:
+        return True
+    spec = range_header.replace("bytes=", "").strip()
+    if spec.startswith("-"):  # suffix range — always satisfiable for size>0
+        return False
+    try:
+        start = int(spec.split("-")[0])
+    except (ValueError, IndexError):
+        return False
+    return start > file_size - 1
+
+
 def parse_range_header(range_header: Optional[str], file_size: int) -> Tuple[int, int]:
     """
     Parse the HTTP Range header to determine byte range.

--- a/apps/api/src/tests/core/test_core_events_runtime.py
+++ b/apps/api/src/tests/core/test_core_events_runtime.py
@@ -274,6 +274,12 @@ async def test_events_startup_shutdown_and_reconcile(monkeypatch):
         "src.services.courses.migration.migration_service.cleanup_old_temp_migrations",
         cleanup_temp_migrations,
     )
+    # The HLS + captions consumers only start when Redis is available; this test
+    # exercises the migration-cleanup lifecycle, so keep them no-ops (no Redis).
+    import src.services.utils.caption_jobs as _cap_jobs
+    import src.services.utils.hls_jobs as _hls_jobs
+    monkeypatch.setattr(_cap_jobs, "get_redis_client", lambda: None)
+    monkeypatch.setattr(_hls_jobs, "get_redis_client", lambda: None)
 
     start_app = core_events.startup_app(app)
     await start_app()

--- a/apps/api/src/tests/routers/test_stream_captions_router.py
+++ b/apps/api/src/tests/routers/test_stream_captions_router.py
@@ -1,0 +1,63 @@
+"""Router tests for the captions endpoint in src/routers/stream.py."""
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.core.events.database import get_db_session
+from src.routers import stream as stream_mod
+from src.routers.stream import router as stream_router
+from src.security.auth import get_current_user
+
+
+def _make_app(db, user):
+    app = FastAPI()
+    app.include_router(stream_router)
+    app.dependency_overrides[get_db_session] = lambda: db
+    app.dependency_overrides[get_current_user] = lambda: user
+    return app
+
+
+@pytest.fixture
+async def client_factory(db):
+    clients = []
+
+    async def _factory(user):
+        c = AsyncClient(transport=ASGITransport(app=_make_app(db, user)), base_url="http://test")
+        clients.append(c)
+        return c
+
+    yield _factory
+    for c in clients:
+        await c.aclose()
+
+
+def _url(org, course, activity, lang):
+    return f"/captions/{org.org_uuid}/{course.course_uuid}/{activity.activity_uuid}/{lang}.vtt"
+
+
+async def test_caption_track_served(client_factory, monkeypatch, org, course, chapter, activity, anonymous_user):
+    vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nHello\n"
+    monkeypatch.setattr(stream_mod, "read_file_content", lambda key: vtt.encode())
+    client = await client_factory(anonymous_user)
+    r = await client.get(_url(org, course, activity, "fr"))
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/vtt")
+    assert "Hello" in r.text
+
+
+async def test_caption_track_not_found(client_factory, monkeypatch, org, course, chapter, activity, anonymous_user):
+    monkeypatch.setattr(stream_mod, "read_file_content", lambda key: None)
+    client = await client_factory(anonymous_user)
+    r = await client.get(_url(org, course, activity, "es"))
+    assert r.status_code == 404
+
+
+async def test_caption_bad_lang_rejected(client_factory, monkeypatch, org, course, chapter, activity, anonymous_user):
+    # Must not even read content for an over-long / malformed lang token.
+    read = {"called": False}
+    monkeypatch.setattr(stream_mod, "read_file_content", lambda key: read.__setitem__("called", True) or b"x")
+    client = await client_factory(anonymous_user)
+    r = await client.get(_url(org, course, activity, "x" * 40))
+    assert r.status_code == 404
+    assert read["called"] is False

--- a/apps/api/src/tests/routers/test_stream_hls_router.py
+++ b/apps/api/src/tests/routers/test_stream_hls_router.py
@@ -1,0 +1,325 @@
+"""Router tests for the HLS endpoint in src/routers/stream.py."""
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.core.events.database import get_db_session
+from src.routers import stream as stream_mod
+from src.routers.stream import router as stream_router
+from src.security.auth import get_current_user
+
+
+def _make_app(db, user):
+    app = FastAPI()
+    app.include_router(stream_router)
+    app.dependency_overrides[get_db_session] = lambda: db
+    app.dependency_overrides[get_current_user] = lambda: user
+    return app
+
+
+@pytest.fixture
+async def client_factory(db):
+    clients = []
+
+    async def _factory(user):
+        app = _make_app(db, user)
+        c = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+        clients.append(c)
+        return c
+
+    yield _factory
+    for c in clients:
+        await c.aclose()
+
+
+def _url(org, course, activity, path):
+    return f"/hls/{org.org_uuid}/{course.course_uuid}/{activity.activity_uuid}/{path}"
+
+
+async def test_master_playlist_served_with_rendition_refs(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    master = "#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1\nv360p/index.m3u8\n"
+    monkeypatch.setattr(stream_mod, "read_file_content", lambda key: master.encode())
+    # Master has no .ts lines, so presign should not be needed; guard anyway.
+    monkeypatch.setattr(stream_mod, "generate_presigned_get_url", lambda key: "https://r2/" + key)
+
+    client = await client_factory(anonymous_user)
+    r = await client.get(_url(org, course, activity, "master.m3u8"))
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("application/vnd.apple.mpegurl")
+    assert "v360p/index.m3u8" in r.text  # rendition ref stays relative
+
+
+async def test_rendition_playlist_segments_presigned(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    rendition = "#EXTM3U\n#EXTINF:6.0,\nseg_0000.ts\n#EXT-X-ENDLIST\n"
+    monkeypatch.setattr(stream_mod, "read_file_content", lambda key: rendition.encode())
+    monkeypatch.setattr(
+        stream_mod, "generate_presigned_get_url",
+        lambda key: f"https://r2.example/{key}?sig=abc",
+    )
+
+    client = await client_factory(anonymous_user)
+    r = await client.get(_url(org, course, activity, "v360p/index.m3u8"))
+    assert r.status_code == 200
+    # The segment line was rewritten to the presigned URL (query param present),
+    # and the bare relative segment name is gone.
+    assert "seg_0000.ts?sig=abc" in r.text
+    assert "\nseg_0000.ts\n" not in r.text
+    # The rewritten line is an absolute URL to the storage host.
+    seg_line = next(ln for ln in r.text.splitlines() if ln.strip().endswith("sig=abc"))
+    assert seg_line.startswith("https://")
+
+
+async def test_segment_request_redirects_to_presigned_in_s3_mode(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    monkeypatch.setattr(stream_mod, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(
+        stream_mod, "generate_presigned_get_url",
+        lambda key: f"https://r2.example/{key}?sig=abc",
+    )
+
+    client = await client_factory(anonymous_user)
+    r = await client.get(
+        _url(org, course, activity, "v360p/seg_0000.ts"), follow_redirects=False
+    )
+    assert r.status_code == 302
+    assert r.headers["location"].startswith("https://r2.example/")
+
+
+def test_safe_hls_relpath_accepts_expected_shapes():
+    assert stream_mod._safe_hls_relpath("master.m3u8") == "master.m3u8"
+    assert stream_mod._safe_hls_relpath("v720p/index.m3u8") == "v720p/index.m3u8"
+    assert stream_mod._safe_hls_relpath("v720p/seg_0001.ts") == "v720p/seg_0001.ts"
+
+
+def test_safe_hls_relpath_rejects_traversal_and_bad_types():
+    for bad in [
+        "../secret.m3u8",
+        "v720p/../../etc.ts",
+        "/abs/master.m3u8",
+        "master.exe",
+        "config.py",
+        "",
+        "a/\x00.ts",
+    ]:
+        assert stream_mod._safe_hls_relpath(bad) is None, bad
+
+
+async def test_thumbnail_sprite_redirects_to_presigned(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    monkeypatch.setattr(stream_mod, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(
+        stream_mod, "generate_presigned_get_url",
+        lambda key: f"https://r2.example/{key}?sig=abc",
+    )
+    client = await client_factory(anonymous_user)
+    r = await client.get(
+        _url(org, course, activity, "thumbnails/sprite.jpg"), follow_redirects=False
+    )
+    assert r.status_code == 302
+    assert r.headers["location"].endswith("thumbnails/sprite.jpg?sig=abc")
+
+
+async def test_aes_key_served_inline_never_redirected(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    # Even with S3 enabled, the key must be returned inline (RBAC-gated), never
+    # redirected to a presigned URL that would expose it publicly.
+    monkeypatch.setattr(stream_mod, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(
+        stream_mod, "generate_presigned_get_url",
+        lambda key: "https://r2.example/LEAKED",
+    )
+    monkeypatch.setattr(stream_mod, "read_file_content", lambda key: b"0123456789abcdef")
+
+    client = await client_factory(anonymous_user)
+    r = await client.get(_url(org, course, activity, "enc.key"), follow_redirects=False)
+    assert r.status_code == 200
+    assert r.content == b"0123456789abcdef"
+    assert "no-store" in r.headers["cache-control"]
+    assert "location" not in r.headers
+
+
+async def test_bad_extension_returns_404_without_reading(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    called = {"read": False}
+
+    def _fail_read(key):
+        called["read"] = True
+        return b"#EXTM3U\n"
+
+    monkeypatch.setattr(stream_mod, "read_file_content", _fail_read)
+    client = await client_factory(anonymous_user)
+    # Valid path shape, disallowed extension → 404, and content is never read.
+    r = await client.get(_url(org, course, activity, "master.exe"))
+    assert r.status_code == 404
+    assert called["read"] is False
+
+
+def test_redirect_to_storage_none_when_s3_disabled(monkeypatch):
+    monkeypatch.setattr(stream_mod, "is_s3_enabled", lambda: False)
+    assert stream_mod._redirect_to_storage("content/x.mp4") is None
+
+
+def test_redirect_to_storage_sets_cacheable_header(monkeypatch):
+    monkeypatch.setattr(stream_mod, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(stream_mod, "generate_presigned_get_url", lambda key: "https://r2/x")
+    resp = stream_mod._redirect_to_storage("content/x.mp4")
+    assert resp is not None
+    assert resp.status_code == 302
+    cc = resp.headers["cache-control"]
+    # Must be cacheable (not no-store) so the browser stops re-resolving per range.
+    assert "no-store" not in cc
+    assert "max-age=21600" in cc and "private" in cc
+
+
+async def test_activity_video_redirects_to_presigned_with_cache(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    monkeypatch.setattr(stream_mod, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(
+        stream_mod, "generate_presigned_get_url",
+        lambda key: f"https://r2.example/{key}?sig=abc",
+    )
+    # Object exists (head_object hit) so the handler proceeds to the redirect.
+    monkeypatch.setattr(stream_mod, "get_file_info", lambda p: (1000, "video/mp4", True))
+    client = await client_factory(anonymous_user)
+    r = await client.get(
+        f"/video/{org.org_uuid}/{course.course_uuid}/{activity.activity_uuid}/clip.mp4",
+        follow_redirects=False,
+    )
+    assert r.status_code == 302
+    assert r.headers["location"].startswith("https://r2.example/")
+    assert "max-age=21600" in r.headers["cache-control"]
+
+
+async def test_activity_video_missing_object_returns_404_in_s3_mode(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    # Missing object → 404 (consistent with HEAD), not a 302 to a dead URL.
+    monkeypatch.setattr(stream_mod, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(stream_mod, "generate_presigned_get_url", lambda key: "https://r2/x")
+    monkeypatch.setattr(stream_mod, "get_file_info", lambda p: (0, "", False))
+    client = await client_factory(anonymous_user)
+    r = await client.get(
+        f"/video/{org.org_uuid}/{course.course_uuid}/{activity.activity_uuid}/missing.mp4",
+        follow_redirects=False,
+    )
+    assert r.status_code == 404
+    assert "location" not in r.headers
+
+
+async def test_get_and_head_agree_for_missing_object(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    monkeypatch.setattr(stream_mod, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(stream_mod, "generate_presigned_get_url", lambda key: "https://r2/x")
+    monkeypatch.setattr(stream_mod, "get_file_info", lambda p: (0, "", False))
+    client = await client_factory(anonymous_user)
+    url = f"/video/{org.org_uuid}/{course.course_uuid}/{activity.activity_uuid}/missing.mp4"
+    head = await client.head(url, follow_redirects=False)
+    get = await client.get(url, follow_redirects=False)
+    assert head.status_code == 404
+    assert get.status_code == 404
+
+
+async def test_unsatisfiable_range_returns_416(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    # Local mode (no redirect); existing file of 10 bytes; ask for byte 999-.
+    monkeypatch.setattr(stream_mod, "is_s3_enabled", lambda: False)
+    monkeypatch.setattr(stream_mod, "get_file_info", lambda p: (10, "video/mp4", True))
+    client = await client_factory(anonymous_user)
+    r = await client.get(
+        f"/video/{org.org_uuid}/{course.course_uuid}/{activity.activity_uuid}/clip.mp4",
+        headers={"Range": "bytes=999-"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 416
+    assert r.headers["content-range"] == "bytes */10"
+
+
+async def test_private_course_denies_anonymous(
+    client_factory, monkeypatch, db, org, course, chapter, activity, anonymous_user
+):
+    course.public = False
+    db.add(course)
+    await db.commit()
+    monkeypatch.setattr(stream_mod, "read_file_content", lambda key: b"#EXTM3U\n")
+
+    client = await client_factory(anonymous_user)
+    r = await client.get(_url(org, course, activity, "master.m3u8"))
+    assert r.status_code in (401, 403)
+
+
+# --------------------------------------------------------------------------
+# Block + podcast GET handlers (cover the duplicated existence-check/redirect)
+# --------------------------------------------------------------------------
+
+async def test_block_video_redirects_in_s3(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    monkeypatch.setattr(stream_mod, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(stream_mod, "get_file_info", lambda p: (1000, "video/mp4", True))
+    monkeypatch.setattr(stream_mod, "generate_presigned_get_url", lambda k: f"https://r2/{k}")
+    client = await client_factory(anonymous_user)
+    r = await client.get(
+        f"/block/{org.org_uuid}/{course.course_uuid}/{activity.activity_uuid}/blk1/v.mp4",
+        follow_redirects=False,
+    )
+    assert r.status_code == 302
+    assert "max-age=21600" in r.headers["cache-control"]
+
+
+async def test_block_video_missing_returns_404(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    monkeypatch.setattr(stream_mod, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(stream_mod, "get_file_info", lambda p: (0, "", False))
+    monkeypatch.setattr(stream_mod, "generate_presigned_get_url", lambda k: "https://r2/x")
+    client = await client_factory(anonymous_user)
+    r = await client.get(
+        f"/block/{org.org_uuid}/{course.course_uuid}/{activity.activity_uuid}/blk1/v.mp4",
+        follow_redirects=False,
+    )
+    assert r.status_code == 404
+
+
+async def test_block_audio_redirects_in_s3(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    monkeypatch.setattr(stream_mod, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(stream_mod, "get_file_info", lambda p: (1000, "audio/mpeg", True))
+    monkeypatch.setattr(stream_mod, "generate_presigned_get_url", lambda k: f"https://r2/{k}")
+    client = await client_factory(anonymous_user)
+    r = await client.get(
+        f"/block/audio/{org.org_uuid}/{course.course_uuid}/{activity.activity_uuid}/blk1/a.mp3",
+        follow_redirects=False,
+    )
+    assert r.status_code == 302
+
+
+async def test_podcast_audio_redirects_in_s3(
+    client_factory, monkeypatch, org, anonymous_user
+):
+    # Focus on the redirect logic (the changed lines); podcast RBAC is exercised
+    # by its own dedicated tests, so stub the access check here.
+    async def _allow(*a, **k):
+        return None
+
+    monkeypatch.setattr(stream_mod, "_verify_podcast_episode_access", _allow)
+    monkeypatch.setattr(stream_mod, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(stream_mod, "get_file_info", lambda p: (1000, "audio/mpeg", True))
+    monkeypatch.setattr(stream_mod, "generate_presigned_get_url", lambda k: f"https://r2/{k}")
+    client = await client_factory(anonymous_user)
+    r = await client.get(
+        f"/audio/{org.org_uuid}/pod_test/ep_test/a.mp3", follow_redirects=False
+    )
+    assert r.status_code == 302

--- a/apps/api/src/tests/services/test_caption_jobs_service.py
+++ b/apps/api/src/tests/services/test_caption_jobs_service.py
@@ -1,0 +1,294 @@
+"""Tests for src/services/utils/caption_jobs.py (AI caption pipeline)."""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.db.courses.activities import Activity, ActivitySubTypeEnum, ActivityTypeEnum
+from src.services.utils import caption_jobs as cj
+
+
+class _FactoryCtx:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _bind_session(monkeypatch, session):
+    monkeypatch.setattr(cj, "_async_session_factory", lambda: _FactoryCtx(session))
+
+
+async def _add_caption_activity(db, org, course, uuid, *, filename="v.mp4", captions=None):
+    a = Activity(
+        name="V",
+        activity_type=ActivityTypeEnum.TYPE_VIDEO,
+        activity_sub_type=ActivitySubTypeEnum.SUBTYPE_VIDEO_HOSTED,
+        content={"filename": filename} if filename else {},
+        published=True,
+        org_id=org.id,
+        course_id=course.id,
+        activity_uuid=uuid,
+        extra_metadata={"captions": captions} if captions else None,
+        creation_date=str(datetime.now()),
+        update_date=str(datetime.now()),
+    )
+    db.add(a)
+    await db.commit()
+    return a
+
+
+# --- concurrency / enqueue -------------------------------------------------
+
+def test_concurrency_parsing(monkeypatch):
+    monkeypatch.setenv("LEARNHOUSE_CAPTIONS_CONCURRENCY", "4")
+    assert cj.concurrency() == 4
+    monkeypatch.setenv("LEARNHOUSE_CAPTIONS_CONCURRENCY", "bad")
+    assert cj.concurrency() == 1
+
+
+def test_enqueue_pushes(monkeypatch):
+    pushed = []
+
+    class _R:
+        def rpush(self, key, val):
+            pushed.append((key, val))
+
+    monkeypatch.setattr(cj, "get_redis_client", lambda: _R())
+    cj.enqueue("act1")
+    assert pushed == [(cj.REDIS_QUEUE_KEY, "act1")]
+
+
+def test_enqueue_no_redis(monkeypatch):
+    monkeypatch.setattr(cj, "get_redis_client", lambda: None)
+    cj.enqueue("act1")  # warns, no raise
+
+
+# --- consumer --------------------------------------------------------------
+
+async def test_consumer_drains_and_survives_errors(monkeypatch):
+    processed = []
+    seq = iter([b"a1", b"a2"])
+
+    class _R:
+        def lpop(self, key):
+            try:
+                return next(seq)
+            except StopIteration:
+                raise asyncio.CancelledError()
+
+    monkeypatch.setattr(cj, "get_redis_client", lambda: _R())
+
+    async def _gen(uuid):
+        processed.append(uuid)
+        if uuid == "a1":
+            raise RuntimeError("boom")
+        return True
+
+    monkeypatch.setattr(cj, "generate_activity_captions", _gen)
+    with pytest.raises(asyncio.CancelledError):
+        await cj._consumer_loop(poll_seconds=0)
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert set(processed) == {"a1", "a2"}
+
+
+async def test_consumer_job_timeout(monkeypatch):
+    monkeypatch.setattr(cj, "JOB_TIMEOUT_SECONDS", 0.01)
+    seq = iter([b"slow"])
+
+    class _R:
+        def lpop(self, key):
+            try:
+                return next(seq)
+            except StopIteration:
+                raise asyncio.CancelledError()
+
+        def rpush(self, *a):
+            pass
+
+    monkeypatch.setattr(cj, "get_redis_client", lambda: _R())
+
+    async def _slow(uuid):
+        await asyncio.sleep(10)
+
+    monkeypatch.setattr(cj, "generate_activity_captions", _slow)
+    status = []
+
+    async def _cap(uuid, **k):
+        status.append(k)
+
+    monkeypatch.setattr(cj, "_patch_captions", _cap)
+    with pytest.raises(asyncio.CancelledError):
+        await cj._consumer_loop(poll_seconds=0)
+    await asyncio.sleep(0.05)
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert any(k.get("status") == "failed" and k.get("error") == "timeout" for k in status)
+
+
+async def test_consumer_empty_poll_then_cancel(monkeypatch):
+    seq = iter([None])
+
+    class _R:
+        def lpop(self, key):
+            v = next(seq, "STOP")
+            if v == "STOP":
+                raise asyncio.CancelledError()
+            return v
+
+    monkeypatch.setattr(cj, "get_redis_client", lambda: _R())
+    with pytest.raises(asyncio.CancelledError):
+        await cj._consumer_loop(poll_seconds=0)
+
+
+async def test_consumer_no_redis_returns(monkeypatch):
+    monkeypatch.setattr(cj, "get_redis_client", lambda: None)
+    await cj._consumer_loop()
+
+
+def test_start_consumer_noop_without_redis(monkeypatch):
+    monkeypatch.setattr(cj, "get_redis_client", lambda: None)
+    cj._consumer_task = None
+    cj._reaper_task = None
+    cj.start_consumer()
+    assert cj._consumer_task is None
+
+
+async def test_reaper_calls_requeue_and_survives(monkeypatch):
+    calls = {"n": 0}
+
+    async def _req():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("x")
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(cj, "_requeue_stale_processing", _req)
+    with pytest.raises(asyncio.CancelledError):
+        await cj._reaper_loop(interval=0)
+    assert calls["n"] == 2
+
+
+async def test_stop_consumer_reenqueues_inflight(monkeypatch):
+    pushed = []
+
+    class _R:
+        def rpush(self, k, v):
+            pushed.append(v)
+
+    monkeypatch.setattr(cj, "get_redis_client", lambda: _R())
+    cj._inflight.clear()
+    cj._inflight.add("busy")
+
+    async def _idle():
+        await asyncio.sleep(3600)
+
+    cj._consumer_task = asyncio.create_task(_idle())
+    cj._reaper_task = asyncio.create_task(_idle())
+    await asyncio.sleep(0)
+    await cj.stop_consumer()
+    assert "busy" in pushed
+    assert cj._consumer_task is None and cj._reaper_task is None
+    cj._inflight.clear()
+
+
+# --- requeue stale ---------------------------------------------------------
+
+async def test_requeue_stale_processing(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    old = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    await _add_caption_activity(db, org, course, "stale", captions={"status": "processing", "updated_at": old})
+    await _add_caption_activity(db, org, course, "fresh", captions={"status": "processing", "updated_at": datetime.now(timezone.utc).isoformat()})
+    await _add_caption_activity(db, org, course, "ready1", captions={"status": "ready"})
+    pushed = []
+
+    class _R:
+        def rpush(self, k, v):
+            pushed.append(v)
+
+    monkeypatch.setattr(cj, "get_redis_client", lambda: _R())
+    n = await cj._requeue_stale_processing(stale_after=1200)
+    assert n == 1 and pushed == ["stale"]
+
+
+async def test_requeue_stale_no_redis(monkeypatch):
+    monkeypatch.setattr(cj, "get_redis_client", lambda: None)
+    assert await cj._requeue_stale_processing() == 0
+
+
+# --- generate_activity_captions (mocked engine + credits) ------------------
+
+def _mock_engine(monkeypatch):
+    async def _chunks(src, out):
+        return ["a.mp3"]
+
+    async def _dur(src):
+        return 60.0
+
+    async def _tvtt(chunks, model, source_language=None):
+        return "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nHello\n"
+
+    async def _trans(vtt, label, model):
+        return "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nBonjour\n"
+
+    monkeypatch.setattr(cj.cap, "extract_audio_chunks", _chunks)
+    monkeypatch.setattr(cj.cap, "probe_duration", _dur)
+    monkeypatch.setattr(cj.cap, "transcribe_to_vtt", _tvtt)
+    monkeypatch.setattr(cj.cap, "translate_vtt", _trans)
+    monkeypatch.setattr(cj, "_fetch_source", lambda key, path: True)
+    monkeypatch.setattr(cj, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(cj, "upload_directory_to_s3", lambda d, p: True)
+
+    import src.security.features_utils.usage as usage
+    import src.services.ai.llm as llm
+
+    async def _feat(*a, **k):
+        return True
+
+    async def _reserve(*a, **k):
+        return 1
+
+    monkeypatch.setattr(usage, "check_feature_enabled", _feat)
+    monkeypatch.setattr(usage, "reserve_ai_credit", _reserve)
+    monkeypatch.setattr(usage, "refund_ai_credit", lambda *a, **k: 0)
+    monkeypatch.setattr(llm, "model_for_tier", lambda tier: "gemini-standard")
+
+
+async def test_generate_captions_success(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    _mock_engine(monkeypatch)
+    await _add_caption_activity(
+        db, org, course, "capA",
+        captions={"enabled": True, "source_language": "auto",
+                  "languages": [{"code": "fr", "label": "French", "status": "queued"}]},
+    )
+    ok = await cj.generate_activity_captions("capA")
+    assert ok is True
+
+
+async def test_generate_captions_disabled_activity(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    await _add_caption_activity(db, org, course, "capOff", captions={"enabled": False, "languages": []})
+    assert await cj.generate_activity_captions("capOff") is False
+
+
+async def test_generate_captions_audio_failure(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    _mock_engine(monkeypatch)
+
+    async def _no_audio(src, out):
+        return []
+
+    monkeypatch.setattr(cj.cap, "extract_audio_chunks", _no_audio)
+    await _add_caption_activity(
+        db, org, course, "capB",
+        captions={"enabled": True, "source_language": "auto",
+                  "languages": [{"code": "fr", "label": "French", "status": "queued"}]},
+    )
+    assert await cj.generate_activity_captions("capB") is False

--- a/apps/api/src/tests/services/test_captions_config_service.py
+++ b/apps/api/src/tests/services/test_captions_config_service.py
@@ -1,0 +1,149 @@
+"""Tests for configure_captions() in src/services/courses/activities/video.py."""
+
+from datetime import datetime
+
+import pytest
+from fastapi import HTTPException
+
+from src.db.courses.activities import Activity, ActivitySubTypeEnum, ActivityTypeEnum
+from src.services.courses.activities import video as video_mod
+from src.services.courses.activities.video import CaptionsConfigIn, CaptionLanguageIn, configure_captions
+
+
+async def _add_video(db, org, course, uuid):
+    a = Activity(
+        name="V",
+        activity_type=ActivityTypeEnum.TYPE_VIDEO,
+        activity_sub_type=ActivitySubTypeEnum.SUBTYPE_VIDEO_HOSTED,
+        content={"filename": "v.mp4"},
+        published=True,
+        org_id=org.id,
+        course_id=course.id,
+        activity_uuid=uuid,
+        creation_date=str(datetime.now()),
+        update_date=str(datetime.now()),
+    )
+    db.add(a)
+    await db.commit()
+    return a
+
+
+def _mock_common(monkeypatch, enqueued):
+    async def _access(*a, **k):
+        return True
+
+    monkeypatch.setattr(video_mod, "check_resource_access", _access)
+
+    import src.security.features_utils.usage as usage
+
+    async def _feat(*a, **k):
+        return True
+
+    async def _summary(*a, **k):
+        return {"remaining_credits": 100}
+
+    monkeypatch.setattr(usage, "check_feature_enabled", _feat)
+    monkeypatch.setattr(usage, "get_ai_credits_summary", _summary)
+
+    import src.services.utils.caption_jobs as cj
+    monkeypatch.setattr(cj, "enqueue", lambda uuid: enqueued.append(uuid))
+
+
+async def test_configure_enables_and_enqueues(monkeypatch, db, org, course, chapter, activity):
+    enqueued = []
+    _mock_common(monkeypatch, enqueued)
+    await _add_video(db, org, course, "capcfg1")
+    cfg = CaptionsConfigIn(
+        enabled=True, source_language="auto",
+        languages=[CaptionLanguageIn(code="fr", label="French"),
+                   CaptionLanguageIn(code="sw", label="Swahili")],  # custom lang
+    )
+    out = await configure_captions(None, "capcfg1", None, db, cfg)
+    assert out["enabled"] is True
+    assert out["status"] == "queued"
+    assert [x["code"] for x in out["languages"]] == ["fr", "sw"]
+    assert enqueued == ["capcfg1"]
+
+
+async def test_configure_rejects_bad_code(monkeypatch, db, org, course, chapter, activity):
+    _mock_common(monkeypatch, [])
+    await _add_video(db, org, course, "capcfg2")
+    cfg = CaptionsConfigIn(enabled=True, languages=[CaptionLanguageIn(code="../etc")])
+    with pytest.raises(HTTPException) as ei:
+        await configure_captions(None, "capcfg2", None, db, cfg)
+    assert ei.value.status_code == 400
+
+
+async def test_configure_enabled_needs_language(monkeypatch, db, org, course, chapter, activity):
+    _mock_common(monkeypatch, [])
+    await _add_video(db, org, course, "capcfg3")
+    cfg = CaptionsConfigIn(enabled=True, languages=[])
+    with pytest.raises(HTTPException) as ei:
+        await configure_captions(None, "capcfg3", None, db, cfg)
+    assert ei.value.status_code == 400
+
+
+async def test_configure_disable_no_enqueue(monkeypatch, db, org, course, chapter, activity):
+    enqueued = []
+    _mock_common(monkeypatch, enqueued)
+    await _add_video(db, org, course, "capcfg4")
+    cfg = CaptionsConfigIn(enabled=False, languages=[])
+    out = await configure_captions(None, "capcfg4", None, db, cfg)
+    assert out["enabled"] is False and out["status"] == "idle"
+    assert enqueued == []
+
+
+async def test_configure_rejects_non_hosted(monkeypatch, db, org, course, chapter, activity):
+    _mock_common(monkeypatch, [])
+    a = Activity(
+        name="Ext",
+        activity_type=ActivityTypeEnum.TYPE_VIDEO,
+        activity_sub_type=ActivitySubTypeEnum.SUBTYPE_VIDEO_YOUTUBE,
+        content={"uri": "https://youtu.be/x"},
+        published=True,
+        org_id=org.id,
+        course_id=course.id,
+        activity_uuid="capcfg5",
+        creation_date=str(datetime.now()),
+        update_date=str(datetime.now()),
+    )
+    db.add(a)
+    await db.commit()
+    cfg = CaptionsConfigIn(enabled=True, languages=[CaptionLanguageIn(code="fr")])
+    with pytest.raises(HTTPException) as ei:
+        await configure_captions(None, "capcfg5", None, db, cfg)
+    assert ei.value.status_code == 400
+
+
+async def test_configure_too_many_languages(monkeypatch, db, org, course, chapter, activity):
+    _mock_common(monkeypatch, [])
+    await _add_video(db, org, course, "capcfg7")
+    many = [CaptionLanguageIn(code=f"l{i:02d}") for i in range(20)]
+    cfg = CaptionsConfigIn(enabled=True, languages=many)
+    with pytest.raises(HTTPException) as ei:
+        await configure_captions(None, "capcfg7", None, db, cfg)
+    assert ei.value.status_code == 400
+
+
+async def test_configure_bad_source_language(monkeypatch, db, org, course, chapter, activity):
+    _mock_common(monkeypatch, [])
+    await _add_video(db, org, course, "capcfg8")
+    cfg = CaptionsConfigIn(enabled=True, source_language="../x", languages=[CaptionLanguageIn(code="fr")])
+    with pytest.raises(HTTPException) as ei:
+        await configure_captions(None, "capcfg8", None, db, cfg)
+    assert ei.value.status_code == 400
+
+
+async def test_configure_no_credits_blocks(monkeypatch, db, org, course, chapter, activity):
+    _mock_common(monkeypatch, [])
+    import src.security.features_utils.usage as usage
+
+    async def _empty(*a, **k):
+        return {"remaining_credits": 0}
+
+    monkeypatch.setattr(usage, "get_ai_credits_summary", _empty)
+    await _add_video(db, org, course, "capcfg6")
+    cfg = CaptionsConfigIn(enabled=True, languages=[CaptionLanguageIn(code="fr")])
+    with pytest.raises(HTTPException) as ei:
+        await configure_captions(None, "capcfg6", None, db, cfg)
+    assert ei.value.status_code == 402

--- a/apps/api/src/tests/services/test_captions_service.py
+++ b/apps/api/src/tests/services/test_captions_service.py
@@ -1,0 +1,141 @@
+"""Unit tests for src/services/ai/captions.py (VTT engine — no real model/ffmpeg)."""
+
+import src.services.ai.captions as cap
+
+
+# --- VTT sanitizing --------------------------------------------------------
+
+def test_sanitize_adds_header_and_strips_fences():
+    raw = "```vtt\n00:00:01.000 --> 00:00:02.000\nHello\n```"
+    out = cap.sanitize_vtt(raw)
+    assert out.startswith("WEBVTT")
+    assert "```" not in out
+    assert "Hello" in out
+
+
+def test_sanitize_converts_srt_commas():
+    raw = "WEBVTT\n\n00:00:01,500 --> 00:00:02,750\nHi"
+    out = cap.sanitize_vtt(raw)
+    assert "00:00:01.500 --> 00:00:02.750" in out
+
+
+def test_sanitize_empty():
+    assert cap.sanitize_vtt("") == "WEBVTT\n"
+
+
+# --- shifting / merging ----------------------------------------------------
+
+def test_shift_vtt_offsets_timestamps():
+    vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nA\n"
+    out = cap.shift_vtt(vtt, 600)  # +10 min
+    assert "00:10:01.000 --> 00:10:02.000" in out
+
+
+def test_shift_vtt_noop_on_zero():
+    vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nA\n"
+    assert cap.shift_vtt(vtt, 0) == vtt
+
+
+def test_merge_chunks_single_header():
+    a = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nA\n"
+    b = "WEBVTT\n\n00:10:01.000 --> 00:10:02.000\nB\n"
+    merged = cap.merge_vtt_chunks([a, b])
+    assert merged.count("WEBVTT") == 1
+    assert "A" in merged and "B" in merged
+    assert "00:10:01.000" in merged
+
+
+def test_has_cues():
+    assert cap.has_cues("WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nX")
+    assert not cap.has_cues("WEBVTT\n\n(no cues)")
+
+
+def test_mm_ss_timestamps_recognized():
+    # Gemini emits MM:SS.mmm (no hours) — this MUST be recognized as cues,
+    # otherwise every real transcript fails with "no cues".
+    vtt = "WEBVTT\n\n00:01.800 --> 00:03.200\nHello"
+    assert cap.has_cues(vtt)
+    shifted = cap.shift_vtt(vtt, 600)  # +10 min -> normalizes to HH:MM:SS
+    assert "00:10:01.800 --> 00:10:03.200" in shifted
+
+
+def test_sanitize_srt_comma_mm_ss():
+    out = cap.sanitize_vtt("WEBVTT\n\n00:01,800 --> 00:03,200\nHi")
+    assert "00:01.800 --> 00:03.200" in out
+    assert cap.has_cues(out)
+
+
+# --- credit estimation -----------------------------------------------------
+
+def test_estimate_credits():
+    assert cap.estimate_credits(0, 0) == 1          # min 1
+    assert cap.estimate_credits(60, 0) == 1         # <10min -> 1 chunk
+    assert cap.estimate_credits(600, 0) == 1        # exactly 10min -> 1 chunk
+    assert cap.estimate_credits(601, 0) == 2        # spills to 2 chunks
+    assert cap.estimate_credits(600, 3) == 4        # 1 chunk + 3 translations
+
+
+# --- transcription / translation (mocked model) ----------------------------
+
+async def test_transcribe_stitches_chunks(monkeypatch, tmp_path):
+    calls = {"n": 0}
+
+    async def _fake_generate(**kwargs):
+        calls["n"] += 1
+        return "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nline"
+
+    import src.services.ai.llm as llm
+    monkeypatch.setattr(llm, "generate", _fake_generate)
+
+    c0 = tmp_path / "chunk_0000.mp3"
+    c1 = tmp_path / "chunk_0001.mp3"
+    c0.write_bytes(b"ID3fake0")
+    c1.write_bytes(b"ID3fake1")
+
+    out = await cap.transcribe_to_vtt([str(c0), str(c1)], "gemini-x", source_language="en")
+    assert calls["n"] == 2
+    assert out.count("WEBVTT") == 1
+    # chunk 0 keeps its time, chunk 1 is offset by +10 min.
+    assert "00:00:01.000 --> 00:00:02.000" in out
+    assert "00:10:01.000 --> 00:10:02.000" in out
+
+
+async def test_transcribe_raises_without_cues(monkeypatch, tmp_path):
+    async def _empty(**kwargs):
+        return "WEBVTT\n\n(silence)"
+
+    import src.services.ai.llm as llm
+    monkeypatch.setattr(llm, "generate", _empty)
+    c0 = tmp_path / "chunk_0000.mp3"
+    c0.write_bytes(b"x")
+    import pytest
+    with pytest.raises(ValueError):
+        await cap.transcribe_to_vtt([str(c0)], "gemini-x")
+
+
+async def test_transcribe_raises_on_no_audio():
+    import pytest
+    with pytest.raises(ValueError):
+        await cap.transcribe_to_vtt([], "gemini-x")
+
+
+async def test_translate_vtt(monkeypatch):
+    async def _fake(**kwargs):
+        # echo a translated cue
+        return "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nBonjour"
+
+    import src.services.ai.llm as llm
+    monkeypatch.setattr(llm, "generate", _fake)
+    out = await cap.translate_vtt("WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nHello", "French", "gemini-x")
+    assert "Bonjour" in out and out.startswith("WEBVTT")
+
+
+async def test_translate_raises_without_cues(monkeypatch):
+    async def _fake(**kwargs):
+        return "sorry I cannot"
+
+    import src.services.ai.llm as llm
+    monkeypatch.setattr(llm, "generate", _fake)
+    import pytest
+    with pytest.raises(ValueError):
+        await cap.translate_vtt("WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nHello", "French", "gemini-x")

--- a/apps/api/src/tests/services/test_hls_jobs_service.py
+++ b/apps/api/src/tests/services/test_hls_jobs_service.py
@@ -516,6 +516,69 @@ async def test_reconcile_no_redis(monkeypatch):
     assert out["requeued"] == 0 and out.get("error") == "no_redis"
 
 
+async def test_reconcile_resilient_to_redis_errors(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    await _add_video_activity(db, org, course, "e1", filename="a.mp4", hls_status="failed")
+
+    class _BadR(_FakeRedis):
+        def lrange(self, *a):
+            raise RuntimeError("boom")
+
+        def exists(self, key):
+            raise RuntimeError("boom")
+
+        def get(self, key):
+            raise RuntimeError("boom")
+
+        def incr(self, key):
+            raise RuntimeError("boom")
+
+        def rpush(self, key, val):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: _BadR())
+    out = await hls_jobs.reconcile_unfinished()  # must not raise despite every op erroring
+    assert out["requeued"] == 0  # rpush failed, so not counted
+
+
+def test_hls_max_retries_parsing(monkeypatch):
+    monkeypatch.delenv("LEARNHOUSE_HLS_MAX_RETRIES", raising=False)
+    assert hls_jobs.hls_max_retries() == 6
+    monkeypatch.setenv("LEARNHOUSE_HLS_MAX_RETRIES", "3")
+    assert hls_jobs.hls_max_retries() == 3
+    monkeypatch.setenv("LEARNHOUSE_HLS_MAX_RETRIES", "bad")
+    assert hls_jobs.hls_max_retries() == 6
+
+
+async def test_lease_heartbeat_swallows_errors(monkeypatch):
+    monkeypatch.setattr(hls_jobs, "LEASE_HEARTBEAT_SECONDS", 0)
+
+    class _C:
+        def expire(self, key, ttl):
+            raise RuntimeError("redis down")  # -> caught, heartbeat returns
+
+    await hls_jobs._lease_heartbeat(_C(), "k")  # returns, no raise
+
+
+async def test_lease_heartbeat_cancellable(monkeypatch):
+    monkeypatch.setattr(hls_jobs, "LEASE_HEARTBEAT_SECONDS", 0)
+    calls = {"n": 0}
+
+    class _C:
+        def expire(self, key, ttl):
+            calls["n"] += 1
+
+    task = asyncio.create_task(hls_jobs._lease_heartbeat(_C(), "k"))
+    for _ in range(30):
+        await asyncio.sleep(0)
+        if calls["n"] >= 1:
+            break
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert calls["n"] >= 1
+
+
 async def test_consumer_loop_no_redis_returns(monkeypatch):
     monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: None)
     await hls_jobs._consumer_loop()  # returns immediately, no raise

--- a/apps/api/src/tests/services/test_hls_jobs_service.py
+++ b/apps/api/src/tests/services/test_hls_jobs_service.py
@@ -1,0 +1,687 @@
+"""Tests for src/services/utils/hls_jobs.py (status writes, gating, backfill)."""
+
+import asyncio
+import os
+from datetime import datetime
+
+import pytest
+
+from src.db.courses.activities import Activity, ActivitySubTypeEnum, ActivityTypeEnum
+from src.services.utils import hls_jobs
+
+
+def _aret(value):
+    async def _f(*a, **k):
+        return value
+    return _f
+
+
+class _FactoryCtx:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _bind_session(monkeypatch, session):
+    """Point hls_jobs' session factory at the test DB session."""
+    monkeypatch.setattr(hls_jobs, "_async_session_factory", lambda: _FactoryCtx(session))
+
+
+# --------------------------------------------------------------------------
+# Flag parsing / gating
+# --------------------------------------------------------------------------
+
+def test_flags_default_off(monkeypatch):
+    monkeypatch.delenv("LEARNHOUSE_HLS_ENABLED", raising=False)
+    monkeypatch.delenv("LEARNHOUSE_HLS_CONCURRENCY", raising=False)
+    assert hls_jobs.hls_enabled() is False
+    assert hls_jobs.hls_concurrency() == 1  # default
+
+
+def test_flags_parse_true(monkeypatch):
+    monkeypatch.setenv("LEARNHOUSE_HLS_ENABLED", "TRUE")
+    assert hls_jobs.hls_enabled() is True
+
+
+def test_hls_concurrency_parsing(monkeypatch):
+    monkeypatch.setenv("LEARNHOUSE_HLS_CONCURRENCY", "3")
+    assert hls_jobs.hls_concurrency() == 3
+    monkeypatch.setenv("LEARNHOUSE_HLS_CONCURRENCY", "0")
+    assert hls_jobs.hls_concurrency() == 1  # clamped to >=1
+    monkeypatch.setenv("LEARNHOUSE_HLS_CONCURRENCY", "bad")
+    assert hls_jobs.hls_concurrency() == 1  # invalid → 1
+
+
+def test_enqueue_is_noop_when_disabled(monkeypatch):
+    monkeypatch.setattr(hls_jobs, "hls_enabled", lambda: False)
+    # Should not touch Redis or spawn tasks; must not raise.
+    called = {"redis": False}
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: called.__setitem__("redis", True))
+    hls_jobs.enqueue("activity_x")
+    assert called["redis"] is False
+
+
+# --------------------------------------------------------------------------
+# Status writes to extra_metadata
+# --------------------------------------------------------------------------
+
+async def test_set_status_writes_hls_metadata(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    await hls_jobs._set_status(activity.activity_uuid, "processing")
+
+    refreshed = await db.get(Activity, activity.id)
+    assert refreshed.extra_metadata["hls"]["status"] == "processing"
+    assert "updated_at" in refreshed.extra_metadata["hls"]
+
+    await hls_jobs._set_status(
+        activity.activity_uuid, "ready", master="master.m3u8", renditions=["720p"]
+    )
+    refreshed = await db.get(Activity, activity.id)
+    assert refreshed.extra_metadata["hls"]["status"] == "ready"
+    assert refreshed.extra_metadata["hls"]["renditions"] == ["720p"]
+
+
+# --------------------------------------------------------------------------
+# Backfill target selection
+# --------------------------------------------------------------------------
+
+async def _add_video_activity(db, org, course, uuid, *, filename, hls_status=None):
+    meta = {"hls": {"status": hls_status}} if hls_status else None
+    a = Activity(
+        name="V",
+        activity_type=ActivityTypeEnum.TYPE_VIDEO,
+        activity_sub_type=ActivitySubTypeEnum.SUBTYPE_VIDEO_HOSTED,
+        content={"filename": filename} if filename else {},
+        published=True,
+        org_id=org.id,
+        course_id=course.id,
+        activity_uuid=uuid,
+        extra_metadata=meta,
+        creation_date=str(datetime.now()),
+        update_date=str(datetime.now()),
+    )
+    db.add(a)
+    await db.commit()
+    return a
+
+
+async def test_backfill_selects_only_unready_hosted_videos(
+    monkeypatch, db, org, course, chapter, activity
+):
+    _bind_session(monkeypatch, db)
+    await _add_video_activity(db, org, course, "vid_todo", filename="a.mp4")
+    await _add_video_activity(db, org, course, "vid_ready", filename="b.mp4", hls_status="ready")
+    await _add_video_activity(db, org, course, "vid_nofile", filename=None)
+
+    processed = []
+
+    async def _fake_transcode(uuid):
+        processed.append(uuid)
+        return True
+
+    monkeypatch.setattr(hls_jobs, "transcode_activity", _fake_transcode)
+
+    result = await hls_jobs.backfill()
+    # Only the hosted video that isn't ready and has a filename is transcoded.
+    assert processed == ["vid_todo"]
+    assert result == {"total": 1, "done": 1, "failed": 0}
+
+
+def test_safe_filename_rejects_traversal_and_separators():
+    assert hls_jobs._safe_filename("uuid_video.mp4") is True
+    for bad in ["../x.mp4", "a/b.mp4", "a\\b.mp4", "..", ".", "", ".hidden.mp4", "x\x00.mp4"]:
+        assert hls_jobs._safe_filename(bad) is False, bad
+
+
+async def test_backfill_tolerates_hls_none_metadata(monkeypatch, db, org, course, chapter, activity):
+    # extra_metadata={"hls": None} must not crash the target-selection .get chain.
+    _bind_session(monkeypatch, db)
+    a = await _add_video_activity(db, org, course, "vid_none", filename="a.mp4")
+    a.extra_metadata = {"hls": None}
+    db.add(a)
+    await db.commit()
+
+    async def _ok(uuid):
+        return True
+
+    monkeypatch.setattr(hls_jobs, "transcode_activity", _ok)
+    result = await hls_jobs.backfill()
+    assert result["done"] == 1  # the {"hls": None} activity is treated as not-ready
+
+
+async def test_backfill_negative_limit_means_no_limit(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    await _add_video_activity(db, org, course, "n1", filename="1.mp4")
+    await _add_video_activity(db, org, course, "n2", filename="2.mp4")
+
+    async def _ok(uuid):
+        return True
+
+    monkeypatch.setattr(hls_jobs, "transcode_activity", _ok)
+    result = await hls_jobs.backfill(limit=-5)
+    assert result["total"] == 2  # negative limit does not silently drop everything
+
+
+async def test_backfill_respects_limit(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    await _add_video_activity(db, org, course, "v1", filename="1.mp4")
+    await _add_video_activity(db, org, course, "v2", filename="2.mp4")
+
+    async def _ok(uuid):
+        return True
+
+    monkeypatch.setattr(hls_jobs, "transcode_activity", _ok)
+    result = await hls_jobs.backfill(limit=1)
+    assert result["total"] == 1
+
+
+# --------------------------------------------------------------------------
+# transcode_activity orchestration (mocked — no ffmpeg/S3 needed)
+# --------------------------------------------------------------------------
+
+def _mock_transcode_deps(monkeypatch, *, resolve, fetch=True, transcode=None,
+                         s3=True, upload=True):
+    monkeypatch.setattr(hls_jobs, "_resolve_source", _aret(resolve))
+    monkeypatch.setattr(hls_jobs, "_fetch_source", lambda src, dst: fetch)
+    monkeypatch.setattr(hls_jobs, "transcode_source_to_hls", _aret(transcode))
+    monkeypatch.setattr(hls_jobs, "is_s3_enabled", lambda: s3)
+    monkeypatch.setattr(hls_jobs, "upload_directory_to_s3", lambda out, prefix: upload)
+    statuses = []
+
+    async def _set(uuid, status, **extra):
+        statuses.append((status, extra))
+
+    monkeypatch.setattr(hls_jobs, "_set_status", _set)
+    return statuses
+
+
+_INFO = {"org_uuid": "O", "course_uuid": "C", "filename": "v.mp4"}
+_RESULT = {"master": "master.m3u8", "renditions": ["720p"], "thumbnails": None}
+
+
+async def test_transcode_activity_success(monkeypatch):
+    statuses = _mock_transcode_deps(monkeypatch, resolve=_INFO, transcode=_RESULT)
+    assert await hls_jobs.transcode_activity("act") is True
+    assert statuses[0][0] == "processing"
+    assert statuses[-1][0] == "ready"
+    assert statuses[-1][1]["master"] == "master.m3u8"
+
+
+async def test_transcode_activity_no_source(monkeypatch):
+    statuses = _mock_transcode_deps(monkeypatch, resolve=None)
+    assert await hls_jobs.transcode_activity("act") is False
+    assert statuses == []  # never marked processing
+
+
+async def test_transcode_activity_fetch_fails(monkeypatch):
+    statuses = _mock_transcode_deps(monkeypatch, resolve=_INFO, fetch=False)
+    assert await hls_jobs.transcode_activity("act") is False
+    assert statuses[-1] == ("failed", {"error": "source_unavailable"})
+
+
+async def test_transcode_activity_transcode_fails(monkeypatch):
+    statuses = _mock_transcode_deps(monkeypatch, resolve=_INFO, transcode=None)
+    assert await hls_jobs.transcode_activity("act") is False
+    assert statuses[-1] == ("failed", {"error": "transcode_failed"})
+
+
+async def test_transcode_activity_upload_fails(monkeypatch):
+    statuses = _mock_transcode_deps(monkeypatch, resolve=_INFO, transcode=_RESULT, upload=False)
+    assert await hls_jobs.transcode_activity("act") is False
+    assert statuses[-1] == ("failed", {"error": "upload_failed"})
+
+
+async def test_transcode_activity_exception_marks_failed(monkeypatch):
+    statuses = _mock_transcode_deps(monkeypatch, resolve=_INFO)
+
+    async def _boom(*a, **k):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(hls_jobs, "transcode_source_to_hls", _boom)
+    assert await hls_jobs.transcode_activity("act") is False
+    assert statuses[-1] == ("failed", {"error": "exception"})
+
+
+# --------------------------------------------------------------------------
+# _fetch_source
+# --------------------------------------------------------------------------
+
+def test_fetch_source_s3_success(monkeypatch, tmp_path):
+    class _C:
+        def download_file(self, bucket, key, local):
+            open(local, "wb").close()
+
+    monkeypatch.setattr(hls_jobs, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(hls_jobs, "get_storage_client", lambda: _C())
+    monkeypatch.setattr(hls_jobs, "get_s3_bucket_name", lambda: "b")
+    dst = str(tmp_path / "o.mp4")
+    assert hls_jobs._fetch_source("content/x.mp4", dst) is True
+    assert os.path.exists(dst)
+
+
+def test_fetch_source_s3_no_client(monkeypatch):
+    monkeypatch.setattr(hls_jobs, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(hls_jobs, "get_storage_client", lambda: None)
+    assert hls_jobs._fetch_source("x", "y") is False
+
+
+def test_fetch_source_s3_error(monkeypatch, tmp_path):
+    class _C:
+        def download_file(self, *a, **k):
+            raise RuntimeError("net")
+
+    monkeypatch.setattr(hls_jobs, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(hls_jobs, "get_storage_client", lambda: _C())
+    monkeypatch.setattr(hls_jobs, "get_s3_bucket_name", lambda: "b")
+    assert hls_jobs._fetch_source("x", str(tmp_path / "d")) is False
+
+
+def test_fetch_source_local(monkeypatch, tmp_path):
+    monkeypatch.setattr(hls_jobs, "is_s3_enabled", lambda: False)
+    src = tmp_path / "s.mp4"
+    src.write_bytes(b"data")
+    dst = str(tmp_path / "d.mp4")
+    assert hls_jobs._fetch_source(str(src), dst) is True
+    assert open(dst, "rb").read() == b"data"
+
+
+def test_fetch_source_local_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(hls_jobs, "is_s3_enabled", lambda: False)
+    assert hls_jobs._fetch_source(str(tmp_path / "nope.mp4"), str(tmp_path / "d")) is False
+
+
+# --------------------------------------------------------------------------
+# _resolve_source
+# --------------------------------------------------------------------------
+
+async def test_resolve_source_success(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    await _add_video_activity(db, org, course, "rs_ok", filename="v.mp4")
+    info = await hls_jobs._resolve_source("rs_ok")
+    assert info == {"org_uuid": org.org_uuid, "course_uuid": course.course_uuid, "filename": "v.mp4"}
+
+
+async def test_resolve_source_unsafe_filename(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    await _add_video_activity(db, org, course, "rs_bad", filename="../evil.mp4")
+    assert await hls_jobs._resolve_source("rs_bad") is None
+
+
+async def test_resolve_source_missing_activity(monkeypatch, db):
+    _bind_session(monkeypatch, db)
+    assert await hls_jobs._resolve_source("nope") is None
+
+
+# --------------------------------------------------------------------------
+# enqueue (Redis push only; the in-app consumer drains)
+# --------------------------------------------------------------------------
+
+def test_enqueue_pushes_to_redis_when_enabled(monkeypatch):
+    monkeypatch.setattr(hls_jobs, "hls_enabled", lambda: True)
+    pushed = []
+
+    class _R:
+        def rpush(self, key, val):
+            pushed.append((key, val))
+
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: _R())
+    hls_jobs.enqueue("act1")
+    assert pushed == [(hls_jobs.REDIS_QUEUE_KEY, "act1")]
+
+
+def test_enqueue_redis_rpush_error_is_swallowed(monkeypatch):
+    monkeypatch.setattr(hls_jobs, "hls_enabled", lambda: True)
+
+    class _R:
+        def rpush(self, *a):
+            raise RuntimeError("redis down")
+
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: _R())
+    hls_jobs.enqueue("act1")  # must not raise
+
+
+def test_enqueue_no_redis_warns(monkeypatch):
+    monkeypatch.setattr(hls_jobs, "hls_enabled", lambda: True)
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: None)
+    hls_jobs.enqueue("act1")  # no-redis warning branch, must not raise
+
+
+# --------------------------------------------------------------------------
+# In-app consumer + enqueue_pending
+# --------------------------------------------------------------------------
+
+async def test_consumer_loop_drains_and_transcodes(monkeypatch):
+    processed = []
+    seq = iter([b"a1", b"a2"])
+
+    class _R:
+        def lpop(self, key):
+            try:
+                return next(seq)
+            except StopIteration:
+                raise asyncio.CancelledError()  # end the test loop
+
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: _R())
+
+    async def _tr(uuid):
+        processed.append(uuid)
+        if uuid == "a1":
+            raise RuntimeError("boom")  # one job errors — consumer must survive
+        return True
+
+    monkeypatch.setattr(hls_jobs, "transcode_activity", _tr)
+    with pytest.raises(asyncio.CancelledError):
+        await hls_jobs._consumer_loop(poll_seconds=0)
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert set(processed) == {"a1", "a2"}
+
+
+async def test_consumer_loop_recovers_from_poll_error(monkeypatch):
+    calls = {"n": 0}
+
+    class _R:
+        def lpop(self, key):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("transient redis error")
+            raise asyncio.CancelledError()
+
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: _R())
+    with pytest.raises(asyncio.CancelledError):
+        await hls_jobs._consumer_loop(poll_seconds=0)
+    assert calls["n"] == 2  # recovered from the first error, polled again
+
+
+async def test_consumer_reenqueues_inflight_on_shutdown(monkeypatch):
+    # A job cancelled mid-transcode (pod shutdown) must be pushed back to Redis.
+    pushed = []
+
+    class _R:
+        def rpush(self, key, val):
+            pushed.append(val)
+
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: _R())
+
+    async def _hang(uuid):
+        await asyncio.sleep(3600)  # simulate an in-flight transcode
+
+    monkeypatch.setattr(hls_jobs, "transcode_activity", _hang)
+    hls_jobs._inflight.clear()
+
+    # Drive one iteration of the loop manually by feeding lpop once.
+    seq = iter([b"stuck1"])
+
+    class _RQ(_R):
+        def lpop(self, key):
+            try:
+                return next(seq)
+            except StopIteration:
+                import asyncio as _a
+                raise _a.CancelledError()
+
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: _RQ())
+    task = asyncio.create_task(hls_jobs._consumer_loop(poll_seconds=0))
+    for _ in range(10):
+        await asyncio.sleep(0)
+        if "stuck1" in hls_jobs._inflight:
+            break
+    assert "stuck1" in hls_jobs._inflight
+    # Cancel the in-flight child → its except-CancelledError re-enqueues it.
+    for t in list(hls_jobs._consumer_children):
+        t.cancel()
+    task.cancel()
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert "stuck1" in pushed
+
+
+async def test_requeue_stale_processing(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    from datetime import datetime, timezone, timedelta
+    old = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    fresh = datetime.now(timezone.utc).isoformat()
+    a1 = await _add_video_activity(db, org, course, "stale1", filename="a.mp4")
+    a1.extra_metadata = {"hls": {"status": "processing", "updated_at": old}}
+    a2 = await _add_video_activity(db, org, course, "fresh1", filename="b.mp4")
+    a2.extra_metadata = {"hls": {"status": "processing", "updated_at": fresh}}
+    db.add(a1)
+    db.add(a2)
+    await db.commit()
+
+    pushed = []
+
+    class _R:
+        def rpush(self, key, val):
+            pushed.append(val)
+
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: _R())
+    n = await hls_jobs._requeue_stale_processing(stale_after=1200)
+    assert n == 1 and pushed == ["stale1"]  # only the >20min-old one is reaped
+
+
+async def test_consumer_loop_no_redis_returns(monkeypatch):
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: None)
+    await hls_jobs._consumer_loop()  # returns immediately, no raise
+
+
+def test_start_consumer_noop_when_disabled(monkeypatch):
+    monkeypatch.setattr(hls_jobs, "hls_enabled", lambda: False)
+    hls_jobs._consumer_task = None
+    hls_jobs.start_consumer()
+    assert hls_jobs._consumer_task is None
+
+
+def test_start_consumer_noop_without_redis(monkeypatch):
+    monkeypatch.setattr(hls_jobs, "hls_enabled", lambda: True)
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: None)
+    hls_jobs._consumer_task = None
+    hls_jobs.start_consumer()
+    assert hls_jobs._consumer_task is None
+
+
+async def test_enqueue_pending_pushes_all_targets(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    await _add_video_activity(db, org, course, "p_todo", filename="a.mp4")
+    await _add_video_activity(db, org, course, "p_ready", filename="b.mp4", hls_status="ready")
+    pushed = []
+
+    class _R:
+        def rpush(self, key, val):
+            pushed.append(val)
+
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: _R())
+    result = await hls_jobs.enqueue_pending()
+    assert pushed == ["p_todo"]
+    assert result == {"pending": 1, "enqueued": 1}
+
+
+async def test_enqueue_pending_no_redis(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    await _add_video_activity(db, org, course, "p1", filename="a.mp4")
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: None)
+    result = await hls_jobs.enqueue_pending()
+    assert result["enqueued"] == 0 and result.get("error") == "no_redis"
+
+
+# --------------------------------------------------------------------------
+# Resilience: job timeout, reaper, graceful shutdown
+# --------------------------------------------------------------------------
+
+async def test_consumer_job_timeout_marks_failed(monkeypatch):
+    monkeypatch.setattr(hls_jobs, "JOB_TIMEOUT_SECONDS", 0.01)
+    seq = iter([b"slow1"])
+
+    class _R:
+        def lpop(self, key):
+            try:
+                return next(seq)
+            except StopIteration:
+                raise asyncio.CancelledError()
+
+        def rpush(self, *a):
+            pass
+
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: _R())
+
+    async def _slow(uuid):
+        await asyncio.sleep(10)  # exceeds JOB_TIMEOUT_SECONDS
+
+    monkeypatch.setattr(hls_jobs, "transcode_activity", _slow)
+    status = []
+
+    async def _ss(uuid, st, **k):
+        status.append((uuid, st, k.get("error")))
+
+    monkeypatch.setattr(hls_jobs, "_set_status", _ss)
+    with pytest.raises(asyncio.CancelledError):
+        await hls_jobs._consumer_loop(poll_seconds=0)
+    await asyncio.sleep(0.05)  # let the child's wait_for time out
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert ("slow1", "failed", "timeout") in status
+
+
+async def test_reaper_loop_calls_requeue_and_survives_errors(monkeypatch):
+    calls = {"n": 0}
+
+    async def _req():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("transient")  # must not kill the reaper
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(hls_jobs, "_requeue_stale_processing", _req)
+    with pytest.raises(asyncio.CancelledError):
+        await hls_jobs._reaper_loop(interval=0)
+    assert calls["n"] == 2
+
+
+async def test_stop_consumer_reenqueues_inflight_and_cancels(monkeypatch):
+    pushed = []
+
+    class _R:
+        def rpush(self, k, v):
+            pushed.append(v)
+
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: _R())
+    hls_jobs._inflight.clear()
+    hls_jobs._inflight.add("busy1")
+
+    async def _idle():
+        await asyncio.sleep(3600)
+
+    hls_jobs._consumer_task = asyncio.create_task(_idle())
+    hls_jobs._reaper_task = asyncio.create_task(_idle())
+    await asyncio.sleep(0)
+    await hls_jobs.stop_consumer()
+    assert "busy1" in pushed
+    assert hls_jobs._consumer_task is None and hls_jobs._reaper_task is None
+    hls_jobs._inflight.clear()
+
+
+async def test_start_consumer_starts_reaper(monkeypatch):
+    monkeypatch.setattr(hls_jobs, "hls_enabled", lambda: True)
+
+    class _R:
+        def lpop(self, key):
+            return None
+
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: _R())
+    hls_jobs._consumer_task = None
+    hls_jobs._reaper_task = None
+    hls_jobs.start_consumer()
+    try:
+        assert hls_jobs._consumer_task is not None
+        assert hls_jobs._reaper_task is not None
+    finally:
+        await hls_jobs.stop_consumer()
+
+
+async def test_requeue_stale_missing_timestamp_is_stale(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    a = await _add_video_activity(db, org, course, "noTs", filename="a.mp4")
+    a.extra_metadata = {"hls": {"status": "processing"}}  # no updated_at → treated stale
+    db.add(a)
+    await db.commit()
+    pushed = []
+
+    class _R:
+        def rpush(self, k, v):
+            pushed.append(v)
+
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: _R())
+    n = await hls_jobs._requeue_stale_processing(stale_after=1200)
+    assert n == 1 and pushed == ["noTs"]
+
+
+async def test_requeue_stale_no_redis_returns_zero(monkeypatch):
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: None)
+    assert await hls_jobs._requeue_stale_processing() == 0
+
+
+async def test_consumer_loop_empty_poll_then_cancel(monkeypatch):
+    seq = iter([None, None])
+
+    class _R:
+        def lpop(self, key):
+            v = next(seq, "STOP")
+            if v == "STOP":
+                raise asyncio.CancelledError()
+            return v
+
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: _R())
+    with pytest.raises(asyncio.CancelledError):
+        await hls_jobs._consumer_loop(poll_seconds=0)
+
+
+async def test_requeue_stale_skips_ready_and_handles_bad_ts(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    ready = await _add_video_activity(db, org, course, "rdy", filename="a.mp4")
+    ready.extra_metadata = {"hls": {"status": "ready"}}  # non-processing → skipped
+    badts = await _add_video_activity(db, org, course, "bad", filename="b.mp4")
+    badts.extra_metadata = {"hls": {"status": "processing", "updated_at": "not-a-date"}}
+    db.add(ready)
+    db.add(badts)
+    await db.commit()
+    pushed = []
+
+    class _R:
+        def rpush(self, k, v):
+            pushed.append(v)
+
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: _R())
+    await hls_jobs._requeue_stale_processing(stale_after=1200)
+    assert pushed == ["bad"]  # ready skipped; unparseable ts treated as stale
+
+
+async def test_backfill_counts_failures(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    await _add_video_activity(db, org, course, "bf1", filename="a.mp4")
+
+    async def _tr(uuid):
+        return False
+
+    monkeypatch.setattr(hls_jobs, "transcode_activity", _tr)
+    r = await hls_jobs.backfill()
+    assert r["failed"] >= 1
+
+
+async def test_stop_consumer_waits_for_children(monkeypatch):
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: None)
+
+    async def _child():
+        await asyncio.sleep(0.01)
+
+    hls_jobs._consumer_children.clear()
+    hls_jobs._consumer_children.add(asyncio.create_task(_child()))
+    hls_jobs._consumer_task = None
+    hls_jobs._reaper_task = None
+    hls_jobs._inflight.clear()
+    await hls_jobs.stop_consumer()  # gathers children
+    hls_jobs._consumer_children.clear()

--- a/apps/api/src/tests/services/test_hls_jobs_service.py
+++ b/apps/api/src/tests/services/test_hls_jobs_service.py
@@ -441,28 +441,79 @@ async def test_consumer_reenqueues_inflight_on_shutdown(monkeypatch):
     assert "stuck1" in pushed
 
 
-async def test_requeue_stale_processing(monkeypatch, db, org, course, chapter, activity):
+class _FakeRedis:
+    """Minimal Redis for reconcile_unfinished tests."""
+    def __init__(self, leases=None, retries=None, queue=None):
+        self.pushed = []
+        self.leases = set(leases or [])
+        self.retries = dict(retries or {})
+        self.queue = list(queue or [])
+
+    def lrange(self, key, a, b):
+        return list(self.queue)
+
+    def exists(self, key):
+        return 1 if key in self.leases else 0
+
+    def get(self, key):
+        return str(self.retries[key]) if key in self.retries else None
+
+    def incr(self, key):
+        self.retries[key] = self.retries.get(key, 0) + 1
+        return self.retries[key]
+
+    def expire(self, key, ttl):
+        return True
+
+    def rpush(self, key, val):
+        self.pushed.append(val)
+        return len(self.pushed)
+
+
+async def test_reconcile_requeues_unfinished_skips_ready(monkeypatch, db, org, course, chapter, activity):
     _bind_session(monkeypatch, db)
-    from datetime import datetime, timezone, timedelta
-    old = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
-    fresh = datetime.now(timezone.utc).isoformat()
-    a1 = await _add_video_activity(db, org, course, "stale1", filename="a.mp4")
-    a1.extra_metadata = {"hls": {"status": "processing", "updated_at": old}}
-    a2 = await _add_video_activity(db, org, course, "fresh1", filename="b.mp4")
-    a2.extra_metadata = {"hls": {"status": "processing", "updated_at": fresh}}
-    db.add(a1)
-    db.add(a2)
-    await db.commit()
+    await _add_video_activity(db, org, course, "todo1", filename="a.mp4")  # hls None
+    await _add_video_activity(db, org, course, "proc1", filename="b.mp4", hls_status="processing")
+    await _add_video_activity(db, org, course, "fail1", filename="c.mp4", hls_status="failed")
+    await _add_video_activity(db, org, course, "rdy1", filename="d.mp4", hls_status="ready")
+    r = _FakeRedis()
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: r)
+    out = await hls_jobs.reconcile_unfinished()
+    assert set(r.pushed) == {"todo1", "proc1", "fail1"}  # ready skipped
+    assert out["requeued"] == 3
 
-    pushed = []
 
-    class _R:
-        def rpush(self, key, val):
-            pushed.append(val)
+async def test_reconcile_skips_active_lease(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    await _add_video_activity(db, org, course, "busy1", filename="a.mp4", hls_status="processing")
+    r = _FakeRedis(leases={hls_jobs._lease_key("busy1")})
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: r)
+    out = await hls_jobs.reconcile_unfinished()
+    assert r.pushed == [] and out["skipped"] == 1
 
-    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: _R())
-    n = await hls_jobs._requeue_stale_processing(stale_after=1200)
-    assert n == 1 and pushed == ["stale1"]  # only the >20min-old one is reaped
+
+async def test_reconcile_skips_already_queued(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    await _add_video_activity(db, org, course, "q1", filename="a.mp4", hls_status="failed")
+    r = _FakeRedis(queue=["q1"])
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: r)
+    out = await hls_jobs.reconcile_unfinished()
+    assert r.pushed == [] and out["skipped"] == 1
+
+
+async def test_reconcile_gives_up_after_max_retries(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    await _add_video_activity(db, org, course, "bad1", filename="a.mp4", hls_status="failed")
+    r = _FakeRedis(retries={hls_jobs._retries_key("bad1"): 6})
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: r)
+    out = await hls_jobs.reconcile_unfinished(max_retries=6)
+    assert r.pushed == [] and out["gaveup"] == 1
+
+
+async def test_reconcile_no_redis(monkeypatch):
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: None)
+    out = await hls_jobs.reconcile_unfinished()
+    assert out["requeued"] == 0 and out.get("error") == "no_redis"
 
 
 async def test_consumer_loop_no_redis_returns(monkeypatch):
@@ -547,18 +598,18 @@ async def test_consumer_job_timeout_marks_failed(monkeypatch):
     assert ("slow1", "failed", "timeout") in status
 
 
-async def test_reaper_loop_calls_requeue_and_survives_errors(monkeypatch):
+async def test_reconcile_loop_calls_and_survives_errors(monkeypatch):
     calls = {"n": 0}
 
-    async def _req():
+    async def _rec(*a, **k):
         calls["n"] += 1
         if calls["n"] == 1:
-            raise RuntimeError("transient")  # must not kill the reaper
+            raise RuntimeError("transient")  # must not kill the loop
         raise asyncio.CancelledError()
 
-    monkeypatch.setattr(hls_jobs, "_requeue_stale_processing", _req)
+    monkeypatch.setattr(hls_jobs, "reconcile_unfinished", _rec)
     with pytest.raises(asyncio.CancelledError):
-        await hls_jobs._reaper_loop(interval=0)
+        await hls_jobs._reconcile_loop(interval=0)
     assert calls["n"] == 2
 
 
@@ -603,26 +654,13 @@ async def test_start_consumer_starts_reaper(monkeypatch):
         await hls_jobs.stop_consumer()
 
 
-async def test_requeue_stale_missing_timestamp_is_stale(monkeypatch, db, org, course, chapter, activity):
+async def test_reconcile_ignores_activities_without_a_file(monkeypatch, db, org, course, chapter, activity):
     _bind_session(monkeypatch, db)
-    a = await _add_video_activity(db, org, course, "noTs", filename="a.mp4")
-    a.extra_metadata = {"hls": {"status": "processing"}}  # no updated_at → treated stale
-    db.add(a)
-    await db.commit()
-    pushed = []
-
-    class _R:
-        def rpush(self, k, v):
-            pushed.append(v)
-
-    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: _R())
-    n = await hls_jobs._requeue_stale_processing(stale_after=1200)
-    assert n == 1 and pushed == ["noTs"]
-
-
-async def test_requeue_stale_no_redis_returns_zero(monkeypatch):
-    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: None)
-    assert await hls_jobs._requeue_stale_processing() == 0
+    await _add_video_activity(db, org, course, "nofile", filename=None, hls_status="failed")
+    r = _FakeRedis()
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: r)
+    out = await hls_jobs.reconcile_unfinished()
+    assert r.pushed == [] and out["requeued"] == 0
 
 
 async def test_consumer_loop_empty_poll_then_cancel(monkeypatch):
@@ -640,24 +678,13 @@ async def test_consumer_loop_empty_poll_then_cancel(monkeypatch):
         await hls_jobs._consumer_loop(poll_seconds=0)
 
 
-async def test_requeue_stale_skips_ready_and_handles_bad_ts(monkeypatch, db, org, course, chapter, activity):
+async def test_reconcile_bumps_retry_counter(monkeypatch, db, org, course, chapter, activity):
     _bind_session(monkeypatch, db)
-    ready = await _add_video_activity(db, org, course, "rdy", filename="a.mp4")
-    ready.extra_metadata = {"hls": {"status": "ready"}}  # non-processing → skipped
-    badts = await _add_video_activity(db, org, course, "bad", filename="b.mp4")
-    badts.extra_metadata = {"hls": {"status": "processing", "updated_at": "not-a-date"}}
-    db.add(ready)
-    db.add(badts)
-    await db.commit()
-    pushed = []
-
-    class _R:
-        def rpush(self, k, v):
-            pushed.append(v)
-
-    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: _R())
-    await hls_jobs._requeue_stale_processing(stale_after=1200)
-    assert pushed == ["bad"]  # ready skipped; unparseable ts treated as stale
+    await _add_video_activity(db, org, course, "retryme", filename="a.mp4", hls_status="failed")
+    r = _FakeRedis()
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: r)
+    await hls_jobs.reconcile_unfinished()
+    assert r.retries.get(hls_jobs._retries_key("retryme")) == 1  # counter incremented
 
 
 async def test_backfill_counts_failures(monkeypatch, db, org, course, chapter, activity):

--- a/apps/api/src/tests/services/test_hls_playlist_service.py
+++ b/apps/api/src/tests/services/test_hls_playlist_service.py
@@ -1,0 +1,127 @@
+"""Unit tests for src/services/utils/hls_playlist.py (playlist URL rewriting)."""
+
+from src.services.utils.hls_playlist import rewrite_playlist, _resolve_key
+
+
+def _presign(key: str):
+    return f"https://r2.example/{key}?sig=abc"
+
+
+def test_segments_rewritten_to_presigned_urls():
+    playlist = (
+        "#EXTM3U\n"
+        "#EXT-X-TARGETDURATION:6\n"
+        "#EXTINF:6.0,\n"
+        "seg_0000.ts\n"
+        "#EXTINF:6.0,\n"
+        "seg_0001.ts\n"
+        "#EXT-X-ENDLIST\n"
+    )
+    out = rewrite_playlist(playlist, "content/o/hls/v480p", _presign)
+    assert "https://r2.example/content/o/hls/v480p/seg_0000.ts?sig=abc" in out
+    assert "https://r2.example/content/o/hls/v480p/seg_0001.ts?sig=abc" in out
+    # Original bare segment names must be gone.
+    assert "\nseg_0000.ts" not in out
+    # Comments/tags are preserved verbatim.
+    assert "#EXT-X-TARGETDURATION:6" in out
+    assert "#EXT-X-ENDLIST" in out
+
+
+def test_nested_playlist_refs_stay_relative():
+    master = (
+        "#EXTM3U\n"
+        '#EXT-X-STREAM-INF:BANDWIDTH=1,RESOLUTION=1280x720\n'
+        "v720p/index.m3u8\n"
+        '#EXT-X-STREAM-INF:BANDWIDTH=1,RESOLUTION=640x360\n'
+        "v360p/index.m3u8\n"
+    )
+    out = rewrite_playlist(master, "content/o/hls", _presign)
+    # Rendition playlists must remain relative so they re-enter the API endpoint.
+    assert "v720p/index.m3u8" in out
+    assert "v360p/index.m3u8" in out
+    assert "r2.example" not in out
+
+
+def test_absolute_urls_pass_through_untouched():
+    playlist = "#EXTM3U\nhttps://cdn.example/already.ts\n"
+    out = rewrite_playlist(playlist, "content/o/hls/v480p", _presign)
+    assert "https://cdn.example/already.ts" in out
+    assert "r2.example" not in out
+
+
+def test_failed_presign_leaves_line_unchanged():
+    playlist = "#EXTM3U\n#EXTINF:6.0,\nseg_0000.ts\n"
+    out = rewrite_playlist(playlist, "content/o/hls/v480p", lambda key: None)
+    assert "seg_0000.ts" in out
+    assert "r2.example" not in out
+
+
+def test_blank_lines_and_comments_preserved():
+    playlist = "#EXTM3U\n\n#COMMENT\n"
+    out = rewrite_playlist(playlist, "content/o/hls", _presign)
+    assert "#EXTM3U" in out
+    assert "#COMMENT" in out
+
+
+def test_resolve_key_handles_subdirs_and_parent():
+    assert _resolve_key("content/o/hls/v480p", "seg_0000.ts") == "content/o/hls/v480p/seg_0000.ts"
+    assert _resolve_key("content/o/hls/v480p", "../v720p/seg.ts") == "content/o/hls/v720p/seg.ts"
+    assert _resolve_key("content/o/hls", "./master.m3u8") == "content/o/hls/master.m3u8"
+
+
+# --- Edge cases added during hardening audit -------------------------------
+
+_ROOT = "content/orgs/O/courses/C/activities/A/video/hls"
+
+
+def test_resolve_key_clamps_traversal_escape():
+    base = f"{_ROOT}/v480p"
+    # A crafted ../ chain that would escape the activity's hls dir → None.
+    assert _resolve_key(base, "../../../../../../secret/x.ts", _ROOT) is None
+    # A legitimate in-tree reference still resolves.
+    assert _resolve_key(base, "seg_0000.ts", _ROOT) == f"{_ROOT}/v480p/seg_0000.ts"
+    # ../enc.key stays within root (used by encrypted renditions).
+    assert _resolve_key(base, "../enc.key", _ROOT) == f"{_ROOT}/enc.key"
+
+
+def test_rewrite_leaves_escaping_segment_untouched():
+    base = f"{_ROOT}/v480p"
+    pl = "#EXTM3U\n#EXTINF:6,\n../../../../../../secret/x.ts\n"
+    out = rewrite_playlist(pl, base, lambda k: "SIGNED:" + k)
+    assert "SIGNED:" not in out  # escape was refused
+    assert "../../../../../../secret/x.ts" in out
+
+
+def test_segment_with_query_params_is_presigned():
+    out = rewrite_playlist("#EXTM3U\nseg_0000.ts?foo=bar\n", f"{_ROOT}/v480p", _presign)
+    # Extension detection ignores the query; the whole ref is signed.
+    assert "sig=abc" in out  # segment was rewritten to the presigned URL
+    assert "seg_0000.ts" in out
+
+
+def test_uppercase_and_protocol_relative_absolute_urls_passthrough():
+    out = rewrite_playlist(
+        "#EXTM3U\nHTTPS://cdn/x.ts\n//cdn/y.ts\n", f"{_ROOT}/v480p", _presign
+    )
+    assert "HTTPS://cdn/x.ts" in out
+    assert "//cdn/y.ts" in out
+    assert "r2.example" not in out
+
+
+def test_ext_x_key_tag_is_preserved_verbatim():
+    # The AES key URI lives in a #-tag and must NOT be presigned/rewritten.
+    pl = '#EXTM3U\n#EXT-X-KEY:METHOD=AES-128,URI="../enc.key",IV=0x1\nseg_0.ts\n'
+    out = rewrite_playlist(pl, f"{_ROOT}/v480p", _presign)
+    assert 'URI="../enc.key"' in out
+
+
+def test_ext_x_map_init_segment_is_presigned():
+    # fMP4 init segment (defensive: we emit TS, but handle it if ever enabled).
+    pl = '#EXTM3U\n#EXT-X-MAP:URI="init.mp4"\nseg_0.m4s\n'
+    out = rewrite_playlist(pl, f"{_ROOT}/v480p", _presign)
+    assert 'URI="https://r2.example/' in out and "init.mp4" in out
+
+
+def test_crlf_line_endings_handled():
+    out = rewrite_playlist("#EXTM3U\r\nseg_0000.ts\r\n", f"{_ROOT}/v480p", _presign)
+    assert "sig=abc" in out  # segment was rewritten to the presigned URL

--- a/apps/api/src/tests/services/test_hls_presign_service.py
+++ b/apps/api/src/tests/services/test_hls_presign_service.py
@@ -1,0 +1,41 @@
+"""Unit tests for generate_presigned_get_url in storage_utils."""
+
+from unittest.mock import Mock
+
+import src.services.courses.transfer.storage_utils as storage_utils
+
+
+def test_presign_returns_none_when_s3_disabled(monkeypatch):
+    monkeypatch.setattr(storage_utils, "is_s3_enabled", lambda: False)
+    assert storage_utils.generate_presigned_get_url("content/x.ts") is None
+
+
+def test_presign_returns_none_without_client(monkeypatch):
+    monkeypatch.setattr(storage_utils, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(storage_utils, "get_storage_client", lambda: None)
+    assert storage_utils.generate_presigned_get_url("content/x.ts") is None
+
+
+def test_presign_returns_signed_url(monkeypatch):
+    client = Mock()
+    client.generate_presigned_url.return_value = "https://r2/x.ts?X-Amz-Signature=sig"
+    monkeypatch.setattr(storage_utils, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(storage_utils, "get_storage_client", lambda: client)
+    monkeypatch.setattr(storage_utils, "get_s3_bucket_name", lambda: "bucket")
+
+    url = storage_utils.generate_presigned_get_url("content/x.ts", expires_in=123)
+    assert url == "https://r2/x.ts?X-Amz-Signature=sig"
+    client.generate_presigned_url.assert_called_once_with(
+        "get_object",
+        Params={"Bucket": "bucket", "Key": "content/x.ts"},
+        ExpiresIn=123,
+    )
+
+
+def test_presign_swallows_errors(monkeypatch):
+    client = Mock()
+    client.generate_presigned_url.side_effect = RuntimeError("boom")
+    monkeypatch.setattr(storage_utils, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(storage_utils, "get_storage_client", lambda: client)
+    monkeypatch.setattr(storage_utils, "get_s3_bucket_name", lambda: "bucket")
+    assert storage_utils.generate_presigned_get_url("content/x.ts") is None

--- a/apps/api/src/tests/services/test_hls_transcode_service.py
+++ b/apps/api/src/tests/services/test_hls_transcode_service.py
@@ -1,0 +1,232 @@
+"""Unit + ffmpeg-integration tests for src/services/utils/hls_transcode.py."""
+
+import asyncio
+import os
+import shutil
+
+import pytest
+
+from src.services.utils import hls_transcode as ht
+
+
+# --------------------------------------------------------------------------
+# Pure ladder selection
+# --------------------------------------------------------------------------
+
+def test_select_ladder_is_source_capped():
+    assert [r.name for r in ht.select_ladder(1080)] == ["1080p", "720p", "480p", "360p"]
+    assert [r.name for r in ht.select_ladder(720)] == ["720p", "480p", "360p"]
+    assert [r.name for r in ht.select_ladder(540)] == ["480p", "360p"]
+    assert [r.name for r in ht.select_ladder(360)] == ["360p"]
+
+
+def test_select_ladder_never_empty_for_tiny_sources():
+    assert [r.name for r in ht.select_ladder(240)] == ["360p"]
+    assert [r.name for r in ht.select_ladder(0)] == ["360p"]
+
+
+def test_thumbnails_grid_math():
+    # interval 10s, 10 columns.
+    assert ht.thumbnails_grid(0) == (10, 1)          # unknown duration → one cell
+    assert ht.thumbnails_grid(100) == (10, 1)        # 10 frames → 1 row
+    assert ht.thumbnails_grid(105) == (10, 2)        # 11 frames → 2 rows
+    assert ht.thumbnails_grid(250) == (10, 3)        # 25 frames → 3 rows
+
+
+def test_thumbnails_grid_guards_zero_interval_and_columns():
+    # Must not raise ZeroDivisionError on degenerate inputs.
+    assert ht.thumbnails_grid(100, interval=0, columns=10) == (10, ht.thumbnails_grid(100, 1, 10)[1])
+    assert ht.thumbnails_grid(100, interval=10, columns=0)[0] == 1
+
+
+def test_sprite_interval_shrinks_for_short_and_caps_for_long():
+    # Short clip: interval shrinks so fps yields ≥1 frame.
+    assert ht._sprite_interval(4, 10, 10) == 2
+    assert ht._sprite_interval(1, 10, 10) == 1
+    # Normal: unchanged.
+    assert ht._sprite_interval(1200, 10, 10) == 10
+    # Very long: interval grows so total cells stay under MAX_THUMBNAILS.
+    long_interval = ht._sprite_interval(100000, 10, 10)
+    assert long_interval > 10
+    import math
+    assert math.ceil(100000 / long_interval) <= ht.MAX_THUMBNAILS
+
+
+async def test_probe_missing_ffprobe_safe_fallback(monkeypatch):
+    # No ffprobe → (0, False, 0.0): no forced 1080 upscale, no audio map.
+    monkeypatch.setattr(ht, "_ffprobe", lambda: None)
+    height, has_audio, duration = await ht._probe("whatever.mp4")
+    assert (height, has_audio, duration) == (0, False, 0.0)
+    # And that height selects a single lowest rung (never upscales).
+    assert [r.name for r in ht.select_ladder(height)] == ["360p"]
+
+
+# --------------------------------------------------------------------------
+# ffmpeg argument construction
+# --------------------------------------------------------------------------
+
+def test_build_ffmpeg_args_with_audio():
+    rungs = ht.select_ladder(720)  # 720p, 480p, 360p
+    args = ht.build_ffmpeg_args("in.mp4", "/out", rungs, has_audio=True)
+    joined = " ".join(args)
+    assert "-filter_complex" in args
+    assert "split=3" in joined
+    assert "scale=-2:720" in joined and "scale=-2:360" in joined
+    # One audio map per rung, and var_stream_map references audio groups.
+    assert args.count("a:0") == 3  # -map a:0 repeated
+    vsm = args[args.index("-var_stream_map") + 1]
+    assert "v:0,a:0,name:720p" in vsm and "v:2,a:2,name:360p" in vsm
+    # Output template + master playlist name.
+    assert args[-1].endswith(os.path.join("v%v", "index.m3u8"))
+    assert "master.m3u8" in args
+
+
+def test_build_ffmpeg_args_without_audio_omits_audio_maps():
+    rungs = ht.select_ladder(360)
+    args = ht.build_ffmpeg_args("in.mp4", "/out", rungs, has_audio=False)
+    assert "a:0" not in args
+    assert "-c:a" not in args
+    vsm = args[args.index("-var_stream_map") + 1]
+    assert vsm == "v:0,name:360p"
+
+
+def test_build_ffmpeg_args_caps_threads(monkeypatch):
+    monkeypatch.setenv("LEARNHOUSE_HLS_FFMPEG_THREADS", "2")
+    args = ht.build_ffmpeg_args("in.mp4", "/out", ht.select_ladder(360), has_audio=True)
+    assert "-threads" in args
+    assert args[args.index("-threads") + 1] == "2"
+
+
+def test_ffmpeg_threads_parsing(monkeypatch):
+    monkeypatch.delenv("LEARNHOUSE_HLS_FFMPEG_THREADS", raising=False)
+    assert ht.ffmpeg_threads() == "1"  # default
+    monkeypatch.setenv("LEARNHOUSE_HLS_FFMPEG_THREADS", "3")
+    assert ht.ffmpeg_threads() == "3"
+    monkeypatch.setenv("LEARNHOUSE_HLS_FFMPEG_THREADS", "bad")
+    assert ht.ffmpeg_threads() == "1"  # invalid -> default
+
+
+def test_build_ffmpeg_args_adds_key_info_when_encrypting():
+    rungs = ht.select_ladder(360)
+    without = ht.build_ffmpeg_args("in.mp4", "/out", rungs, has_audio=True)
+    assert "-hls_key_info_file" not in without
+
+    with_key = ht.build_ffmpeg_args("in.mp4", "/out", rungs, has_audio=True, key_info_file="/tmp/k.keyinfo")
+    assert "-hls_key_info_file" in with_key
+    assert with_key[with_key.index("-hls_key_info_file") + 1] == "/tmp/k.keyinfo"
+    # The key flag must precede the output playlist template.
+    assert with_key.index("-hls_key_info_file") < len(with_key) - 1
+
+
+# --------------------------------------------------------------------------
+# Real ffmpeg end-to-end (skipped when ffmpeg is unavailable)
+# --------------------------------------------------------------------------
+
+_HAS_FFMPEG = shutil.which("ffmpeg") is not None and shutil.which("ffprobe") is not None
+
+
+def _make_clip(path: str, seconds: int = 4):
+    import subprocess
+    subprocess.run(
+        ["ffmpeg", "-y", "-loglevel", "error",
+         "-f", "lavfi", "-i", f"testsrc=duration={seconds}:size=1280x720:rate=24",
+         "-f", "lavfi", "-i", f"sine=frequency=440:duration={seconds}",
+         "-c:v", "libx264", "-pix_fmt", "yuv420p", "-c:a", "aac", path],
+        check=True,
+    )
+
+
+@pytest.mark.skipif(not _HAS_FFMPEG, reason="ffmpeg/ffprobe not installed")
+def test_transcode_source_to_hls_end_to_end(tmp_path):
+    src = str(tmp_path / "src.mp4")
+    out = str(tmp_path / "hls")
+    _make_clip(src)
+
+    result = asyncio.run(ht.transcode_source_to_hls(src, out))
+    assert result is not None
+    assert result["master"] == "master.m3u8"
+    # 720p source → 720p/480p/360p rungs.
+    assert result["renditions"] == ["720p", "480p", "360p"]
+
+    assert os.path.isfile(os.path.join(out, "master.m3u8"))
+    for name in result["renditions"]:
+        assert os.path.isfile(os.path.join(out, f"v{name}", "index.m3u8"))
+        segs = [f for f in os.listdir(os.path.join(out, f"v{name}")) if f.endswith(".ts")]
+        assert segs, f"no segments produced for {name}"
+
+    # Hover-preview sprite is generated and its config returned.
+    thumbs = result["thumbnails"]
+    assert thumbs is not None
+    assert thumbs["url"] == "thumbnails/sprite.jpg"
+    assert thumbs["columns"] == 10 and thumbs["width"] == 160 and thumbs["height"] == 90
+    assert os.path.isfile(os.path.join(out, "thumbnails", "sprite.jpg"))
+
+    # AES-128 encryption on by default: key present, playlists reference it, and
+    # the keyinfo temp file was cleaned up (not left in the output).
+    assert os.path.isfile(os.path.join(out, "enc.key"))
+    rendition = open(os.path.join(out, "v360p", "index.m3u8")).read()
+    assert "#EXT-X-KEY:METHOD=AES-128" in rendition
+    assert 'URI="../enc.key"' in rendition
+    assert not any(f.endswith(".keyinfo") for f in os.listdir(out))
+
+
+@pytest.mark.skipif(not _HAS_FFMPEG, reason="ffmpeg/ffprobe not installed")
+def test_transcode_without_encryption(tmp_path, monkeypatch):
+    monkeypatch.setenv("LEARNHOUSE_HLS_ENCRYPT", "false")
+    src = str(tmp_path / "src.mp4")
+    out = str(tmp_path / "hls")
+    _make_clip(src)
+    result = asyncio.run(ht.transcode_source_to_hls(src, out))
+    assert result is not None
+    assert not os.path.isfile(os.path.join(out, "enc.key"))
+    rendition = open(os.path.join(out, "v360p", "index.m3u8")).read()
+    assert "#EXT-X-KEY" not in rendition
+
+
+@pytest.mark.skipif(not _HAS_FFMPEG, reason="ffmpeg not installed")
+def test_transcode_missing_source_returns_none(tmp_path):
+    result = asyncio.run(
+        ht.transcode_source_to_hls(str(tmp_path / "nope.mp4"), str(tmp_path / "out"))
+    )
+    assert result is None
+
+
+# --- Error-path coverage (no real hang/ffmpeg needed) ----------------------
+
+async def test_run_subprocess_returns_output():
+    # Uses a real trivial process (python) — no ffmpeg needed.
+    import sys
+    rc, out, _ = await ht._run_subprocess([sys.executable, "-c", "print('ok')"], 30)
+    assert rc == 0 and out.strip() == b"ok"
+
+
+async def test_run_subprocess_timeout_returns_minus_one():
+    import sys
+    rc, _, _ = await ht._run_subprocess(
+        [sys.executable, "-c", "import time; time.sleep(30)"], 1
+    )
+    assert rc == -1  # killed on timeout, no hang
+
+
+async def test_transcode_and_sprite_return_none_without_ffmpeg(monkeypatch, tmp_path):
+    monkeypatch.setattr(ht, "_ffmpeg", lambda: None)
+    src = tmp_path / "x.mp4"
+    src.write_bytes(b"data")
+    assert await ht.transcode_source_to_hls(str(src), str(tmp_path / "o")) is None
+    assert await ht.generate_sprite_thumbnails(str(src), str(tmp_path / "o2"), 10) is None
+
+
+@pytest.mark.skipif(not _HAS_FFMPEG, reason="ffmpeg not installed")
+async def test_transcode_bogus_source_returns_none(tmp_path):
+    # ffmpeg present but the input isn't a valid media file → rc!=0 → None.
+    bogus = tmp_path / "bogus.mp4"
+    bogus.write_bytes(b"not a real video")
+    assert await ht.transcode_source_to_hls(str(bogus), str(tmp_path / "out")) is None
+
+
+@pytest.mark.skipif(not _HAS_FFMPEG, reason="ffprobe not installed")
+async def test_probe_non_media_returns_safe_defaults(tmp_path):
+    p = tmp_path / "notvideo.mp4"
+    p.write_bytes(b"just text, not a video")
+    height, has_audio, duration = await ht._probe(str(p))
+    assert height == 0 and has_audio is False and duration == 0.0

--- a/apps/api/src/tests/services/test_storage_utils_service.py
+++ b/apps/api/src/tests/services/test_storage_utils_service.py
@@ -65,7 +65,14 @@ class TestValidateLocalPath:
         content_dir.mkdir()
         (content_dir / "ok.txt").write_text("data")
 
-        assert storage_utils._validate_local_path("content/ok.txt") == "content/ok.txt"
+        # Returns the canonicalized, containment-checked absolute path (not the
+        # original tainted string) so callers open the validated path.
+        result = storage_utils._validate_local_path("content/ok.txt")
+        import os as _os
+        assert result is not None
+        assert _os.path.isabs(result)
+        assert result == _os.path.realpath("content/ok.txt")
+        assert result.replace("\\", "/").endswith("content/ok.txt")
 
     def test_rejects_path_escaping_content_root(self, tmp_path, monkeypatch):
         # A path that normalizes inside but realpath-escapes the content root

--- a/apps/api/src/tests/services/test_upload_faststart_wiring.py
+++ b/apps/api/src/tests/services/test_upload_faststart_wiring.py
@@ -1,0 +1,65 @@
+"""The upload pipeline must apply faststart to stored videos."""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+import src.services.utils.upload_content as upload_content_mod
+from src.services.utils.upload_content import upload_content, _safe_content_path
+
+
+def test_safe_content_path_contains_within_root(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    p = _safe_content_path("orgs", "org_x", "courses/c/video", "clip.mp4")
+    import os
+    assert os.path.isabs(p)
+    assert p == os.path.realpath("content/orgs/org_x/courses/c/video/clip.mp4")
+
+
+def test_safe_content_path_rejects_traversal(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    for bad in [("..", "escape.mp4"), ("orgs", "../../etc/passwd"), ("orgs", "x\x00.mp4")]:
+        with pytest.raises(HTTPException) as ei:
+            _safe_content_path(*bad)
+        assert ei.value.status_code == 400
+
+
+async def test_filesystem_upload_invokes_faststart(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    cfg = SimpleNamespace(
+        hosting_config=SimpleNamespace(
+            content_delivery=SimpleNamespace(type="filesystem")
+        )
+    )
+    monkeypatch.setattr(upload_content_mod, "get_learnhouse_config", lambda: cfg)
+
+    seen = {}
+    monkeypatch.setattr(
+        upload_content_mod, "ensure_faststart",
+        lambda path: seen.setdefault("path", path),
+    )
+
+    await upload_content(
+        directory="courses/c/activities/a/video",
+        type_of_dir="orgs",
+        uuid="org_x",
+        file_binary=b"videobytes",
+        file_and_format="clip.mp4",
+    )
+
+    written = tmp_path / "content/orgs/org_x/courses/c/activities/a/video/clip.mp4"
+    assert written.read_bytes() == b"videobytes"
+    # faststart was applied to the freshly-written file.
+    assert seen["path"].endswith(
+        "content/orgs/org_x/courses/c/activities/a/video/clip.mp4"
+    )
+
+
+def test_safe_content_path_rejects_absolute_escape(tmp_path, monkeypatch):
+    # An absolute part resets the join and escapes the content root → 400 via
+    # the realpath/commonpath containment check (not the ".." fast-path).
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(HTTPException) as ei:
+        _safe_content_path("orgs", "/etc/passwd")
+    assert ei.value.status_code == 400

--- a/apps/api/src/tests/services/test_video_processing_service.py
+++ b/apps/api/src/tests/services/test_video_processing_service.py
@@ -1,0 +1,161 @@
+"""Unit + ffmpeg-integration tests for src/services/utils/video_processing.py."""
+
+import shutil
+import subprocess
+
+import pytest
+
+from src.services.utils import video_processing as vp
+
+
+# --------------------------------------------------------------------------
+# is_faststart (byte-level moov/mdat ordering)
+# --------------------------------------------------------------------------
+
+def test_is_faststart_true_when_moov_before_mdat(tmp_path):
+    p = tmp_path / "a.mp4"
+    p.write_bytes(b"\x00\x00ftyp....moov....mdat....")
+    assert vp.is_faststart(str(p)) is True
+
+
+def test_is_faststart_false_when_mdat_before_moov(tmp_path):
+    p = tmp_path / "b.mp4"
+    p.write_bytes(b"\x00\x00ftyp....mdat....moov....")
+    assert vp.is_faststart(str(p)) is False
+
+
+def test_is_faststart_false_when_no_moov(tmp_path):
+    p = tmp_path / "c.mp4"
+    p.write_bytes(b"\x00\x00ftyp....mdat....data")
+    assert vp.is_faststart(str(p)) is False
+
+
+# --------------------------------------------------------------------------
+# ensure_faststart guard rails
+# --------------------------------------------------------------------------
+
+def test_ensure_faststart_skips_non_mp4(tmp_path):
+    p = tmp_path / "clip.webm"
+    p.write_bytes(b"whatever")
+    assert vp.ensure_faststart(str(p)) is False
+
+
+def test_ensure_faststart_missing_file_returns_false(tmp_path):
+    assert vp.ensure_faststart(str(tmp_path / "missing.mp4")) is False
+
+
+def test_ensure_faststart_already_faststart_is_noop(tmp_path, monkeypatch):
+    p = tmp_path / "d.mp4"
+    p.write_bytes(b"\x00\x00ftyp....moov....mdat....")
+    # If ffmpeg were called this would explode — assert it is NOT called.
+    monkeypatch.setattr(vp, "_ffmpeg_available", lambda: (_ for _ in ()).throw(AssertionError("ffmpeg should not run")))
+    assert vp.ensure_faststart(str(p)) is True
+
+
+def test_ensure_faststart_without_ffmpeg_returns_false(tmp_path, monkeypatch):
+    p = tmp_path / "e.mp4"
+    p.write_bytes(b"\x00\x00ftyp....mdat....moov....")  # non-faststart
+    monkeypatch.setattr(vp.shutil, "which", lambda name: None)
+    assert vp.ensure_faststart(str(p)) is False
+
+
+# --------------------------------------------------------------------------
+# Real ffmpeg remux (skipped when ffmpeg unavailable)
+# --------------------------------------------------------------------------
+
+_HAS_FFMPEG = shutil.which("ffmpeg") is not None
+
+
+def test_ensure_faststart_recognizes_uppercase_extensions(tmp_path, monkeypatch):
+    # Already-faststart .MP4 (uppercase) → True without invoking ffmpeg.
+    p = tmp_path / "CLIP.MP4"
+    p.write_bytes(b"\x00\x00ftyp....moov....mdat....")
+    monkeypatch.setattr(vp, "_ffmpeg_available", lambda: (_ for _ in ()).throw(AssertionError("no ffmpeg")))
+    assert vp.ensure_faststart(str(p)) is True
+
+
+def _fake_completed(returncode):
+    class _R:
+        pass
+    r = _R()
+    r.returncode = returncode
+    r.stderr = "boom"
+    return r
+
+
+def test_ensure_faststart_remux_failure_keeps_original_and_cleans_temp(tmp_path, monkeypatch):
+    p = tmp_path / "v.mp4"
+    original = b"\x00\x00ftyp....mdat....moov...."  # non-faststart
+    p.write_bytes(original)
+    monkeypatch.setattr(vp.shutil, "which", lambda name: "/usr/bin/ffmpeg")
+    # ffmpeg "runs" but fails (rc=1); it must not touch the original.
+    monkeypatch.setattr(vp.subprocess, "run", lambda *a, **k: _fake_completed(1))
+    assert vp.ensure_faststart(str(p)) is False
+    assert p.read_bytes() == original                      # original intact
+    assert not (tmp_path / "v.mp4.faststart.mp4").exists()  # temp cleaned up
+
+
+def test_ensure_faststart_zero_byte_output_is_failure(tmp_path, monkeypatch):
+    p = tmp_path / "v.mp4"
+    original = b"\x00\x00ftyp....mdat....moov...."
+    p.write_bytes(original)
+    monkeypatch.setattr(vp.shutil, "which", lambda name: "/usr/bin/ffmpeg")
+
+    def _fake_run(args, **kwargs):
+        # ffmpeg "succeeds" (rc=0) but produces an empty output file.
+        open(args[-1], "wb").close()
+        return _fake_completed(0)
+
+    monkeypatch.setattr(vp.subprocess, "run", _fake_run)
+    assert vp.ensure_faststart(str(p)) is False
+    assert p.read_bytes() == original
+    assert not (tmp_path / "v.mp4.faststart.mp4").exists()
+
+
+def test_ensure_faststart_timeout_keeps_original(tmp_path, monkeypatch):
+    p = tmp_path / "v.mp4"
+    original = b"\x00\x00ftyp....mdat....moov...."
+    p.write_bytes(original)
+    monkeypatch.setattr(vp.shutil, "which", lambda name: "/usr/bin/ffmpeg")
+
+    def _raise_timeout(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="ffmpeg", timeout=1)
+
+    monkeypatch.setattr(vp.subprocess, "run", _raise_timeout)
+    assert vp.ensure_faststart(str(p)) is False
+    assert p.read_bytes() == original
+
+
+@pytest.mark.skipif(not _HAS_FFMPEG, reason="ffmpeg not installed")
+def test_ensure_faststart_moves_moov_to_front(tmp_path):
+    src = str(tmp_path / "vid.mp4")
+    # Default mp4 muxing puts moov at the END (non-faststart).
+    subprocess.run(
+        ["ffmpeg", "-y", "-loglevel", "error",
+         "-f", "lavfi", "-i", "testsrc=duration=2:size=320x240:rate=24",
+         "-c:v", "libx264", "-pix_fmt", "yuv420p", src],
+        check=True,
+    )
+    assert vp.is_faststart(src) is False  # sanity: starts non-faststart
+
+    assert vp.ensure_faststart(src) is True
+    assert vp.is_faststart(src) is True   # moov now at the front
+
+
+def test_is_faststart_unreadable_file_returns_false(tmp_path):
+    # Opening a nonexistent path raises OSError → treated as not-faststart.
+    assert vp.is_faststart(str(tmp_path / "missing.mp4")) is False
+
+
+def test_ensure_faststart_generic_subprocess_error_keeps_original(tmp_path, monkeypatch):
+    p = tmp_path / "v.mp4"
+    original = b"\x00\x00ftyp....mdat....moov...."
+    p.write_bytes(original)
+    monkeypatch.setattr(vp.shutil, "which", lambda name: "/usr/bin/ffmpeg")
+
+    def _raise(*a, **k):
+        raise OSError("exec format error")
+
+    monkeypatch.setattr(vp.subprocess, "run", _raise)
+    assert vp.ensure_faststart(str(p)) is False
+    assert p.read_bytes() == original

--- a/apps/api/src/tests/services/test_video_streaming_range.py
+++ b/apps/api/src/tests/services/test_video_streaming_range.py
@@ -1,0 +1,35 @@
+"""Unit tests for Range helpers in video_streaming (416 / zero-length edges)."""
+
+from src.services.utils.video_streaming import is_range_unsatisfiable, parse_range_header
+
+
+def test_no_range_is_satisfiable():
+    assert is_range_unsatisfiable(None, 100) is False
+    assert is_range_unsatisfiable("", 100) is False
+
+
+def test_empty_resource_with_range_is_unsatisfiable():
+    assert is_range_unsatisfiable("bytes=0-", 0) is True
+    assert is_range_unsatisfiable("bytes=0-100", 0) is True
+
+
+def test_start_past_eof_is_unsatisfiable():
+    assert is_range_unsatisfiable("bytes=100-", 100) is True   # last byte is 99
+    assert is_range_unsatisfiable("bytes=999-1000", 100) is True
+
+
+def test_in_range_is_satisfiable():
+    assert is_range_unsatisfiable("bytes=0-", 100) is False
+    assert is_range_unsatisfiable("bytes=99-", 100) is False
+    assert is_range_unsatisfiable("bytes=50-80", 100) is False
+
+
+def test_suffix_range_is_satisfiable_for_nonempty():
+    assert is_range_unsatisfiable("bytes=-500", 100) is False
+    assert is_range_unsatisfiable("bytes=-500", 0) is True  # empty file
+
+
+def test_malformed_range_is_treated_as_satisfiable():
+    # Falls through to normal parsing (which yields the full range / 200).
+    assert is_range_unsatisfiable("bytes=abc-", 100) is False
+    assert parse_range_header("bytes=abc-", 100) == (0, 99)

--- a/apps/web/bun.lock
+++ b/apps/web/bun.lock
@@ -71,6 +71,7 @@
         "@tiptap/suggestion": "^3.17.1",
         "@uiw/codemirror-theme-tokyo-night": "^4.25.4",
         "@uiw/react-codemirror": "^4.25.4",
+        "@videojs/themes": "^1",
         "avvvatars-react": "^0.4.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -123,6 +124,10 @@
         "unsplash-js": "^8.0.0",
         "usehooks-ts": "^3.1.1",
         "uuid": "^14.0.0",
+        "video.js": "^8.23.9",
+        "videojs-contrib-quality-levels": "^4",
+        "videojs-hls-quality-selector": "^2",
+        "videojs-sprite-thumbnails": "^2",
         "wavesurfer.js": "^7.12.1",
         "y-prosemirror": "^1.2.12",
         "yjs": "^13.6.20",
@@ -148,10 +153,13 @@
   "overrides": {
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
+    "dompurify": ">=3.2.4",
     "js-yaml": ">=4.1.1",
-    "jspdf": ">=4.0.0",
+    "jspdf": ">=4.2.1",
     "lodash": ">=4.17.23",
     "lodash-es": ">=4.17.23",
+    "nth-check": ">=2.0.1",
+    "postcss": ">=8.4.31",
     "preact": ">=10.27.3",
     "prosemirror-model": "1.25.9",
     "prosemirror-view": "1.41.9",
@@ -991,6 +999,14 @@
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
 
+    "@videojs/http-streaming": ["@videojs/http-streaming@3.17.5", "", { "dependencies": { "@babel/runtime": "^7.12.5", "@videojs/vhs-utils": "^4.1.2", "aes-decrypter": "^4.0.2", "global": "^4.4.0", "m3u8-parser": "^7.2.0", "mpd-parser": "^1.4.0", "mux.js": "7.1.0", "video.js": "^7 || ^8" } }, "sha512-PRRQVu0hYW5h0XvRWpIyIpEatpMZzZtf7L1avV89Hnu+69f+0c7oLsSL9jwpg2nbvzGkdX5rQxQkz5Vc7tFR9w=="],
+
+    "@videojs/themes": ["@videojs/themes@1.0.1", "", { "dependencies": { "postcss-inline-svg": "^4.1.0" } }, "sha512-2b6YIIIz5x+/eSFdkSZ2RZJfHIMfP7bGODR3wDzLTqFF2kEKnJVIXxBUNzdZC/qiVETqAA2Ba6mCp+iXTUYt4A=="],
+
+    "@videojs/vhs-utils": ["@videojs/vhs-utils@4.1.2", "", { "dependencies": { "@babel/runtime": "^7.12.5", "global": "^4.4.0" } }, "sha512-1Dsv5dtWOq0LP1G37O46FQFA2tKAZON5UMe6dFPxT7JvPhEx8QIXcFQxan8+hHI3fX6aomFRFrUBJNgRYQDSXA=="],
+
+    "@videojs/xhr": ["@videojs/xhr@2.7.0", "", { "dependencies": { "@babel/runtime": "^7.5.5", "global": "~4.4.0", "is-function": "^1.0.1" } }, "sha512-giab+EVRanChIupZK7gXjHy90y3nncA2phIOyG3Ne5fvpiMJzvqYwiTOnEVW2S4CoYcuKJkomat7bMXA/UoUZQ=="],
+
     "@webassemblyjs/ast": ["@webassemblyjs/ast@1.14.1", "", { "dependencies": { "@webassemblyjs/helper-numbers": "1.13.2", "@webassemblyjs/helper-wasm-bytecode": "1.13.2" } }, "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ=="],
 
     "@webassemblyjs/floating-point-hex-parser": ["@webassemblyjs/floating-point-hex-parser@1.13.2", "", {}, "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA=="],
@@ -1021,6 +1037,8 @@
 
     "@webassemblyjs/wast-printer": ["@webassemblyjs/wast-printer@1.14.1", "", { "dependencies": { "@webassemblyjs/ast": "1.14.1", "@xtuc/long": "4.2.2" } }, "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw=="],
 
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
+
     "@xtuc/ieee754": ["@xtuc/ieee754@1.2.0", "", {}, "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="],
 
     "@xtuc/long": ["@xtuc/long@4.2.2", "", {}, "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="],
@@ -1032,6 +1050,8 @@
     "acorn-import-phases": ["acorn-import-phases@1.0.4", "", { "peerDependencies": { "acorn": "^8.14.0" } }, "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "aes-decrypter": ["aes-decrypter@4.0.2", "", { "dependencies": { "@babel/runtime": "^7.12.5", "@videojs/vhs-utils": "^4.1.1", "global": "^4.4.0", "pkcs7": "^1.0.4" } }, "sha512-lc+/9s6iJvuaRe5qDlMTpCFjnwpkeOXp8qP3oiZ5jsj1MRg+SBVUmmICrhxHvc8OELSmc+fEyyxAuppY6hrWzw=="],
 
     "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
@@ -1086,6 +1106,8 @@
     "base64-arraybuffer": ["base64-arraybuffer@1.0.2", "", {}, "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.0", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA=="],
+
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
@@ -1163,6 +1185,10 @@
 
     "css-line-break": ["css-line-break@2.1.0", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w=="],
 
+    "css-select": ["css-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^3.2.1", "domutils": "^1.7.0", "nth-check": "^1.0.2" } }, "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ=="],
+
+    "css-what": ["css-what@3.4.2", "", {}, "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "currency-codes": ["currency-codes@2.2.0", "", { "dependencies": { "first-match": "~0.0.1", "nub": "~0.0.0" } }, "sha512-vpbQc5sEYHGdTVAYUhHnKv0DWiYLRvzl/KKyqeHzBh7HD/j3UlWoScpZ9tN/jG6w2feddWoObsBbaNVu5yDapg=="],
@@ -1227,7 +1253,17 @@
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
-    "dompurify": ["dompurify@3.3.1", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q=="],
+    "dom-serializer": ["dom-serializer@0.1.1", "", { "dependencies": { "domelementtype": "^1.3.0", "entities": "^1.1.1" } }, "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA=="],
+
+    "dom-walk": ["dom-walk@0.1.2", "", {}, "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="],
+
+    "domelementtype": ["domelementtype@1.3.1", "", {}, "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="],
+
+    "domhandler": ["domhandler@2.4.2", "", { "dependencies": { "domelementtype": "1" } }, "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA=="],
+
+    "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
+
+    "domutils": ["domutils@1.7.0", "", { "dependencies": { "dom-serializer": "0", "domelementtype": "1" } }, "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg=="],
 
     "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
@@ -1387,6 +1423,8 @@
 
     "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
 
+    "global": ["global@4.4.0", "", { "dependencies": { "min-document": "^2.19.0", "process": "^0.11.10" } }, "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w=="],
+
     "globals": ["globals@16.4.0", "", {}, "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw=="],
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
@@ -1449,6 +1487,8 @@
 
     "html2canvas-pro": ["html2canvas-pro@1.6.7", "", { "dependencies": { "css-line-break": "^2.1.0", "text-segmentation": "^1.0.3" } }, "sha512-BzuCTXx0jf2TfnrJrtjMCY1FR9rxlPdy7yLWt9ZMhZm7Ylaw9MLb7agSheqv2mT/ARduBHDAqvJIFlbxrZfyOA=="],
 
+    "htmlparser2": ["htmlparser2@3.10.1", "", { "dependencies": { "domelementtype": "^1.3.1", "domhandler": "^2.3.0", "domutils": "^1.5.1", "entities": "^1.1.1", "inherits": "^2.0.1", "readable-stream": "^3.1.1" } }, "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ=="],
+
     "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "i18next": ["i18next@26.0.3", "", { "dependencies": { "@babel/runtime": "^7.29.2" }, "peerDependencies": { "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-1571kXINxHKY7LksWp8wP+zP0YqHSSpl/OW0Y0owFEf2H3s8gCAffWaZivcz14rMkOvn3R/psiQxVsR9t2Nafg=="],
@@ -1464,6 +1504,8 @@
     "import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
@@ -1502,6 +1544,8 @@
     "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-function": ["is-function@1.0.2", "", {}, "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="],
 
     "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
 
@@ -1567,7 +1611,7 @@
 
     "json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
 
-    "jspdf": ["jspdf@4.2.0", "", { "dependencies": { "@babel/runtime": "^7.28.6", "fast-png": "^6.2.0", "fflate": "^0.8.1" }, "optionalDependencies": { "canvg": "^3.0.11", "core-js": "^3.6.0", "dompurify": "^3.3.1", "html2canvas": "^1.0.0-rc.5" } }, "sha512-hR/hnRevAXXlrjeqU5oahOE+Ln9ORJUB5brLHHqH67A+RBQZuFr5GkbI9XQI8OUFSEezKegsi45QRpc4bGj75Q=="],
+    "jspdf": ["jspdf@4.2.1", "", { "dependencies": { "@babel/runtime": "^7.28.6", "fast-png": "^6.2.0", "fflate": "^0.8.1" }, "optionalDependencies": { "canvg": "^3.0.11", "core-js": "^3.6.0", "dompurify": "^3.3.1", "html2canvas": "^1.0.0-rc.5" } }, "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ=="],
 
     "jspdf-html2canvas": ["jspdf-html2canvas@1.6.0", "", { "dependencies": { "html2canvas-pro": "^1.5.8", "jspdf": "^2.5.1" } }, "sha512-dOYDhJqtbD8vmoiBH5CUS5bSIDO9nLnHeUSsKCIX2KZ1+yFO8dM1PqUMuAok5vmBmWbO7208Dq/q76R55vo+GQ=="],
 
@@ -1636,6 +1680,8 @@
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "lucide-react": ["lucide-react@1.7.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg=="],
+
+    "m3u8-parser": ["m3u8-parser@7.2.0", "", { "dependencies": { "@babel/runtime": "^7.12.5", "@videojs/vhs-utils": "^4.1.1", "global": "^4.4.0" } }, "sha512-CRatFqpjVtMiMaKXxNvuI3I++vUumIXVVT/JpCpdU/FynV/ceVw1qpPyyBNindL+JlPMSesx+WX1QJaZEJSaMQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -1743,6 +1789,8 @@
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "min-document": ["min-document@2.19.2", "", { "dependencies": { "dom-walk": "^0.1.0" } }, "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A=="],
+
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
@@ -1757,7 +1805,11 @@
 
     "motion-utils": ["motion-utils@12.29.2", "", {}, "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A=="],
 
+    "mpd-parser": ["mpd-parser@1.4.0", "", { "dependencies": { "@babel/runtime": "^7.12.5", "@videojs/vhs-utils": "^4.1.2", "@xmldom/xmldom": "^0.8.3", "global": "^4.4.0" }, "bin": { "mpd-to-m3u8-json": "bin/parse.js" } }, "sha512-blbA7XpAaOdC/PR0Tu8GiUxlx6CpBuRowQPYV7lhi9Yr9G9+dkPXIUjqjzc/NCn/uZZPopluaJlIYntIEI/VLw=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mux.js": ["mux.js@7.1.0", "", { "dependencies": { "@babel/runtime": "^7.11.2", "global": "^4.4.0" }, "bin": { "muxjs-transmux": "bin/transmux.js" } }, "sha512-NTxawK/BBELJrYsZThEulyUMDVlLizKdxyAsMuzoCD1eFj97BVaA8D/CvKsKu6FOLYkFojN5CbM9h++ZTZtknA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -1778,6 +1830,8 @@
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 
     "nprogress": ["nprogress@0.2.0", "", {}, "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA=="],
+
+    "nth-check": ["nth-check@3.0.1", "", { "dependencies": { "boolbase": "^2.0.0" } }, "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ=="],
 
     "nub": ["nub@0.0.0", "", {}, "sha512-dK0Ss9C34R/vV0FfYJXuqDAqHlaW9fvWVufq9MmGF2umCuDbd5GRfRD9fpi/LiM0l4ZXf8IBB+RYmZExqCrf0w=="],
 
@@ -1843,11 +1897,17 @@
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
+    "pkcs7": ["pkcs7@1.0.4", "", { "dependencies": { "@babel/runtime": "^7.5.5" }, "bin": { "pkcs7": "bin/cli.js" } }, "sha512-afRERtHn54AlwaF2/+LFszyAANTCggGilmcmILUzEjvs3XgFZT+xE6+QWQcAGmu4xajy+Xtj7acLOPdx5/eXWQ=="],
+
     "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "postcss-inline-svg": ["postcss-inline-svg@4.1.0", "", { "dependencies": { "css-select": "^2.0.2", "dom-serializer": "^0.1.1", "htmlparser2": "^3.10.1", "postcss": "^7.0.17", "postcss-value-parser": "^4.0.0" } }, "sha512-0pYBJyoQ9/sJViYRc1cNOOTM7DYh0/rmASB0TBeRmWkG8YFK2tmgdkfjHkbRma1iFtBFKFHZFsHwRTDZTMKzSQ=="],
+
+    "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
     "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
 
@@ -1862,6 +1922,8 @@
     "preact": ["preact@10.29.3", "", {}, "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 
@@ -1958,6 +2020,8 @@
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
     "react-youtube": ["react-youtube@10.1.0", "", { "dependencies": { "fast-deep-equal": "3.1.3", "prop-types": "15.8.1", "youtube-player": "5.5.2" }, "peerDependencies": { "react": ">=0.14.1" } }, "sha512-ZfGtcVpk0SSZtWCSTYOQKhfx5/1cfyEW1JN/mugGNfAxT3rmVJeMbGpA9+e78yG21ls5nc/5uZJETE3cm3knBg=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "recharts": ["recharts@3.7.0", "", { "dependencies": { "@reduxjs/toolkit": "1.x.x || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew=="],
 
@@ -2081,6 +2145,8 @@
 
     "string.prototype.trimstart": ["string.prototype.trimstart@1.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg=="],
 
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -2199,6 +2265,8 @@
 
     "usehooks-ts": ["usehooks-ts@3.1.1", "", { "dependencies": { "lodash.debounce": "^4.0.8" }, "peerDependencies": { "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA=="],
 
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
     "utrie": ["utrie@1.0.2", "", { "dependencies": { "base64-arraybuffer": "^1.0.2" } }, "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw=="],
 
     "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
@@ -2210,6 +2278,18 @@
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
+
+    "video.js": ["video.js@8.23.9", "", { "dependencies": { "@babel/runtime": "^7.28.4", "@videojs/http-streaming": "^3.17.5", "@videojs/vhs-utils": "^4.1.2", "@videojs/xhr": "2.7.0", "aes-decrypter": "^4.0.2", "global": "4.4.0", "m3u8-parser": "^7.2.0", "mpd-parser": "^1.4.0", "mux.js": "^7.0.1", "videojs-contrib-quality-levels": "4.1.0", "videojs-font": "4.2.0", "videojs-vtt.js": "0.15.5" } }, "sha512-3UCqyFW4wIusQu4TuhgRUxqtbzbj0WPT9hps0XIEXST43QBD11zb+bG7tBPrinrZztwVYdXCiOBo2pcGj9L05w=="],
+
+    "videojs-contrib-quality-levels": ["videojs-contrib-quality-levels@4.1.0", "", { "dependencies": { "global": "^4.4.0" }, "peerDependencies": { "video.js": "^8" } }, "sha512-TfrXJJg1Bv4t6TOCMEVMwF/CoS8iENYsWNKip8zfhB5kTcegiFYezEA0eHAJPU64ZC8NQbxQgOwAsYU8VXbOWA=="],
+
+    "videojs-font": ["videojs-font@4.2.0", "", {}, "sha512-YPq+wiKoGy2/M7ccjmlvwi58z2xsykkkfNMyIg4xb7EZQQNwB71hcSsB3o75CqQV7/y5lXkXhI/rsGAS7jfEmQ=="],
+
+    "videojs-hls-quality-selector": ["videojs-hls-quality-selector@2.0.0", "", { "dependencies": { "global": "^4.4.0", "video.js": "^8" } }, "sha512-x0AQKGwryDdD94s1it+Jolb6j1mg4Q+c7g1PlCIG6dXBdipVPaZmg71fxaFZJgx1k326DFnRaWrLxQ72/TKd2A=="],
+
+    "videojs-sprite-thumbnails": ["videojs-sprite-thumbnails@2.2.5", "", { "dependencies": { "global": "^4.4.0", "video.js": "^8" } }, "sha512-q+rzTfNu9Rze4Jy3gD2Kpw88pa7jXEWwbkowlFL6/H4udTbz80yuZjQij4WMvo5X1tgvgAfvGep7nXl89zKjGw=="],
+
+    "videojs-vtt.js": ["videojs-vtt.js@0.15.5", "", { "dependencies": { "global": "^4.3.1" } }, "sha512-yZbBxvA7QMYn15Lr/ZfhhLPrNpI/RmCSCqgIff57GC2gIrV5YfyzLfLyZMj0NnZSAz8syB4N0nHXpZg9MyrMOQ=="],
 
     "void-elements": ["void-elements@3.1.0", "", {}, "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="],
 
@@ -2405,9 +2485,19 @@
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
+    "@videojs/http-streaming/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@videojs/vhs-utils/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@videojs/xhr/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "aes-decrypter/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
     "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "ajv-keywords/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "dom-serializer/entities": ["entities@1.1.2", "", {}, "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="],
 
     "emblor/@radix-ui/react-dialog": ["@radix-ui/react-dialog@1.0.4", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/primitive": "1.0.1", "@radix-ui/react-compose-refs": "1.0.1", "@radix-ui/react-context": "1.0.1", "@radix-ui/react-dismissable-layer": "1.0.4", "@radix-ui/react-focus-guards": "1.0.1", "@radix-ui/react-focus-scope": "1.0.3", "@radix-ui/react-id": "1.0.1", "@radix-ui/react-portal": "1.0.3", "@radix-ui/react-presence": "1.0.1", "@radix-ui/react-primitive": "1.0.3", "@radix-ui/react-slot": "1.0.2", "@radix-ui/react-use-controllable-state": "1.0.1", "aria-hidden": "^1.1.1", "react-remove-scroll": "2.5.5" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0", "react-dom": "^16.8 || ^17.0 || ^18.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-hJtRy/jPULGQZceSAP2Re6/4NpKo8im6V8P2hUqZsdFiSL8l35kYsw3qbRI6Ay5mQd2+wlLqje770eq+RJ3yZg=="],
 
@@ -2431,6 +2521,8 @@
 
     "happy-dom/@types/node": ["@types/node@24.11.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw=="],
 
+    "htmlparser2/entities": ["entities@1.1.2", "", {}, "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="],
+
     "i18next/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "is-bun-module/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
@@ -2439,17 +2531,25 @@
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
+    "jspdf/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "m3u8-parser/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
     "markdown-it/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
-    "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+    "mpd-parser/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "mux.js/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "next/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "node-exports-info/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "nth-check/boolbase": ["boolbase@2.0.0", "", {}, "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
@@ -2457,7 +2557,7 @@
 
     "path-scurry/lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
-    "posthog-js/dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
+    "pkcs7/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "posthog-js/fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
@@ -2472,6 +2572,8 @@
     "string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
+
+    "video.js/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "webpack/eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^4.1.1" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
 

--- a/apps/web/components/BackgroundTasks/BackgroundTasksPanel.tsx
+++ b/apps/web/components/BackgroundTasks/BackgroundTasksPanel.tsx
@@ -1,0 +1,149 @@
+'use client'
+import React, { useState } from 'react'
+import {
+  CaretDown,
+  CheckCircle,
+  CircleNotch,
+  Warning,
+  X,
+  UploadSimple,
+} from '@phosphor-icons/react'
+import { useBackgroundTasks, type BgTask } from '@components/Contexts/BackgroundTasksContext'
+
+function StatusIcon({ status }: { status: BgTask['status'] }) {
+  if (status === 'done') return <CheckCircle size={16} weight="fill" className="text-green-500" />
+  if (status === 'error' || status === 'interrupted')
+    return <Warning size={16} weight="fill" className="text-red-500" />
+  if (status === 'processing')
+    return <CircleNotch size={16} className="text-violet-500 animate-spin" />
+  return <UploadSimple size={16} className="text-violet-500" />
+}
+
+function TaskRow({ task, onDismiss }: { task: BgTask; onDismiss: (_id: string) => void }) {
+  const active = task.status === 'uploading' || task.status === 'processing'
+  const body = (
+    <div className="flex items-start gap-2.5 py-2 px-3">
+      <div className="mt-0.5 shrink-0">
+        <StatusIcon status={task.status} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-2">
+          <span className="truncate text-sm font-medium text-gray-800">{task.title}</span>
+          {task.status === 'uploading' && !task.indeterminate && (
+            <span className="shrink-0 text-[11px] tabular-nums text-gray-400">
+              {Math.round(task.progress)}%
+            </span>
+          )}
+        </div>
+        {(task.subtitle || task.error) && (
+          <p
+            className={`truncate text-xs ${task.error ? 'text-red-500' : 'text-gray-400'}`}
+          >
+            {task.error || task.subtitle}
+          </p>
+        )}
+        {active && (
+          <div className="mt-1.5 h-1 w-full overflow-hidden rounded-full bg-gray-100">
+            <div
+              className={`h-full rounded-full bg-violet-500 transition-[width] duration-200 ${
+                task.indeterminate || task.status === 'processing' ? 'animate-pulse w-1/3' : ''
+              }`}
+              style={
+                task.indeterminate || task.status === 'processing'
+                  ? undefined
+                  : { width: `${Math.min(100, Math.max(0, task.progress))}%` }
+              }
+            />
+          </div>
+        )}
+      </div>
+      {!active && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            onDismiss(task.id)
+          }}
+          className="shrink-0 text-gray-300 hover:text-gray-500"
+          aria-label="Dismiss"
+        >
+          <X size={14} />
+        </button>
+      )}
+    </div>
+  )
+  return task.href ? (
+    <a href={task.href} className="block hover:bg-gray-50 transition-colors">
+      {body}
+    </a>
+  ) : (
+    <div>{body}</div>
+  )
+}
+
+/**
+ * Global, persistent, expandable notification panel (top-right — sits above
+ * page content, survives navigation and reloads). Generic: renders whatever
+ * background tasks are registered via useBackgroundTasks().
+ */
+export default function BackgroundTasksPanel() {
+  const { tasks, removeTask, clearFinished } = useBackgroundTasks()
+  const [collapsed, setCollapsed] = useState(false)
+
+  if (tasks.length === 0) return null
+
+  const activeCount = tasks.filter(
+    (t) => t.status === 'uploading' || t.status === 'processing'
+  ).length
+
+  return (
+    <div className="fixed top-4 right-4 z-[9999] w-[320px] max-w-[calc(100vw-2rem)]">
+      <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xl">
+        {/* Header */}
+        <button
+          type="button"
+          onClick={() => setCollapsed((c) => !c)}
+          className="flex w-full items-center justify-between gap-2 bg-gray-50 px-3 py-2 text-left"
+        >
+          <span className="flex items-center gap-2 text-sm font-semibold text-gray-700">
+            {activeCount > 0 ? (
+              <CircleNotch size={16} className="text-violet-500 animate-spin" />
+            ) : (
+              <CheckCircle size={16} weight="fill" className="text-green-500" />
+            )}
+            {activeCount > 0 ? `${activeCount} in progress` : 'Tasks'}
+          </span>
+          <span className="flex items-center gap-1">
+            {activeCount === 0 && (
+              <span
+                role="button"
+                tabIndex={0}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  clearFinished()
+                }}
+                className="mr-1 cursor-pointer text-[11px] font-medium text-gray-400 hover:text-gray-600"
+              >
+                Clear
+              </span>
+            )}
+            <CaretDown
+              size={16}
+              className={`text-gray-400 transition-transform ${collapsed ? '-rotate-90' : ''}`}
+            />
+          </span>
+        </button>
+
+        {/* List */}
+        {!collapsed && (
+          <div className="max-h-[50vh] divide-y divide-gray-100 overflow-y-auto">
+            {tasks.map((t) => (
+              <TaskRow key={t.id} task={t} onDismiss={removeTask} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/Contexts/BackgroundTasksContext.tsx
+++ b/apps/web/components/Contexts/BackgroundTasksContext.tsx
@@ -1,0 +1,146 @@
+'use client'
+import React, { createContext, useContext, useEffect, useMemo, useReducer, useRef } from 'react'
+
+/**
+ * A small, generic "background tasks" store. It's not upload-specific — any
+ * feature can register a long-running task (upload, export, generation, …) and
+ * it shows up in the global notification panel. State is persisted to
+ * localStorage so the panel survives a page reload.
+ *
+ * Note: an in-flight browser transfer (XHR) cannot survive a hard reload — the
+ * request dies with the page. So on hydrate we mark any task still in
+ * `uploading` as `interrupted` (the notification persists; the transfer doesn't).
+ */
+export type BgTaskStatus = 'uploading' | 'processing' | 'done' | 'error' | 'interrupted'
+
+export interface BgTask {
+  id: string
+  /** Category, so consumers can style/route (e.g. 'video-upload'). */
+  kind: string
+  title: string
+  subtitle?: string
+  /** 0–100; ignored when indeterminate. */
+  progress: number
+  indeterminate?: boolean
+  status: BgTaskStatus
+  error?: string
+  /** Optional link opened when the row is clicked (e.g. the created activity). */
+  href?: string
+  createdAt: number
+}
+
+type NewTask = Omit<BgTask, 'createdAt' | 'progress' | 'status' | 'id'> &
+  Partial<Pick<BgTask, 'id' | 'progress' | 'status' | 'indeterminate'>>
+
+const STORAGE_KEY = 'lh_bg_tasks'
+
+type Action =
+  | { type: 'hydrate'; tasks: BgTask[] }
+  | { type: 'add'; task: BgTask }
+  | { type: 'update'; id: string; patch: Partial<BgTask> }
+  | { type: 'remove'; id: string }
+  | { type: 'clearFinished' }
+
+function reducer(state: BgTask[], action: Action): BgTask[] {
+  switch (action.type) {
+    case 'hydrate':
+      return action.tasks
+    case 'add':
+      return [action.task, ...state.filter((t) => t.id !== action.task.id)]
+    case 'update':
+      return state.map((t) => (t.id === action.id ? { ...t, ...action.patch } : t))
+    case 'remove':
+      return state.filter((t) => t.id !== action.id)
+    case 'clearFinished':
+      return state.filter((t) => t.status === 'uploading' || t.status === 'processing')
+    default:
+      return state
+  }
+}
+
+function loadPersisted(): BgTask[] {
+  try {
+    const raw = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null
+    if (!raw) return []
+    const tasks = JSON.parse(raw) as BgTask[]
+    if (!Array.isArray(tasks)) return []
+    return tasks.map((t) =>
+      t.status === 'uploading'
+        ? { ...t, status: 'interrupted' as const, error: 'Interrupted by a page reload' }
+        : t
+    )
+  } catch {
+    return []
+  }
+}
+
+interface BackgroundTasksApi {
+  tasks: BgTask[]
+  addTask: (_task: NewTask) => string
+  updateTask: (_id: string, _patch: Partial<BgTask>) => void
+  removeTask: (_id: string) => void
+  clearFinished: () => void
+}
+
+const BackgroundTasksContext = createContext<BackgroundTasksApi | null>(null)
+
+let _seq = 0
+function makeId(): string {
+  _seq += 1
+  return `bg_${Date.now().toString(36)}_${_seq}`
+}
+
+export function BackgroundTasksProvider({ children }: { children: React.ReactNode }) {
+  const [tasks, dispatch] = useReducer(reducer, [])
+  const hydrated = useRef(false)
+
+  // Hydrate once on mount (client only).
+  useEffect(() => {
+    dispatch({ type: 'hydrate', tasks: loadPersisted() })
+    hydrated.current = true
+  }, [])
+
+  // Persist on every change (after the initial hydrate).
+  useEffect(() => {
+    if (!hydrated.current) return
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks))
+    } catch {
+      /* quota / private mode — ignore */
+    }
+  }, [tasks])
+
+  const api = useMemo<BackgroundTasksApi>(
+    () => ({
+      tasks,
+      addTask: (task) => {
+        const id = task.id || makeId()
+        dispatch({
+          type: 'add',
+          task: {
+            progress: 0,
+            status: 'uploading',
+            createdAt: Date.now(),
+            ...task,
+            id,
+          },
+        })
+        return id
+      },
+      updateTask: (id, patch) => dispatch({ type: 'update', id, patch }),
+      removeTask: (id) => dispatch({ type: 'remove', id }),
+      clearFinished: () => dispatch({ type: 'clearFinished' }),
+    }),
+    [tasks]
+  )
+
+  return <BackgroundTasksContext.Provider value={api}>{children}</BackgroundTasksContext.Provider>
+}
+
+export function useBackgroundTasks(): BackgroundTasksApi {
+  const ctx = useContext(BackgroundTasksContext)
+  if (!ctx) {
+    throw new Error('useBackgroundTasks must be used within a BackgroundTasksProvider')
+  }
+  return ctx
+}

--- a/apps/web/components/Dashboard/Pages/Course/EditCourseStructure/Buttons/NewActivityButton.tsx
+++ b/apps/web/components/Dashboard/Pages/Course/EditCourseStructure/Buttons/NewActivityButton.tsx
@@ -5,7 +5,10 @@ import {
   createActivity,
   createExternalVideoActivity,
   createFileActivity,
+  createVideoActivityWithProgress,
+  updateVideoCaptions,
 } from '@services/courses/activities'
+import { useBackgroundTasks } from '@components/Contexts/BackgroundTasksContext'
 import { getOrganizationContextInfoWithoutCredentials } from '@services/organizations/orgs'
 import { revalidateTags } from '@services/utils/ts/requests'
 import { Layers } from 'lucide-react'
@@ -34,6 +37,7 @@ function NewActivityButton(props: NewActivityButtonProps) {
   const session = useLHSession() as any;
   const access_token = session?.data?.tokens?.access_token;
   const queryClient = useQueryClient()
+  const { addTask, updateTask } = useBackgroundTasks()
   const cleanCourseUuid = (id: string) => id?.replace(/^course_/, '') ?? id
 
   const openNewActivityModal = async (_chapterId: any) => {
@@ -62,32 +66,76 @@ function NewActivityButton(props: NewActivityButtonProps) {
     router.refresh()
   }
 
+  const refreshStructure = async () => {
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.courses.meta(cleanCourseUuid(course.courseStructure.course_uuid)),
+    })
+    await revalidateTags(['courses'], props.orgslug)
+    router.refresh()
+  }
+
   // Submit File Upload
   const submitFileActivity = async (
     file: any,
     type: any,
     activity: any,
-    chapterId: string
+    chapterId: string,
+    captions?: { enabled: boolean; source_language: string; languages: { code: string; label?: string }[] }
   ) => {
+    // Video uploads run in the BACKGROUND with a progress notification, so the
+    // modal closes immediately and the teacher can keep working.
+    if (type === 'video') {
+      setNewActivityModal(false)
+      const taskId = addTask({
+        kind: 'video-upload',
+        title: activity?.name || 'Video',
+        subtitle: 'Uploading…',
+      })
+      try {
+        const created = await createVideoActivityWithProgress(
+          file,
+          activity,
+          chapterId,
+          access_token,
+          (pct) => updateTask(taskId, { progress: pct })
+        )
+        updateTask(taskId, { status: 'processing', subtitle: 'Finishing up…', progress: 100 })
+        if (captions && created?.activity_uuid) {
+          try {
+            await updateVideoCaptions(created.activity_uuid, captions, access_token)
+          } catch {
+            /* captions are best-effort; upload already succeeded */
+          }
+        }
+        track(AnalyticsEvent.ActivityFileUploaded, { file_type: type, upload_succeeded: true })
+        await refreshStructure()
+        updateTask(taskId, { status: 'done', subtitle: 'Uploaded' })
+      } catch (error: any) {
+        track(AnalyticsEvent.ActivityFileUploaded, { file_type: type, upload_succeeded: false })
+        updateTask(taskId, {
+          status: 'error',
+          error: error?.message || t('dashboard.courses.structure.activity.toasts.upload_error'),
+        })
+      }
+      return
+    }
+
+    // Non-video files keep the original inline flow.
     const toast_loading = toast.loading(t('dashboard.courses.structure.activity.toasts.uploading'))
     try {
       await createFileActivity(file, type, activity, chapterId, access_token)
     } catch (error: any) {
-      // Without this, an upload failure (e.g. a 413 from the proxy on a large
-      // video) left the loading toast spinning forever with no feedback.
       track(AnalyticsEvent.ActivityFileUploaded, { file_type: type, upload_succeeded: false })
       toast.dismiss(toast_loading)
       toast.error(error?.message || t('dashboard.courses.structure.activity.toasts.upload_error'))
       return
     }
     track(AnalyticsEvent.ActivityFileUploaded, { file_type: type, upload_succeeded: true })
-    queryClient.invalidateQueries({ queryKey: queryKeys.courses.meta(cleanCourseUuid(course.courseStructure.course_uuid)) })
     setNewActivityModal(false)
     toast.dismiss(toast_loading)
     toast.success(t('dashboard.courses.structure.activity.toasts.upload_success'))
     toast.success(t('dashboard.courses.structure.activity.toasts.create_success'))
-    await revalidateTags(['courses'], props.orgslug)
-    router.refresh()
+    await refreshStructure()
   }
 
   // Submit YouTube Video Upload

--- a/apps/web/components/Objects/Activities/Video/CaptionsSettings.tsx
+++ b/apps/web/components/Objects/Activities/Video/CaptionsSettings.tsx
@@ -1,0 +1,182 @@
+'use client'
+import React from 'react'
+import { ClosedCaptioning, Plus, X } from '@phosphor-icons/react'
+import { AVAILABLE_LANGUAGES } from '@/lib/languages'
+import toast from 'react-hot-toast'
+
+export interface CaptionsValue {
+  enabled: boolean
+  sourceLang: string
+  languages: { code: string; label: string; status?: string }[]
+}
+
+export const EMPTY_CAPTIONS: CaptionsValue = { enabled: false, sourceLang: 'auto', languages: [] }
+
+/** Shared "AI Closed Captions" panel used by both the create and edit video modals. */
+export default function CaptionsSettings({
+  value,
+  onChange,
+  status,
+}: {
+  value: CaptionsValue
+  onChange: (_next: CaptionsValue) => void
+  status?: string | null
+}) {
+  const [customCode, setCustomCode] = React.useState('')
+  const [customLabel, setCustomLabel] = React.useState('')
+
+  const toggleLang = (code: string, label: string) => {
+    const on = value.languages.some((l) => l.code === code)
+    onChange({
+      ...value,
+      languages: on
+        ? value.languages.filter((l) => l.code !== code)
+        : [...value.languages, { code, label }],
+    })
+  }
+
+  const addCustom = () => {
+    const code = customCode.trim()
+    if (!/^[A-Za-z0-9-]{2,20}$/.test(code)) {
+      toast.error('Enter a valid language code (e.g. sw, es-419)')
+      return
+    }
+    if (value.languages.some((l) => l.code === code)) return
+    onChange({ ...value, languages: [...value.languages, { code, label: customLabel.trim() || code }] })
+    setCustomCode('')
+    setCustomLabel('')
+  }
+
+  return (
+    <div className="rounded-xl nice-shadow p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="flex items-center gap-2 text-sm font-medium text-gray-700">
+          <ClosedCaptioning size={18} weight="duotone" className="text-violet-400" />
+          AI Closed Captions
+        </h3>
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={value.enabled}
+            onChange={(e) => onChange({ ...value, enabled: e.target.checked })}
+            className="rounded border-gray-300 text-black focus:ring-black"
+          />
+          <span className="text-sm text-gray-600">Generate with AI</span>
+        </label>
+      </div>
+      <p className="text-xs text-gray-400 -mt-1">
+        Transcribes the video and translates captions into the languages you choose. Uses your
+        organization&apos;s AI credits.
+      </p>
+
+      {value.enabled && (
+        <>
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-gray-500">Spoken language</label>
+            <select
+              value={value.sourceLang}
+              onChange={(e) => onChange({ ...value, sourceLang: e.target.value })}
+              className="w-full h-9 px-3 text-sm rounded-lg bg-gray-50 border border-gray-200 outline-none focus:border-gray-300"
+            >
+              <option value="auto">Auto-detect</option>
+              {AVAILABLE_LANGUAGES.map((l) => (
+                <option key={l.code} value={l.code}>{l.nativeName}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-gray-500">Caption languages</label>
+            <div className="flex flex-wrap gap-1.5">
+              {AVAILABLE_LANGUAGES.map((l) => {
+                const on = value.languages.some((c) => c.code === l.code)
+                return (
+                  <button
+                    type="button"
+                    key={l.code}
+                    onClick={() => toggleLang(l.code, l.nativeName)}
+                    className={`px-2.5 py-1 rounded-full text-xs font-medium transition-colors ${
+                      on
+                        ? 'bg-violet-100 text-violet-700 ring-1 ring-violet-200'
+                        : 'bg-gray-50 text-gray-500 hover:bg-gray-100'
+                    }`}
+                  >
+                    {l.nativeName}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+
+          <div className="flex items-end gap-2">
+            <div className="flex-1 space-y-1">
+              <label className="text-[11px] text-gray-400">Custom code</label>
+              <input
+                value={customCode}
+                onChange={(e) => setCustomCode(e.target.value)}
+                placeholder="e.g. sw"
+                className="w-full h-8 px-2 text-sm rounded-lg bg-gray-50 border border-gray-200 outline-none"
+              />
+            </div>
+            <div className="flex-1 space-y-1">
+              <label className="text-[11px] text-gray-400">Name</label>
+              <input
+                value={customLabel}
+                onChange={(e) => setCustomLabel(e.target.value)}
+                placeholder="e.g. Swahili"
+                className="w-full h-8 px-2 text-sm rounded-lg bg-gray-50 border border-gray-200 outline-none"
+              />
+            </div>
+            <button
+              type="button"
+              onClick={addCustom}
+              className="inline-flex items-center gap-1 h-8 px-3 text-xs font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200"
+            >
+              <Plus size={14} /> Add
+            </button>
+          </div>
+
+          {value.languages.length > 0 && (
+            <div className="space-y-1.5">
+              <label className="text-[11px] text-gray-400">Selected ({value.languages.length})</label>
+              <div className="flex flex-wrap gap-1.5">
+                {value.languages.map((l) => (
+                  <span
+                    key={l.code}
+                    className="inline-flex items-center gap-1.5 pl-2.5 pr-1.5 py-1 rounded-full text-xs bg-gray-100 text-gray-700"
+                  >
+                    {l.label}
+                    {l.status && (
+                      <span
+                        className={`text-[10px] font-medium ${
+                          l.status === 'ready'
+                            ? 'text-green-600'
+                            : l.status === 'failed'
+                              ? 'text-red-500'
+                              : 'text-amber-500'
+                        }`}
+                      >
+                        {l.status}
+                      </span>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() =>
+                        onChange({ ...value, languages: value.languages.filter((c) => c.code !== l.code) })
+                      }
+                      className="text-gray-400 hover:text-gray-600"
+                    >
+                      <X size={12} />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {status && <p className="text-xs text-gray-400">Status: {status}</p>}
+    </div>
+  )
+}

--- a/apps/web/components/Objects/Activities/Video/LearnHousePlayer.tsx
+++ b/apps/web/components/Objects/Activities/Video/LearnHousePlayer.tsx
@@ -1,17 +1,36 @@
 'use client'
 
-import React, { useRef, useState, useCallback, useEffect } from 'react'
-import { useMediaQuery } from 'usehooks-ts'
-import {
-  Play,
-  Pause,
-  Volume2,
-  VolumeX,
-  Maximize,
-  Minimize,
-  Settings,
-  Loader2,
-} from 'lucide-react'
+import React, { useEffect, useRef, useState } from 'react'
+import 'video.js/dist/video-js.css'
+import './player-controls.css'
+import { shouldSendHlsCredentials, type CaptionTrack } from './videoSource'
+
+const SEEK_SECONDS = 15
+
+/* Register ±15s seek-button components once (Video.js Button API — no plugin). */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function registerSeekButtons(videojs: any) {
+  const Button = videojs.getComponent('Button')
+  const make = (name: string, cls: string, label: string, delta: number) => {
+    if (videojs.getComponent(name)) return
+    class SeekButton extends Button {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      constructor(player: any, options: any) {
+        super(player, options)
+        this.controlText(label)
+        this.addClass(cls)
+      }
+      handleClick() {
+        const cur = this.player().currentTime() ?? 0
+        const dur = this.player().duration() || Infinity
+        this.player().currentTime(Math.max(0, Math.min(dur, cur + delta)))
+      }
+    }
+    videojs.registerComponent(name, SeekButton)
+  }
+  make('LhSeekBack', 'vjs-seek-back-15', `Rewind ${SEEK_SECONDS} seconds`, -SEEK_SECONDS)
+  make('LhSeekForward', 'vjs-seek-forward-15', `Forward ${SEEK_SECONDS} seconds`, SEEK_SECONDS)
+}
 
 interface VideoDetails {
   startTime?: number
@@ -20,409 +39,302 @@ interface VideoDetails {
   muted?: boolean
 }
 
+export interface ThumbnailsConfig {
+  /** Absolute URL of the sprite sheet. */
+  url: string
+  interval: number
+  width: number
+  height: number
+  columns: number
+  rows: number
+}
+
 interface LearnHousePlayerProps {
   src: string
+  /** When true, `src` is an HLS master playlist (.m3u8). */
+  isHls?: boolean
+  /** Progressive MP4 URL to fall back to if the HLS source errors. */
+  fallbackSrc?: string
   details?: VideoDetails
   onReady?: () => void
   poster?: string
-}
-
-function formatTime(seconds: number): string {
-  if (isNaN(seconds) || !isFinite(seconds)) return '0:00'
-  const h = Math.floor(seconds / 3600)
-  const m = Math.floor((seconds % 3600) / 60)
-  const s = Math.floor(seconds % 60)
-  if (h > 0) {
-    return `${h}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`
-  }
-  return `${m}:${s.toString().padStart(2, '0')}`
+  /** Hover-scrub preview sprite config (HLS only). */
+  thumbnails?: ThumbnailsConfig | null
+  /** Ready WebVTT caption tracks to attach (subtitles/CC menu). */
+  captions?: CaptionTrack[]
 }
 
 const PLAYBACK_RATES = [0.5, 0.75, 1, 1.25, 1.5, 2]
 
+/**
+ * Video.js-based player (default skin): adaptive HLS with an automatic quality
+ * selector and hover-scrub thumbnail previews; falls back to a progressive MP4
+ * source when HLS isn't ready.
+ *
+ * Video.js and its plugins are imported dynamically inside an effect so nothing
+ * touches `window`/`document` during SSR.
+ */
 const LearnHousePlayer: React.FC<LearnHousePlayerProps> = ({
   src,
+  isHls = false,
+  fallbackSrc,
   details,
   onReady,
   poster,
+  thumbnails,
+  captions,
 }) => {
-  const videoRef = useRef<HTMLVideoElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
-  const hideControlsTimeout = useRef<NodeJS.Timeout | null>(null)
 
-  const [isReady, setIsReady] = useState(false)
-  const [isPlaying, setIsPlaying] = useState(false)
-  const [isMuted, setIsMuted] = useState(details?.muted ?? false)
-  const [volume, setVolume] = useState(0.8)
-  const [currentTime, setCurrentTime] = useState(0)
-  const [duration, setDuration] = useState(0)
-  const [buffered, setBuffered] = useState(0)
-  const [showControls, setShowControls] = useState(true)
-  const [isBuffering, setIsBuffering] = useState(false)
-  const [playbackRate, setPlaybackRate] = useState(1)
-  const [showSettings, setShowSettings] = useState(false)
-  const [showVolumeSlider, setShowVolumeSlider] = useState(false)
-  const [isFullscreen, setIsFullscreen] = useState(false)
-  const isMobile = useMediaQuery('(max-width: 768px)')
+  const playerRef = useRef<any>(null)
+  const fellBackRef = useRef(false)
+  const captionBlobUrls = useRef<string[]>([])
+  const retriedRef = useRef(false)
+  const [loadError, setLoadError] = useState(false)
+  const [reloadNonce, setReloadNonce] = useState(0)
 
-  // Hide controls after inactivity
-  const resetHideControlsTimer = useCallback(() => {
-    if (hideControlsTimeout.current) {
-      clearTimeout(hideControlsTimeout.current)
-    }
-    setShowControls(true)
-    if (isPlaying) {
-      hideControlsTimeout.current = setTimeout(() => {
-        setShowControls(false)
-        setShowSettings(false)
-        setShowVolumeSlider(false)
-      }, 3000)
-    }
-  }, [isPlaying])
-
-  // Cleanup timeout on unmount
   useEffect(() => {
-    return () => {
-      if (hideControlsTimeout.current) {
-        clearTimeout(hideControlsTimeout.current)
+    let disposed = false
+    fellBackRef.current = false
+    retriedRef.current = false
+    setLoadError(false)
+
+    ;(async () => {
+      const { default: videojs } = await import('video.js')
+      // Order matters: quality-levels must register before the selector.
+      await import('videojs-contrib-quality-levels')
+      await import('videojs-hls-quality-selector')
+      await import('videojs-sprite-thumbnails')
+      if (disposed || !containerRef.current) return
+
+      registerSeekButtons(videojs)
+
+
+      // Send the auth cookie only to our API playlist endpoint (RBAC); presigned
+      // R2 segment requests must stay uncredentialed (R2 CORS).
+       
+      const Vhs = (videojs as any).Vhs
+      if (Vhs && !Vhs.__lhBeforeRequestSet) {
+         
+        Vhs.xhr.beforeRequest = (options: any) => {
+          if (options?.uri && shouldSendHlsCredentials(options.uri)) {
+            options.withCredentials = true
+          }
+          return options
+        }
+        Vhs.__lhBeforeRequestSet = true
       }
-    }
-  }, [])
 
-  // Reset player state and reload video when src changes
-  useEffect(() => {
-    const video = videoRef.current
-    if (!video) return
+      const videoEl = document.createElement('video-js')
+      videoEl.classList.add('vjs-big-play-centered')
+      videoEl.setAttribute('playsinline', '')
+      containerRef.current.appendChild(videoEl)
 
-    // Reset all player state
-    setIsReady(false)
-    setIsPlaying(false)
-    setCurrentTime(0)
-    setDuration(0)
-    setBuffered(0)
-    setIsBuffering(true)
-    setPlaybackRate(1)
-    setShowSettings(false)
+      const player = videojs(videoEl, {
+        controls: true,
+        // fill (not fluid) so the player always fills its aspect-video parent and
+        // the control bar is visible IMMEDIATELY — even before video metadata
+        // loads or if the source errors. `fluid` sized from metadata, so a slow/
+        // broken source left the player collapsed with no visible controls.
+        fill: true,
+        preload: 'metadata',
+        poster: poster || undefined,
+        autoplay: !!details?.autoplay,
+        muted: !!details?.muted,
+        playbackRates: PLAYBACK_RATES,
+        sources: [{ src, type: isHls ? 'application/x-mpegURL' : 'video/mp4' }],
+        html5: {
+          vhs: { overrideNative: true },
+          nativeAudioTracks: false,
+          nativeVideoTracks: false,
+        },
+      }, () => {
+        onReady?.()
+      })
+      playerRef.current = player
 
-    // Force the video element to reload with the new source
-    video.load()
-  }, [src])
-
-  // Handle fullscreen changes
-  useEffect(() => {
-    const handleFullscreenChange = () => {
-      setIsFullscreen(!!document.fullscreenElement)
-    }
-    document.addEventListener('fullscreenchange', handleFullscreenChange)
-    return () => {
-      document.removeEventListener('fullscreenchange', handleFullscreenChange)
-    }
-  }, [])
-
-  // Sync volume state with video element
-  useEffect(() => {
-    if (videoRef.current && isReady) {
-      videoRef.current.volume = volume
-    }
-  }, [volume, isReady])
-
-  // Sync muted state with video element
-  useEffect(() => {
-    if (videoRef.current) {
-      videoRef.current.muted = isMuted
-    }
-  }, [isMuted])
-
-  const handlePlayPause = useCallback(() => {
-    const video = videoRef.current
-    if (!video) return
-
-    if (video.paused) {
-      video.play().catch((err) => console.error('Play error:', err))
-    } else {
-      video.pause()
-    }
-  }, [])
-
-  const handleLoadedMetadata = () => {
-    const video = videoRef.current
-    if (!video) return
-
-    setDuration(video.duration)
-    setIsReady(true)
-    setIsBuffering(false)
-
-    // Seek to start time if specified
-    if (details?.startTime) {
-      video.currentTime = details.startTime
-    }
-
-    // Start playing if autoplay is enabled
-    if (details?.autoplay) {
-      video.play().catch((err) => console.error('Autoplay error:', err))
-    }
-
-    onReady?.()
-  }
-
-  const handleTimeUpdate = () => {
-    const video = videoRef.current
-    if (!video) return
-
-    setCurrentTime(video.currentTime)
-
-    // Update buffered
-    if (video.buffered.length > 0) {
-      const bufferedEnd = video.buffered.end(video.buffered.length - 1)
-      setBuffered(bufferedEnd / video.duration)
-    }
-
-    // Handle end time
-    if (details?.endTime && video.currentTime >= details.endTime) {
-      video.pause()
-    }
-  }
-
-  const handleProgressBarClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    const video = videoRef.current
-    if (!video || !duration) return
-
-    const rect = e.currentTarget.getBoundingClientRect()
-    const pos = (e.clientX - rect.left) / rect.width
-    video.currentTime = pos * duration
-  }
-
-  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newVolume = parseFloat(e.target.value)
-    setVolume(newVolume)
-    if (newVolume > 0) {
-      setIsMuted(false)
-    }
-  }
-
-  const toggleMute = () => {
-    setIsMuted(!isMuted)
-  }
-
-  const toggleFullscreen = async () => {
-    if (!containerRef.current) return
-    try {
-      if (document.fullscreenElement) {
-        await document.exitFullscreen()
-      } else {
-        await containerRef.current.requestFullscreen()
+      // Durable, layered recovery so the user is NEVER left with a dead player:
+      //   1. HLS source errors/stalls -> switch to the progressive MP4
+      //   2. still fails               -> one silent reload of the current source
+      //   3. still fails               -> clean "couldn't load" + Retry overlay
+      // A watchdog also covers sources that HANG without firing 'error' (e.g. an
+      // HLS master that loads but whose segments never arrive).
+      const LOAD_WATCHDOG_MS = 15000
+      let metaLoaded = false
+      let watchdog: ReturnType<typeof setTimeout> | null = null
+      const clearWatchdog = () => {
+        if (watchdog) clearTimeout(watchdog)
+        watchdog = null
       }
-    } catch (err) {
-      console.error('Fullscreen error:', err)
+      const armWatchdog = () => {
+        clearWatchdog()
+        watchdog = setTimeout(() => {
+          if (!metaLoaded && !disposed) recover()
+        }, LOAD_WATCHDOG_MS)
+      }
+      const reloadCurrent = (nextSrc?: { src: string; type: string }) => {
+        const resume = player.currentTime?.() ?? 0
+        metaLoaded = false
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(player as any).error(null) // clear the error overlay before retrying
+          if (nextSrc) player.src(nextSrc)
+          player.load()
+          player.one('loadedmetadata', () => {
+            try { if (resume > 0) player.currentTime(resume) } catch { /* noop */ }
+          })
+          player.play?.()
+          armWatchdog()
+        } catch {
+          /* best-effort */
+        }
+      }
+      const recover = () => {
+        if (disposed) return
+        clearWatchdog()
+        if (isHls && fallbackSrc && !fellBackRef.current) {
+          fellBackRef.current = true
+          reloadCurrent({ src: fallbackSrc, type: 'video/mp4' })
+          return
+        }
+        if (!retriedRef.current) {
+          retriedRef.current = true
+          reloadCurrent()
+          return
+        }
+        setLoadError(true)
+      }
+      player.on('error', recover)
+      player.one('loadedmetadata', () => {
+        metaLoaded = true
+        clearWatchdog()
+      })
+      player.on('dispose', clearWatchdog)
+      armWatchdog()
+
+      // Insert the ±15s seek buttons right after the play button.
+      try {
+        const bar = player.getChild('ControlBar')
+        if (bar && !bar.getChild('LhSeekBack')) {
+          bar.addChild('LhSeekBack', {}, 1)
+          bar.addChild('LhSeekForward', {}, 2)
+        }
+      } catch {
+        /* seek buttons are best-effort */
+      }
+
+      // Casual-download deterrents (cosmetic — not real protection; the segments
+      // are AES-128 encrypted server-side for the actual bar-raising). Picture-in-
+      // picture is intentionally LEFT ENABLED (users asked for it).
+      try {
+        const techEl = player.el().querySelector('video') as HTMLVideoElement | null
+        if (techEl) {
+          techEl.setAttribute('controlsList', 'nodownload')
+        }
+        player.el().addEventListener('contextmenu', (e: Event) => e.preventDefault())
+      } catch {
+        /* best-effort */
+      }
+
+      // Quality gear (populated from HLS renditions; harmless for MP4).
+      try {
+         
+        ;(player as any).hlsQualitySelector?.({ displayCurrentQuality: true })
+      } catch {
+        /* selector is best-effort */
+      }
+
+      // Hover-scrub preview thumbnails.
+      if (thumbnails?.url) {
+        try {
+           
+          ;(player as any).spriteThumbnails?.({
+            url: thumbnails.url,
+            width: thumbnails.width,
+            height: thumbnails.height,
+            columns: thumbnails.columns,
+            rows: thumbnails.rows,
+            interval: thumbnails.interval,
+            // downlink:0 disables the plugin's bandwidth gate, which otherwise
+            // SILENTLY hides thumbnails whenever the browser reports
+            // connection.downlink < 1.5 Mbps (its default).
+            downlink: 0,
+          })
+        } catch {
+          /* thumbnails are best-effort */
+        }
+      }
+
+      // Captions: fetch each ready VTT with credentials (RBAC) and attach it as a
+      // subtitles text track. Fetching to a blob (instead of a <track src>) avoids
+      // cross-origin credential limitations on private courses.
+      if (captions && captions.length) {
+        captions.forEach(async (track) => {
+          try {
+            const res = await fetch(track.url, { credentials: 'include' })
+            if (!res.ok || disposed) return
+            const vtt = await res.text()
+            const blobUrl = URL.createObjectURL(new Blob([vtt], { type: 'text/vtt' }))
+            captionBlobUrls.current.push(blobUrl)
+            if (disposed) {
+              URL.revokeObjectURL(blobUrl)
+              return
+            }
+            player.addRemoteTextTrack(
+              { kind: 'subtitles', src: blobUrl, srclang: track.code, label: track.label },
+              false
+            )
+          } catch {
+            /* captions are best-effort */
+          }
+        })
+      }
+
+      // Honor per-video start/stop bounds. video.js's currentTime() getter is
+      // typed number | undefined, so coalesce before comparing.
+      const startTime = details?.startTime
+      if (startTime) {
+        player.one('loadedmetadata', () => player.currentTime(startTime))
+      }
+      const endTime = details?.endTime
+      if (endTime) {
+        player.on('timeupdate', () => {
+          if ((player.currentTime() ?? 0) >= endTime) player.pause()
+        })
+      }
+    })()
+
+    return () => {
+      disposed = true
+      if (playerRef.current) {
+        playerRef.current.dispose()
+        playerRef.current = null
+      }
+      captionBlobUrls.current.forEach((u) => URL.revokeObjectURL(u))
+      captionBlobUrls.current = []
     }
-  }
-
-  const handlePlaybackRateChange = (rate: number) => {
-    const video = videoRef.current
-    if (!video) return
-
-    setPlaybackRate(rate)
-    video.playbackRate = rate
-    setShowSettings(false)
-  }
-
-  const played = duration > 0 ? currentTime / duration : 0
+    // Rebuild when the source changes, or when the user hits Retry (reloadNonce).
+  }, [src, isHls, fallbackSrc, reloadNonce])
 
   return (
-    <div
-      ref={containerRef}
-      className={`learnhouse-player relative w-full aspect-video overflow-hidden bg-black ${
-        isMobile ? 'rounded-none' : 'rounded-xl shadow-md shadow-gray-300/25 outline outline-1 outline-neutral-200/40'
-      }`}
-      onMouseMove={!isMobile ? resetHideControlsTimer : undefined}
-      onMouseLeave={!isMobile ? () => isPlaying && setShowControls(false) : undefined}
-    >
-      {/* Video Element */}
-      <video
-        ref={videoRef}
-        src={src}
-        poster={poster}
-        className="absolute inset-0 w-full h-full object-contain"
-        preload="metadata"
-        playsInline
-        muted={isMuted}
-        controls={isMobile}
-        controlsList="nodownload"
-        onLoadedMetadata={handleLoadedMetadata}
-        onTimeUpdate={handleTimeUpdate}
-        onPlay={() => setIsPlaying(true)}
-        onPause={() => setIsPlaying(false)}
-        onEnded={() => setIsPlaying(false)}
-        onWaiting={() => setIsBuffering(true)}
-        onCanPlay={() => setIsBuffering(false)}
-        onVolumeChange={() => {
-          const video = videoRef.current
-          if (video) {
-            setVolume(video.volume)
-            setIsMuted(video.muted)
-          }
-        }}
-        onError={(e) => console.error('Video error:', e)}
-      />
-
-      {/* Custom controls - desktop only */}
-      {!isMobile && (
-        <>
-      {/* Click overlay for play/pause */}
-      <div
-        className="absolute inset-0 z-10 cursor-pointer"
-        onClick={handlePlayPause}
-      />
-
-      {/* Center play button (when paused and ready) */}
-      {!isPlaying && isReady && !isBuffering && (
-        <button
-          onClick={handlePlayPause}
-          className="absolute inset-0 z-20 flex items-center justify-center transition-opacity"
-        >
-          <Play className="w-16 h-16 text-white/90 drop-shadow-lg" fill="white" fillOpacity={0.9} />
-        </button>
-      )}
-
-      {/* Buffering/Loading indicator */}
-      {isBuffering && (
-        <div className="absolute inset-0 z-20 flex items-center justify-center bg-black/30 pointer-events-none">
-          <Loader2 className="w-12 h-12 text-white animate-spin" />
-        </div>
-      )}
-
-      {/* Controls overlay */}
-      <div
-        className={`absolute inset-0 z-30 flex flex-col justify-end transition-opacity duration-300 pointer-events-none ${
-          showControls || !isPlaying ? 'opacity-100' : 'opacity-0'
-        }`}
-      >
-        {/* Gradient background */}
-        <div className="absolute inset-x-0 bottom-0 h-28 bg-gradient-to-t from-black/70 via-black/30 to-transparent" />
-
-        {/* Controls container */}
-        <div className="relative z-10 px-4 pb-3 space-y-2 pointer-events-auto">
-          {/* Progress bar */}
-          <div
-            className="relative h-1 bg-white/30 rounded-full cursor-pointer group/progress hover:h-1.5 transition-all"
-            onClick={handleProgressBarClick}
+    // h-full chain is required for the player's `fill` mode to size to the
+    // aspect-video parent (otherwise the video collapses to zero height).
+    <div className="learnhouse-player relative w-full h-full" data-vjs-player>
+      <div ref={containerRef} className="w-full h-full" />
+      {loadError && (
+        <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-black/80 p-4 text-center text-white">
+          <p className="text-sm opacity-90">This video couldn’t be loaded.</p>
+          <button
+            type="button"
+            onClick={() => {
+              setLoadError(false)
+              setReloadNonce((n) => n + 1)
+            }}
+            className="rounded-md bg-white/15 px-4 py-1.5 text-sm font-medium transition-colors hover:bg-white/25"
           >
-            {/* Buffered */}
-            <div
-              className="absolute inset-y-0 left-0 bg-white/50 rounded-full"
-              style={{ width: `${buffered * 100}%` }}
-            />
-            {/* Progress */}
-            <div
-              className="absolute inset-y-0 left-0 bg-white rounded-full"
-              style={{ width: `${played * 100}%` }}
-            />
-            {/* Thumb */}
-            <div
-              className="absolute top-1/2 -translate-y-1/2 w-3 h-3 bg-white rounded-full shadow opacity-0 group-hover/progress:opacity-100 transition-opacity"
-              style={{ left: `calc(${played * 100}% - 6px)` }}
-            />
-          </div>
-
-          {/* Control buttons */}
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-0.5">
-              {/* Play/Pause */}
-              <button
-                onClick={handlePlayPause}
-                className="p-2 rounded-lg hover:bg-white/15 transition-colors"
-              >
-                {isPlaying ? (
-                  <Pause className="w-5 h-5 text-white" />
-                ) : (
-                  <Play className="w-5 h-5 text-white" fill="white" />
-                )}
-              </button>
-
-              {/* Volume */}
-              <div
-                className="relative flex items-center"
-                onMouseEnter={() => setShowVolumeSlider(true)}
-                onMouseLeave={() => setShowVolumeSlider(false)}
-              >
-                <button
-                  onClick={toggleMute}
-                  className="p-2 rounded-lg hover:bg-white/15 transition-colors"
-                >
-                  {isMuted || volume === 0 ? (
-                    <VolumeX className="w-5 h-5 text-white" />
-                  ) : (
-                    <Volume2 className="w-5 h-5 text-white" />
-                  )}
-                </button>
-                <div
-                  className={`flex items-center transition-all duration-200 overflow-hidden ${
-                    showVolumeSlider ? 'w-20 ml-1' : 'w-0'
-                  }`}
-                >
-                  <input
-                    type="range"
-                    min={0}
-                    max={1}
-                    step={0.05}
-                    value={isMuted ? 0 : volume}
-                    onChange={handleVolumeChange}
-                    className="w-full h-1 bg-white/30 rounded-full appearance-none cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white"
-                  />
-                </div>
-              </div>
-
-              {/* Time */}
-              <div className="text-white/90 text-xs font-medium tabular-nums ml-2">
-                {formatTime(currentTime)} / {formatTime(duration)}
-              </div>
-            </div>
-
-            <div className="flex items-center gap-0.5">
-              {/* Settings */}
-              <div className="relative">
-                <button
-                  onClick={() => setShowSettings(!showSettings)}
-                  className="p-2 rounded-lg hover:bg-white/15 transition-colors"
-                >
-                  <Settings className="w-5 h-5 text-white" />
-                </button>
-                {showSettings && (
-                  <div className="absolute bottom-full right-0 mb-2 bg-neutral-900/95 backdrop-blur-lg border border-white/10 rounded-lg overflow-hidden min-w-[140px] shadow-xl">
-                    <div className="px-3 py-2 text-xs text-white/60 font-medium border-b border-white/10">
-                      Speed
-                    </div>
-                    {PLAYBACK_RATES.map((rate) => (
-                      <button
-                        key={rate}
-                        onClick={() => handlePlaybackRateChange(rate)}
-                        className={`w-full px-3 py-2 text-left text-sm hover:bg-white/10 transition-colors ${
-                          playbackRate === rate ? 'text-white font-medium' : 'text-white/80'
-                        }`}
-                      >
-                        {rate === 1 ? 'Normal' : `${rate}x`}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              {/* Fullscreen */}
-              <button
-                onClick={toggleFullscreen}
-                className="p-2 rounded-lg hover:bg-white/15 transition-colors"
-              >
-                {isFullscreen ? (
-                  <Minimize className="w-5 h-5 text-white" />
-                ) : (
-                  <Maximize className="w-5 h-5 text-white" />
-                )}
-              </button>
-            </div>
-          </div>
+            Retry
+          </button>
         </div>
-      </div>
-        </>
       )}
     </div>
   )

--- a/apps/web/components/Objects/Activities/Video/Video.tsx
+++ b/apps/web/components/Objects/Activities/Video/Video.tsx
@@ -1,8 +1,13 @@
 import React from 'react'
 import YouTube from 'react-youtube'
-import { getActivityVideoStreamUrl } from '@services/media/media'
 import { useOrg } from '@components/Contexts/OrgContext'
 import LearnHousePlayer from './LearnHousePlayer'
+import {
+  isActivityHlsReady,
+  resolveActivityVideoSource,
+  resolveHlsThumbnails,
+  resolveActivityCaptions,
+} from './videoSource'
 
 interface VideoDetails {
   startTime?: number
@@ -20,6 +25,23 @@ interface VideoActivityProps {
       uri?: string
     }
     details?: VideoDetails
+    extra_metadata?: {
+      hls?: {
+        status?: string
+        thumbnails?: {
+          url?: string
+          interval?: number
+          width?: number
+          height?: number
+          columns?: number
+          rows?: number
+        } | null
+      }
+      captions?: {
+        enabled?: boolean
+        languages?: { code?: string; label?: string; status?: string }[]
+      } | null
+    } | null
   }
   course: {
     course_uuid: string
@@ -39,15 +61,18 @@ function VideoActivity({ activity, course, orgUuid }: VideoActivityProps) {
     }
   }, [activity, org])
 
-  const getVideoSrc = () => {
-    if (!activity.content?.filename) return ''
-    return getActivityVideoStreamUrl(
-      resolvedOrgUuid,
-      course?.course_uuid,
-      activity.activity_uuid,
-      activity.content.filename
-    )
-  }
+  // Prefer adaptive HLS once transcoding is ready; otherwise fall back to the
+  // (optimized) progressive MP4 so playback always works.
+  const hlsReady = isActivityHlsReady(activity)
+
+  const getVideoSource = () =>
+    resolveActivityVideoSource({
+      hlsReady,
+      orgUuid: resolvedOrgUuid,
+      courseUuid: course?.course_uuid,
+      activityUuid: activity.activity_uuid,
+      filename: activity.content?.filename,
+    })
 
   return (
     <div className="w-full max-w-full px-0 sm:px-4">
@@ -57,12 +82,40 @@ function VideoActivity({ activity, course, orgUuid }: VideoActivityProps) {
             <div className="my-0 sm:my-3 md:my-5 w-full">
               <div className="relative w-full aspect-video sm:rounded-lg overflow-hidden ring-0 sm:ring-1 sm:ring-gray-200/10 sm:dark:ring-gray-700/20 shadow-none">
                 {(() => {
-                  const src = getVideoSrc()
+                  const { src, isHls } = getVideoSource()
+                  const thumbnails = isHls
+                    ? resolveHlsThumbnails(activity, {
+                        orgUuid: resolvedOrgUuid,
+                        courseUuid: course?.course_uuid,
+                        activityUuid: activity.activity_uuid,
+                      })
+                    : null
+                  // Always compute the progressive MP4 URL so the player can fall
+                  // back to it if the HLS source errors (partial/broken transcode).
+                  const fallbackSrc = isHls
+                    ? resolveActivityVideoSource({
+                        hlsReady: false,
+                        orgUuid: resolvedOrgUuid,
+                        courseUuid: course?.course_uuid,
+                        activityUuid: activity.activity_uuid,
+                        filename: activity.content?.filename,
+                      }).src
+                    : undefined
+                  // Ready AI caption tracks attach to either source (HLS or MP4).
+                  const captions = resolveActivityCaptions(activity, {
+                    orgUuid: resolvedOrgUuid,
+                    courseUuid: course?.course_uuid,
+                    activityUuid: activity.activity_uuid,
+                  })
                   return src ? (
                     <LearnHousePlayer
-                      key={activity.activity_uuid}
+                      key={src}
                       src={src}
+                      isHls={isHls}
+                      fallbackSrc={fallbackSrc}
                       details={activity.details}
+                      thumbnails={thumbnails}
+                      captions={captions}
                     />
                   ) : null
                 })()}

--- a/apps/web/components/Objects/Activities/Video/player-controls.css
+++ b/apps/web/components/Objects/Activities/Video/player-controls.css
@@ -1,0 +1,29 @@
+/* Minimal add-on to the default Video.js skin: icons for the ±15s seek buttons.
+   Everything else stays stock. */
+.video-js .vjs-seek-back-15 .vjs-icon-placeholder::before,
+.video-js .vjs-seek-forward-15 .vjs-icon-placeholder::before {
+  content: '';
+  display: inline-block;
+  width: 1.4em;
+  height: 1.4em;
+  vertical-align: middle;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+}
+
+/* Rewind 15s — counter-clockwise circular arrow (rotate-ccw) with "15". */
+.video-js .vjs-seek-back-15 .vjs-icon-placeholder::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23fff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8'/%3E%3Cpath d='M3 3v5h5'/%3E%3Ctext x='12.5' y='15.5' font-size='7.5' fill='%23fff' stroke='none' text-anchor='middle' font-family='Arial,Helvetica,sans-serif' font-weight='700'%3E15%3C/text%3E%3C/svg%3E");
+}
+
+/* Forward 15s — clockwise circular arrow (rotate-cw) with "15". */
+.video-js .vjs-seek-forward-15 .vjs-icon-placeholder::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23fff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 12a9 9 0 1 1-9-9 9.75 9.75 0 0 1 6.74 2.74L21 8'/%3E%3Cpath d='M21 3v5h-5'/%3E%3Ctext x='11.5' y='15.5' font-size='7.5' fill='%23fff' stroke='none' text-anchor='middle' font-family='Arial,Helvetica,sans-serif' font-weight='700'%3E15%3C/text%3E%3C/svg%3E");
+}
+
+.video-js .vjs-seek-back-15,
+.video-js .vjs-seek-forward-15 {
+  cursor: pointer;
+  text-align: center;
+}

--- a/apps/web/components/Objects/Activities/Video/videoSource.ts
+++ b/apps/web/components/Objects/Activities/Video/videoSource.ts
@@ -1,0 +1,157 @@
+import {
+  getActivityVideoStreamUrl,
+  getActivityHlsMasterUrl,
+  getActivityHlsThumbnailsUrl,
+  getActivityCaptionUrl,
+} from '@services/media/media'
+
+/**
+ * Pure helpers for choosing a video activity's playback source.
+ *
+ * Extracted from the components so the decision logic (HLS-when-ready with an
+ * MP4 fallback, the credentials rule, and thumbnail config) can be unit-tested.
+ */
+
+export interface HlsThumbnails {
+  url: string
+  interval: number
+  width: number
+  height: number
+  columns: number
+  rows: number
+}
+
+export interface HlsActivityMeta {
+  extra_metadata?: {
+    hls?: {
+      status?: string
+      thumbnails?: {
+        url?: string
+        interval?: number
+        width?: number
+        height?: number
+        columns?: number
+        rows?: number
+      } | null
+    }
+  } | null
+}
+
+/** True once transcoding has produced a ready HLS ladder for the activity. */
+export function isActivityHlsReady(activity: HlsActivityMeta): boolean {
+  return activity?.extra_metadata?.hls?.status === 'ready'
+}
+
+export interface VideoSourceArgs {
+  hlsReady: boolean
+  orgUuid: string
+  courseUuid: string
+  activityUuid: string
+  filename?: string
+}
+
+export interface VideoSource {
+  src: string
+  isHls: boolean
+}
+
+/**
+ * Resolve the source URL for a hosted video: adaptive HLS when ready, otherwise
+ * the (optimized) progressive MP4 stream. Empty when there's no file.
+ */
+export function resolveActivityVideoSource(args: VideoSourceArgs): VideoSource {
+  const { hlsReady, orgUuid, courseUuid, activityUuid, filename } = args
+  // Guard against a missing filename (incl. whitespace-only) or any missing id —
+  // otherwise we'd build a URL containing the literal string "undefined".
+  if (!filename || !filename.trim()) return { src: '', isHls: false }
+  if (!orgUuid || !courseUuid || !activityUuid) return { src: '', isHls: false }
+  if (hlsReady) {
+    return { src: getActivityHlsMasterUrl(orgUuid, courseUuid, activityUuid), isHls: true }
+  }
+  return {
+    src: getActivityVideoStreamUrl(orgUuid, courseUuid, activityUuid, filename),
+    isHls: false,
+  }
+}
+
+/**
+ * The player requests both API playlists and R2 segments. Send the auth cookie
+ * only to our API playlist endpoint (for RBAC); presigned R2 segment requests
+ * must stay uncredentialed (R2 CORS rejects credentialed wildcard requests).
+ */
+export function shouldSendHlsCredentials(url: string): boolean {
+  // Our authed playlist/key endpoint — but NEVER a presigned object-storage URL
+  // (those always carry X-Amz-* query params). Sending the cookie cross-origin
+  // to R2 would fail CORS and leak the cookie to storage.
+  return url.includes('/api/v1/stream/hls/') && !url.includes('X-Amz-')
+}
+
+export interface ThumbnailArgs {
+  orgUuid: string
+  courseUuid: string
+  activityUuid: string
+}
+
+/**
+ * Resolve the hover-scrub thumbnail config for the player from the activity's
+ * HLS metadata, or null when unavailable/incomplete. Only valid when HLS is
+ * ready (the sprite lives alongside the HLS output).
+ */
+export function resolveHlsThumbnails(
+  activity: HlsActivityMeta,
+  ids: ThumbnailArgs
+): HlsThumbnails | null {
+  const t = activity?.extra_metadata?.hls?.thumbnails
+  if (!t || !t.url) return null
+  if (!ids.orgUuid || !ids.courseUuid || !ids.activityUuid) return null
+  // Every numeric field must be a positive number; reject 0/negative/NaN so the
+  // sprite plugin can't be handed a broken grid (which would mis-map or divide).
+  const pos = (n: unknown): n is number => typeof n === 'number' && Number.isFinite(n) && n > 0
+  if (!pos(t.interval) || !pos(t.width) || !pos(t.height) || !pos(t.columns)) {
+    return null
+  }
+  const rows = pos(t.rows) ? t.rows : 1
+  return {
+    url: getActivityHlsThumbnailsUrl(ids.orgUuid, ids.courseUuid, ids.activityUuid, t.url),
+    interval: t.interval,
+    width: t.width,
+    height: t.height,
+    columns: t.columns,
+    rows,
+  }
+}
+
+export interface CaptionTrack {
+  code: string
+  label: string
+  url: string
+}
+
+interface CaptionsActivityMeta {
+  extra_metadata?: {
+    captions?: {
+      enabled?: boolean
+      languages?: { code?: string; label?: string; status?: string }[]
+    } | null
+  } | null
+}
+
+/**
+ * Resolve the ready caption tracks for an activity from its captions metadata.
+ * Only languages whose generation finished (`status === 'ready'`) are returned.
+ */
+export function resolveActivityCaptions(
+  activity: CaptionsActivityMeta,
+  ids: ThumbnailArgs
+): CaptionTrack[] {
+  const caps = activity?.extra_metadata?.captions
+  if (!caps || !caps.enabled) return []
+  if (!ids.orgUuid || !ids.courseUuid || !ids.activityUuid) return []
+  return (caps.languages || [])
+    .filter((l) => l && l.status === 'ready' && !!l.code)
+    .map((l) => ({
+      code: l.code as string,
+      label: l.label || (l.code as string),
+      url: getActivityCaptionUrl(ids.orgUuid, ids.courseUuid, ids.activityUuid, l.code as string),
+    }))
+}

--- a/apps/web/components/Objects/Activities/Video/videojs-plugins.d.ts
+++ b/apps/web/components/Objects/Activities/Video/videojs-plugins.d.ts
@@ -1,0 +1,6 @@
+// Ambient declarations for Video.js plugins that ship without TypeScript types.
+// They register themselves on the Video.js Player (side-effect imports); we call
+// them via `(player as any).<plugin>(...)`.
+declare module 'videojs-contrib-quality-levels'
+declare module 'videojs-hls-quality-selector'
+declare module 'videojs-sprite-thumbnails'

--- a/apps/web/components/Objects/Modals/Activities/Create/NewActivityModal/VideoActivityModal.tsx
+++ b/apps/web/components/Objects/Modals/Activities/Create/NewActivityModal/VideoActivityModal.tsx
@@ -3,6 +3,10 @@ import * as Form from '@radix-ui/react-form'
 import BarLoader from 'react-spinners/BarLoader'
 import { PlayCircle, Upload, YoutubeLogo } from '@phosphor-icons/react'
 import { constructAcceptValue } from '@/lib/constants'
+import CaptionsSettings, {
+  type CaptionsValue,
+  EMPTY_CAPTIONS,
+} from '@components/Objects/Activities/Video/CaptionsSettings'
 
 const SUPPORTED_FILES = constructAcceptValue(['mp4', 'webm'])
 
@@ -40,6 +44,7 @@ function VideoModal({
     autoplay: false,
     muted: false,
   })
+  const [captions, setCaptions] = React.useState<CaptionsValue>(EMPTY_CAPTIONS)
 
   const handleVideoChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files?.[0]) {
@@ -66,7 +71,14 @@ function VideoModal({
             course_id: course.id,
             details: videoDetails,
           },
-          chapterId
+          chapterId,
+          captions.enabled && captions.languages.length > 0
+            ? {
+                enabled: true,
+                source_language: captions.sourceLang,
+                languages: captions.languages.map((l) => ({ code: l.code, label: l.label })),
+              }
+            : undefined
         )
       }
 
@@ -331,6 +343,10 @@ function VideoModal({
           </label>
         </div>
       </div>
+
+      {selectedView === 'file' && (
+        <CaptionsSettings value={captions} onChange={setCaptions} />
+      )}
 
       <div className="flex justify-end">
         <button

--- a/apps/web/components/Objects/Modals/Activities/Edit/EditVideoActivityModal.tsx
+++ b/apps/web/components/Objects/Modals/Activities/Edit/EditVideoActivityModal.tsx
@@ -1,13 +1,21 @@
 'use client'
 import React, { useEffect, useState } from 'react'
 import BarLoader from 'react-spinners/BarLoader'
-import { PlayCircle, Upload, YoutubeLogo } from '@phosphor-icons/react'
+import { PlayCircle, Upload, YoutubeLogo, Sparkle } from '@phosphor-icons/react'
 import { constructAcceptValue } from '@/lib/constants'
-import { getActivity, updateHostedVideoActivity, updateExternalVideoActivity } from '@services/courses/activities'
+import CaptionsSettings, {
+  type CaptionsValue,
+  EMPTY_CAPTIONS,
+} from '@components/Objects/Activities/Video/CaptionsSettings'
+import {
+  getActivity,
+  updateHostedVideoActivity,
+  updateExternalVideoActivity,
+  updateVideoCaptions,
+} from '@services/courses/activities'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
 import toast from 'react-hot-toast'
 import { mutate } from 'swr'
-import { getAPIUrl } from '@services/config/config'
 
 const SUPPORTED_FILES = constructAcceptValue(['mp4', 'webm'])
 
@@ -20,12 +28,12 @@ interface VideoDetails {
 
 interface EditVideoActivityModalProps {
   activity: any
-  courseUuid: string
-  orgSlug: string
+  courseUuid?: string
+  orgSlug?: string
   onClose: () => void
 }
 
-function EditVideoActivityModal({ activity, courseUuid, orgSlug, onClose }: EditVideoActivityModalProps) {
+function EditVideoActivityModal({ activity, onClose }: EditVideoActivityModalProps) {
   const session = useLHSession() as any
   const access_token = session?.data?.tokens?.access_token
   const isYouTube = activity.activity_sub_type === 'SUBTYPE_VIDEO_YOUTUBE'
@@ -42,6 +50,11 @@ function EditVideoActivityModal({ activity, courseUuid, orgSlug, onClose }: Edit
   const [isLoading, setIsLoading] = useState(true)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
+  // --- AI captions state (hosted video only) ---
+  const [captions, setCaptions] = useState<CaptionsValue>(EMPTY_CAPTIONS)
+  const [capStatus, setCapStatus] = useState<string | null>(null)
+  const [isSavingCaptions, setIsSavingCaptions] = useState(false)
+
   useEffect(() => {
     async function loadActivity() {
       const data = await getActivity(activity.activity_uuid, null, access_token)
@@ -56,10 +69,52 @@ function EditVideoActivityModal({ activity, courseUuid, orgSlug, onClose }: Edit
       if (data?.content?.uri) {
         setYoutubeUrl(data.content.uri)
       }
+      const caps = data?.extra_metadata?.captions
+      if (caps) {
+        setCapStatus(caps.status || null)
+        setCaptions({
+          enabled: !!caps.enabled,
+          sourceLang: caps.source_language || 'auto',
+          languages: (caps.languages || []).map((l: any) => ({
+            code: l.code,
+            label: l.label || l.code,
+            status: l.status,
+          })),
+        })
+      }
       setIsLoading(false)
     }
     loadActivity()
   }, [activity.activity_uuid])
+
+  const saveCaptions = async () => {
+    setIsSavingCaptions(true)
+    const toastId = toast.loading('Saving caption settings...')
+    try {
+      const res = await updateVideoCaptions(
+        activity.activity_uuid,
+        {
+          enabled: captions.enabled,
+          source_language: captions.sourceLang,
+          languages: captions.languages.map((l) => ({ code: l.code, label: l.label })),
+        },
+        access_token
+      )
+      if (res?.success === false) {
+        toast.error(res?.data?.detail || 'Failed to save captions', { id: toastId })
+      } else {
+        toast.success(
+          captions.enabled ? 'Captions queued — generating in the background' : 'Captions disabled',
+          { id: toastId }
+        )
+        setCapStatus(res?.data?.status || (captions.enabled ? 'queued' : 'idle'))
+      }
+    } catch {
+      toast.error('Failed to save captions', { id: toastId })
+    } finally {
+      setIsSavingCaptions(false)
+    }
+  }
 
   const convertToSeconds = (minutes: number, seconds: number) => minutes * 60 + seconds
   const convertFromSeconds = (totalSeconds: number) => ({
@@ -279,6 +334,28 @@ function EditVideoActivityModal({ activity, courseUuid, orgSlug, onClose }: Edit
           </label>
         </div>
       </div>
+
+      {!isYouTube && (
+        <div className="space-y-2">
+          <CaptionsSettings value={captions} onChange={setCaptions} status={capStatus} />
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={saveCaptions}
+              disabled={isSavingCaptions}
+              className="inline-flex items-center gap-1.5 h-8 px-4 text-xs font-medium text-white bg-violet-600 rounded-lg hover:bg-violet-700 transition-colors disabled:opacity-50"
+            >
+              {isSavingCaptions ? (
+                <BarLoader cssOverride={{ borderRadius: 60 }} width={40} color="#ffffff" />
+              ) : (
+                <>
+                  <Sparkle size={14} weight="duotone" /> {captions.enabled ? 'Generate captions' : 'Save'}
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      )}
 
       <div className="flex justify-end">
         <button

--- a/apps/web/components/Providers.tsx
+++ b/apps/web/components/Providers.tsx
@@ -6,6 +6,8 @@ import LHSessionProvider from '@components/Contexts/LHSessionContext'
 import AuthFetchInterceptor from '@components/Contexts/AuthFetchInterceptor'
 import PostHogProvider from '@components/Contexts/PostHogProvider'
 import I18nProvider from '@components/Contexts/I18nContext'
+import { BackgroundTasksProvider } from '@components/Contexts/BackgroundTasksContext'
+import BackgroundTasksPanel from '@components/BackgroundTasks/BackgroundTasksPanel'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { makeQueryClient } from '@/lib/query/client'
@@ -19,7 +21,12 @@ export default function Providers({ children }: { children: React.ReactNode }) {
         <AuthFetchInterceptor />
         <LHSessionProvider>
           <PostHogProvider>
-            <I18nProvider>{children}</I18nProvider>
+            <I18nProvider>
+              <BackgroundTasksProvider>
+                {children}
+                <BackgroundTasksPanel />
+              </BackgroundTasksProvider>
+            </I18nProvider>
           </PostHogProvider>
         </LHSessionProvider>
       </SessionProvider>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -79,6 +79,7 @@
     "@tiptap/suggestion": "^3.17.1",
     "@uiw/codemirror-theme-tokyo-night": "^4.25.4",
     "@uiw/react-codemirror": "^4.25.4",
+    "@videojs/themes": "^1",
     "avvvatars-react": "^0.4.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -131,6 +132,10 @@
     "unsplash-js": "^8.0.0",
     "usehooks-ts": "^3.1.1",
     "uuid": "^14.0.0",
+    "video.js": "^8.23.9",
+    "videojs-contrib-quality-levels": "^4",
+    "videojs-hls-quality-selector": "^2",
+    "videojs-sprite-thumbnails": "^2",
     "wavesurfer.js": "^7.12.1",
     "y-prosemirror": "^1.2.12",
     "yjs": "^13.6.20",
@@ -158,8 +163,25 @@
     "lodash-es": ">=4.17.23",
     "preact": ">=10.27.3",
     "js-yaml": ">=4.1.1",
-    "jspdf": ">=4.0.0",
+    "jspdf": ">=4.2.1",
     "prosemirror-view": "1.41.9",
-    "prosemirror-model": "1.25.9"
+    "prosemirror-model": "1.25.9",
+    "nth-check": ">=2.0.1",
+    "dompurify": ">=3.2.4",
+    "postcss": ">=8.4.31"
+  },
+  "pnpm": {
+    "overrides": {
+      "@types/react": "19.2.17",
+      "@types/react-dom": "19.2.3",
+      "preact": ">=10.27.3",
+      "js-yaml": ">=4.1.1",
+      "jspdf": ">=4.2.1",
+      "prosemirror-view": "1.41.9",
+      "prosemirror-model": "1.25.9",
+      "nth-check": ">=2.0.1",
+      "dompurify": ">=3.2.4",
+      "postcss": ">=8.4.31"
+    }
   }
 }

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -4,6 +4,18 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@types/react': 19.2.17
+  '@types/react-dom': 19.2.3
+  preact: '>=10.27.3'
+  js-yaml: '>=4.1.1'
+  jspdf: '>=4.2.1'
+  prosemirror-view: 1.41.9
+  prosemirror-model: 1.25.9
+  nth-check: '>=2.0.1'
+  dompurify: '>=3.2.4'
+  postcss: '>=8.4.31'
+
 importers:
 
   .:
@@ -206,6 +218,9 @@ importers:
       '@uiw/react-codemirror':
         specifier: ^4.25.4
         version: 4.25.10(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.3)(codemirror@6.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@videojs/themes':
+        specifier: ^1
+        version: 1.0.1
       avvvatars-react:
         specifier: ^0.4.2
         version: 0.4.2(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -228,7 +243,7 @@ importers:
         specifier: ^1.11.19
         version: 1.11.21
       dompurify:
-        specifier: ^3.3.1
+        specifier: '>=3.2.4'
         version: 3.4.11
       emblor:
         specifier: ^1.4.8
@@ -255,7 +270,7 @@ importers:
         specifier: ^8.2.0
         version: 8.2.1
       jspdf:
-        specifier: ^4.0.0
+        specifier: '>=4.2.1'
         version: 4.2.1
       jspdf-html2canvas:
         specifier: ^1.5.2
@@ -281,6 +296,9 @@ importers:
       pdfjs-dist:
         specifier: ^6.0.227
         version: 6.0.227
+      posthog-js:
+        specifier: ^1.395.0
+        version: 1.396.3
       prosemirror-state:
         specifier: ^1.4.4
         version: 1.4.4
@@ -359,6 +377,18 @@ importers:
       uuid:
         specifier: ^14.0.0
         version: 14.0.1
+      video.js:
+        specifier: ^8.23.9
+        version: 8.23.9
+      videojs-contrib-quality-levels:
+        specifier: ^4
+        version: 4.1.0(video.js@8.23.9)
+      videojs-hls-quality-selector:
+        specifier: ^2
+        version: 2.0.0
+      videojs-sprite-thumbnails:
+        specifier: ^2
+        version: 2.2.5
       wavesurfer.js:
         specifier: ^7.12.1
         version: 7.12.8
@@ -403,7 +433,7 @@ importers:
         specifier: ^4.3.0
         version: 4.4.1(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))
       postcss:
-        specifier: ^8.5.6
+        specifier: '>=8.4.31'
         version: 8.5.15
       tailwindcss:
         specifier: ^4.1.16
@@ -1225,6 +1255,12 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
+  '@posthog/core@1.39.2':
+    resolution: {integrity: sha512-G/TL5Xykl+9xCDtBwHHPRSToS/43UjzyxKOfhlTwu/hJHt3v39Q2OFu8hdum71Iu7+tuxxISGVcFMlIST7ksjA==}
+
+  '@posthog/types@1.392.0':
+    resolution: {integrity: sha512-nctNujXL3FC1v99FktaTMSugSD9ZOZekEpahUSafkU2TSvW+XGKNkQZbokuJtiWvPBK208dwMJva8UfBkChqpw==}
+
   '@radix-ui/number@1.1.2':
     resolution: {integrity: sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==}
 
@@ -1240,8 +1276,8 @@ packages:
   '@radix-ui/react-arrow@1.1.10':
     resolution: {integrity: sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1253,8 +1289,8 @@ packages:
   '@radix-ui/react-aspect-ratio@1.1.10':
     resolution: {integrity: sha512-kbI7NrqhDeuytYrq7JjAsoXczvL8wgj2tc1MyaYWm+50bMKHCHQtVWCryslx4cCpmCTTkBcwQckE4CmmGV2haQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1266,8 +1302,8 @@ packages:
   '@radix-ui/react-checkbox@1.3.5':
     resolution: {integrity: sha512-pREzrmNnVwGvYaBoM64huTRK7B3lrTRuwj8A9nwhPiEtMb+yudiWh6zWAqEtP0Dzd5+iBa1Ki7V1pCxV8ExMdA==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1279,8 +1315,8 @@ packages:
   '@radix-ui/react-collection@1.1.10':
     resolution: {integrity: sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1297,7 +1333,7 @@ packages:
   '@radix-ui/react-compose-refs@1.0.1':
     resolution: {integrity: sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
@@ -1306,7 +1342,7 @@ packages:
   '@radix-ui/react-compose-refs@1.1.3':
     resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1320,7 +1356,7 @@ packages:
   '@radix-ui/react-context@1.0.1':
     resolution: {integrity: sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
@@ -1329,7 +1365,7 @@ packages:
   '@radix-ui/react-context@1.1.4':
     resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1344,8 +1380,8 @@ packages:
   '@radix-ui/react-dialog@1.0.4':
     resolution: {integrity: sha512-hJtRy/jPULGQZceSAP2Re6/4NpKo8im6V8P2hUqZsdFiSL8l35kYsw3qbRI6Ay5mQd2+wlLqje770eq+RJ3yZg==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
@@ -1357,8 +1393,8 @@ packages:
   '@radix-ui/react-dialog@1.1.17':
     resolution: {integrity: sha512-TDTYmpdq8dI2+Xgvgj9AJ8Ghqq+Eph/TRVEdaFQPDItIY+6QSkU7MJMeevw1568Yw/2Ijz8BTphPSP2XejKphw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1370,7 +1406,7 @@ packages:
   '@radix-ui/react-direction@1.1.2':
     resolution: {integrity: sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1385,8 +1421,8 @@ packages:
   '@radix-ui/react-dismissable-layer@1.0.4':
     resolution: {integrity: sha512-7UpBa/RKMoHJYjie1gkF1DlK8l1fdU/VKDpoS3rCCo8YBJR294GwcEHyxHw72yvphJ7ld0AXEcSLAzY2F/WyCg==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
@@ -1398,8 +1434,8 @@ packages:
   '@radix-ui/react-dismissable-layer@1.1.13':
     resolution: {integrity: sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1411,8 +1447,8 @@ packages:
   '@radix-ui/react-dropdown-menu@2.1.18':
     resolution: {integrity: sha512-PZGV82gFk0WltDRI//SsG28ZIjlo9ANTmoNYg0jLNzXXiDsAy5PkOOYQaVD1pPxY6t7gxffb1QMD6qaUvsBZdw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1429,7 +1465,7 @@ packages:
   '@radix-ui/react-focus-guards@1.0.1':
     resolution: {integrity: sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
@@ -1438,7 +1474,7 @@ packages:
   '@radix-ui/react-focus-guards@1.1.4':
     resolution: {integrity: sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1453,8 +1489,8 @@ packages:
   '@radix-ui/react-focus-scope@1.0.3':
     resolution: {integrity: sha512-upXdPfqI4islj2CslyfUBNlaJCPybbqRHAi1KER7Isel9Q2AtSJ0zRBZv8mWQiFXD2nyAJ4BhC3yXgZ6kMBSrQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
@@ -1466,8 +1502,8 @@ packages:
   '@radix-ui/react-focus-scope@1.1.10':
     resolution: {integrity: sha512-Fas/lXQqhVvqwAb64s5RFeHiHYElZ6SUQbZaNd6EkfhP/Al7wTIQ9WIR4QVX475tlu5yFCEdDcJH6/UwsZjMWw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1479,8 +1515,8 @@ packages:
   '@radix-ui/react-form@0.1.10':
     resolution: {integrity: sha512-1NfuvctVtX4sU3Mmq/IdrR8UunxiCMiVg3A5UENKhFzxUBeOyaQQ+lmaQaV7Tc8cqvBKsJL3/KGBsixK0D8WFg==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1492,8 +1528,8 @@ packages:
   '@radix-ui/react-hover-card@1.1.17':
     resolution: {integrity: sha512-GjZQIEANVkuuWeztlKz6QEHe31ZX2iDfHzcTMCQVZXC0JyQrgfKWSC+LOOEw6aVV64zyjzobIzSA4AU4eKWrHA==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1515,7 +1551,7 @@ packages:
   '@radix-ui/react-id@1.0.1':
     resolution: {integrity: sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
@@ -1524,7 +1560,7 @@ packages:
   '@radix-ui/react-id@1.1.2':
     resolution: {integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1533,8 +1569,8 @@ packages:
   '@radix-ui/react-label@2.1.10':
     resolution: {integrity: sha512-ib0zvq2ZsAqKm5tRnqGJn3vOxSgIts5ToxsXT0q1S/GfLD1Zj7UOEnkw8u2w6sRmn47djpQWuSU1DCL1R29/yw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1546,8 +1582,8 @@ packages:
   '@radix-ui/react-menu@2.1.18':
     resolution: {integrity: sha512-lj8Rxjtn6zJq1oSbE/uDtAwCbB9BnxgHD+8MwJMuTh6u1dPamYhW9iuELr/Z8d0D/UysFblYYHeBPwi7T4k0YQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1559,8 +1595,8 @@ packages:
   '@radix-ui/react-navigation-menu@1.2.16':
     resolution: {integrity: sha512-nJ0SkrSQgudyYhMiYeHA1ayLVuduEJCFLan1RZZN7c9kqzzCFLaU9kuy81uNtqzweM9YaQPgWzxi9MwQ9jZ04g==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1572,8 +1608,8 @@ packages:
   '@radix-ui/react-popover@1.1.17':
     resolution: {integrity: sha512-/YSAOdJ7YJvdn7bn5sdSx2egW+SKY+u7O5RyAVs94Ymrg2fg5QTSFPMRkzvhGyFuE4/qsmPBdrwYoZMZh/4f+g==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1585,8 +1621,8 @@ packages:
   '@radix-ui/react-popper@1.3.1':
     resolution: {integrity: sha512-bhnq/0DEPTi2lsOD3J5rTL65qUKHbKbhqHsmN9TMiclSXpipi651ooUKPPp6G5lF/WiHBdn1s0Wuqsn+myVAvw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1604,8 +1640,8 @@ packages:
   '@radix-ui/react-portal@1.0.3':
     resolution: {integrity: sha512-xLYZeHrWoPmA5mEKEfZZevoVRK/Q43GfzRXkWV6qawIWWK8t6ifIiLQdd7rmQ4Vk1bmI21XhqF9BN3jWf+phpA==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
@@ -1617,8 +1653,8 @@ packages:
   '@radix-ui/react-portal@1.1.12':
     resolution: {integrity: sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1636,8 +1672,8 @@ packages:
   '@radix-ui/react-presence@1.0.1':
     resolution: {integrity: sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
@@ -1649,8 +1685,8 @@ packages:
   '@radix-ui/react-presence@1.1.6':
     resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1668,8 +1704,8 @@ packages:
   '@radix-ui/react-primitive@1.0.3':
     resolution: {integrity: sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
@@ -1681,8 +1717,8 @@ packages:
   '@radix-ui/react-primitive@2.1.6':
     resolution: {integrity: sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1694,8 +1730,8 @@ packages:
   '@radix-ui/react-roving-focus@1.1.13':
     resolution: {integrity: sha512-9gkwneI0guf8JDmrFxPjJF6Ozzgioyw+/lonYNCwefS9ZHA05er0BVHiXr+LbWGHxUfczvMY6G1oiZZi1VzjRw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1707,8 +1743,8 @@ packages:
   '@radix-ui/react-select@2.3.1':
     resolution: {integrity: sha512-w6eDvY78LE9ZUiNnXCA1QVK8RYN7k9galFv09kjVydJqBAgHd7Y9A6h0UJ/6DCZNGZMZrB2ohcSW1Bo9d8+wWA==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1725,7 +1761,7 @@ packages:
   '@radix-ui/react-slot@1.0.2':
     resolution: {integrity: sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
@@ -1734,7 +1770,7 @@ packages:
   '@radix-ui/react-slot@1.3.0':
     resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1743,8 +1779,8 @@ packages:
   '@radix-ui/react-switch@1.3.1':
     resolution: {integrity: sha512-55bQtCnOB0BohomSHi6qvQXpJEEqUGDm6hRrM0Bph5OXwhSegqkd8IqgBAQkM1IlgUlWZIxpxRcpOEfRIgimyw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1756,8 +1792,8 @@ packages:
   '@radix-ui/react-tabs@1.1.15':
     resolution: {integrity: sha512-kxc9gI6/HfcU4nfMMVS3AmQK414kbU1IE6UCJmMmxjhO3cRPXOyYnmvyKD+ODt7q56nRq9l7Wovi6uaGwKgMlg==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1769,8 +1805,8 @@ packages:
   '@radix-ui/react-toggle-group@1.1.13':
     resolution: {integrity: sha512-Xb9PLtlvU66F36LiKba6dFswu6V2mDkgidO4fNSbQHQwmZ9ObxMIO17MN/LJ4aWJecVuSVLAHPZjyeMzJrgeiA==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1782,8 +1818,8 @@ packages:
   '@radix-ui/react-toggle@1.1.12':
     resolution: {integrity: sha512-AsAVsYNZIlRBsci7BhE+QyQeKd1h6TffJYt+lF0QQkd5OpQ3klfIByPsCb4G0h/Fq6PJwh1FYNluzBFYzhk4+w==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1795,8 +1831,8 @@ packages:
   '@radix-ui/react-tooltip@1.2.10':
     resolution: {integrity: sha512-NlNe8D0dWEpVfXFli90IO6X07Josx/b1iu98tDnx9Xv0HT4wLIL+m2VOheMHhK7qbp2HoTBqALEFzGyZs/levw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1813,7 +1849,7 @@ packages:
   '@radix-ui/react-use-callback-ref@1.0.1':
     resolution: {integrity: sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
@@ -1822,7 +1858,7 @@ packages:
   '@radix-ui/react-use-callback-ref@1.1.2':
     resolution: {integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1836,7 +1872,7 @@ packages:
   '@radix-ui/react-use-controllable-state@1.0.1':
     resolution: {integrity: sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
@@ -1845,7 +1881,7 @@ packages:
   '@radix-ui/react-use-controllable-state@1.2.3':
     resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1854,7 +1890,7 @@ packages:
   '@radix-ui/react-use-effect-event@0.0.3':
     resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1868,7 +1904,7 @@ packages:
   '@radix-ui/react-use-escape-keydown@1.0.3':
     resolution: {integrity: sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
@@ -1877,7 +1913,7 @@ packages:
   '@radix-ui/react-use-escape-keydown@1.1.2':
     resolution: {integrity: sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1891,7 +1927,7 @@ packages:
   '@radix-ui/react-use-layout-effect@1.0.1':
     resolution: {integrity: sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
@@ -1900,7 +1936,7 @@ packages:
   '@radix-ui/react-use-layout-effect@1.1.2':
     resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1909,7 +1945,7 @@ packages:
   '@radix-ui/react-use-previous@1.1.2':
     resolution: {integrity: sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1918,7 +1954,7 @@ packages:
   '@radix-ui/react-use-rect@1.1.2':
     resolution: {integrity: sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1927,7 +1963,7 @@ packages:
   '@radix-ui/react-use-size@1.1.2':
     resolution: {integrity: sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1936,8 +1972,8 @@ packages:
   '@radix-ui/react-visually-hidden@1.2.6':
     resolution: {integrity: sha512-jCE0WljWifTI4niIMCll06kGpsJTAPiZVU9H4WR1N6qW7At9ystHbN7dDB+we2xH535roFHj7qKS+RGj0FMDWQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -2570,8 +2606,8 @@ packages:
     peerDependencies:
       '@tiptap/core': 3.27.1
       '@tiptap/pm': 3.27.1
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      '@types/react-dom': ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -2589,9 +2625,9 @@ packages:
     resolution: {integrity: sha512-WoK5z3jMW+9nzumcWAxEDRCSC7yQmdq4NN0157MaxQBl9dGWwjxJx3+11mb+WAqR37oDeAMKMmSNy+/hm2XGlA==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
     peerDependencies:
-      prosemirror-model: ^1.7.1
+      prosemirror-model: 1.25.9
       prosemirror-state: ^1.2.3
-      prosemirror-view: ^1.9.10
+      prosemirror-view: 1.41.9
       y-protocols: ^1.0.1
       yjs: ^13.5.38
 
@@ -2640,7 +2676,7 @@ packages:
   '@types/hoist-non-react-statics@3.3.7':
     resolution: {integrity: sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -2669,7 +2705,7 @@ packages:
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
-      '@types/react': ^19.2.0
+      '@types/react': 19.2.17
 
   '@types/react-katex@3.0.4':
     resolution: {integrity: sha512-aLkykKzSKLpXI6REJ3uClao6P47HAFfR1gcHOZwDeTuALsyjgMhz+oynLV4gX0kiJVnvHrBKF/TLXqyNTpHDUg==}
@@ -2899,6 +2935,22 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@videojs/http-streaming@3.17.5':
+    resolution: {integrity: sha512-PRRQVu0hYW5h0XvRWpIyIpEatpMZzZtf7L1avV89Hnu+69f+0c7oLsSL9jwpg2nbvzGkdX5rQxQkz5Vc7tFR9w==}
+    engines: {node: '>=8', npm: '>=5'}
+    peerDependencies:
+      video.js: ^8.19.0
+
+  '@videojs/themes@1.0.1':
+    resolution: {integrity: sha512-2b6YIIIz5x+/eSFdkSZ2RZJfHIMfP7bGODR3wDzLTqFF2kEKnJVIXxBUNzdZC/qiVETqAA2Ba6mCp+iXTUYt4A==}
+
+  '@videojs/vhs-utils@4.1.2':
+    resolution: {integrity: sha512-1Dsv5dtWOq0LP1G37O46FQFA2tKAZON5UMe6dFPxT7JvPhEx8QIXcFQxan8+hHI3fX6aomFRFrUBJNgRYQDSXA==}
+    engines: {node: '>=8', npm: '>=5'}
+
+  '@videojs/xhr@2.7.0':
+    resolution: {integrity: sha512-giab+EVRanChIupZK7gXjHy90y3nncA2phIOyG3Ne5fvpiMJzvqYwiTOnEVW2S4CoYcuKJkomat7bMXA/UoUZQ==}
+
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
 
@@ -2944,6 +2996,10 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+    engines: {node: '>=10.0.0'}
+
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -2970,6 +3026,9 @@ packages:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  aes-decrypter@4.0.2:
+    resolution: {integrity: sha512-lc+/9s6iJvuaRe5qDlMTpCFjnwpkeOXp8qP3oiZ5jsj1MRg+SBVUmmICrhxHvc8OELSmc+fEyyxAuppY6hrWzw==}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -3056,11 +3115,6 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
-  atob@2.1.2:
-    resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
-    engines: {node: '>= 4.5.0'}
-    hasBin: true
-
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -3098,6 +3152,13 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  boolbase@2.0.0:
+    resolution: {integrity: sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==}
+    engines: {node: '>=20.19.0'}
+
   brace-expansion@1.1.15:
     resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
@@ -3112,11 +3173,6 @@ packages:
   browserslist@4.28.4:
     resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
-  btoa@1.2.1:
-    resolution: {integrity: sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==}
-    engines: {node: '>= 0.4.0'}
     hasBin: true
 
   buffer-from@1.1.2:
@@ -3251,6 +3307,13 @@ packages:
 
   css-line-break@2.1.0:
     resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
+
+  css-select@2.1.0:
+    resolution: {integrity: sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==}
+
+  css-what@3.4.2:
+    resolution: {integrity: sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==}
+    engines: {node: '>= 6'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -3391,11 +3454,23 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
-  dompurify@2.5.9:
-    resolution: {integrity: sha512-i6mvVmWN4xo9LrhCOZrDgSs9noW6nOahbrmzjRbPF36YPyj5Ue5lgok0MHDWkG7xzpWFO2OYttXdzM7rJxHvNA==}
+  dom-serializer@0.1.1:
+    resolution: {integrity: sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==}
+
+  dom-walk@0.1.2:
+    resolution: {integrity: sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==}
+
+  domelementtype@1.3.1:
+    resolution: {integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==}
+
+  domhandler@2.4.2:
+    resolution: {integrity: sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==}
 
   dompurify@3.4.11:
     resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+
+  domutils@1.7.0:
+    resolution: {integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -3430,6 +3505,9 @@ packages:
   enhanced-resolve@5.24.1:
     resolution: {integrity: sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==}
     engines: {node: '>=10.13.0'}
+
+  entities@1.1.2:
+    resolution: {integrity: sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -3681,6 +3759,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
+
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
@@ -3798,6 +3879,9 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
+  global@4.4.0:
+    resolution: {integrity: sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==}
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -3910,6 +3994,9 @@ packages:
     resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
     engines: {node: '>=8.0.0'}
 
+  htmlparser2@3.10.1:
+    resolution: {integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
@@ -3950,6 +4037,9 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -4024,6 +4114,9 @@ packages:
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-function@1.0.2:
+    resolution: {integrity: sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==}
 
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
@@ -4151,9 +4244,6 @@ packages:
 
   jspdf-html2canvas@1.6.0:
     resolution: {integrity: sha512-dOYDhJqtbD8vmoiBH5CUS5bSIDO9nLnHeUSsKCIX2KZ1+yFO8dM1PqUMuAok5vmBmWbO7208Dq/q76R55vo+GQ==}
-
-  jspdf@2.5.2:
-    resolution: {integrity: sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==}
 
   jspdf@4.2.1:
     resolution: {integrity: sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==}
@@ -4310,6 +4400,9 @@ packages:
     resolution: {integrity: sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  m3u8-parser@7.2.0:
+    resolution: {integrity: sha512-CRatFqpjVtMiMaKXxNvuI3I++vUumIXVVT/JpCpdU/FynV/ceVw1qpPyyBNindL+JlPMSesx+WX1QJaZEJSaMQ==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -4469,6 +4562,9 @@ packages:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
+  min-document@2.19.2:
+    resolution: {integrity: sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -4549,11 +4645,20 @@ packages:
       react-dom:
         optional: true
 
+  mpd-parser@1.4.0:
+    resolution: {integrity: sha512-blbA7XpAaOdC/PR0Tu8GiUxlx6CpBuRowQPYV7lhi9Yr9G9+dkPXIUjqjzc/NCn/uZZPopluaJlIYntIEI/VLw==}
+    hasBin: true
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mux.js@7.1.0:
+    resolution: {integrity: sha512-NTxawK/BBELJrYsZThEulyUMDVlLizKdxyAsMuzoCD1eFj97BVaA8D/CvKsKu6FOLYkFojN5CbM9h++ZTZtknA==}
+    engines: {node: '>=8', npm: '>=5'}
+    hasBin: true
 
   nanoid@3.3.15:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
@@ -4618,6 +4723,10 @@ packages:
 
   nprogress@0.2.0:
     resolution: {integrity: sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==}
+
+  nth-check@3.0.1:
+    resolution: {integrity: sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==}
+    engines: {node: '>=20.19.0'}
 
   nub@0.0.0:
     resolution: {integrity: sha512-dK0Ss9C34R/vV0FfYJXuqDAqHlaW9fvWVufq9MmGF2umCuDbd5GRfRD9fpi/LiM0l4ZXf8IBB+RYmZExqCrf0w==}
@@ -4737,6 +4846,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pkcs7@1.0.4:
+    resolution: {integrity: sha512-afRERtHn54AlwaF2/+LFszyAANTCggGilmcmILUzEjvs3XgFZT+xE6+QWQcAGmu4xajy+Xtj7acLOPdx5/eXWQ==}
+    hasBin: true
+
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
@@ -4745,17 +4858,29 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
+  postcss-inline-svg@4.1.0:
+    resolution: {integrity: sha512-0pYBJyoQ9/sJViYRc1cNOOTM7DYh0/rmASB0TBeRmWkG8YFK2tmgdkfjHkbRma1iFtBFKFHZFsHwRTDZTMKzSQ==}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.396.3:
+    resolution: {integrity: sha512-CL4mH3F2azsONko/zC2931RLdt6RxTsEr7x7Lyk0SDmj5hZuvBCTbg9MKViXwSRhBr3/SaGcaHS1n95WxTrsCw==}
+
+  preact@10.29.3:
+    resolution: {integrity: sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
 
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
@@ -4820,6 +4945,9 @@ packages:
     resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -4892,13 +5020,13 @@ packages:
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
-      '@types/react': '>=18'
+      '@types/react': 19.2.17
       react: '>=18'
 
   react-redux@9.3.0:
     resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
     peerDependencies:
-      '@types/react': ^18.2.25 || ^19
+      '@types/react': 19.2.17
       react: ^18.0 || ^19
       redux: ^5.0.0
     peerDependenciesMeta:
@@ -4911,7 +5039,7 @@ packages:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
@@ -4921,7 +5049,7 @@ packages:
     resolution: {integrity: sha512-xGVKJJr0SJGQVirVFAUZ2k1QLyO6m+2fy0l8Qawbp5Jgrv3DeLalrfMNBFSlmz5kriGGzsVBtGVnf4pTKIhhWA==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      '@types/react': 19.2.17
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     peerDependenciesMeta:
       '@types/react':
@@ -4931,7 +5059,7 @@ packages:
     resolution: {integrity: sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      '@types/react': 19.2.17
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     peerDependenciesMeta:
       '@types/react':
@@ -4941,7 +5069,7 @@ packages:
     resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -4957,7 +5085,7 @@ packages:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -4972,6 +5100,10 @@ packages:
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   recharts@3.9.0:
     resolution: {integrity: sha512-dCEcE9y20c8H2tkVeByrAXhhnBJk6/QLbxKmn+dJUptOfc5NMjwRh1jo0vZPRLD+5dMrHrP+hPEsfbGBMfnf5Q==}
@@ -5070,6 +5202,9 @@ packages:
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
@@ -5207,6 +5342,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -5424,7 +5562,7 @@ packages:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -5434,7 +5572,7 @@ packages:
     resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': 19.2.17
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -5450,6 +5588,9 @@ packages:
     engines: {node: '>=16.15.0'}
     peerDependencies:
       react: ^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   utrie@1.0.2:
     resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
@@ -5470,6 +5611,29 @@ packages:
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
+  video.js@8.23.9:
+    resolution: {integrity: sha512-3UCqyFW4wIusQu4TuhgRUxqtbzbj0WPT9hps0XIEXST43QBD11zb+bG7tBPrinrZztwVYdXCiOBo2pcGj9L05w==}
+
+  videojs-contrib-quality-levels@4.1.0:
+    resolution: {integrity: sha512-TfrXJJg1Bv4t6TOCMEVMwF/CoS8iENYsWNKip8zfhB5kTcegiFYezEA0eHAJPU64ZC8NQbxQgOwAsYU8VXbOWA==}
+    engines: {node: '>=16', npm: '>=8'}
+    peerDependencies:
+      video.js: ^8
+
+  videojs-font@4.2.0:
+    resolution: {integrity: sha512-YPq+wiKoGy2/M7ccjmlvwi58z2xsykkkfNMyIg4xb7EZQQNwB71hcSsB3o75CqQV7/y5lXkXhI/rsGAS7jfEmQ==}
+
+  videojs-hls-quality-selector@2.0.0:
+    resolution: {integrity: sha512-x0AQKGwryDdD94s1it+Jolb6j1mg4Q+c7g1PlCIG6dXBdipVPaZmg71fxaFZJgx1k326DFnRaWrLxQ72/TKd2A==}
+    engines: {node: '>=14', npm: '>=6'}
+
+  videojs-sprite-thumbnails@2.2.5:
+    resolution: {integrity: sha512-q+rzTfNu9Rze4Jy3gD2Kpw88pa7jXEWwbkowlFL6/H4udTbz80yuZjQij4WMvo5X1tgvgAfvGep7nXl89zKjGw==}
+    engines: {node: '>=14', npm: '>=6'}
+
+  videojs-vtt.js@0.15.5:
+    resolution: {integrity: sha512-yZbBxvA7QMYn15Lr/ZfhhLPrNpI/RmCSCqgIff57GC2gIrV5YfyzLfLyZMj0NnZSAz8syB4N0nHXpZg9MyrMOQ==}
+
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
@@ -5486,6 +5650,9 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -5559,9 +5726,9 @@ packages:
     resolution: {integrity: sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
     peerDependencies:
-      prosemirror-model: ^1.7.1
+      prosemirror-model: 1.25.9
       prosemirror-state: ^1.2.3
-      prosemirror-view: ^1.9.10
+      prosemirror-view: 1.41.9
       y-protocols: ^1.0.1
       yjs: ^13.5.38
 
@@ -6494,6 +6661,12 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
 
   '@popperjs/core@2.11.8': {}
+
+  '@posthog/core@1.39.2':
+    dependencies:
+      '@posthog/types': 1.392.0
+
+  '@posthog/types@1.392.0': {}
 
   '@radix-ui/number@1.1.2': {}
 
@@ -8184,6 +8357,32 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
+  '@videojs/http-streaming@3.17.5(video.js@8.23.9)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@videojs/vhs-utils': 4.1.2
+      aes-decrypter: 4.0.2
+      global: 4.4.0
+      m3u8-parser: 7.2.0
+      mpd-parser: 1.4.0
+      mux.js: 7.1.0
+      video.js: 8.23.9
+
+  '@videojs/themes@1.0.1':
+    dependencies:
+      postcss-inline-svg: 4.1.0
+
+  '@videojs/vhs-utils@4.1.2':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      global: 4.4.0
+
+  '@videojs/xhr@2.7.0':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      global: 4.4.0
+      is-function: 1.0.2
+
   '@webassemblyjs/ast@1.14.1':
     dependencies:
       '@webassemblyjs/helper-numbers': 1.13.2
@@ -8260,6 +8459,8 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
+  '@xmldom/xmldom@0.8.13': {}
+
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
@@ -8277,6 +8478,13 @@ snapshots:
       acorn: 8.17.0
 
   acorn@8.17.0: {}
+
+  aes-decrypter@4.0.2:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@videojs/vhs-utils': 4.1.2
+      global: 4.4.0
+      pkcs7: 1.0.4
 
   agent-base@6.0.2:
     dependencies:
@@ -8394,8 +8602,6 @@ snapshots:
 
   async-function@1.0.0: {}
 
-  atob@2.1.2: {}
-
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -8422,6 +8628,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.38: {}
 
+  boolbase@1.0.0: {}
+
+  boolbase@2.0.0: {}
+
   brace-expansion@1.1.15:
     dependencies:
       balanced-match: 1.0.2
@@ -8442,8 +8652,6 @@ snapshots:
       electron-to-chromium: 1.5.378
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
-
-  btoa@1.2.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -8569,8 +8777,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  core-js@3.49.0:
-    optional: true
+  core-js@3.49.0: {}
 
   crelt@1.0.6: {}
 
@@ -8587,6 +8794,15 @@ snapshots:
   css-line-break@2.1.0:
     dependencies:
       utrie: 1.0.2
+
+  css-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 3.4.2
+      domutils: 1.7.0
+      nth-check: 3.0.1
+
+  css-what@3.4.2: {}
 
   csstype@3.2.3: {}
 
@@ -8707,12 +8923,27 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
-  dompurify@2.5.9:
-    optional: true
+  dom-serializer@0.1.1:
+    dependencies:
+      domelementtype: 1.3.1
+      entities: 1.1.2
+
+  dom-walk@0.1.2: {}
+
+  domelementtype@1.3.1: {}
+
+  domhandler@2.4.2:
+    dependencies:
+      domelementtype: 1.3.1
 
   dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  domutils@1.7.0:
+    dependencies:
+      dom-serializer: 0.1.1
+      domelementtype: 1.3.1
 
   dotenv@16.6.1: {}
 
@@ -8755,6 +8986,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@1.1.2: {}
 
   entities@6.0.1: {}
 
@@ -9140,6 +9373,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fflate@0.4.8: {}
+
   fflate@0.8.3: {}
 
   file-entry-cache@8.0.0:
@@ -9268,6 +9503,11 @@ snapshots:
       minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
+
+  global@4.4.0:
+    dependencies:
+      min-document: 2.19.2
+      process: 0.11.10
 
   globals@14.0.0: {}
 
@@ -9435,6 +9675,15 @@ snapshots:
       css-line-break: 2.1.0
       text-segmentation: 1.0.3
 
+  htmlparser2@3.10.1:
+    dependencies:
+      domelementtype: 1.3.1
+      domhandler: 2.4.2
+      domutils: 1.7.0
+      entities: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
@@ -9471,6 +9720,8 @@ snapshots:
       module-details-from-path: 1.0.4
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -9548,6 +9799,8 @@ snapshots:
       call-bound: 1.0.4
 
   is-fullwidth-code-point@3.0.0: {}
+
+  is-function@1.0.2: {}
 
   is-generator-function@1.1.2:
     dependencies:
@@ -9667,19 +9920,7 @@ snapshots:
   jspdf-html2canvas@1.6.0:
     dependencies:
       html2canvas-pro: 1.6.7
-      jspdf: 2.5.2
-
-  jspdf@2.5.2:
-    dependencies:
-      '@babel/runtime': 7.29.7
-      atob: 2.1.2
-      btoa: 1.2.1
-      fflate: 0.8.3
-    optionalDependencies:
-      canvg: 3.0.11
-      core-js: 3.49.0
-      dompurify: 2.5.9
-      html2canvas: 1.4.1
+      jspdf: 4.2.1
 
   jspdf@4.2.1:
     dependencies:
@@ -9818,6 +10059,12 @@ snapshots:
   lucide-react@1.21.0(react@19.2.7):
     dependencies:
       react: 19.2.7
+
+  m3u8-parser@7.2.0:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@videojs/vhs-utils': 4.1.2
+      global: 4.4.0
 
   magic-string@0.30.21:
     dependencies:
@@ -10184,6 +10431,10 @@ snapshots:
 
   mime-db@1.54.0: {}
 
+  min-document@2.19.2:
+    dependencies:
+      dom-walk: 0.1.2
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -10222,9 +10473,21 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  mpd-parser@1.4.0:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@videojs/vhs-utils': 4.1.2
+      '@xmldom/xmldom': 0.8.13
+      global: 4.4.0
+
   ms@2.0.0: {}
 
   ms@2.1.3: {}
+
+  mux.js@7.1.0:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      global: 4.4.0
 
   nanoid@3.3.15: {}
 
@@ -10240,7 +10503,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.38
       caniuse-lite: 1.0.30001799
-      postcss: 8.4.31
+      postcss: 8.5.15
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
@@ -10281,6 +10544,10 @@ snapshots:
   node-releases@2.0.50: {}
 
   nprogress@0.2.0: {}
+
+  nth-check@3.0.1:
+    dependencies:
+      boolbase: 2.0.0
 
   nub@0.0.0: {}
 
@@ -10411,15 +10678,23 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pkcs7@1.0.4:
+    dependencies:
+      '@babel/runtime': 7.29.7
+
   pngjs@5.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.4.31:
+  postcss-inline-svg@4.1.0:
     dependencies:
-      nanoid: 3.3.15
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
+      css-select: 2.1.0
+      dom-serializer: 0.1.1
+      htmlparser2: 3.10.1
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  postcss-value-parser@4.2.0: {}
 
   postcss@8.5.15:
     dependencies:
@@ -10427,7 +10702,22 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.396.3:
+    dependencies:
+      '@posthog/core': 1.39.2
+      '@posthog/types': 1.392.0
+      core-js: 3.49.0
+      dompurify: 3.4.11
+      fflate: 0.4.8
+      preact: 10.29.3
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+
+  preact@10.29.3: {}
+
   prelude-ls@1.2.1: {}
+
+  process@0.11.10: {}
 
   progress@2.0.3: {}
 
@@ -10524,6 +10814,8 @@ snapshots:
       dijkstrajs: 1.0.3
       pngjs: 5.0.0
       yargs: 15.4.1
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -10674,6 +10966,12 @@ snapshots:
       - supports-color
 
   react@19.2.7: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   recharts@3.9.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1):
     dependencies:
@@ -10849,6 +11147,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       isarray: 2.0.5
+
+  safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
     dependencies:
@@ -11083,6 +11383,10 @@ snapshots:
       call-bind: 1.0.9
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   stringify-entities@4.0.4:
     dependencies:
@@ -11362,6 +11666,8 @@ snapshots:
       lodash.debounce: 4.0.8
       react: 19.2.7
 
+  util-deprecate@1.0.2: {}
+
   utrie@1.0.2:
     dependencies:
       base64-arraybuffer: 1.0.2
@@ -11400,6 +11706,42 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  video.js@8.23.9:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@videojs/http-streaming': 3.17.5(video.js@8.23.9)
+      '@videojs/vhs-utils': 4.1.2
+      '@videojs/xhr': 2.7.0
+      aes-decrypter: 4.0.2
+      global: 4.4.0
+      m3u8-parser: 7.2.0
+      mpd-parser: 1.4.0
+      mux.js: 7.1.0
+      videojs-contrib-quality-levels: 4.1.0(video.js@8.23.9)
+      videojs-font: 4.2.0
+      videojs-vtt.js: 0.15.5
+
+  videojs-contrib-quality-levels@4.1.0(video.js@8.23.9):
+    dependencies:
+      global: 4.4.0
+      video.js: 8.23.9
+
+  videojs-font@4.2.0: {}
+
+  videojs-hls-quality-selector@2.0.0:
+    dependencies:
+      global: 4.4.0
+      video.js: 8.23.9
+
+  videojs-sprite-thumbnails@2.2.5:
+    dependencies:
+      global: 4.4.0
+      video.js: 8.23.9
+
+  videojs-vtt.js@0.15.5:
+    dependencies:
+      global: 4.4.0
+
   void-elements@3.1.0: {}
 
   w3c-keyname@2.2.8: {}
@@ -11411,6 +11753,8 @@ snapshots:
   wavesurfer.js@7.12.8: {}
 
   web-namespaces@2.0.1: {}
+
+  web-vitals@5.3.0: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/apps/web/services/courses/activities.ts
+++ b/apps/web/services/courses/activities.ts
@@ -23,6 +23,66 @@ export async function createActivity(
   return res
 }
 
+/**
+ * Upload a hosted-video activity with real upload progress (XHR — fetch can't
+ * report upload progress). Resolves with the created activity JSON. Used by the
+ * background-upload flow so the modal can close immediately.
+ */
+export function createVideoActivityWithProgress(
+  file: File,
+  data: any,
+  chapter_id: any,
+  access_token: string,
+  onProgress: (_percent: number) => void
+): Promise<any> {
+  const formData = new FormData()
+  formData.append('chapter_id', chapter_id)
+  formData.append('name', data.name)
+  formData.append('video_file', file)
+  if (data.details) {
+    formData.append(
+      'details',
+      JSON.stringify({
+        startTime: data.details.startTime || 0,
+        endTime: data.details.endTime || null,
+        autoplay: data.details.autoplay || false,
+        muted: data.details.muted || false,
+      })
+    )
+  }
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest()
+    xhr.open('POST', `${getAPIUrl()}activities/video`)
+    xhr.withCredentials = true
+    xhr.setRequestHeader('Authorization', `Bearer ${access_token}`)
+    xhr.upload.onprogress = (e) => {
+      if (e.lengthComputable) onProgress((e.loaded / e.total) * 100)
+    }
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          resolve(JSON.parse(xhr.responseText))
+        } catch {
+          resolve({})
+        }
+      } else if (xhr.status === 413) {
+        reject(new Error('The file is too large to upload.'))
+      } else {
+        let detail: string | undefined
+        try {
+          detail = JSON.parse(xhr.responseText)?.detail
+        } catch {
+          /* non-JSON error body */
+        }
+        reject(new Error(detail || `Upload failed (HTTP ${xhr.status})`))
+      }
+    }
+    xhr.onerror = () => reject(new Error('Network error during upload'))
+    xhr.onabort = () => reject(new Error('Upload cancelled'))
+    xhr.send(formData)
+  })
+}
+
 export async function createFileActivity(
   file: File,
   type: string,
@@ -223,6 +283,25 @@ export async function updateHostedVideoActivity(
   const result = await fetch(
     `${getAPIUrl()}activities/video/${activityUuid}`,
     RequestBodyFormWithAuthHeader('PUT', formData, null, access_token)
+  )
+  return getResponseMetadata(result)
+}
+
+export interface CaptionsConfigPayload {
+  enabled: boolean
+  source_language: string
+  languages: { code: string; label?: string }[]
+}
+
+/** Enable/disable AI captions + choose target languages (queues generation). */
+export async function updateVideoCaptions(
+  activityUuid: string,
+  config: CaptionsConfigPayload,
+  access_token: string,
+) {
+  const result = await fetch(
+    `${getAPIUrl()}activities/video/${activityUuid}/captions`,
+    RequestBodyWithAuthHeader('POST', config, null, access_token)
   )
   return getResponseMetadata(result)
 }

--- a/apps/web/services/media/media.ts
+++ b/apps/web/services/media/media.ts
@@ -10,7 +10,10 @@ function getMediaUrl() {
 }
 
 function getApiUrl() {
-  return getBackendUrl();
+  // Normalize so URL building is correct whether or not the configured backend
+  // URL carries a trailing slash (otherwise we'd get "...ioapi/v1/...").
+  const base = getBackendUrl();
+  return base.endsWith('/') ? base : `${base}/`;
 }
 
 /**
@@ -24,6 +27,45 @@ export function getActivityVideoStreamUrl(
   filename: string
 ) {
   return `${getApiUrl()}api/v1/stream/video/${orgUUID}/${courseUUID}/${activityUUID}/${filename}`
+}
+
+/**
+ * Get the HLS master-playlist URL for an activity video.
+ * The API returns the playlist (after an RBAC check) with segment URLs
+ * presigned to R2, so hls.js streams segments directly from object storage.
+ */
+export function getActivityHlsMasterUrl(
+  orgUUID: string,
+  courseUUID: string,
+  activityUUID: string
+) {
+  return `${getApiUrl()}api/v1/stream/hls/${orgUUID}/${courseUUID}/${activityUUID}/master.m3u8`
+}
+
+/**
+ * Get the URL of an activity's HLS hover-preview sprite sheet. The API redirects
+ * this to a presigned R2 URL; it's loaded as a CSS background image (no CORS).
+ */
+export function getActivityHlsThumbnailsUrl(
+  orgUUID: string,
+  courseUUID: string,
+  activityUUID: string,
+  spritePath: string
+) {
+  return `${getApiUrl()}api/v1/stream/hls/${orgUUID}/${courseUUID}/${activityUUID}/${spritePath}`
+}
+
+/**
+ * Get the URL of an activity's WebVTT caption track for a language. Served inline
+ * by the API after an RBAC check (same access as the video).
+ */
+export function getActivityCaptionUrl(
+  orgUUID: string,
+  courseUUID: string,
+  activityUUID: string,
+  lang: string
+) {
+  return `${getApiUrl()}api/v1/stream/captions/${orgUUID}/${courseUUID}/${activityUUID}/${lang}.vtt`
 }
 
 /**

--- a/apps/web/tests/video-source.test.mjs
+++ b/apps/web/tests/video-source.test.mjs
@@ -1,0 +1,168 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isActivityHlsReady,
+  resolveActivityVideoSource,
+  resolveHlsThumbnails,
+  resolveActivityCaptions,
+  shouldSendHlsCredentials,
+} from "../components/Objects/Activities/Video/videoSource.ts";
+
+describe("resolveActivityCaptions", () => {
+  const ids = { orgUuid: "org_1", courseUuid: "course_1", activityUuid: "activity_1" };
+
+  test("returns only ready tracks with built URLs", () => {
+    const activity = {
+      extra_metadata: {
+        captions: {
+          enabled: true,
+          languages: [
+            { code: "fr", label: "French", status: "ready" },
+            { code: "es", label: "Spanish", status: "processing" },
+            { code: "de", label: "German", status: "failed" },
+          ],
+        },
+      },
+    };
+    const tracks = resolveActivityCaptions(activity, ids);
+    expect(tracks.length).toBe(1);
+    expect(tracks[0].code).toBe("fr");
+    expect(tracks[0].url).toContain("/stream/captions/org_1/course_1/activity_1/fr.vtt");
+  });
+
+  test("empty when disabled, absent, or ids missing", () => {
+    expect(resolveActivityCaptions({ extra_metadata: { captions: { enabled: false, languages: [{ code: "fr", status: "ready" }] } } }, ids)).toEqual([]);
+    expect(resolveActivityCaptions({ extra_metadata: {} }, ids)).toEqual([]);
+    expect(resolveActivityCaptions({}, ids)).toEqual([]);
+    expect(resolveActivityCaptions({ extra_metadata: { captions: { enabled: true, languages: [{ code: "fr", status: "ready" }] } } }, { orgUuid: "", courseUuid: "c", activityUuid: "a" })).toEqual([]);
+  });
+});
+
+describe("isActivityHlsReady", () => {
+  test("true only when hls status is 'ready'", () => {
+    expect(isActivityHlsReady({ extra_metadata: { hls: { status: "ready" } } })).toBe(true);
+  });
+
+  test("false for processing/failed/missing metadata", () => {
+    expect(isActivityHlsReady({ extra_metadata: { hls: { status: "processing" } } })).toBe(false);
+    expect(isActivityHlsReady({ extra_metadata: { hls: { status: "failed" } } })).toBe(false);
+    expect(isActivityHlsReady({ extra_metadata: {} })).toBe(false);
+    expect(isActivityHlsReady({ extra_metadata: null })).toBe(false);
+    expect(isActivityHlsReady({})).toBe(false);
+  });
+});
+
+describe("resolveActivityVideoSource", () => {
+  const base = {
+    orgUuid: "org_1",
+    courseUuid: "course_1",
+    activityUuid: "activity_1",
+    filename: "clip.mp4",
+  };
+
+  test("empty when there is no filename", () => {
+    expect(resolveActivityVideoSource({ ...base, filename: undefined, hlsReady: false })).toEqual({
+      src: "",
+      isHls: false,
+    });
+  });
+
+  test("empty for whitespace-only filename", () => {
+    expect(resolveActivityVideoSource({ ...base, filename: "   ", hlsReady: false })).toEqual({
+      src: "",
+      isHls: false,
+    });
+  });
+
+  test("empty when any id is missing (never emits 'undefined' in the URL)", () => {
+    const r = resolveActivityVideoSource({ ...base, orgUuid: undefined, hlsReady: false });
+    expect(r.src).toBe("");
+    const r2 = resolveActivityVideoSource({ ...base, activityUuid: "", hlsReady: true });
+    expect(r2.src).toBe("");
+  });
+
+  test("no double slash regardless of backend trailing slash", () => {
+    const { src } = resolveActivityVideoSource({ ...base, hlsReady: false });
+    expect(src).not.toContain("ioapi");
+    expect(src.split("://")[1]).not.toContain("//");
+  });
+
+  test("uses the MP4 stream endpoint when HLS is not ready", () => {
+    const { src, isHls } = resolveActivityVideoSource({ ...base, hlsReady: false });
+    expect(isHls).toBe(false);
+    expect(src).toContain("api/v1/stream/video/org_1/course_1/activity_1/clip.mp4");
+    expect(src).not.toContain("/hls/");
+  });
+
+  test("uses the HLS master playlist when ready", () => {
+    const { src, isHls } = resolveActivityVideoSource({ ...base, hlsReady: true });
+    expect(isHls).toBe(true);
+    expect(src).toContain("api/v1/stream/hls/org_1/course_1/activity_1/master.m3u8");
+    expect(src).not.toContain("clip.mp4");
+  });
+});
+
+describe("resolveHlsThumbnails", () => {
+  const ids = { orgUuid: "org_1", courseUuid: "course_1", activityUuid: "activity_1" };
+  const full = {
+    extra_metadata: {
+      hls: {
+        status: "ready",
+        thumbnails: { url: "thumbnails/sprite.jpg", interval: 10, width: 160, height: 90, columns: 10, rows: 6 },
+      },
+    },
+  };
+
+  test("builds an absolute sprite URL and passes config through", () => {
+    const t = resolveHlsThumbnails(full, ids);
+    expect(t).not.toBeNull();
+    expect(t.url).toContain("api/v1/stream/hls/org_1/course_1/activity_1/thumbnails/sprite.jpg");
+    expect(t).toMatchObject({ interval: 10, width: 160, height: 90, columns: 10, rows: 6 });
+  });
+
+  test("null when thumbnails metadata is missing or incomplete", () => {
+    expect(resolveHlsThumbnails({ extra_metadata: { hls: { status: "ready" } } }, ids)).toBeNull();
+    expect(resolveHlsThumbnails({ extra_metadata: { hls: { thumbnails: { url: "x.jpg" } } } }, ids)).toBeNull();
+    expect(resolveHlsThumbnails({}, ids)).toBeNull();
+  });
+
+  test("null for negative/zero/NaN numeric fields", () => {
+    const mk = (over) => ({ extra_metadata: { hls: { thumbnails: { url: "s.jpg", interval: 5, width: 160, height: 90, columns: 10, ...over } } } });
+    expect(resolveHlsThumbnails(mk({ interval: 0 }), ids)).toBeNull();
+    expect(resolveHlsThumbnails(mk({ width: -160 }), ids)).toBeNull();
+    expect(resolveHlsThumbnails(mk({ columns: 0 }), ids)).toBeNull();
+    expect(resolveHlsThumbnails(mk({ height: Number.NaN }), ids)).toBeNull();
+  });
+
+  test("null when an id is missing", () => {
+    expect(resolveHlsThumbnails(full, { ...ids, orgUuid: undefined })).toBeNull();
+  });
+
+  test("defaults rows to 1 when omitted or non-positive", () => {
+    const mk = (rows) => ({ extra_metadata: { hls: { thumbnails: { url: "s.jpg", interval: 5, width: 160, height: 90, columns: 10, ...(rows === undefined ? {} : { rows }) } } } });
+    expect(resolveHlsThumbnails(mk(undefined), ids).rows).toBe(1);
+    expect(resolveHlsThumbnails(mk(0), ids).rows).toBe(1);
+    expect(resolveHlsThumbnails(mk(-3), ids).rows).toBe(1);
+  });
+});
+
+describe("shouldSendHlsCredentials", () => {
+  test("credentials only for our API playlist endpoint", () => {
+    expect(shouldSendHlsCredentials("https://api.learnhouse.io/api/v1/stream/hls/o/c/a/master.m3u8")).toBe(true);
+    expect(shouldSendHlsCredentials("https://api.learnhouse.io/api/v1/stream/hls/o/c/a/v720p/index.m3u8")).toBe(true);
+  });
+
+  test("no credentials for presigned R2 segment URLs", () => {
+    expect(
+      shouldSendHlsCredentials("https://acct.r2.cloudflarestorage.com/bucket/content/.../seg_0000.ts?X-Amz-Signature=x")
+    ).toBe(false);
+  });
+
+  test("never sends credentials to a presigned URL even if it contains the API path", () => {
+    // Pathological URL that both looks like our API path AND is presigned:
+    // the X-Amz- guard must win so the cookie is not leaked to storage.
+    expect(
+      shouldSendHlsCredentials("https://r2/bucket/api/v1/stream/hls/x/seg.ts?X-Amz-Credential=abc")
+    ).toBe(false);
+  });
+});

--- a/docs/content/platform/courses/_meta.json
+++ b/docs/content/platform/courses/_meta.json
@@ -1,6 +1,7 @@
 {
   "index": "Overview",
   "chapters-and-activities": "Chapters & Activities",
+  "video-captions": "AI Video Captions",
   "collections": "Collections",
   "trails": "Trails"
 }

--- a/docs/content/platform/courses/video-captions.mdx
+++ b/docs/content/platform/courses/video-captions.mdx
@@ -1,0 +1,71 @@
+import { Callout } from 'nextra/components'
+
+# AI Video Captions
+
+LearnHouse can automatically generate closed captions (subtitles) for **hosted video** activities and translate them into any languages you choose. Captions are transcribed from the video's audio with AI, so you don't have to write or time them by hand.
+
+<Callout type="info">
+  Captions are available for **hosted videos** (files you upload) — not for embedded
+  YouTube videos, which use YouTube's own captions.
+</Callout>
+
+## Enabling captions
+
+You can set captions up in **two places** — the panel is the same in both:
+
+- **When uploading a video** — the **AI Closed Captions** panel appears in the new-video dialog, so captions start generating as soon as the upload finishes.
+- **Later, from the editor** — edit an existing hosted-video activity to add, change, or regenerate captions.
+
+To configure them:
+
+1. Open the new-video dialog (or edit a hosted-video activity).
+2. In the **AI Closed Captions** panel, turn on **Generate with AI**.
+3. Pick the **spoken language** of the video, or leave it on **Auto-detect**.
+4. Choose the **caption languages** you want. You can:
+   - select any of the platform's built-in languages, and/or
+   - **add a custom language** by entering its code (e.g. `sw` for Swahili, `es-419` for Latin-American Spanish) and a display name.
+5. Click **Generate captions**.
+
+Generation runs in the background. Each language shows a status — **queued → processing → ready** — and captions appear in the player's subtitles/CC menu as soon as they're ready. You can close the editor and come back later; you don't need to keep it open.
+
+## How it works
+
+1. The audio is extracted from your video.
+2. The AI transcribes it into timed WebVTT subtitles in the original language.
+3. Each requested language is translated from that transcript, preserving the timings.
+4. The finished tracks are stored alongside the video and served to the player.
+
+Long videos are transcribed in segments and stitched back together, so a two-hour lecture works the same as a two-minute clip.
+
+## Playback
+
+Once at least one language is ready, learners get a **CC / subtitles button** in the video player and can switch languages from its menu. Captions work on both the adaptive (HLS) and standard playback paths.
+
+## AI usage & credits
+
+Caption generation uses your organization's **AI credits**, the same pool used by the AI chat and course tools.
+
+- The cost scales with the video's length and the number of languages you request (roughly one credit per ~10 minutes of audio, plus one per translated language).
+- If your organization has AI disabled or has run out of credits, you'll be told when you try to generate — nothing is charged in that case.
+- If the source language is among your chosen languages, it is reused directly and not re-translated (saving a credit).
+
+<Callout type="warning">
+  AI captions are a strong first draft, but automatic transcription and translation
+  can contain mistakes. Review important captions before relying on them, especially
+  for names, technical terms, and accessibility-critical content.
+</Callout>
+
+## Regenerating or disabling
+
+- Re-open the panel and change the languages, then **Generate captions** again to update.
+- Turn off **Generate with AI** and save to disable captions for the activity.
+
+## Requirements (self-hosted)
+
+Captions are available automatically wherever these are in place — no extra
+feature flag:
+
+- A configured AI provider (Gemini by default — see the AI settings) with the AI
+  feature enabled for the organization.
+- `ffmpeg` available to the API (already included in the official image).
+- Redis (used to queue and process caption jobs).


### PR DESCRIPTION
## Problem

Video activities buffer constantly (~every 3s) on long videos even though files are hosted on Cloudflare R2.

**Root cause:** every video byte is proxied through the FastAPI backend instead of being served by R2 directly. The browser hits `/api/v1/stream/video/...`, which calls `_stream_from_s3()` — and that issues a **separate `get_object(Range=...)` HTTPS call to R2 for every 1MB chunk, sequentially, with no read-ahead**. A long video becomes hundreds of serialized R2 round-trips, each re-paying TLS/auth/latency, all funneled back out through the app server. That serialized double-hop is the stalling.

The HTML5 player itself (`preload="metadata"`, no `crossOrigin`) is fine and unchanged.

## Fix

When S3/R2 is enabled, the stream endpoints now enforce RBAC and then **302-redirect to a short-lived (12h) presigned R2 URL**. The browser follows the redirect and streams bytes **directly from object storage** with native HTTP Range support and full throughput — zero bytes through the API.

- `generate_presigned_get_url()` added to `storage_utils.py` (uses the existing S3 client, which already signs R2 requests correctly).
- `_redirect_to_storage()` helper in `stream.py`; the redirect runs **after** the RBAC check, so the presigned URL only ever issues to an authorized request. `Cache-Control: no-store` on the 302 so each load gets a fresh link.
- Applied to all four GET stream handlers: activity video, video block, audio block, podcast episode audio.
- **Local-filesystem mode is unchanged** — it keeps the existing chunked `StreamingResponse` path (the redirect branch is a no-op when S3 is off).

## Notes

- Bucket stays private; access stays gated by RBAC at the redirect endpoint.
- No frontend change needed: the video `src` is already an absolute `api.learnhouse.io` URL, so the browser follows the backend 302 straight to R2 (it never traverses the Next proxy).
- Verified against the live prod config: `s3api` enabled, R2 endpoint is the public `*.r2.cloudflarestorage.com` host (browser-reachable, supports Range), and S3 credentials are present in the API env.

## Verification

1. Local/dev (`filesystem`): playback streams via the existing path, no redirect.
2. S3/staging: `stream/video/...` returns **302** → browser issues **206** range requests directly to R2; playback is smooth and seeking is instant with no rebuffer.
3. Private course: redirect endpoint still `403`s non-members (RBAC before presign).