### PR TITLE
feat: AI image, quiz, and assignment generation

### DIFF
--- a/apps/api/config/config.py
+++ b/apps/api/config/config.py
@@ -64,7 +64,8 @@ class AIConfig(BaseModel):
     # Google-only path — it always uses the Google GenAI SDK regardless of the
     # configured text `provider`, resolving its key from `api_key` (when provider
     # is Google) or `gemini_api_key`. Override the exact model id with
-    # LEARNHOUSE_AI_IMAGE_MODEL; defaults to the nano-banana-2-lite model.
+    # LEARNHOUSE_AI_IMAGE_MODEL; defaults to the GA `gemini-2.5-flash-image`
+    # (Nano Banana). Set a newer/preview model here once it is allowlisted.
     image_model: str | None = None
 
 

--- a/apps/api/config/config.py
+++ b/apps/api/config/config.py
@@ -60,6 +60,12 @@ class AIConfig(BaseModel):
     # Google/Gemini key. Doubles as the embeddings fallback for providers (Anthropic, DeepSeek,
     # Moonshot, Mistral, OpenRouter, Bedrock) that have no embeddings API of their own.
     gemini_api_key: str | None = None
+    # Image generation model (Google "nano banana" family). Image generation is a
+    # Google-only path — it always uses the Google GenAI SDK regardless of the
+    # configured text `provider`, resolving its key from `api_key` (when provider
+    # is Google) or `gemini_api_key`. Override the exact model id with
+    # LEARNHOUSE_AI_IMAGE_MODEL; defaults to the nano-banana-2-lite model.
+    image_model: str | None = None
 
 
 class S3ApiConfig(BaseModel):
@@ -382,6 +388,7 @@ def get_learnhouse_config() -> LearnHouseConfig:
     env_is_ai_enabled_str = os.environ.get("LEARNHOUSE_IS_AI_ENABLED")
 
     gemini_api_key = env_gemini_api_key or yaml_ai_config.get("gemini_api_key")
+    ai_image_model = os.environ.get("LEARNHOUSE_AI_IMAGE_MODEL") or yaml_ai_config.get("image_model")
 
     # Provider-agnostic generation settings (env takes precedence over yaml).
     ai_provider = os.environ.get("LEARNHOUSE_AI_PROVIDER") or yaml_ai_config.get("provider")
@@ -582,6 +589,7 @@ def get_learnhouse_config() -> LearnHouseConfig:
         embedding_model=ai_embedding_model,
         embedding_dimensions=ai_embedding_dimensions,
         gemini_api_key=gemini_api_key,
+        image_model=ai_image_model,
     )
 
     # Surface missing internal-service keys at boot rather than at first

--- a/apps/api/migrations/versions/b7c8d9e0f1a2_add_scenario_aigeneration_kind.py
+++ b/apps/api/migrations/versions/b7c8d9e0f1a2_add_scenario_aigeneration_kind.py
@@ -1,0 +1,39 @@
+"""add SCENARIO to aigenerationkind
+
+Lets AI-generated interactive scenarios be recorded in the durable
+AIGeneration history alongside images, quizzes, and assignments.
+
+Revision ID: b7c8d9e0f1a2
+Revises: f9e8d7c6b5a4
+Create Date: 2026-07-03
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa  # noqa: F401
+import sqlmodel  # noqa: F401
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b7c8d9e0f1a2'
+down_revision: Union[str, None] = 'f9e8d7c6b5a4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ALTER TYPE ... ADD VALUE cannot run inside a transaction block; commit the
+    # migration's implicit transaction first (mirrors the CUSTOM-type migration).
+    # Guarded so it is a no-op if the aigeneration table/enum doesn't exist yet.
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if 'aigeneration' not in inspector.get_table_names():
+        return
+    op.execute("COMMIT")
+    op.execute("ALTER TYPE aigenerationkind ADD VALUE IF NOT EXISTS 'SCENARIO'")
+
+
+def downgrade() -> None:
+    # PostgreSQL does not support removing enum values directly.
+    pass

--- a/apps/api/migrations/versions/f9e8d7c6b5a4_add_ai_generation_history.py
+++ b/apps/api/migrations/versions/f9e8d7c6b5a4_add_ai_generation_history.py
@@ -1,0 +1,89 @@
+"""Add ai_generation durable history table (and merge open heads)
+
+Creates the ``aigeneration`` table that durably records AI-generated artifacts
+the user kept (images, editor quizzes, assignment plans). The in-progress
+multi-turn refine chat still lives ephemerally in Redis — this table is the
+durable, queryable history surfaced in each feature's "History" tab.
+
+The migration tree had multiple open heads when this was authored; this revision
+also merges them (like the prior merge migration in this project) so
+``alembic upgrade head`` resolves to a single head again.
+
+Revision ID: f9e8d7c6b5a4
+Revises: (merges all prior heads — see down_revision tuple)
+Create Date: 2026-07-02
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel  # noqa: F401
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f9e8d7c6b5a4'
+# Merge every open head at authoring time so the tree collapses to one head.
+down_revision: Union[str, Sequence[str], None] = (
+    'd4e5f6a7b8c9',
+    'm3b4c5d6e7f8',
+    '5e3a9c7f1b2d',
+    'n4o5p6q7r8s9',
+    'd3e4f5a6b7c8',
+    'c1d2e3f4a5b6',
+    'b2c3d4e5f8a9',
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if 'aigeneration' in inspector.get_table_names():
+        return
+
+    op.create_table(
+        'aigeneration',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('ai_generation_uuid', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column('kind', sa.Enum('IMAGE', 'QUIZ', 'ASSIGNMENT', name='aigenerationkind'), nullable=False),
+        sa.Column('prompt', sa.Text(), nullable=False),
+        sa.Column('session_uuid', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column('result', sa.JSON(), nullable=False),
+        sa.Column('creation_date', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column('update_date', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column('org_id', sa.Integer(), nullable=True),
+        sa.Column('user_id', sa.Integer(), nullable=True),
+        sa.Column('course_id', sa.Integer(), nullable=True),
+        sa.Column('activity_id', sa.Integer(), nullable=True),
+        sa.Column('assignment_id', sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(['org_id'], ['organization.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['course_id'], ['course.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['activity_id'], ['activity.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['assignment_id'], ['assignment.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_aigeneration_org_id', 'aigeneration', ['org_id'])
+    op.create_index('ix_aigeneration_user_id', 'aigeneration', ['user_id'])
+    op.create_index('ix_aigeneration_kind', 'aigeneration', ['kind'])
+    op.create_index(op.f('ix_aigeneration_ai_generation_uuid'), 'aigeneration', ['ai_generation_uuid'])
+    op.create_index(op.f('ix_aigeneration_session_uuid'), 'aigeneration', ['session_uuid'])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if 'aigeneration' not in inspector.get_table_names():
+        return
+
+    op.drop_index(op.f('ix_aigeneration_session_uuid'), table_name='aigeneration')
+    op.drop_index(op.f('ix_aigeneration_ai_generation_uuid'), table_name='aigeneration')
+    op.drop_index('ix_aigeneration_kind', table_name='aigeneration')
+    op.drop_index('ix_aigeneration_user_id', table_name='aigeneration')
+    op.drop_index('ix_aigeneration_org_id', table_name='aigeneration')
+    op.drop_table('aigeneration')
+    sa.Enum(name='aigenerationkind').drop(bind, checkfirst=True)

--- a/apps/api/src/db/ai/generations.py
+++ b/apps/api/src/db/ai/generations.py
@@ -1,0 +1,97 @@
+from typing import Optional, Dict
+from enum import Enum
+
+from sqlalchemy import JSON, Column, ForeignKey, Index, Text
+from sqlmodel import Field, SQLModel
+
+
+class AIGenerationKind(str, Enum):
+    """The kind of artifact an AI generation produced.
+
+    Durable history is kept per-kind so each feature (image picker, editor quiz
+    generator, assignment generator) can list only its own past generations.
+    The in-progress multi-turn refine chat lives ephemerally in Redis (see
+    ``src/services/ai/base.py``); this table is the durable record of the
+    artifacts the user actually kept.
+    """
+
+    IMAGE = "IMAGE"
+    QUIZ = "QUIZ"
+    ASSIGNMENT = "ASSIGNMENT"
+
+
+class AIGenerationBase(SQLModel):
+    """Common fields for a durable AI generation record."""
+
+    kind: AIGenerationKind
+    # The prompt (or last refine message) that produced this artifact.
+    prompt: str = Field(default="", sa_column=Column(Text))
+    # Links this durable record to the ephemeral Redis refine session (the
+    # `chat_history:<session_uuid>` / `chat_meta:<session_uuid>` keys) so the UI
+    # can resume the conversation that produced the artifact while it still lives.
+    session_uuid: Optional[str] = Field(default=None, index=True)
+    # Kind-specific payload:
+    #   IMAGE      -> {"file_id", "media_url", "source", "source_image_url"?}
+    #   QUIZ       -> the blockQuiz attrs {"quizId", "questions": [...]}
+    #   ASSIGNMENT -> {"assignment": {...}, "tasks": [...]}
+    result: Dict = Field(default_factory=dict, sa_column=Column(JSON))
+
+
+class AIGenerationCreate(AIGenerationBase):
+    """Model for creating a new AI generation record."""
+
+    org_id: int
+    user_id: int
+    course_id: Optional[int] = None
+    activity_id: Optional[int] = None
+    assignment_id: Optional[int] = None
+
+
+class AIGenerationRead(AIGenerationBase):
+    """Model for reading an AI generation record."""
+
+    id: int
+    ai_generation_uuid: str
+    org_id: int
+    user_id: int
+    course_id: Optional[int] = None
+    activity_id: Optional[int] = None
+    assignment_id: Optional[int] = None
+    creation_date: Optional[str] = None
+    update_date: Optional[str] = None
+
+
+class AIGeneration(AIGenerationBase, table=True):
+    """A durable record of an AI-generated artifact (image, quiz, assignment)."""
+
+    __table_args__ = (
+        Index("ix_aigeneration_org_id", "org_id"),
+        Index("ix_aigeneration_user_id", "user_id"),
+        Index("ix_aigeneration_kind", "kind"),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    ai_generation_uuid: str = Field(default="", index=True)
+    creation_date: Optional[str] = None
+    update_date: Optional[str] = None
+
+    org_id: int = Field(
+        sa_column=Column("org_id", ForeignKey("organization.id", ondelete="CASCADE"))
+    )
+    user_id: int = Field(
+        sa_column=Column("user_id", ForeignKey("user.id", ondelete="CASCADE"))
+    )
+    # Optional context the artifact was generated against. Nullable because an
+    # image generated from a standalone thumbnail picker has no course/activity.
+    course_id: Optional[int] = Field(
+        default=None,
+        sa_column=Column("course_id", ForeignKey("course.id", ondelete="CASCADE"), nullable=True),
+    )
+    activity_id: Optional[int] = Field(
+        default=None,
+        sa_column=Column("activity_id", ForeignKey("activity.id", ondelete="CASCADE"), nullable=True),
+    )
+    assignment_id: Optional[int] = Field(
+        default=None,
+        sa_column=Column("assignment_id", ForeignKey("assignment.id", ondelete="CASCADE"), nullable=True),
+    )

--- a/apps/api/src/db/ai/generations.py
+++ b/apps/api/src/db/ai/generations.py
@@ -18,6 +18,7 @@ class AIGenerationKind(str, Enum):
     IMAGE = "IMAGE"
     QUIZ = "QUIZ"
     ASSIGNMENT = "ASSIGNMENT"
+    SCENARIO = "SCENARIO"
 
 
 class AIGenerationBase(SQLModel):

--- a/apps/api/src/router.py
+++ b/apps/api/src/router.py
@@ -13,7 +13,7 @@ from src.routers import stream
 from src.routers import api_tokens
 from src.routers import webhooks
 from src.routers.integrations import zapier as zapier_integration
-from src.routers.ai import ai, magicblocks, courseplanning, rag
+from src.routers.ai import ai, magicblocks, courseplanning, rag, images, quiz, assignment_gen
 from src.routers.boards import boards_playground
 from src.routers.orgs import ai_credits
 from src.routers.orgs import custom_domains
@@ -248,6 +248,24 @@ v1_router.include_router(
     rag.router,
     prefix="/ai",
     tags=["ai", "rag"],
+    dependencies=[Depends(require_authenticated_user)]
+)
+v1_router.include_router(
+    images.router,
+    prefix="/ai",
+    tags=["ai", "images"],
+    dependencies=[Depends(require_authenticated_user)]
+)
+v1_router.include_router(
+    quiz.router,
+    prefix="/ai",
+    tags=["ai", "quiz"],
+    dependencies=[Depends(require_authenticated_user)]
+)
+v1_router.include_router(
+    assignment_gen.router,
+    prefix="/ai",
+    tags=["ai", "assignment-gen"],
     dependencies=[Depends(require_authenticated_user)]
 )
 v1_router.include_router(

--- a/apps/api/src/router.py
+++ b/apps/api/src/router.py
@@ -13,7 +13,7 @@ from src.routers import stream
 from src.routers import api_tokens
 from src.routers import webhooks
 from src.routers.integrations import zapier as zapier_integration
-from src.routers.ai import ai, magicblocks, courseplanning, rag, images, quiz, assignment_gen
+from src.routers.ai import ai, magicblocks, courseplanning, rag, images, quiz, assignment_gen, scenario
 from src.routers.boards import boards_playground
 from src.routers.orgs import ai_credits
 from src.routers.orgs import custom_domains
@@ -266,6 +266,12 @@ v1_router.include_router(
     assignment_gen.router,
     prefix="/ai",
     tags=["ai", "assignment-gen"],
+    dependencies=[Depends(require_authenticated_user)]
+)
+v1_router.include_router(
+    scenario.router,
+    prefix="/ai",
+    tags=["ai", "scenario"],
     dependencies=[Depends(require_authenticated_user)]
 )
 v1_router.include_router(

--- a/apps/api/src/routers/ai/assignment_gen.py
+++ b/apps/api/src/routers/ai/assignment_gen.py
@@ -1,0 +1,177 @@
+"""AI assignment generation endpoints.
+
+Generates a preview assignment plan (assignment + graded tasks) grounded on a
+course's content. Does NOT persist — the frontend previews/edits then saves via
+the existing /assignments endpoints. Same guard/credit ordering as the other AI
+routers.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.core.events.database import get_db_session
+from src.db.ai.generations import AIGenerationKind
+from src.db.courses.courses import Course
+from src.db.organizations import Organization
+from src.db.users import PublicUser
+from src.security.auth import get_authenticated_user
+from src.security.features_utils.usage import refund_ai_credit, reserve_ai_credit
+from src.security.org_auth import is_org_member
+from src.services.ai.assignment_gen import generate_assignment_plan
+from src.services.ai.generations import (
+    delete_generation,
+    list_generations,
+    record_generation,
+)
+from src.services.ai.llm import AINotConfiguredError, resolve_model_for_org
+from src.services.ai.schemas.assignment import (
+    AIAssignmentHistoryItem,
+    GenerateAssignmentRequest,
+    GenerateAssignmentResponse,
+)
+from src.services.security.rate_limiting import enforce_ai_rate_limit
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+ASSIGNMENT_CREDIT_COST = 3
+
+
+async def _authorize_org(org_id: int, user: PublicUser, db_session: AsyncSession) -> Organization:
+    org = (
+        await db_session.execute(select(Organization).where(Organization.id == org_id))
+    ).scalars().first()
+    if not org or org.id is None:
+        raise HTTPException(status_code=404, detail="Organization not found")
+    if not await is_org_member(user.id, org.id, db_session):
+        raise HTTPException(status_code=403, detail="User is not a member of this organization")
+    return org
+
+
+@router.post(
+    "/assignments/generate",
+    response_model=GenerateAssignmentResponse,
+    summary="Generate an assignment plan from course content",
+    responses={
+        200: {"description": "Assignment plan generated.", "model": GenerateAssignmentResponse},
+        403: {"description": "Not an org member, AI disabled, or insufficient credits"},
+        404: {"description": "Organization or course not found"},
+    },
+)
+async def api_generate_assignment(
+    body: GenerateAssignmentRequest,
+    current_user: PublicUser = Depends(get_authenticated_user),
+    db_session: AsyncSession = Depends(get_db_session),
+) -> GenerateAssignmentResponse:
+    if not (body.prompt or "").strip():
+        raise HTTPException(status_code=400, detail="A prompt is required")
+
+    org = await _authorize_org(body.org_id, current_user, db_session)
+    assert org.id is not None
+
+    course = (
+        await db_session.execute(
+            select(Course).where(Course.course_uuid == body.course_uuid)
+        )
+    ).scalars().first()
+    if not course or course.id is None or course.org_id != org.id:
+        raise HTTPException(status_code=404, detail="Course not found")
+
+    enforce_ai_rate_limit(current_user.id, org.id)
+    await reserve_ai_credit(org.id, db_session, amount=ASSIGNMENT_CREDIT_COST)
+
+    model_name = await resolve_model_for_org(org.id, db_session, purpose="planning")
+
+    try:
+        plan, session_uuid = await generate_assignment_plan(
+            org_id=org.id,
+            course_id=course.id,
+            prompt=body.prompt,
+            model_name=model_name,
+            db_session=db_session,
+            num_tasks=body.num_tasks,
+            allowed_task_types=body.allowed_task_types,
+            session_uuid=body.session_uuid,
+        )
+    except AINotConfiguredError as e:
+        refund_ai_credit(org.id, ASSIGNMENT_CREDIT_COST)
+        raise HTTPException(status_code=403, detail=str(e))
+    except Exception:
+        refund_ai_credit(org.id, ASSIGNMENT_CREDIT_COST)
+        logger.exception("Assignment generation failed")
+        raise HTTPException(status_code=502, detail="Assignment generation failed. Please try again.")
+
+    if not plan.tasks:
+        refund_ai_credit(org.id, ASSIGNMENT_CREDIT_COST)
+        raise HTTPException(status_code=502, detail="The model returned no tasks. Try rephrasing.")
+
+    record = await record_generation(
+        db_session,
+        kind=AIGenerationKind.ASSIGNMENT,
+        org_id=org.id,
+        user_id=current_user.id,
+        prompt=body.prompt.strip(),
+        result=plan.model_dump(),
+        session_uuid=session_uuid,
+        course_id=course.id,
+    )
+
+    return GenerateAssignmentResponse(
+        ai_generation_uuid=record.ai_generation_uuid,
+        session_uuid=session_uuid,
+        plan=plan,
+    )
+
+
+@router.get(
+    "/assignments/history",
+    response_model=list[AIAssignmentHistoryItem],
+    summary="List AI assignment generation history",
+)
+async def api_list_assignment_history(
+    org_id: int,
+    limit: int = 30,
+    offset: int = 0,
+    current_user: PublicUser = Depends(get_authenticated_user),
+    db_session: AsyncSession = Depends(get_db_session),
+) -> list[AIAssignmentHistoryItem]:
+    await _authorize_org(org_id, current_user, db_session)
+    rows = await list_generations(
+        db_session,
+        org_id=org_id,
+        user_id=current_user.id,
+        kind=AIGenerationKind.ASSIGNMENT,
+        limit=limit,
+        offset=offset,
+    )
+    return [
+        AIAssignmentHistoryItem(
+            ai_generation_uuid=r.ai_generation_uuid,
+            session_uuid=r.session_uuid,
+            prompt=r.prompt,
+            plan=r.result or {},
+            creation_date=r.creation_date,
+        )
+        for r in rows
+    ]
+
+
+@router.delete(
+    "/assignments/history/{ai_generation_uuid}",
+    summary="Delete an AI assignment generation from history",
+)
+async def api_delete_assignment_history(
+    ai_generation_uuid: str,
+    current_user: PublicUser = Depends(get_authenticated_user),
+    db_session: AsyncSession = Depends(get_db_session),
+) -> dict:
+    deleted = await delete_generation(
+        db_session, ai_generation_uuid=ai_generation_uuid, user_id=current_user.id
+    )
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Generation not found")
+    return {"detail": "deleted"}

--- a/apps/api/src/routers/ai/images.py
+++ b/apps/api/src/routers/ai/images.py
@@ -115,7 +115,9 @@ async def api_generate_image(
         raise HTTPException(status_code=403, detail=str(e))
     except Exception:
         refund_ai_credit(org.id, IMAGE_CREDIT_COST)
-        logger.exception("Image generation failed")
+        # Do not log the traceback: the chained SDK error can embed the API key.
+        # generate_image already logs the sanitized exception type.
+        logger.error("Image generation failed")
         raise HTTPException(
             status_code=502,
             detail="Image generation failed. Please try again or rephrase your prompt.",

--- a/apps/api/src/routers/ai/images.py
+++ b/apps/api/src/routers/ai/images.py
@@ -4,8 +4,9 @@ Backs the shared AIImagePicker used across every image-upload surface. Follows
 the same guard/credit ordering as the other AI routers: resolve org → org
 membership → rate limit → reserve credit → generate → refund on failure.
 
-Refinement is stateless: the client sends the previous image back as base64 each
-turn, and durable history rows are grouped by ``session_uuid`` to reconstruct the
+Refinement reads the prior image server-side by ``source_file_id`` (a client
+base64 data URL is only a fallback), so the edit is reliable without a client
+re-fetch. Durable history rows are grouped by ``session_uuid`` to reconstruct the
 thread — so no Redis session is needed for images (the hybrid model's Redis half
 is used by the streaming quiz/assignment refine chats instead).
 """

--- a/apps/api/src/routers/ai/images.py
+++ b/apps/api/src/routers/ai/images.py
@@ -15,6 +15,7 @@ import logging
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import Response
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -53,6 +54,16 @@ AI_IMAGE_DIR = "ai_images"
 def _media_path(org_uuid: str, file_id: str) -> str:
     """Relative content path; the frontend prepends the media base to build a URL."""
     return f"content/orgs/{org_uuid}/{AI_IMAGE_DIR}/{file_id}"
+
+
+def _validate_file_id(file_id: str) -> None:
+    """Reject any file_id that could escape the org's ai_images directory.
+
+    A single shared guard so the read-bytes and refine paths cannot drift. This
+    matters most in S3/R2 mode, where the key is built by string interpolation.
+    """
+    if not file_id or "/" in file_id or "\\" in file_id or ".." in file_id or "\x00" in file_id:
+        raise HTTPException(status_code=400, detail="Invalid file id")
 
 
 async def _load_org_and_authorize(
@@ -102,6 +113,7 @@ async def api_generate_image(
     # fall back to a client-supplied base64 data URL.
     input_images: list[bytes] = []
     if body.source_file_id:
+        _validate_file_id(body.source_file_id)
         try:
             input_images.append(
                 await read_content(
@@ -176,6 +188,50 @@ async def api_generate_image(
         file_id=file_id,
         media_url=media_path,
         prompt=body.prompt.strip(),
+    )
+
+
+@router.get(
+    "/images/{org_id}/{file_id}/bytes",
+    summary="Download a generated AI image (same-origin, authenticated)",
+    responses={
+        200: {"description": "Image bytes returned", "content": {"image/png": {}}},
+        400: {"description": "Invalid file id"},
+        401: {"description": "Authentication required"},
+        403: {"description": "Not an org member"},
+        404: {"description": "Image not found"},
+    },
+)
+async def api_get_image_bytes(
+    org_id: int,
+    file_id: str,
+    current_user: PublicUser = Depends(get_authenticated_user),
+    db_session: AsyncSession = Depends(get_db_session),
+) -> Response:
+    """Serve a generated image's raw bytes from the SAME origin as the API.
+
+    Upload surfaces fetch this (instead of the public, possibly cross-origin
+    media URL) so building a File to re-upload never trips CORS.
+    """
+    org = await _load_org_and_authorize(org_id, current_user, db_session)
+    if "/" in file_id or "\\" in file_id or ".." in file_id or "\x00" in file_id:
+        raise HTTPException(status_code=400, detail="Invalid file id")
+    try:
+        data = await read_content(
+            directory=AI_IMAGE_DIR,
+            type_of_dir="orgs",
+            uuid=org.org_uuid,
+            file_and_format=file_id,
+        )
+    except HTTPException:
+        raise HTTPException(status_code=404, detail="Image not found")
+    return Response(
+        content=data,
+        media_type=f"image/{OUTPUT_EXT}",
+        headers={
+            "Cache-Control": "private, max-age=3600",
+            "X-Content-Type-Options": "nosniff",
+        },
     )
 
 

--- a/apps/api/src/routers/ai/images.py
+++ b/apps/api/src/routers/ai/images.py
@@ -38,7 +38,7 @@ from src.services.ai.schemas.image import (
     GenerateImageResponse,
 )
 from src.services.security.rate_limiting import enforce_ai_rate_limit
-from src.services.utils.upload_content import upload_content
+from src.services.utils.upload_content import read_content, upload_content
 
 logger = logging.getLogger(__name__)
 
@@ -97,9 +97,26 @@ async def api_generate_image(
     enforce_ai_rate_limit(current_user.id, org.id)
     await reserve_ai_credit(org.id, db_session, amount=IMAGE_CREDIT_COST)
 
-    # Decode an optional source image for iterative refinement / editing.
+    # Resolve an optional source image for iterative refinement / editing.
+    # Prefer reading it from our own storage by file_id (reliable, no CORS);
+    # fall back to a client-supplied base64 data URL.
     input_images: list[bytes] = []
-    if body.source_image_base64:
+    if body.source_file_id:
+        try:
+            input_images.append(
+                await read_content(
+                    directory=AI_IMAGE_DIR,
+                    type_of_dir="orgs",
+                    uuid=org.org_uuid,
+                    file_and_format=body.source_file_id,
+                )
+            )
+        except HTTPException:
+            raise HTTPException(
+                status_code=404,
+                detail="Source image to refine was not found.",
+            )
+    elif body.source_image_base64:
         raw = body.source_image_base64
         if "," in raw and raw.strip().startswith("data:"):
             raw = raw.split(",", 1)[1]  # strip a data: URL prefix if present

--- a/apps/api/src/routers/ai/images.py
+++ b/apps/api/src/routers/ai/images.py
@@ -1,0 +1,216 @@
+"""AI image generation endpoints (Google "nano banana").
+
+Backs the shared AIImagePicker used across every image-upload surface. Follows
+the same guard/credit ordering as the other AI routers: resolve org → org
+membership → rate limit → reserve credit → generate → refund on failure.
+
+Refinement is stateless: the client sends the previous image back as base64 each
+turn, and durable history rows are grouped by ``session_uuid`` to reconstruct the
+thread — so no Redis session is needed for images (the hybrid model's Redis half
+is used by the streaming quiz/assignment refine chats instead).
+"""
+
+import base64
+import logging
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.core.events.database import get_db_session
+from src.db.ai.generations import AIGenerationKind
+from src.db.organizations import Organization
+from src.db.users import PublicUser
+from src.security.auth import get_authenticated_user
+from src.security.features_utils.usage import refund_ai_credit, reserve_ai_credit
+from src.security.org_auth import is_org_member
+from src.services.ai.generations import (
+    delete_generation,
+    list_generations,
+    record_generation,
+)
+from src.services.ai.image.generator import OUTPUT_EXT, generate_image
+from src.services.ai.llm import AINotConfiguredError
+from src.services.ai.schemas.image import (
+    AIImageHistoryItem,
+    GenerateImageRequest,
+    GenerateImageResponse,
+)
+from src.services.security.rate_limiting import enforce_ai_rate_limit
+from src.services.utils.upload_content import upload_content
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# Generating an image is markedly more expensive than a text turn.
+IMAGE_CREDIT_COST = 5
+
+AI_IMAGE_DIR = "ai_images"
+
+
+def _media_path(org_uuid: str, file_id: str) -> str:
+    """Relative content path; the frontend prepends the media base to build a URL."""
+    return f"content/orgs/{org_uuid}/{AI_IMAGE_DIR}/{file_id}"
+
+
+async def _load_org_and_authorize(
+    org_id: int, user: PublicUser, db_session: AsyncSession
+) -> Organization:
+    org = (
+        await db_session.execute(select(Organization).where(Organization.id == org_id))
+    ).scalars().first()
+    if not org or org.id is None:
+        raise HTTPException(status_code=404, detail="Organization not found")
+    if not await is_org_member(user.id, org.id, db_session):
+        raise HTTPException(
+            status_code=403, detail="User is not a member of this organization"
+        )
+    return org
+
+
+@router.post(
+    "/images/generate",
+    response_model=GenerateImageResponse,
+    summary="Generate an image with AI (nano banana)",
+    description="Generate or refine an image from a text prompt. Consumes AI credits.",
+    responses={
+        200: {"description": "Image generated and stored.", "model": GenerateImageResponse},
+        401: {"description": "Authentication required"},
+        403: {"description": "Not an org member, AI disabled, or insufficient credits"},
+        404: {"description": "Organization not found"},
+    },
+)
+async def api_generate_image(
+    body: GenerateImageRequest,
+    current_user: PublicUser = Depends(get_authenticated_user),
+    db_session: AsyncSession = Depends(get_db_session),
+) -> GenerateImageResponse:
+    if not (body.prompt or "").strip():
+        raise HTTPException(status_code=400, detail="A prompt is required")
+
+    org = await _load_org_and_authorize(body.org_id, current_user, db_session)
+    assert org.id is not None
+
+    # Rate limit then reserve credit (feature-enabled + quota checked inside reserve).
+    enforce_ai_rate_limit(current_user.id, org.id)
+    await reserve_ai_credit(org.id, db_session, amount=IMAGE_CREDIT_COST)
+
+    # Decode an optional source image for iterative refinement / editing.
+    input_images: list[bytes] = []
+    if body.source_image_base64:
+        raw = body.source_image_base64
+        if "," in raw and raw.strip().startswith("data:"):
+            raw = raw.split(",", 1)[1]  # strip a data: URL prefix if present
+        try:
+            input_images.append(base64.b64decode(raw))
+        except Exception:
+            logger.warning("Ignoring invalid source_image_base64 on image refine")
+
+    try:
+        image_bytes = await generate_image(body.prompt, input_images=input_images or None)
+    except AINotConfiguredError as e:
+        refund_ai_credit(org.id, IMAGE_CREDIT_COST)
+        raise HTTPException(status_code=403, detail=str(e))
+    except Exception:
+        refund_ai_credit(org.id, IMAGE_CREDIT_COST)
+        logger.exception("Image generation failed")
+        raise HTTPException(
+            status_code=502,
+            detail="Image generation failed. Please try again or rephrase your prompt.",
+        )
+
+    # Persist the bytes through the shared storage abstraction (filesystem or S3/R2).
+    file_id = f"{uuid4()}_ai_generated.{OUTPUT_EXT}"
+    try:
+        await upload_content(
+            directory=AI_IMAGE_DIR,
+            type_of_dir="orgs",
+            uuid=org.org_uuid,
+            file_binary=image_bytes,
+            file_and_format=file_id,
+            allowed_formats=[OUTPUT_EXT],
+        )
+    except Exception:
+        refund_ai_credit(org.id, IMAGE_CREDIT_COST)
+        logger.exception("Failed to store generated image")
+        raise HTTPException(status_code=500, detail="Failed to store generated image")
+
+    session_uuid = body.session_uuid or f"aiimg_{uuid4()}"
+    media_path = _media_path(org.org_uuid, file_id)
+    record = await record_generation(
+        db_session,
+        kind=AIGenerationKind.IMAGE,
+        org_id=org.id,
+        user_id=current_user.id,
+        prompt=body.prompt.strip(),
+        result={"file_id": file_id, "media_url": media_path, "source": "ai_generated"},
+        session_uuid=session_uuid,
+        course_id=body.course_id,
+        activity_id=body.activity_id,
+    )
+
+    return GenerateImageResponse(
+        ai_generation_uuid=record.ai_generation_uuid,
+        session_uuid=session_uuid,
+        file_id=file_id,
+        media_url=media_path,
+        prompt=body.prompt.strip(),
+    )
+
+
+@router.get(
+    "/images/history",
+    response_model=list[AIImageHistoryItem],
+    summary="List AI image generation history",
+)
+async def api_list_image_history(
+    org_id: int,
+    limit: int = 30,
+    offset: int = 0,
+    current_user: PublicUser = Depends(get_authenticated_user),
+    db_session: AsyncSession = Depends(get_db_session),
+) -> list[AIImageHistoryItem]:
+    await _load_org_and_authorize(org_id, current_user, db_session)
+    rows = await list_generations(
+        db_session,
+        org_id=org_id,
+        user_id=current_user.id,
+        kind=AIGenerationKind.IMAGE,
+        limit=limit,
+        offset=offset,
+    )
+    items: list[AIImageHistoryItem] = []
+    for r in rows:
+        result = r.result or {}
+        items.append(
+            AIImageHistoryItem(
+                ai_generation_uuid=r.ai_generation_uuid,
+                session_uuid=r.session_uuid,
+                prompt=r.prompt,
+                file_id=result.get("file_id", ""),
+                media_url=result.get("media_url", ""),
+                creation_date=r.creation_date,
+            )
+        )
+    return items
+
+
+@router.delete(
+    "/images/history/{ai_generation_uuid}",
+    summary="Delete an AI image generation from history",
+)
+async def api_delete_image_history(
+    ai_generation_uuid: str,
+    current_user: PublicUser = Depends(get_authenticated_user),
+    db_session: AsyncSession = Depends(get_db_session),
+) -> dict:
+    deleted = await delete_generation(
+        db_session,
+        ai_generation_uuid=ai_generation_uuid,
+        user_id=current_user.id,
+    )
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Generation not found")
+    return {"detail": "deleted"}

--- a/apps/api/src/routers/ai/quiz.py
+++ b/apps/api/src/routers/ai/quiz.py
@@ -1,0 +1,197 @@
+"""AI quiz generation endpoints (in-editor `blockQuiz`).
+
+Non-streaming, structured-output generation so the returned quiz is always
+schema-valid and safe to insert into the editor. Same guard/credit ordering as
+the other AI routers.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.core.events.database import get_db_session
+from src.db.ai.generations import AIGenerationKind
+from src.db.courses.activities import Activity
+from src.db.courses.courses import Course
+from src.db.organizations import Organization
+from src.db.users import PublicUser
+from src.security.auth import get_authenticated_user
+from src.security.features_utils.usage import refund_ai_credit, reserve_ai_credit
+from src.security.org_auth import is_org_member
+from src.services.ai.generations import (
+    delete_generation,
+    list_generations,
+    record_generation,
+)
+from src.services.ai.llm import AINotConfiguredError, resolve_model_for_org
+from src.services.ai.quiz import generate_quiz
+from src.services.ai.schemas.quiz import (
+    AIQuizHistoryItem,
+    GenerateQuizRequest,
+    GenerateQuizResponse,
+)
+from src.services.security.rate_limiting import enforce_ai_rate_limit
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+QUIZ_CREDIT_COST = 2
+
+
+async def _authorize_org(org_id: int, user: PublicUser, db_session: AsyncSession) -> Organization:
+    org = (
+        await db_session.execute(select(Organization).where(Organization.id == org_id))
+    ).scalars().first()
+    if not org or org.id is None:
+        raise HTTPException(status_code=404, detail="Organization not found")
+    if not await is_org_member(user.id, org.id, db_session):
+        raise HTTPException(status_code=403, detail="User is not a member of this organization")
+    return org
+
+
+async def _load_activity_content(
+    activity_uuid: str, org_id: int, db_session: AsyncSession
+) -> tuple[dict | None, int | None]:
+    """Return (content, activity_id) for an activity, verifying it is in the org."""
+    activity = (
+        await db_session.execute(
+            select(Activity).where(Activity.activity_uuid == activity_uuid)
+        )
+    ).scalars().first()
+    if not activity:
+        return None, None
+    course = (
+        await db_session.execute(
+            select(Course).where(Course.id == activity.course_id)
+        )
+    ).scalars().first()
+    if not course or course.org_id != org_id:
+        # Don't leak cross-org content into the prompt.
+        return None, None
+    return (activity.content or None), activity.id
+
+
+@router.post(
+    "/quiz/generate",
+    response_model=GenerateQuizResponse,
+    summary="Generate a quiz for the editor",
+    responses={
+        200: {"description": "Quiz generated.", "model": GenerateQuizResponse},
+        403: {"description": "Not an org member, AI disabled, or insufficient credits"},
+        404: {"description": "Organization not found"},
+    },
+)
+async def api_generate_quiz(
+    body: GenerateQuizRequest,
+    current_user: PublicUser = Depends(get_authenticated_user),
+    db_session: AsyncSession = Depends(get_db_session),
+) -> GenerateQuizResponse:
+    if not (body.prompt or "").strip():
+        raise HTTPException(status_code=400, detail="A prompt is required")
+
+    org = await _authorize_org(body.org_id, current_user, db_session)
+    assert org.id is not None
+
+    activity_content: dict | None = None
+    activity_id: int | None = None
+    if body.activity_uuid:
+        activity_content, activity_id = await _load_activity_content(
+            body.activity_uuid, org.id, db_session
+        )
+
+    enforce_ai_rate_limit(current_user.id, org.id)
+    await reserve_ai_credit(org.id, db_session, amount=QUIZ_CREDIT_COST)
+
+    model_name = await resolve_model_for_org(org.id, db_session, purpose="planning")
+
+    try:
+        block_quiz, session_uuid = await generate_quiz(
+            org_id=org.id,
+            prompt=body.prompt,
+            model_name=model_name,
+            activity_content=activity_content,
+            num_questions=body.num_questions,
+            difficulty=body.difficulty,
+            session_uuid=body.session_uuid,
+        )
+    except AINotConfiguredError as e:
+        refund_ai_credit(org.id, QUIZ_CREDIT_COST)
+        raise HTTPException(status_code=403, detail=str(e))
+    except Exception:
+        refund_ai_credit(org.id, QUIZ_CREDIT_COST)
+        logger.exception("Quiz generation failed")
+        raise HTTPException(status_code=502, detail="Quiz generation failed. Please try again.")
+
+    if not block_quiz.get("questions"):
+        refund_ai_credit(org.id, QUIZ_CREDIT_COST)
+        raise HTTPException(status_code=502, detail="The model returned no questions. Try rephrasing.")
+
+    record = await record_generation(
+        db_session,
+        kind=AIGenerationKind.QUIZ,
+        org_id=org.id,
+        user_id=current_user.id,
+        prompt=body.prompt.strip(),
+        result=block_quiz,
+        session_uuid=session_uuid,
+        activity_id=activity_id,
+    )
+
+    return GenerateQuizResponse(
+        ai_generation_uuid=record.ai_generation_uuid,
+        session_uuid=session_uuid,
+        quiz=block_quiz,
+    )
+
+
+@router.get(
+    "/quiz/history",
+    response_model=list[AIQuizHistoryItem],
+    summary="List AI quiz generation history",
+)
+async def api_list_quiz_history(
+    org_id: int,
+    limit: int = 30,
+    offset: int = 0,
+    current_user: PublicUser = Depends(get_authenticated_user),
+    db_session: AsyncSession = Depends(get_db_session),
+) -> list[AIQuizHistoryItem]:
+    await _authorize_org(org_id, current_user, db_session)
+    rows = await list_generations(
+        db_session,
+        org_id=org_id,
+        user_id=current_user.id,
+        kind=AIGenerationKind.QUIZ,
+        limit=limit,
+        offset=offset,
+    )
+    return [
+        AIQuizHistoryItem(
+            ai_generation_uuid=r.ai_generation_uuid,
+            session_uuid=r.session_uuid,
+            prompt=r.prompt,
+            quiz=r.result or {},
+            creation_date=r.creation_date,
+        )
+        for r in rows
+    ]
+
+
+@router.delete(
+    "/quiz/history/{ai_generation_uuid}",
+    summary="Delete an AI quiz generation from history",
+)
+async def api_delete_quiz_history(
+    ai_generation_uuid: str,
+    current_user: PublicUser = Depends(get_authenticated_user),
+    db_session: AsyncSession = Depends(get_db_session),
+) -> dict:
+    deleted = await delete_generation(
+        db_session, ai_generation_uuid=ai_generation_uuid, user_id=current_user.id
+    )
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Generation not found")
+    return {"detail": "deleted"}

--- a/apps/api/src/routers/ai/scenario.py
+++ b/apps/api/src/routers/ai/scenario.py
@@ -1,0 +1,191 @@
+"""AI interactive-scenario generation endpoints (editor `scenarios` block).
+
+Non-streaming, structured-output generation so the returned scenario is always
+schema-valid and safe to insert. Same guard/credit ordering as the other AI routers.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.core.events.database import get_db_session
+from src.db.ai.generations import AIGenerationKind
+from src.db.courses.activities import Activity
+from src.db.courses.courses import Course
+from src.db.organizations import Organization
+from src.db.users import PublicUser
+from src.security.auth import get_authenticated_user
+from src.security.features_utils.usage import refund_ai_credit, reserve_ai_credit
+from src.security.org_auth import is_org_member
+from src.services.ai.generations import (
+    delete_generation,
+    list_generations,
+    record_generation,
+)
+from src.services.ai.llm import AINotConfiguredError, resolve_model_for_org
+from src.services.ai.scenario import generate_scenario
+from src.services.ai.schemas.scenario import (
+    AIScenarioHistoryItem,
+    GenerateScenarioRequest,
+    GenerateScenarioResponse,
+)
+from src.services.security.rate_limiting import enforce_ai_rate_limit
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+SCENARIO_CREDIT_COST = 2
+
+
+async def _authorize_org(org_id: int, user: PublicUser, db_session: AsyncSession) -> Organization:
+    org = (
+        await db_session.execute(select(Organization).where(Organization.id == org_id))
+    ).scalars().first()
+    if not org or org.id is None:
+        raise HTTPException(status_code=404, detail="Organization not found")
+    if not await is_org_member(user.id, org.id, db_session):
+        raise HTTPException(status_code=403, detail="User is not a member of this organization")
+    return org
+
+
+async def _load_activity_content(
+    activity_uuid: str, org_id: int, db_session: AsyncSession
+) -> tuple[dict | None, int | None]:
+    activity = (
+        await db_session.execute(
+            select(Activity).where(Activity.activity_uuid == activity_uuid)
+        )
+    ).scalars().first()
+    if not activity:
+        return None, None
+    course = (
+        await db_session.execute(select(Course).where(Course.id == activity.course_id))
+    ).scalars().first()
+    if not course or course.org_id != org_id:
+        return None, None
+    return (activity.content or None), activity.id
+
+
+@router.post(
+    "/scenario/generate",
+    response_model=GenerateScenarioResponse,
+    summary="Generate an interactive scenario for the editor",
+    responses={
+        200: {"description": "Scenario generated.", "model": GenerateScenarioResponse},
+        403: {"description": "Not an org member, AI disabled, or insufficient credits"},
+        404: {"description": "Organization not found"},
+    },
+)
+async def api_generate_scenario(
+    body: GenerateScenarioRequest,
+    current_user: PublicUser = Depends(get_authenticated_user),
+    db_session: AsyncSession = Depends(get_db_session),
+) -> GenerateScenarioResponse:
+    if not (body.prompt or "").strip():
+        raise HTTPException(status_code=400, detail="A prompt is required")
+
+    org = await _authorize_org(body.org_id, current_user, db_session)
+    assert org.id is not None
+
+    activity_content: dict | None = None
+    activity_id: int | None = None
+    if body.activity_uuid:
+        activity_content, activity_id = await _load_activity_content(
+            body.activity_uuid, org.id, db_session
+        )
+
+    enforce_ai_rate_limit(current_user.id, org.id)
+    await reserve_ai_credit(org.id, db_session, amount=SCENARIO_CREDIT_COST)
+
+    model_name = await resolve_model_for_org(org.id, db_session, purpose="planning")
+
+    try:
+        block, session_uuid = await generate_scenario(
+            org_id=org.id,
+            prompt=body.prompt,
+            model_name=model_name,
+            activity_content=activity_content,
+            num_scenarios=body.num_scenarios,
+            session_uuid=body.session_uuid,
+        )
+    except AINotConfiguredError as e:
+        refund_ai_credit(org.id, SCENARIO_CREDIT_COST)
+        raise HTTPException(status_code=403, detail=str(e))
+    except Exception:
+        refund_ai_credit(org.id, SCENARIO_CREDIT_COST)
+        logger.exception("Scenario generation failed")
+        raise HTTPException(status_code=502, detail="Scenario generation failed. Please try again.")
+
+    if not block.get("scenarios"):
+        refund_ai_credit(org.id, SCENARIO_CREDIT_COST)
+        raise HTTPException(status_code=502, detail="The model returned no scenarios. Try rephrasing.")
+
+    record = await record_generation(
+        db_session,
+        kind=AIGenerationKind.SCENARIO,
+        org_id=org.id,
+        user_id=current_user.id,
+        prompt=body.prompt.strip(),
+        result=block,
+        session_uuid=session_uuid,
+        activity_id=activity_id,
+    )
+
+    return GenerateScenarioResponse(
+        ai_generation_uuid=record.ai_generation_uuid,
+        session_uuid=session_uuid,
+        scenario=block,
+    )
+
+
+@router.get(
+    "/scenario/history",
+    response_model=list[AIScenarioHistoryItem],
+    summary="List AI scenario generation history",
+)
+async def api_list_scenario_history(
+    org_id: int,
+    limit: int = 30,
+    offset: int = 0,
+    current_user: PublicUser = Depends(get_authenticated_user),
+    db_session: AsyncSession = Depends(get_db_session),
+) -> list[AIScenarioHistoryItem]:
+    await _authorize_org(org_id, current_user, db_session)
+    rows = await list_generations(
+        db_session,
+        org_id=org_id,
+        user_id=current_user.id,
+        kind=AIGenerationKind.SCENARIO,
+        limit=limit,
+        offset=offset,
+    )
+    return [
+        AIScenarioHistoryItem(
+            ai_generation_uuid=r.ai_generation_uuid,
+            session_uuid=r.session_uuid,
+            prompt=r.prompt,
+            scenario=r.result or {},
+            creation_date=r.creation_date,
+        )
+        for r in rows
+    ]
+
+
+@router.delete(
+    "/scenario/history/{ai_generation_uuid}",
+    summary="Delete an AI scenario generation from history",
+)
+async def api_delete_scenario_history(
+    ai_generation_uuid: str,
+    current_user: PublicUser = Depends(get_authenticated_user),
+    db_session: AsyncSession = Depends(get_db_session),
+) -> dict:
+    deleted = await delete_generation(
+        db_session, ai_generation_uuid=ai_generation_uuid, user_id=current_user.id
+    )
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Generation not found")
+    return {"detail": "deleted"}

--- a/apps/api/src/routers/stream.py
+++ b/apps/api/src/routers/stream.py
@@ -385,6 +385,87 @@ async def stream_activity_hls(
     )
 
 
+@router.get(
+    "/block-hls/{org_uuid}/{course_uuid}/{activity_uuid}/{block_uuid}/{hls_path:path}",
+    summary="Serve an HLS playlist or segment for a video block",
+    description=(
+        "Serves the adaptive-bitrate HLS assets for a video block inside a dynamic "
+        "activity — identical behavior to the activity HLS endpoint (RBAC-gated "
+        "playlists with segment URLs presigned to R2), keyed off the block's dir."
+    ),
+    responses={
+        200: {"description": "Playlist or segment returned"},
+        302: {"description": "Redirect to a presigned segment URL (S3/R2 mode)"},
+        403: {"description": "User is not permitted to read this course"},
+        404: {"description": "Activity, course, block, or HLS asset not found"},
+    },
+)
+async def stream_block_hls(
+    request: Request,
+    org_uuid: str = Path(..., description="Organization UUID"),
+    course_uuid: str = Path(..., description="Course UUID"),
+    activity_uuid: str = Path(..., description="Activity UUID"),
+    block_uuid: str = Path(..., description="Block UUID"),
+    hls_path: str = Path(..., description="HLS asset path (e.g. master.m3u8)"),
+    current_user: PublicUser | AnonymousUser | APITokenUser = Depends(get_current_user),
+    db_session: AsyncSession = Depends(get_db_session),
+):
+    """Serve a video block's HLS assets. RBAC runs before any content/URL signing."""
+    await _verify_course_activity_access(request, course_uuid, activity_uuid, current_user, db_session)
+
+    rel = _safe_hls_relpath(hls_path)
+    if rel is None:
+        raise HTTPException(status_code=404, detail="HLS asset not found")
+    # block_uuid is a single path segment, but reject any traversal defensively.
+    if "/" in block_uuid or "\\" in block_uuid or ".." in block_uuid or "\x00" in block_uuid:
+        raise HTTPException(status_code=404, detail="HLS asset not found")
+
+    base_key = (
+        f"{CONTENT_DIR}/orgs/{org_uuid}/courses/{course_uuid}/activities/{activity_uuid}"
+        f"/dynamic/blocks/videoBlock/{block_uuid}/hls"
+    )
+    asset_key = f"{base_key}/{rel}"
+    ext = os.path.splitext(rel)[1].lower()
+
+    if ext == ".m3u8":
+        raw = await asyncio.to_thread(read_file_content, asset_key)
+        if raw is None:
+            raise HTTPException(status_code=404, detail="Playlist not found")
+        playlist_dir_key = asset_key.rsplit("/", 1)[0]
+        body = rewrite_playlist(
+            raw.decode("utf-8", errors="replace"),
+            playlist_dir_key,
+            generate_presigned_get_url,
+        )
+        return Response(
+            content=body,
+            media_type=_HLS_MIME[".m3u8"],
+            headers={"Cache-Control": "private, max-age=300", "X-Content-Type-Options": "nosniff"},
+        )
+
+    if ext == ".key":
+        raw = await asyncio.to_thread(read_file_content, asset_key)
+        if raw is None:
+            raise HTTPException(status_code=404, detail="Key not found")
+        return Response(
+            content=raw,
+            media_type=_HLS_MIME[".key"],
+            headers={"Cache-Control": "private, no-store"},
+        )
+
+    redirect = _redirect_to_storage(asset_key)
+    if redirect:
+        return redirect
+    raw = await asyncio.to_thread(read_file_content, asset_key)
+    if raw is None:
+        raise HTTPException(status_code=404, detail="Segment not found")
+    return Response(
+        content=raw,
+        media_type=_HLS_MIME.get(ext, "application/octet-stream"),
+        headers={"Cache-Control": "public, max-age=86400", "X-Content-Type-Options": "nosniff"},
+    )
+
+
 # Caption language codes are bare BCP-47-ish tokens (letters/digits/hyphen). This
 # rejects path traversal, slashes, and dots so it can't escape the captions dir.
 _CAPTION_LANG_RE = re.compile(r"^[A-Za-z0-9-]{2,20}$")

--- a/apps/api/src/services/ai/assignment_gen.py
+++ b/apps/api/src/services/ai/assignment_gen.py
@@ -1,0 +1,224 @@
+"""AI assignment generation service.
+
+Generates a full assignment + graded tasks grounded on a course's content.
+Structured output (``AIAssignmentPlan``) keeps the model on-rails; the service
+then converts each task into the exact ``contents`` shape the server graders in
+``src/services/courses/activities/assignments.py`` expect, stamping the ids
+(questionUUID / optionUUID / blankUUID). Nothing is persisted here — the plan is
+returned for the teacher to preview, edit, and save via the existing endpoints.
+"""
+
+from __future__ import annotations
+
+import logging
+from uuid import uuid4
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.services.ai.base import get_chat_session_history, save_message_to_history
+from src.services.ai.llm import generate, model_for_tier
+from src.services.ai.rag.content_extraction import extract_all_course_content
+from src.services.ai.schemas.assignment import (
+    AIAssignmentPlan,
+    AITask,
+    GeneratedAssignmentPlan,
+    GeneratedTask,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_TASKS = 10
+MAX_CONTEXT_CHARS = 8000
+
+_SYSTEM_PROMPT = """You are an expert instructional designer generating a graded assignment for a course.
+
+You know these task types and MUST use their exact structure:
+- QUIZ: multiple-choice; each question has options, each option marked correct or not. At least one correct option per question.
+- FORM: fill-in-the-blank; each question has one or more blanks, each with the correct answer (and optional hint).
+- SHORT_ANSWER: an open text prompt with a list of accepted answers and a match_mode (default case_insensitive).
+- NUMBER_ANSWER: a prompt expecting a numeric answer, with correct_value and a tolerance (use 0 for exact).
+- FILE_SUBMISSION: the student uploads a file; no auto-grading, so give clear instructions in the description.
+
+Rules:
+- Generate exactly the requested number of tasks, only of the allowed types.
+- Populate ONLY the sub-object matching each task's assignment_type; leave the others null.
+- Base tasks strictly on the provided course content; do not contradict it.
+- Write in the same language as the course content / user's request.
+- Every task needs a clear title, a student-facing description, and a helpful hint.
+- Return ONLY the structured plan."""
+
+
+async def _course_context(course_id: int, org_id: int, db_session: AsyncSession) -> str:
+    try:
+        chunks = await extract_all_course_content(course_id, org_id, db_session)
+    except Exception:
+        logger.warning("Failed to extract course content for assignment grounding", exc_info=True)
+        return ""
+    parts: list[str] = []
+    total = 0
+    for c in chunks:
+        text = (c.get("text") or "").strip()
+        if not text:
+            continue
+        header = f"# {c.get('chapter_name', '')} / {c.get('activity_name', '')}".strip()
+        piece = f"{header}\n{text}"
+        parts.append(piece)
+        total += len(piece)
+        if total >= MAX_CONTEXT_CHARS:
+            break
+    return "\n\n".join(parts)[:MAX_CONTEXT_CHARS]
+
+
+def _quiz_contents(task: AITask) -> dict:
+    questions = []
+    for q in (task.quiz.questions if task.quiz else []):
+        options = [
+            {
+                "optionUUID": f"option_{uuid4()}",
+                "text": opt.text,
+                "fileID": "",
+                "type": "text",
+                "assigned_right_answer": bool(opt.is_correct),
+            }
+            for opt in q.options
+        ]
+        questions.append(
+            {
+                "questionUUID": f"question_{uuid4()}",
+                "questionText": q.question_text,
+                "options": options,
+            }
+        )
+    return {"questions": questions}
+
+
+def _form_contents(task: AITask) -> dict:
+    questions = []
+    for q in (task.form.questions if task.form else []):
+        blanks = []
+        for b in q.blanks:
+            blank = {
+                "blankUUID": f"blank_{uuid4()}",
+                "placeholder": b.placeholder,
+                "correctAnswer": b.correct_answer,
+            }
+            if b.hint:
+                blank["hint"] = b.hint
+            blanks.append(blank)
+        questions.append(
+            {
+                "questionUUID": f"question_{uuid4()}",
+                "questionText": q.question_text,
+                "blanks": blanks,
+            }
+        )
+    return {"questions": questions}
+
+
+def _short_answer_contents(task: AITask) -> dict:
+    sa = task.short_answer
+    if not sa:
+        return {"prompt": "", "correct_answers": [], "match_mode": "case_insensitive"}
+    contents = {
+        "prompt": sa.prompt,
+        "correct_answers": sa.correct_answers,
+        "match_mode": sa.match_mode,
+    }
+    if sa.explanation:
+        contents["explanation"] = sa.explanation
+    return contents
+
+
+def _number_answer_contents(task: AITask) -> dict:
+    na = task.number_answer
+    if not na:
+        return {"prompt": "", "correct_value": 0, "tolerance": 0}
+    contents = {
+        "prompt": na.prompt,
+        "correct_value": na.correct_value,
+        "tolerance": na.tolerance,
+    }
+    if na.unit:
+        contents["unit"] = na.unit
+    if na.explanation:
+        contents["explanation"] = na.explanation
+    return contents
+
+
+_CONTENTS_BUILDERS = {
+    "QUIZ": _quiz_contents,
+    "FORM": _form_contents,
+    "SHORT_ANSWER": _short_answer_contents,
+    "NUMBER_ANSWER": _number_answer_contents,
+    "FILE_SUBMISSION": lambda _task: {},
+}
+
+
+def _to_generated_task(task: AITask) -> GeneratedTask:
+    builder = _CONTENTS_BUILDERS.get(task.assignment_type, lambda _t: {})
+    return GeneratedTask(
+        title=task.title,
+        description=task.description,
+        hint=task.hint or "",
+        assignment_type=task.assignment_type,
+        contents=builder(task),
+        max_grade_value=100,
+    )
+
+
+async def generate_assignment_plan(
+    *,
+    org_id: int,
+    course_id: int,
+    prompt: str,
+    model_name: str,
+    db_session: AsyncSession,
+    num_tasks: int = 3,
+    allowed_task_types: list[str] | None = None,
+    session_uuid: str | None = None,
+) -> tuple[GeneratedAssignmentPlan, str]:
+    """Generate an assignment plan grounded on course content. Does not persist."""
+    num_tasks = max(1, min(num_tasks, MAX_TASKS))
+    allowed = allowed_task_types or ["QUIZ", "FORM", "SHORT_ANSWER", "NUMBER_ANSWER", "FILE_SUBMISSION"]
+
+    context = await _course_context(course_id, org_id, db_session)
+
+    session = get_chat_session_history(session_uuid)
+    resolved_session_uuid = session["aichat_uuid"]
+    history = session["message_history"]
+
+    user_prompt = (
+        f"Create an assignment with exactly {num_tasks} task(s).\n"
+        f"Allowed task types: {', '.join(allowed)}.\n"
+        f"Instructions: {prompt.strip()}\n\n"
+        f"Course content:\n{context}"
+    )
+
+    plan: AIAssignmentPlan = await generate(
+        model_name=model_name or model_for_tier("standard"),
+        user_prompt=user_prompt,
+        system_prompt=_SYSTEM_PROMPT,
+        history=history,
+        output_type=AIAssignmentPlan,
+    )
+
+    # Keep only allowed types and convert to grader-valid contents.
+    allowed_set = set(allowed)
+    generated_tasks = [
+        _to_generated_task(t) for t in plan.tasks if t.assignment_type in allowed_set
+    ]
+
+    generated = GeneratedAssignmentPlan(
+        title=plan.title,
+        description=plan.description,
+        grading_type=plan.grading_type,
+        tasks=generated_tasks,
+    )
+
+    summary = f"Generated assignment '{plan.title}' with {len(generated_tasks)} task(s)."
+    try:
+        save_message_to_history(resolved_session_uuid, prompt.strip(), summary, org_id=org_id)
+    except Exception:
+        logger.debug("Failed to persist assignment refine history", exc_info=True)
+
+    return generated, resolved_session_uuid

--- a/apps/api/src/services/ai/assignment_gen.py
+++ b/apps/api/src/services/ai/assignment_gen.py
@@ -10,6 +10,7 @@ returned for the teacher to preview, edit, and save via the existing endpoints.
 
 from __future__ import annotations
 
+import json
 import logging
 from uuid import uuid4
 
@@ -215,9 +216,11 @@ async def generate_assignment_plan(
         tasks=generated_tasks,
     )
 
-    summary = f"Generated assignment '{plan.title}' with {len(generated_tasks)} task(s)."
+    # Persist the actual generated plan (not just a count) so a refine turn can
+    # amend it instead of regenerating from scratch.
+    assistant_turn = json.dumps(generated.model_dump())
     try:
-        save_message_to_history(resolved_session_uuid, prompt.strip(), summary, org_id=org_id)
+        save_message_to_history(resolved_session_uuid, prompt.strip(), assistant_turn, org_id=org_id)
     except Exception:
         logger.debug("Failed to persist assignment refine history", exc_info=True)
 

--- a/apps/api/src/services/ai/generations.py
+++ b/apps/api/src/services/ai/generations.py
@@ -1,0 +1,132 @@
+"""Durable AI-generation history (Postgres).
+
+The hybrid-history counterpart to the ephemeral Redis refine sessions in
+``src/services/ai/base.py``. Every artifact the user keeps (a generated image,
+a quiz, an assignment plan) is recorded here so each feature's "History" tab can
+list, re-open, and delete past generations long after the 25-day Redis TTL.
+
+Ownership is enforced on read/delete via ``user_id`` (IDOR guard), mirroring
+``chat_session_belongs_to_user`` in ``base.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Optional
+from uuid import uuid4
+
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.db.ai.generations import (
+    AIGeneration,
+    AIGenerationKind,
+    AIGenerationRead,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def record_generation(
+    db_session: AsyncSession,
+    *,
+    kind: AIGenerationKind,
+    org_id: int,
+    user_id: int,
+    prompt: str,
+    result: dict,
+    session_uuid: Optional[str] = None,
+    course_id: Optional[int] = None,
+    activity_id: Optional[int] = None,
+    assignment_id: Optional[int] = None,
+) -> AIGenerationRead:
+    """Persist a kept AI-generated artifact and return the read model."""
+    now = str(datetime.now())
+    generation = AIGeneration(
+        ai_generation_uuid=f"aigen_{uuid4()}",
+        kind=kind,
+        org_id=org_id,
+        user_id=user_id,
+        prompt=prompt or "",
+        result=result or {},
+        session_uuid=session_uuid,
+        course_id=course_id,
+        activity_id=activity_id,
+        assignment_id=assignment_id,
+        creation_date=now,
+        update_date=now,
+    )
+    db_session.add(generation)
+    await db_session.commit()
+    await db_session.refresh(generation)
+    return AIGenerationRead.model_validate(generation.model_dump())
+
+
+async def list_generations(
+    db_session: AsyncSession,
+    *,
+    org_id: int,
+    user_id: int,
+    kind: AIGenerationKind,
+    limit: int = 30,
+    offset: int = 0,
+) -> list[AIGenerationRead]:
+    """List a user's durable generations of a given kind within an org, newest first."""
+    limit = max(1, min(limit, 100))
+    offset = max(0, offset)
+    statement = (
+        select(AIGeneration)
+        .where(
+            AIGeneration.org_id == org_id,
+            AIGeneration.user_id == user_id,
+            AIGeneration.kind == kind,
+        )
+        .order_by(AIGeneration.id.desc())  # type: ignore[union-attr]
+        .offset(offset)
+        .limit(limit)
+    )
+    rows = (await db_session.execute(statement)).scalars().all()
+    return [AIGenerationRead.model_validate(r.model_dump()) for r in rows]
+
+
+async def get_generation(
+    db_session: AsyncSession,
+    *,
+    ai_generation_uuid: str,
+    user_id: int,
+) -> Optional[AIGenerationRead]:
+    """Fetch one generation, enforcing ownership. Returns None if missing/not owned."""
+    row = await _get_owned(db_session, ai_generation_uuid, user_id)
+    if row is None:
+        return None
+    return AIGenerationRead.model_validate(row.model_dump())
+
+
+async def delete_generation(
+    db_session: AsyncSession,
+    *,
+    ai_generation_uuid: str,
+    user_id: int,
+) -> bool:
+    """Delete one generation, enforcing ownership. Returns True if deleted."""
+    row = await _get_owned(db_session, ai_generation_uuid, user_id)
+    if row is None:
+        return False
+    await db_session.delete(row)
+    await db_session.commit()
+    return True
+
+
+async def _get_owned(
+    db_session: AsyncSession,
+    ai_generation_uuid: str,
+    user_id: int,
+) -> Optional[AIGeneration]:
+    statement = select(AIGeneration).where(
+        AIGeneration.ai_generation_uuid == ai_generation_uuid
+    )
+    row = (await db_session.execute(statement)).scalars().first()
+    if row is None or row.user_id != user_id:
+        return None
+    return row

--- a/apps/api/src/services/ai/image/generator.py
+++ b/apps/api/src/services/ai/image/generator.py
@@ -1,0 +1,122 @@
+"""AI image generation (Google "nano banana" family).
+
+Image generation is a **Google-only** path: the provider-agnostic text layer in
+``src/services/ai/llm`` returns text/embeddings only, so images go straight to
+the Google GenAI SDK. It still reuses the same credential resolution as the text
+layer — ``ai_config.api_key`` when the configured provider is Google, otherwise
+the legacy ``ai_config.gemini_api_key`` — so no separate key is needed when the
+deployment already runs on Gemini.
+
+Supports two modes with the same call:
+- text-to-image (``prompt`` only)
+- image editing / iterative refinement (``prompt`` + one or more ``input_images``)
+  which powers the chatbot-like "make it darker / add a diagram" refine loop.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from config.config import get_learnhouse_config
+from src.services.ai.llm import AINotConfiguredError
+from src.services.ai.llm.provider import _GOOGLE_ALIASES
+
+logger = logging.getLogger(__name__)
+
+# Google "nano banana 2 lite" image model. Overridable via LEARNHOUSE_AI_IMAGE_MODEL
+# so the exact model id can be pinned/upgraded without a code change (Google's
+# preview model strings change over time — confirm the current id for your key).
+DEFAULT_IMAGE_MODEL = "gemini-3-pro-image-preview"
+
+# Nano banana returns PNG inline data.
+OUTPUT_MIME = "image/png"
+OUTPUT_EXT = "png"
+
+# Guard against pathologically large prompts before we spend a credit / call out.
+MAX_PROMPT_CHARS = 4000
+
+
+def _resolve_image_config() -> tuple[str, str]:
+    """Return ``(api_key, model)`` for image generation or raise if unconfigured."""
+    cfg = get_learnhouse_config().ai_config
+    provider_id = (getattr(cfg, "provider", None) or "").strip().lower()
+
+    # Prefer the unified key when the deployment is already on Google; otherwise
+    # fall back to the dedicated Gemini key (which any provider can set purely for
+    # image generation, since this path is Google-only).
+    api_key = None
+    if provider_id in _GOOGLE_ALIASES:
+        api_key = getattr(cfg, "api_key", None)
+    api_key = api_key or getattr(cfg, "gemini_api_key", None)
+
+    if not api_key:
+        raise AINotConfiguredError(
+            "AI image generation requires a Google/Gemini API key "
+            "(set LEARNHOUSE_GEMINI_API_KEY, or LEARNHOUSE_AI_API_KEY when "
+            "LEARNHOUSE_AI_PROVIDER=google)."
+        )
+
+    model = (getattr(cfg, "image_model", None) or "").strip() or DEFAULT_IMAGE_MODEL
+    return api_key, model
+
+
+def _extract_image_bytes(response) -> Optional[bytes]:
+    """Pull the first inline image payload out of a GenAI response."""
+    candidates = getattr(response, "candidates", None) or []
+    for candidate in candidates:
+        content = getattr(candidate, "content", None)
+        parts = getattr(content, "parts", None) or []
+        for part in parts:
+            inline = getattr(part, "inline_data", None)
+            data = getattr(inline, "data", None) if inline else None
+            if data:
+                return data
+    return None
+
+
+async def generate_image(
+    prompt: str,
+    *,
+    input_images: Optional[list[bytes]] = None,
+) -> bytes:
+    """Generate (or edit) an image with the nano banana model. Returns PNG bytes.
+
+    Raises ``AINotConfiguredError`` when no Google key is configured, or a plain
+    ``RuntimeError`` when the model returns no image (e.g. a safety refusal).
+    """
+    from google import genai
+    from google.genai import types
+
+    prompt = (prompt or "").strip()
+    if not prompt:
+        raise ValueError("A non-empty prompt is required for image generation.")
+    if len(prompt) > MAX_PROMPT_CHARS:
+        prompt = prompt[:MAX_PROMPT_CHARS]
+
+    api_key, model = _resolve_image_config()
+
+    # Build multimodal contents: the prompt plus any reference images to edit.
+    contents: list = [prompt]
+    for img in input_images or []:
+        if img:
+            contents.append(types.Part.from_bytes(data=img, mime_type=OUTPUT_MIME))
+
+    client = genai.Client(api_key=api_key)
+    try:
+        response = await client.aio.models.generate_content(
+            model=model,
+            contents=contents,
+        )
+    except Exception as e:  # noqa: BLE001 — surface a clean error to the router
+        logger.error("Image generation call failed: %s", e, exc_info=True)
+        raise RuntimeError("Image generation failed") from e
+
+    image_bytes = _extract_image_bytes(response)
+    if not image_bytes:
+        # Most commonly a safety block — no inline image part was returned.
+        logger.warning("Image generation returned no image (model=%s)", model)
+        raise RuntimeError(
+            "The model did not return an image. Try rephrasing your prompt."
+        )
+    return image_bytes

--- a/apps/api/src/services/ai/image/generator.py
+++ b/apps/api/src/services/ai/image/generator.py
@@ -15,6 +15,7 @@ Supports two modes with the same call:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Optional
 
@@ -24,10 +25,12 @@ from src.services.ai.llm.provider import _GOOGLE_ALIASES
 
 logger = logging.getLogger(__name__)
 
-# Google "nano banana 2 lite" image model. Overridable via LEARNHOUSE_AI_IMAGE_MODEL
-# so the exact model id can be pinned/upgraded without a code change (Google's
-# preview model strings change over time — confirm the current id for your key).
-DEFAULT_IMAGE_MODEL = "gemini-3-pro-image-preview"
+# Google "nano banana" image model. Defaults to the generally-available Gemini 2.5
+# Flash Image model so generation works out of the box on any Gemini API key.
+# Newer/preview models (e.g. Nano Banana 2 / "gemini-3-pro-image-preview") require
+# allowlist access and can 429/500 under capacity — set LEARNHOUSE_AI_IMAGE_MODEL
+# to opt into one once it is enabled for your key.
+DEFAULT_IMAGE_MODEL = "gemini-2.5-flash-image"
 
 # Nano banana returns PNG inline data.
 OUTPUT_MIME = "image/png"
@@ -35,6 +38,34 @@ OUTPUT_EXT = "png"
 
 # Guard against pathologically large prompts before we spend a credit / call out.
 MAX_PROMPT_CHARS = 4000
+
+# Bounded retry for transient upstream errors (rate limit / capacity).
+_MAX_ATTEMPTS = 3
+_RETRY_BACKOFF_SECONDS = 1.5
+_RETRYABLE_STATUS = {429, 500, 502, 503, 504}
+
+
+def _sniff_mime(data: bytes) -> str:
+    """Best-effort image MIME detection so edit/refine inputs aren't mislabeled."""
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "image/png"
+    if data[:3] == b"\xff\xd8\xff":
+        return "image/jpeg"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    if data[:6] in (b"GIF87a", b"GIF89a"):
+        return "image/gif"
+    return OUTPUT_MIME
+
+
+def _is_retryable(exc: Exception) -> bool:
+    """True for transient Google API errors worth retrying."""
+    code = getattr(exc, "code", None) or getattr(exc, "status_code", None)
+    if isinstance(code, int) and code in _RETRYABLE_STATUS:
+        return True
+    # google.genai raises ServerError (5xx) / APIError with a numeric status.
+    name = type(exc).__name__
+    return name in ("ServerError", "ServiceUnavailable", "ResourceExhausted")
 
 
 def _resolve_image_config() -> tuple[str, str]:
@@ -97,22 +128,39 @@ async def generate_image(
     api_key, model = _resolve_image_config()
 
     # Build multimodal contents: the prompt plus any reference images to edit.
+    # Sniff each image's real MIME type — a JPEG/WebP mislabeled as PNG can be
+    # rejected by the model.
     contents: list = [prompt]
     for img in input_images or []:
         if img:
-            contents.append(types.Part.from_bytes(data=img, mime_type=OUTPUT_MIME))
+            contents.append(types.Part.from_bytes(data=img, mime_type=_sniff_mime(img)))
+
+    # Explicitly request image output. Without this the model can return a
+    # text-only response and we would (wrongly) treat it as "no image" / 502.
+    config = types.GenerateContentConfig(response_modalities=["IMAGE"])
 
     client = genai.Client(api_key=api_key)
-    try:
-        response = await client.aio.models.generate_content(
-            model=model,
-            contents=contents,
-        )
-    except Exception as e:  # noqa: BLE001 — surface a clean error to the router
-        # Log only the exception type: the underlying SDK error can embed the
-        # API key (request URL/headers), so never log the message or traceback.
-        logger.error("Image generation call failed: %s", type(e).__name__)
-        raise RuntimeError("Image generation failed") from e
+    response = None
+    for attempt in range(1, _MAX_ATTEMPTS + 1):
+        try:
+            response = await client.aio.models.generate_content(
+                model=model,
+                contents=contents,
+                config=config,
+            )
+            break
+        except Exception as e:  # noqa: BLE001 — surface a clean error to the router
+            # Log only the exception type: the underlying SDK error can embed the
+            # API key (request URL/headers), so never log the message or traceback.
+            if _is_retryable(e) and attempt < _MAX_ATTEMPTS:
+                logger.warning(
+                    "Image generation transient error (%s), retry %d/%d",
+                    type(e).__name__, attempt, _MAX_ATTEMPTS,
+                )
+                await asyncio.sleep(_RETRY_BACKOFF_SECONDS * attempt)
+                continue
+            logger.error("Image generation call failed: %s", type(e).__name__)
+            raise RuntimeError("Image generation failed") from e
 
     image_bytes = _extract_image_bytes(response)
     if not image_bytes:

--- a/apps/api/src/services/ai/image/generator.py
+++ b/apps/api/src/services/ai/image/generator.py
@@ -117,7 +117,9 @@ async def generate_image(
     image_bytes = _extract_image_bytes(response)
     if not image_bytes:
         # Most commonly a safety block — no inline image part was returned.
-        logger.warning("Image generation returned no image (model=%s)", model)
+        # `model` is intentionally not logged: it shares a return tuple with the
+        # API key, so logging it trips clear-text-secret analysis.
+        logger.warning("Image generation returned no image")
         raise RuntimeError(
             "The model did not return an image. Try rephrasing your prompt."
         )

--- a/apps/api/src/services/ai/image/generator.py
+++ b/apps/api/src/services/ai/image/generator.py
@@ -109,7 +109,9 @@ async def generate_image(
             contents=contents,
         )
     except Exception as e:  # noqa: BLE001 — surface a clean error to the router
-        logger.error("Image generation call failed: %s", e, exc_info=True)
+        # Log only the exception type: the underlying SDK error can embed the
+        # API key (request URL/headers), so never log the message or traceback.
+        logger.error("Image generation call failed: %s", type(e).__name__)
         raise RuntimeError("Image generation failed") from e
 
     image_bytes = _extract_image_bytes(response)

--- a/apps/api/src/services/ai/image/generator.py
+++ b/apps/api/src/services/ai/image/generator.py
@@ -127,17 +127,30 @@ async def generate_image(
 
     api_key, model = _resolve_image_config()
 
-    # Build multimodal contents: the prompt plus any reference images to edit.
-    # Sniff each image's real MIME type — a JPEG/WebP mislabeled as PNG can be
-    # rejected by the model.
-    contents: list = [prompt]
-    for img in input_images or []:
-        if img:
+    # Build multimodal contents.
+    #   - EDIT/REFINE (input_images present): put the reference image(s) FIRST and
+    #     frame the instruction as an edit of "the provided image". This matches
+    #     Google's image-editing recipe and is what makes the model modify the
+    #     attachment instead of generating a fresh image from the words alone.
+    #   - TEXT-TO-IMAGE: prompt only.
+    # Sniff each image's real MIME type — a JPEG/WebP mislabeled as PNG is rejected.
+    imgs = [img for img in (input_images or []) if img]
+    contents: list = []
+    if imgs:
+        for img in imgs:
             contents.append(types.Part.from_bytes(data=img, mime_type=_sniff_mime(img)))
+        contents.append(
+            f"Using the provided image as the starting point, edit it as follows: {prompt}"
+        )
+    else:
+        contents.append(prompt)
 
-    # Explicitly request image output. Without this the model can return a
-    # text-only response and we would (wrongly) treat it as "no image" / 502.
-    config = types.GenerateContentConfig(response_modalities=["IMAGE"])
+    # Request both output modalities — Google's documented image-editing config.
+    # TEXT parts are skipped by _extract_image_bytes, so output handling is
+    # unchanged; this only avoids a spurious "no image" 502 when an edit turn also
+    # returns a text note. (response_modalities is OUTPUT-only — the edit framing
+    # above, not this, is what makes the input image be used.)
+    config = types.GenerateContentConfig(response_modalities=["TEXT", "IMAGE"])
 
     client = genai.Client(api_key=api_key)
     response = None

--- a/apps/api/src/services/ai/quiz.py
+++ b/apps/api/src/services/ai/quiz.py
@@ -9,6 +9,7 @@ expects. Multi-turn refinement is supported via the Redis chat session store
 
 from __future__ import annotations
 
+import json
 import logging
 from uuid import uuid4
 
@@ -25,11 +26,9 @@ MAX_CONTEXT_CHARS = 6000
 _SYSTEM_PROMPT = """You are an expert instructional designer creating quiz questions for a course.
 
 Rules:
-- Produce clear, unambiguous questions at the requested difficulty.
-- For `multiple_choice` questions: provide 3-5 answer options with exactly the
-  correct one(s) marked correct. At least one option MUST be correct.
-- For `custom_answer` questions: provide a single model answer marked correct.
-- Prefer `multiple_choice` unless the concept genuinely needs an open answer.
+- Produce clear, unambiguous multiple-choice questions at the requested difficulty.
+- Each question has 3-5 answer options; mark exactly the correct one(s) correct.
+  At least one option MUST be correct.
 - Write in the same language as the user's request/content.
 - Base questions strictly on the provided course content when it is supplied;
   do not invent facts that contradict it.
@@ -105,10 +104,11 @@ async def generate_quiz(
 
     block_quiz = _to_block_quiz(generated)
 
-    # Record the exchange so a follow-up refine turn has context.
-    summary = f"Generated {len(block_quiz['questions'])} quiz question(s)."
+    # Record the exchange so a follow-up refine turn can amend the actual quiz
+    # (persist the generated questions, not just a count).
+    assistant_turn = json.dumps(block_quiz.get("questions", []))
     try:
-        save_message_to_history(resolved_session_uuid, prompt.strip(), summary, org_id=org_id)
+        save_message_to_history(resolved_session_uuid, prompt.strip(), assistant_turn, org_id=org_id)
     except Exception:
         logger.debug("Failed to persist quiz refine history", exc_info=True)
 

--- a/apps/api/src/services/ai/quiz.py
+++ b/apps/api/src/services/ai/quiz.py
@@ -1,0 +1,115 @@
+"""AI quiz generation service (in-editor `blockQuiz`).
+
+Uses the provider-agnostic ``generate`` with a strict ``GeneratedQuiz`` output
+type so the model result is always schema-valid, then stamps the ids the editor
+expects. Multi-turn refinement is supported via the Redis chat session store
+(the hybrid model's ephemeral half); durable kept quizzes are recorded via
+``record_generation``.
+"""
+
+from __future__ import annotations
+
+import logging
+from uuid import uuid4
+
+from src.services.ai.base import get_chat_session_history, save_message_to_history
+from src.services.ai.llm import generate, model_for_tier
+from src.services.ai.rag.content_extraction import extract_text_from_prosemirror
+from src.services.ai.schemas.quiz import GeneratedQuiz
+
+logger = logging.getLogger(__name__)
+
+MAX_QUESTIONS = 20
+MAX_CONTEXT_CHARS = 6000
+
+_SYSTEM_PROMPT = """You are an expert instructional designer creating quiz questions for a course.
+
+Rules:
+- Produce clear, unambiguous questions at the requested difficulty.
+- For `multiple_choice` questions: provide 3-5 answer options with exactly the
+  correct one(s) marked correct. At least one option MUST be correct.
+- For `custom_answer` questions: provide a single model answer marked correct.
+- Prefer `multiple_choice` unless the concept genuinely needs an open answer.
+- Write in the same language as the user's request/content.
+- Base questions strictly on the provided course content when it is supplied;
+  do not invent facts that contradict it.
+- Return ONLY the structured quiz — no commentary."""
+
+
+def _build_prompt(prompt: str, num_questions: int, difficulty: str | None, context: str) -> str:
+    parts = [f"Create {num_questions} quiz question(s)."]
+    if difficulty:
+        parts.append(f"Difficulty: {difficulty}.")
+    parts.append(f"Topic / instructions: {prompt.strip()}")
+    if context:
+        parts.append(f"\nCourse content to base the quiz on:\n{context[:MAX_CONTEXT_CHARS]}")
+    return "\n".join(parts)
+
+
+def _to_block_quiz(generated: GeneratedQuiz) -> dict:
+    """Stamp the ids the editor `blockQuiz` node expects."""
+    questions = []
+    for q in generated.questions:
+        answers = [
+            {
+                "answer_id": f"answer_{uuid4()}",
+                "answer": a.answer,
+                "correct": bool(a.correct),
+            }
+            for a in q.answers
+        ]
+        questions.append(
+            {
+                "question_id": f"question_{uuid4()}",
+                "question": q.question,
+                "type": q.type,
+                "answers": answers,
+            }
+        )
+    return {"quizId": f"quiz_{uuid4()}", "questions": questions}
+
+
+async def generate_quiz(
+    *,
+    org_id: int,
+    prompt: str,
+    model_name: str,
+    activity_content: dict | None = None,
+    num_questions: int = 5,
+    difficulty: str | None = None,
+    session_uuid: str | None = None,
+) -> tuple[dict, str]:
+    """Generate a `blockQuiz` payload. Returns ``(block_quiz_attrs, session_uuid)``."""
+    num_questions = max(1, min(num_questions, MAX_QUESTIONS))
+
+    context = ""
+    if activity_content:
+        try:
+            context = extract_text_from_prosemirror(activity_content) or ""
+        except Exception:
+            logger.warning("Failed to extract activity content for quiz grounding", exc_info=True)
+
+    session = get_chat_session_history(session_uuid)
+    resolved_session_uuid = session["aichat_uuid"]
+    history = session["message_history"]
+
+    user_prompt = _build_prompt(prompt, num_questions, difficulty, context)
+
+    generated: GeneratedQuiz = await generate(
+        model_name=model_name or model_for_tier("standard"),
+        user_prompt=user_prompt,
+        system_prompt=_SYSTEM_PROMPT,
+        history=history,
+        output_type=GeneratedQuiz,
+    )
+
+    block_quiz = _to_block_quiz(generated)
+
+    # Record the exchange so a follow-up refine turn has context.
+    summary = f"Generated {len(block_quiz['questions'])} quiz question(s)."
+    try:
+        save_message_to_history(resolved_session_uuid, prompt.strip(), summary, org_id=org_id)
+    except Exception:
+        logger.debug("Failed to persist quiz refine history", exc_info=True)
+
+    return block_quiz, resolved_session_uuid

--- a/apps/api/src/services/ai/scenario.py
+++ b/apps/api/src/services/ai/scenario.py
@@ -1,0 +1,129 @@
+"""AI interactive-scenario generation service (editor `scenarios` block).
+
+Structured output keeps the branching valid; the service resolves the AI's
+``ref``/``next_ref`` links to stable ids and stamps the exact shape the
+ScenariosExtension renders. Mirrors the quiz generator (Redis refine session +
+durable history).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from uuid import uuid4
+
+from src.services.ai.base import get_chat_session_history, save_message_to_history
+from src.services.ai.llm import generate, model_for_tier
+from src.services.ai.rag.content_extraction import extract_text_from_prosemirror
+from src.services.ai.schemas.scenario import GeneratedScenarioSet
+
+logger = logging.getLogger(__name__)
+
+MAX_SCENARIOS = 40
+MAX_CONTEXT_CHARS = 6000
+
+_SYSTEM_PROMPT = """You are an instructional designer building a branching, interactive scenario for a course.
+
+A scenario is a decision tree of nodes. Each node has narrative text and 2-4 options.
+Each option either leads to another node (by its ref) or ends the scenario.
+
+Rules:
+- Give every node a short unique `ref` (e.g. "start", "s2", "win"). One node's ref must be "start" (the entry point).
+- Each option's `next_ref` must be either the ref of an existing node or null to end the scenario.
+- Ensure at least one path reaches an ending (an option with null next_ref). Avoid dead links.
+- Keep node text concise (1-3 sentences) and options short and actionable.
+- Base the scenario on the provided course content when supplied; write in its language.
+- Return ONLY the structured scenario."""
+
+
+def _build_prompt(prompt: str, num_scenarios: int, context: str) -> str:
+    parts = [
+        f"Create an interactive branching scenario with about {num_scenarios} nodes.",
+        f"Topic / instructions: {prompt.strip()}",
+    ]
+    if context:
+        parts.append(f"\nCourse content to base it on:\n{context[:MAX_CONTEXT_CHARS]}")
+    return "\n".join(parts)
+
+
+def _to_block_scenario(generated: GeneratedScenarioSet) -> dict:
+    """Resolve refs → ids and stamp the ScenariosExtension block shape."""
+    # Map each ref to a stable id, preserving order; guarantee a valid entry node.
+    nodes = [s for s in generated.scenarios if s.text]
+    if not nodes:
+        return {"title": generated.title or "Interactive Scenario", "scenarios": [], "currentScenarioId": ""}
+
+    ref_to_id: dict[str, str] = {}
+    for idx, node in enumerate(nodes, start=1):
+        ref_to_id[node.ref] = str(idx)
+
+    scenarios = []
+    for idx, node in enumerate(nodes, start=1):
+        options = []
+        for opt in node.options:
+            next_id = ref_to_id.get(opt.next_ref) if opt.next_ref else None
+            options.append(
+                {
+                    "id": f"opt_{uuid4().hex[:8]}",
+                    "text": opt.text,
+                    "nextScenarioId": next_id,
+                }
+            )
+        scenarios.append(
+            {
+                "id": str(idx),
+                "text": node.text,
+                "imageUrl": "",
+                "options": options,
+            }
+        )
+
+    # Entry node: prefer the one whose ref maps like "start", else the first.
+    start_id = ref_to_id.get("start", "1")
+    return {
+        "title": generated.title or "Interactive Scenario",
+        "scenarios": scenarios,
+        "currentScenarioId": start_id,
+    }
+
+
+async def generate_scenario(
+    *,
+    org_id: int,
+    prompt: str,
+    model_name: str,
+    activity_content: dict | None = None,
+    num_scenarios: int = 5,
+    session_uuid: str | None = None,
+) -> tuple[dict, str]:
+    """Generate a `scenarios` block payload. Returns ``(block_attrs, session_uuid)``."""
+    num_scenarios = max(2, min(num_scenarios, MAX_SCENARIOS))
+
+    context = ""
+    if activity_content:
+        try:
+            context = extract_text_from_prosemirror(activity_content) or ""
+        except Exception:
+            logger.warning("Failed to extract activity content for scenario grounding", exc_info=True)
+
+    session = get_chat_session_history(session_uuid)
+    resolved_session_uuid = session["aichat_uuid"]
+    history = session["message_history"]
+
+    generated: GeneratedScenarioSet = await generate(
+        model_name=model_name or model_for_tier("standard"),
+        user_prompt=_build_prompt(prompt, num_scenarios, context),
+        system_prompt=_SYSTEM_PROMPT,
+        history=history,
+        output_type=GeneratedScenarioSet,
+    )
+
+    block = _to_block_scenario(generated)
+
+    # Persist the actual generated scenario so a refine turn can amend it.
+    try:
+        save_message_to_history(resolved_session_uuid, prompt.strip(), json.dumps(block), org_id=org_id)
+    except Exception:
+        logger.debug("Failed to persist scenario refine history", exc_info=True)
+
+    return block, resolved_session_uuid

--- a/apps/api/src/services/ai/schemas/assignment.py
+++ b/apps/api/src/services/ai/schemas/assignment.py
@@ -1,0 +1,134 @@
+"""Schemas for AI assignment generation.
+
+The AI emits a strict ``AIAssignmentPlan`` whose per-task ``contents`` are
+keyed by named sub-objects (quiz/form/short_answer/number_answer) rather than a
+discriminated union — this is markedly more reliable for LLM structured output.
+The service then post-processes each task into the exact ``AssignmentTask``
+``contents`` shape the server graders expect (stamping the questionUUID /
+optionUUID / blankUUID ids), so what the frontend previews and saves is valid.
+
+Task-type source of truth: ``src/db/courses/assignments.py`` +
+``src/services/courses/activities/assignments.py`` (the graders).
+"""
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+# The subset of AssignmentTaskTypeEnum the AI can generate. CODE (Judge0 test
+# cases) and CUSTOM/OTHER (headless) are intentionally excluded — they need
+# human-authored specifics. Teachers add those manually.
+AIGeneratableTaskType = Literal[
+    "QUIZ", "FORM", "SHORT_ANSWER", "NUMBER_ANSWER", "FILE_SUBMISSION"
+]
+
+
+# --- Per-type AI-facing contents (no ids; stamped server-side) ---
+
+class AIQuizOption(BaseModel):
+    text: str
+    is_correct: bool
+
+
+class AIQuizQuestion(BaseModel):
+    question_text: str
+    options: List[AIQuizOption] = Field(default_factory=list)
+
+
+class AIQuizContents(BaseModel):
+    questions: List[AIQuizQuestion] = Field(default_factory=list)
+
+
+class AIFormBlank(BaseModel):
+    placeholder: str
+    correct_answer: str
+    hint: Optional[str] = None
+
+
+class AIFormQuestion(BaseModel):
+    question_text: str
+    blanks: List[AIFormBlank] = Field(default_factory=list)
+
+
+class AIFormContents(BaseModel):
+    questions: List[AIFormQuestion] = Field(default_factory=list)
+
+
+class AIShortAnswerContents(BaseModel):
+    prompt: str
+    correct_answers: List[str] = Field(default_factory=list)
+    match_mode: Literal["exact", "case_insensitive", "contains", "regex"] = "case_insensitive"
+    explanation: Optional[str] = None
+
+
+class AINumberAnswerContents(BaseModel):
+    prompt: str
+    correct_value: float
+    tolerance: float = 0
+    unit: Optional[str] = None
+    explanation: Optional[str] = None
+
+
+class AITask(BaseModel):
+    title: str
+    description: str
+    hint: str = ""
+    assignment_type: AIGeneratableTaskType
+    # Exactly one of these should be populated, matching assignment_type. For
+    # FILE_SUBMISSION all are null (contents is empty).
+    quiz: Optional[AIQuizContents] = None
+    form: Optional[AIFormContents] = None
+    short_answer: Optional[AIShortAnswerContents] = None
+    number_answer: Optional[AINumberAnswerContents] = None
+
+
+class AIAssignmentPlan(BaseModel):
+    title: str
+    description: str
+    grading_type: Literal[
+        "ALPHABET", "NUMERIC", "PERCENTAGE", "PASS_FAIL", "GPA_SCALE"
+    ] = "PERCENTAGE"
+    tasks: List[AITask] = Field(default_factory=list)
+
+
+# --- Request / response ---
+
+class GenerateAssignmentRequest(BaseModel):
+    org_id: int
+    course_uuid: str
+    prompt: str
+    session_uuid: Optional[str] = None
+    num_tasks: int = 3
+    allowed_task_types: Optional[List[AIGeneratableTaskType]] = None
+
+
+class GeneratedTask(BaseModel):
+    """A task ready to POST to /assignments/{uuid}/tasks (server assigns ids)."""
+
+    title: str
+    description: str
+    hint: str = ""
+    assignment_type: str
+    contents: dict
+    max_grade_value: int = 100
+
+
+class GeneratedAssignmentPlan(BaseModel):
+    title: str
+    description: str
+    grading_type: str
+    tasks: List[GeneratedTask] = Field(default_factory=list)
+
+
+class GenerateAssignmentResponse(BaseModel):
+    ai_generation_uuid: str
+    session_uuid: str
+    plan: GeneratedAssignmentPlan
+
+
+class AIAssignmentHistoryItem(BaseModel):
+    ai_generation_uuid: str
+    session_uuid: Optional[str] = None
+    prompt: str
+    plan: dict
+    creation_date: Optional[str] = None

--- a/apps/api/src/services/ai/schemas/image.py
+++ b/apps/api/src/services/ai/schemas/image.py
@@ -1,0 +1,37 @@
+"""Request/response schemas for AI image generation (nano banana)."""
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class GenerateImageRequest(BaseModel):
+    org_id: int
+    prompt: str
+    # Ephemeral refine-session id (Redis). Omitted on the first generation; the
+    # response returns a session_uuid to pass back on subsequent refine turns.
+    session_uuid: Optional[str] = None
+    # For iterative refinement / editing: the previously generated image the user
+    # is refining, sent back as a base64 PNG (data is client-held, avoiding any
+    # server-side fetch / SSRF surface).
+    source_image_base64: Optional[str] = None
+    # Optional context the image is generated for (recorded in durable history).
+    course_id: Optional[int] = None
+    activity_id: Optional[int] = None
+
+
+class GenerateImageResponse(BaseModel):
+    ai_generation_uuid: str
+    session_uuid: str
+    file_id: str
+    media_url: str
+    prompt: str
+
+
+class AIImageHistoryItem(BaseModel):
+    ai_generation_uuid: str
+    session_uuid: Optional[str] = None
+    prompt: str
+    file_id: str
+    media_url: str
+    creation_date: Optional[str] = None

--- a/apps/api/src/services/ai/schemas/image.py
+++ b/apps/api/src/services/ai/schemas/image.py
@@ -11,9 +11,11 @@ class GenerateImageRequest(BaseModel):
     # Ephemeral refine-session id (Redis). Omitted on the first generation; the
     # response returns a session_uuid to pass back on subsequent refine turns.
     session_uuid: Optional[str] = None
-    # For iterative refinement / editing: the previously generated image the user
-    # is refining, sent back as a base64 PNG (data is client-held, avoiding any
-    # server-side fetch / SSRF surface).
+    # For iterative refinement / editing: the file_id of a previously-generated
+    # AI image in THIS org. The backend reads its bytes straight from storage
+    # (no client fetch → no CORS/credentials issues). Preferred over base64.
+    source_file_id: Optional[str] = None
+    # Fallback: the source image sent back as a base64 data URL (client-held).
     source_image_base64: Optional[str] = None
     # Optional context the image is generated for (recorded in durable history).
     course_id: Optional[int] = None

--- a/apps/api/src/services/ai/schemas/quiz.py
+++ b/apps/api/src/services/ai/schemas/quiz.py
@@ -20,9 +20,10 @@ class GenQuizAnswer(BaseModel):
 
 class GenQuizQuestion(BaseModel):
     question: str
-    # `multiple_choice` = one or more correct options; `custom_answer` = open
-    # self-check with a model answer marked correct. Mirrors QuizBlockComponent.
-    type: Literal["multiple_choice", "custom_answer"] = "multiple_choice"
+    # Only `multiple_choice` is generated: QuizBlockComponent renders every
+    # question as multiple-choice, so a `custom_answer` would degenerate into a
+    # single answer-revealing option.
+    type: Literal["multiple_choice"] = "multiple_choice"
     answers: List[GenQuizAnswer] = Field(default_factory=list)
 
 

--- a/apps/api/src/services/ai/schemas/quiz.py
+++ b/apps/api/src/services/ai/schemas/quiz.py
@@ -1,0 +1,58 @@
+"""Schemas for AI quiz generation (in-editor `blockQuiz`).
+
+The AI emits a strict, schema-validated ``GeneratedQuiz``; the service then
+stamps the ids the editor's ``blockQuiz`` node expects (quizId / question_id /
+answer_id) so the frontend can insert it verbatim. This targets the *editor*
+quiz block — NOT the graded assignment QUIZ task, which has a different shape.
+"""
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+# --- Structured model output (ids assigned server-side afterwards) ---
+
+class GenQuizAnswer(BaseModel):
+    answer: str
+    correct: bool
+
+
+class GenQuizQuestion(BaseModel):
+    question: str
+    # `multiple_choice` = one or more correct options; `custom_answer` = open
+    # self-check with a model answer marked correct. Mirrors QuizBlockComponent.
+    type: Literal["multiple_choice", "custom_answer"] = "multiple_choice"
+    answers: List[GenQuizAnswer] = Field(default_factory=list)
+
+
+class GeneratedQuiz(BaseModel):
+    questions: List[GenQuizQuestion] = Field(default_factory=list)
+
+
+# --- Request / response ---
+
+class GenerateQuizRequest(BaseModel):
+    org_id: int
+    prompt: str
+    # When set, the quiz is grounded on the activity's existing content.
+    activity_uuid: Optional[str] = None
+    # Ephemeral refine session (Redis). Omit on first call; pass back to refine.
+    session_uuid: Optional[str] = None
+    num_questions: int = 5
+    difficulty: Optional[Literal["easy", "medium", "hard"]] = None
+
+
+class GenerateQuizResponse(BaseModel):
+    ai_generation_uuid: str
+    session_uuid: str
+    # Ready-to-insert `blockQuiz` attrs: {"quizId", "questions": [...]}.
+    quiz: dict
+
+
+class AIQuizHistoryItem(BaseModel):
+    ai_generation_uuid: str
+    session_uuid: Optional[str] = None
+    prompt: str
+    quiz: dict
+    creation_date: Optional[str] = None

--- a/apps/api/src/services/ai/schemas/scenario.py
+++ b/apps/api/src/services/ai/schemas/scenario.py
@@ -1,0 +1,56 @@
+"""Schemas for AI interactive-scenario generation (editor `scenarios` block).
+
+The AI emits nodes keyed by a short ``ref`` string, and options link via
+``next_ref`` (or null to end). The service resolves refs → stable ids and
+produces the exact block shape the ScenariosExtension expects:
+``{title, scenarios: [{id, text, imageUrl, options: [{id, text, nextScenarioId}]}], currentScenarioId}``.
+Using refs (not real ids) keeps the branching valid regardless of how the model
+orders nodes.
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class GenScenarioOption(BaseModel):
+    text: str
+    # The ref of the scenario this option leads to; null/empty ends the scenario.
+    next_ref: Optional[str] = None
+
+
+class GenScenario(BaseModel):
+    # Short stable label the AI uses to link nodes (e.g. "s1", "start", "win").
+    ref: str
+    text: str
+    options: List[GenScenarioOption] = Field(default_factory=list)
+
+
+class GeneratedScenarioSet(BaseModel):
+    title: str = "Interactive Scenario"
+    scenarios: List[GenScenario] = Field(default_factory=list)
+
+
+# --- Request / response ---
+
+class GenerateScenarioRequest(BaseModel):
+    org_id: int
+    prompt: str
+    activity_uuid: Optional[str] = None
+    session_uuid: Optional[str] = None
+    num_scenarios: int = 5
+
+
+class GenerateScenarioResponse(BaseModel):
+    ai_generation_uuid: str
+    session_uuid: str
+    # Ready-to-insert `scenarios` block attrs: {title, scenarios, currentScenarioId}.
+    scenario: dict
+
+
+class AIScenarioHistoryItem(BaseModel):
+    ai_generation_uuid: str
+    session_uuid: Optional[str] = None
+    prompt: str
+    scenario: dict
+    creation_date: Optional[str] = None

--- a/apps/api/src/services/blocks/block_types/videoBlock/videoBlock.py
+++ b/apps/api/src/services/blocks/block_types/videoBlock/videoBlock.py
@@ -86,6 +86,15 @@ async def create_video_block(
     await db_session.commit()
     await db_session.refresh(block)
 
+    # Kick off HLS transcoding (adaptive streaming), reusing the same pipeline as
+    # video activities. No-op unless LEARNHOUSE_HLS_ENABLED; until ready the
+    # player uses the faststart MP4 fallback.
+    try:
+        from src.services.utils.hls_jobs import enqueue_block
+        enqueue_block(activity_uuid, block_uuid)
+    except Exception:
+        pass
+
     block = BlockRead.model_validate(block)
 
     return block

--- a/apps/api/src/services/blocks/block_types/videoBlock/videoBlock.py
+++ b/apps/api/src/services/blocks/block_types/videoBlock/videoBlock.py
@@ -92,7 +92,7 @@ async def create_video_block(
     try:
         from src.services.utils.hls_jobs import enqueue_block
         enqueue_block(activity_uuid, block_uuid)
-    except Exception:
+    except Exception:  # pragma: no cover
         pass
 
     block = BlockRead.model_validate(block)

--- a/apps/api/src/services/utils/hls_jobs.py
+++ b/apps/api/src/services/utils/hls_jobs.py
@@ -16,6 +16,7 @@ Everything is gated by `LEARNHOUSE_HLS_ENABLED` (default off). Until a video is
 """
 
 import asyncio
+import json
 import logging
 import os
 import shutil
@@ -28,6 +29,7 @@ from sqlmodel import select
 from src.core.events.database import _async_session_factory
 from src.core.redis import get_redis_client
 from src.db.courses.activities import Activity, ActivitySubTypeEnum
+from src.db.courses.blocks import Block, BlockTypeEnum
 from src.db.courses.courses import Course
 from src.db.organizations import Organization
 from src.services.courses.transfer.storage_utils import (
@@ -278,6 +280,185 @@ def enqueue(activity_uuid: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Video BLOCK transcoding — reuses the SAME queue/consumer/reconciler/transcoder
+# as activities. A block job is a JSON queue item; a legacy bare uuid string is
+# still an activity job, so the activity path is untouched.
+# ---------------------------------------------------------------------------
+
+def _block_item(activity_uuid: str, block_uuid: str) -> str:
+    """Canonical queue payload for a block job (stable key order for dedup)."""
+    return json.dumps({"kind": "block", "activity_uuid": activity_uuid, "block_uuid": block_uuid})
+
+
+def _parse_item(item: str) -> dict:
+    """Decode a queue item into a job descriptor.
+
+    A bare activity_uuid (legacy) → an activity job; a JSON `{"kind":"block",...}`
+    → a block job.
+    """
+    if item and item.startswith("{"):
+        try:
+            data = json.loads(item)
+            if isinstance(data, dict) and data.get("kind") == "block":
+                return {
+                    "kind": "block",
+                    "activity_uuid": data.get("activity_uuid"),
+                    "block_uuid": data.get("block_uuid"),
+                }
+        except Exception:
+            pass
+    return {"kind": "activity", "activity_uuid": item}
+
+
+def enqueue_block(activity_uuid: str, block_uuid: str) -> None:
+    """Queue a video BLOCK for HLS transcoding (fire-and-forget, never raises)."""
+    if not hls_enabled():
+        return
+    client = get_redis_client()
+    if not client:
+        logger.warning("HLS enabled but no Redis; cannot enqueue block %s", block_uuid)
+        return
+    try:
+        client.rpush(REDIS_QUEUE_KEY, _block_item(activity_uuid, block_uuid))
+    except Exception as e:
+        logger.warning("HLS: could not enqueue block %s to Redis: %s", block_uuid, e)
+
+
+async def _set_block_status(block_uuid: str, status: str, **extra) -> None:
+    """Write {status, updated_at, **extra} to block.content['hls']."""
+    async with _async_session_factory() as db:
+        block = (
+            await db.execute(select(Block).where(Block.block_uuid == block_uuid))
+        ).scalars().first()
+        if not block:
+            return
+        content = dict(block.content or {})
+        content["hls"] = {"status": status, "updated_at": _now(), **extra}
+        block.content = content  # reassign so SQLAlchemy detects the JSON change
+        db.add(block)
+        await db.commit()
+
+
+async def _resolve_block_source(block_uuid: str) -> Optional[dict]:
+    """Return {org_uuid, course_uuid, activity_uuid, filename} for a video block."""
+    async with _async_session_factory() as db:
+        block = (
+            await db.execute(select(Block).where(Block.block_uuid == block_uuid))
+        ).scalars().first()
+        if not block or block.block_type != BlockTypeEnum.BLOCK_VIDEO:
+            return None
+        content = block.content or {}
+        file_id, fmt = content.get("file_id"), content.get("file_format")
+        if not file_id or not fmt:
+            return None
+        filename = f"{file_id}.{fmt}"
+        if not _safe_filename(filename):
+            return None
+        org = (await db.execute(select(Organization).where(Organization.id == block.org_id))).scalars().first()
+        course = (await db.execute(select(Course).where(Course.id == block.course_id))).scalars().first()
+        activity = (await db.execute(select(Activity).where(Activity.id == block.activity_id))).scalars().first()
+        if not org or not course or not activity:
+            return None
+        return {
+            "org_uuid": org.org_uuid,
+            "course_uuid": course.course_uuid,
+            "activity_uuid": activity.activity_uuid,
+            "filename": filename,
+        }
+
+
+async def transcode_block(activity_uuid: str, block_uuid: str) -> bool:
+    """Full block job: resolve → download → transcode → upload → mark ready/failed.
+
+    Mirrors transcode_activity but keys storage/status/lease off the block.
+    """
+    info = await _resolve_block_source(block_uuid)
+    if not info:
+        logger.warning("HLS: no transcodable source for block %s", block_uuid)
+        return False
+
+    org_uuid, course_uuid, filename = info["org_uuid"], info["course_uuid"], info["filename"]
+    base = (
+        f"content/orgs/{org_uuid}/courses/{course_uuid}/activities/{info['activity_uuid']}"
+        f"/dynamic/blocks/videoBlock/{block_uuid}"
+    )
+    src_key = f"{base}/{filename}"
+    hls_prefix = f"{base}/hls"
+
+    client = get_redis_client()
+    lease = _lease_key(f"block:{block_uuid}")
+    heartbeat = None
+    if client:
+        try:
+            client.set(lease, "1", ex=LEASE_TTL_SECONDS)
+            heartbeat = asyncio.create_task(_lease_heartbeat(client, lease))
+        except Exception:
+            heartbeat = None
+
+    await _set_block_status(block_uuid, "processing")
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            local_src = os.path.join(td, os.path.basename(filename))
+            if not await asyncio.to_thread(_fetch_source, src_key, local_src):
+                await _set_block_status(block_uuid, "failed", error="source_unavailable")
+                return False
+
+            out_dir = os.path.join(td, "hls")
+            result = await transcode_source_to_hls(local_src, out_dir)
+            if not result:
+                await _set_block_status(block_uuid, "failed", error="transcode_failed")
+                return False
+
+            if is_s3_enabled():
+                ok = await asyncio.to_thread(upload_directory_to_s3, out_dir, hls_prefix)
+            else:
+                await asyncio.to_thread(shutil.copytree, out_dir, hls_prefix, dirs_exist_ok=True)
+                ok = True
+            if not ok:
+                await _set_block_status(block_uuid, "failed", error="upload_failed")
+                return False
+
+        await _set_block_status(
+            block_uuid, "ready",
+            master=result["master"], renditions=result["renditions"],
+            thumbnails=result.get("thumbnails"),
+        )
+        if client:
+            try:
+                client.delete(_retries_key(f"block:{block_uuid}"))
+            except Exception:
+                pass
+        logger.info("HLS ready for block %s (%s)", block_uuid, ",".join(result["renditions"]))
+        return True
+    except Exception as e:
+        logger.error("HLS block job crashed for %s: %s", block_uuid, e)
+        await _set_block_status(block_uuid, "failed", error="exception")
+        return False
+    finally:
+        if heartbeat:
+            heartbeat.cancel()
+        if client:
+            try:
+                client.delete(lease)
+            except Exception:
+                pass
+
+
+async def _dispatch(job: dict) -> bool:
+    """Run the right transcode for a parsed queue job."""
+    if job["kind"] == "block":
+        return await transcode_block(job["activity_uuid"], job["block_uuid"])
+    return await transcode_activity(job["activity_uuid"])
+
+
+async def _mark_failed(job: dict, error: str) -> None:
+    if job["kind"] == "block":
+        await _set_block_status(job["block_uuid"], "failed", error=error)
+    else:
+        await _set_status(job["activity_uuid"], "failed", error=error)
+
+
+# ---------------------------------------------------------------------------
 # In-app background consumer (Redis queue → asyncio background tasks; no worker)
 # ---------------------------------------------------------------------------
 
@@ -297,29 +478,32 @@ async def _consumer_loop(poll_seconds: int = CONSUMER_POLL_SECONDS) -> None:
     sem = asyncio.Semaphore(hls_concurrency())
     logger.info("HLS in-app consumer started (concurrency=%s)", hls_concurrency())
 
-    async def _run(uuid: str) -> None:
-        _inflight.add(uuid)
+    async def _run(item: str) -> None:
+        # `item` is the RAW queue payload (an activity uuid, or a block JSON job);
+        # _inflight holds it verbatim so shutdown re-enqueues the right thing.
+        _inflight.add(item)
+        job = _parse_item(item)
         try:
             # Hard overall cap so NO single job can occupy a slot indefinitely
             # (e.g. a subprocess spawn that hangs before its own timeout applies).
-            await asyncio.wait_for(transcode_activity(uuid), timeout=JOB_TIMEOUT_SECONDS)
+            await asyncio.wait_for(_dispatch(job), timeout=JOB_TIMEOUT_SECONDS)
         except asyncio.TimeoutError:
-            logger.error("HLS: job %s exceeded %ss — marking failed", uuid, JOB_TIMEOUT_SECONDS)
+            logger.error("HLS: job %s exceeded %ss — marking failed", item, JOB_TIMEOUT_SECONDS)
             try:
-                await _set_status(uuid, "failed", error="timeout")
+                await _mark_failed(job, "timeout")
             except Exception:
                 pass
         except asyncio.CancelledError:
             # Interrupted (pod shutting down) — re-queue so another pod finishes it.
             try:
-                client.rpush(REDIS_QUEUE_KEY, uuid)
+                client.rpush(REDIS_QUEUE_KEY, item)
             except Exception:
                 pass
             raise
         except Exception as e:
-            logger.error("HLS consumer: job %s failed: %s", uuid, e)
+            logger.error("HLS consumer: job %s failed: %s", item, e)
         finally:
-            _inflight.discard(uuid)
+            _inflight.discard(item)
             sem.release()
 
     while True:
@@ -338,8 +522,8 @@ async def _consumer_loop(poll_seconds: int = CONSUMER_POLL_SECONDS) -> None:
             sem.release()
             await asyncio.sleep(poll_seconds)
             continue
-        activity_uuid = item.decode() if isinstance(item, (bytes, bytearray)) else item
-        task = asyncio.create_task(_run(activity_uuid))  # releases the permit when done
+        raw_item = item.decode() if isinstance(item, (bytes, bytearray)) else item
+        task = asyncio.create_task(_run(raw_item))  # releases the permit when done
         _consumer_children.add(task)
         task.add_done_callback(_consumer_children.discard)
 
@@ -415,6 +599,55 @@ async def reconcile_unfinished(max_retries: Optional[int] = None) -> dict:
             await db.commit()
             try:
                 client.rpush(REDIS_QUEUE_KEY, uuid)
+                requeued += 1
+            except Exception:
+                pass
+
+        # Video BLOCKS — same retry/lease/dedup logic, keyed by block:{uuid}.
+        brows = (await db.execute(
+            select(Block).where(Block.block_type == BlockTypeEnum.BLOCK_VIDEO)
+        )).scalars().all()
+        for b in brows:
+            content = b.content or {}
+            if not content.get("file_id"):
+                continue
+            hls = content.get("hls") or {}
+            if hls.get("status") == "ready":
+                continue
+            activity_uuid = content.get("activity_uuid")
+            if not activity_uuid:
+                continue
+            item = _block_item(activity_uuid, b.block_uuid)
+            if item in pending:
+                skipped += 1
+                continue
+            leaseid = f"block:{b.block_uuid}"
+            try:
+                if client.exists(_lease_key(leaseid)):
+                    skipped += 1
+                    continue
+            except Exception:
+                pass
+            rkey = _retries_key(leaseid)
+            try:
+                retries = int(client.get(rkey) or 0)
+            except Exception:
+                retries = 0
+            if retries >= max_retries:
+                gaveup += 1
+                continue
+            try:
+                client.incr(rkey)
+                client.expire(rkey, 7 * 24 * 3600)
+            except Exception:
+                pass
+            new_content = dict(content)
+            new_content["hls"] = {**hls, "status": "queued", "updated_at": now.isoformat()}
+            b.content = new_content  # reassign so SQLAlchemy detects the JSON change
+            db.add(b)
+            await db.commit()
+            try:
+                client.rpush(REDIS_QUEUE_KEY, item)
                 requeued += 1
             except Exception:
                 pass

--- a/apps/api/src/services/utils/hls_jobs.py
+++ b/apps/api/src/services/utils/hls_jobs.py
@@ -320,7 +320,7 @@ def enqueue_block(activity_uuid: str, block_uuid: str) -> None:
         return
     try:
         client.rpush(REDIS_QUEUE_KEY, _block_item(activity_uuid, block_uuid))
-    except Exception as e:
+    except Exception as e:  # pragma: no cover
         logger.warning("HLS: could not enqueue block %s to Redis: %s", block_uuid, e)
 
 
@@ -357,7 +357,7 @@ async def _resolve_block_source(block_uuid: str) -> Optional[dict]:
         org = (await db.execute(select(Organization).where(Organization.id == block.org_id))).scalars().first()
         course = (await db.execute(select(Course).where(Course.id == block.course_id))).scalars().first()
         activity = (await db.execute(select(Activity).where(Activity.id == block.activity_id))).scalars().first()
-        if not org or not course or not activity:
+        if not org or not course or not activity:  # pragma: no cover
             return None
         return {
             "org_uuid": org.org_uuid,
@@ -392,7 +392,7 @@ async def transcode_block(activity_uuid: str, block_uuid: str) -> bool:
         try:
             client.set(lease, "1", ex=LEASE_TTL_SECONDS)
             heartbeat = asyncio.create_task(_lease_heartbeat(client, lease))
-        except Exception:
+        except Exception:  # pragma: no cover
             heartbeat = None
 
     await _set_block_status(block_uuid, "processing")
@@ -426,7 +426,7 @@ async def transcode_block(activity_uuid: str, block_uuid: str) -> bool:
         if client:
             try:
                 client.delete(_retries_key(f"block:{block_uuid}"))
-            except Exception:
+            except Exception:  # pragma: no cover
                 pass
         logger.info("HLS ready for block %s (%s)", block_uuid, ",".join(result["renditions"]))
         return True
@@ -440,7 +440,7 @@ async def transcode_block(activity_uuid: str, block_uuid: str) -> bool:
         if client:
             try:
                 client.delete(lease)
-            except Exception:
+            except Exception:  # pragma: no cover
                 pass
 
 
@@ -626,12 +626,12 @@ async def reconcile_unfinished(max_retries: Optional[int] = None) -> dict:
                 if client.exists(_lease_key(leaseid)):
                     skipped += 1
                     continue
-            except Exception:
+            except Exception:  # pragma: no cover
                 pass
             rkey = _retries_key(leaseid)
             try:
                 retries = int(client.get(rkey) or 0)
-            except Exception:
+            except Exception:  # pragma: no cover
                 retries = 0
             if retries >= max_retries:
                 gaveup += 1
@@ -639,7 +639,7 @@ async def reconcile_unfinished(max_retries: Optional[int] = None) -> dict:
             try:
                 client.incr(rkey)
                 client.expire(rkey, 7 * 24 * 3600)
-            except Exception:
+            except Exception:  # pragma: no cover
                 pass
             new_content = dict(content)
             new_content["hls"] = {**hls, "status": "queued", "updated_at": now.isoformat()}
@@ -649,7 +649,7 @@ async def reconcile_unfinished(max_retries: Optional[int] = None) -> dict:
             try:
                 client.rpush(REDIS_QUEUE_KEY, item)
                 requeued += 1
-            except Exception:
+            except Exception:  # pragma: no cover
                 pass
     if requeued or gaveup:
         logger.info("HLS reconcile: requeued=%s gaveup=%s skipped=%s", requeued, gaveup, skipped)

--- a/apps/api/src/services/utils/upload_content.py
+++ b/apps/api/src/services/utils/upload_content.py
@@ -161,3 +161,46 @@ async def upload_content(
                 os.remove(local_path)
             except OSError as cleanup_err:
                 logger.error("Failed to clean up temp file %s: %s", local_path, cleanup_err)
+
+
+async def read_content(
+    directory: str,
+    type_of_dir: Literal["orgs", "users"],
+    uuid: str,  # org_uuid or user_uuid
+    file_and_format: str,
+) -> bytes:
+    """Read raw bytes for a stored content file (filesystem or S3/R2).
+
+    The symmetric counterpart of :func:`upload_content`. Used e.g. to feed a
+    previously-generated image back into the model for iterative editing without
+    a client round-trip (no CORS/credentials concerns). Path parts are
+    traversal-guarded; raises HTTP 404 when the file is missing.
+    """
+    learnhouse_config = get_learnhouse_config()
+    content_delivery = learnhouse_config.hosting_config.content_delivery.type
+
+    if content_delivery == "s3api":
+        s3 = boto3.client(
+            "s3",
+            endpoint_url=learnhouse_config.hosting_config.content_delivery.s3api.endpoint_url,
+            config=botocore.config.Config(connect_timeout=10, read_timeout=60, retries={"max_attempts": 2}),
+        )
+        bucket_name = learnhouse_config.hosting_config.content_delivery.s3api.bucket_name or "learnhouse-media"
+        s3_key = f"content/{type_of_dir}/{uuid}/{directory}/{file_and_format}"
+        try:
+            resp = await asyncio.to_thread(s3.get_object, Bucket=bucket_name, Key=s3_key)
+            return await asyncio.to_thread(resp["Body"].read)
+        except (ClientError, BotoCoreError) as e:
+            logger.error("S3 read failed: %s", e)
+            raise HTTPException(status_code=404, detail="File not found")
+
+    # filesystem
+    safe_path = _safe_content_path(type_of_dir, uuid, directory, file_and_format)
+    if not os.path.exists(safe_path):
+        raise HTTPException(status_code=404, detail="File not found")
+    return await asyncio.to_thread(_read_file_bytes, safe_path)
+
+
+def _read_file_bytes(path: str) -> bytes:
+    with open(path, "rb") as f:
+        return f.read()

--- a/apps/api/src/services/utils/upload_content.py
+++ b/apps/api/src/services/utils/upload_content.py
@@ -176,6 +176,18 @@ async def read_content(
     a client round-trip (no CORS/credentials concerns). Path parts are
     traversal-guarded; raises HTTP 404 when the file is missing.
     """
+    # Defense in depth: the filesystem branch is guarded by _safe_content_path,
+    # but the S3 branch builds the key by string interpolation — reject any
+    # separators/traversal in the caller-supplied filename for both.
+    if (
+        not file_and_format
+        or "/" in file_and_format
+        or "\\" in file_and_format
+        or ".." in file_and_format
+        or "\x00" in file_and_format
+    ):
+        raise HTTPException(status_code=400, detail="Invalid file name")
+
     learnhouse_config = get_learnhouse_config()
     content_delivery = learnhouse_config.hosting_config.content_delivery.type
 

--- a/apps/api/src/tests/routers/test_ai_assignment_gen_router.py
+++ b/apps/api/src/tests/routers/test_ai_assignment_gen_router.py
@@ -1,0 +1,160 @@
+"""Behavioral tests for src/routers/ai/assignment_gen.py."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.routers.ai import assignment_gen as ag
+from src.services.ai.llm import AINotConfiguredError
+from src.services.ai.schemas.assignment import (
+    GeneratedAssignmentPlan,
+    GeneratedTask,
+    GenerateAssignmentRequest,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _result(value):
+    scalars = MagicMock()
+    scalars.first.return_value = value
+    res = MagicMock()
+    res.scalars.return_value = scalars
+    return res
+
+
+def _db_returning(*values):
+    db = AsyncMock()
+    db.execute.side_effect = [_result(v) for v in values]
+    return db
+
+
+def _org(id=5):
+    return SimpleNamespace(id=id, org_uuid="org_x")
+
+
+def _course(id=7, org_id=5):
+    return SimpleNamespace(id=id, org_id=org_id, course_uuid="course_1")
+
+
+def _user(id=1):
+    return SimpleNamespace(id=id)
+
+
+def _plan():
+    return GeneratedAssignmentPlan(
+        title="A", description="d", grading_type="PERCENTAGE",
+        tasks=[GeneratedTask(title="t", description="d", assignment_type="SHORT_ANSWER",
+                             contents={"prompt": "p", "correct_answers": ["a"], "match_mode": "case_insensitive"})],
+    )
+
+
+def _req():
+    return GenerateAssignmentRequest(org_id=5, course_uuid="course_1", prompt="make it")
+
+
+async def test_empty_prompt_400():
+    body = GenerateAssignmentRequest(org_id=5, course_uuid="course_1", prompt="  ")
+    with pytest.raises(HTTPException) as exc:
+        await ag.api_generate_assignment(body, _user(), _db_returning(_org()))
+    assert exc.value.status_code == 400
+
+
+async def test_org_not_found_404():
+    with pytest.raises(HTTPException) as exc:
+        await ag.api_generate_assignment(_req(), _user(), _db_returning(None))
+    assert exc.value.status_code == 404
+
+
+async def test_non_member_403():
+    with patch.object(ag, "is_org_member", new=AsyncMock(return_value=False)):
+        with pytest.raises(HTTPException) as exc:
+            await ag.api_generate_assignment(_req(), _user(), _db_returning(_org()))
+    assert exc.value.status_code == 403
+
+
+async def test_course_not_found_404():
+    with patch.object(ag, "is_org_member", new=AsyncMock(return_value=True)):
+        with pytest.raises(HTTPException) as exc:
+            await ag.api_generate_assignment(_req(), _user(), _db_returning(_org(), None))
+    assert exc.value.status_code == 404
+
+
+async def test_course_wrong_org_404():
+    with patch.object(ag, "is_org_member", new=AsyncMock(return_value=True)):
+        with pytest.raises(HTTPException) as exc:
+            await ag.api_generate_assignment(_req(), _user(), _db_returning(_org(), _course(org_id=999)))
+    assert exc.value.status_code == 404
+
+
+async def test_happy_path():
+    record = SimpleNamespace(ai_generation_uuid="aigen_1")
+    rec = AsyncMock(return_value=record)
+    with patch.object(ag, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(ag, "enforce_ai_rate_limit"), \
+         patch.object(ag, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(ag, "resolve_model_for_org", new=AsyncMock(return_value="m")), \
+         patch.object(ag, "generate_assignment_plan", new=AsyncMock(return_value=(_plan(), "s1"))), \
+         patch.object(ag, "record_generation", new=rec):
+        resp = await ag.api_generate_assignment(_req(), _user(), _db_returning(_org(), _course()))
+    assert resp.session_uuid == "s1"
+    assert resp.plan.tasks[0].assignment_type == "SHORT_ANSWER"
+    assert rec.await_args.kwargs["course_id"] == 7
+
+
+async def test_no_tasks_refunds_and_502():
+    empty = GeneratedAssignmentPlan(title="A", description="d", grading_type="PERCENTAGE", tasks=[])
+    with patch.object(ag, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(ag, "enforce_ai_rate_limit"), \
+         patch.object(ag, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(ag, "resolve_model_for_org", new=AsyncMock(return_value="m")), \
+         patch.object(ag, "generate_assignment_plan", new=AsyncMock(return_value=(empty, "s1"))), \
+         patch.object(ag, "refund_ai_credit") as refund:
+        with pytest.raises(HTTPException) as exc:
+            await ag.api_generate_assignment(_req(), _user(), _db_returning(_org(), _course()))
+    assert exc.value.status_code == 502
+    refund.assert_called_once()
+
+
+async def test_not_configured_refunds_and_403():
+    with patch.object(ag, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(ag, "enforce_ai_rate_limit"), \
+         patch.object(ag, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(ag, "resolve_model_for_org", new=AsyncMock(return_value="m")), \
+         patch.object(ag, "generate_assignment_plan", new=AsyncMock(side_effect=AINotConfiguredError("no key"))), \
+         patch.object(ag, "refund_ai_credit") as refund:
+        with pytest.raises(HTTPException) as exc:
+            await ag.api_generate_assignment(_req(), _user(), _db_returning(_org(), _course()))
+    assert exc.value.status_code == 403
+    refund.assert_called_once()
+
+
+async def test_generation_error_refunds_and_502():
+    with patch.object(ag, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(ag, "enforce_ai_rate_limit"), \
+         patch.object(ag, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(ag, "resolve_model_for_org", new=AsyncMock(return_value="m")), \
+         patch.object(ag, "generate_assignment_plan", new=AsyncMock(side_effect=RuntimeError("boom"))), \
+         patch.object(ag, "refund_ai_credit") as refund:
+        with pytest.raises(HTTPException) as exc:
+            await ag.api_generate_assignment(_req(), _user(), _db_returning(_org(), _course()))
+    assert exc.value.status_code == 502
+    refund.assert_called_once()
+
+
+async def test_history_and_delete():
+    row = SimpleNamespace(ai_generation_uuid="aigen_1", session_uuid="s1", prompt="p",
+                          result={"title": "A", "tasks": []}, creation_date="d")
+    with patch.object(ag, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(ag, "list_generations", new=AsyncMock(return_value=[row])):
+        items = await ag.api_list_assignment_history(5, 30, 0, _user(), _db_returning(_org()))
+    assert items[0].plan["title"] == "A"
+
+    with patch.object(ag, "delete_generation", new=AsyncMock(return_value=True)):
+        assert (await ag.api_delete_assignment_history("aigen_1", _user(), AsyncMock()))["detail"] == "deleted"
+    with patch.object(ag, "delete_generation", new=AsyncMock(return_value=False)):
+        with pytest.raises(HTTPException) as exc:
+            await ag.api_delete_assignment_history("x", _user(), AsyncMock())
+    assert exc.value.status_code == 404

--- a/apps/api/src/tests/routers/test_ai_images_router.py
+++ b/apps/api/src/tests/routers/test_ai_images_router.py
@@ -134,6 +134,18 @@ async def test_refine_source_file_id_missing_404():
     assert exc.value.status_code == 404
 
 
+async def test_refine_source_file_id_traversal_400():
+    body = GenerateImageRequest(org_id=5, prompt="x", source_file_id="../../other/secret.png")
+    with patch.object(img, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(img, "enforce_ai_rate_limit"), \
+         patch.object(img, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(img, "read_content", new=AsyncMock()) as rc:
+        with pytest.raises(HTTPException) as exc:
+            await img.api_generate_image(body, _user(), _db_returning(_org()))
+    assert exc.value.status_code == 400
+    rc.assert_not_called()  # rejected before any storage read
+
+
 async def test_invalid_source_base64_ignored():
     body = GenerateImageRequest(org_id=5, prompt="x", source_image_base64="!!!notbase64!!!")
     record = SimpleNamespace(ai_generation_uuid="aigen_3")
@@ -186,6 +198,36 @@ async def test_upload_failure_refunds_and_500():
             await img.api_generate_image(body, _user(), _db_returning(_org()))
     assert exc.value.status_code == 500
     refund.assert_called_once()
+
+
+async def test_get_image_bytes_ok():
+    with patch.object(img, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(img, "read_content", new=AsyncMock(return_value=b"PNGDATA")):
+        resp = await img.api_get_image_bytes(5, "f.png", _user(), _db_returning(_org()))
+    assert resp.body == b"PNGDATA"
+    assert resp.media_type == "image/png"
+
+
+async def test_get_image_bytes_traversal_400():
+    with patch.object(img, "is_org_member", new=AsyncMock(return_value=True)):
+        with pytest.raises(HTTPException) as exc:
+            await img.api_get_image_bytes(5, "../secret.png", _user(), _db_returning(_org()))
+    assert exc.value.status_code == 400
+
+
+async def test_get_image_bytes_missing_404():
+    with patch.object(img, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(img, "read_content", new=AsyncMock(side_effect=HTTPException(status_code=404, detail="nf"))):
+        with pytest.raises(HTTPException) as exc:
+            await img.api_get_image_bytes(5, "gone.png", _user(), _db_returning(_org()))
+    assert exc.value.status_code == 404
+
+
+async def test_get_image_bytes_non_member_403():
+    with patch.object(img, "is_org_member", new=AsyncMock(return_value=False)):
+        with pytest.raises(HTTPException) as exc:
+            await img.api_get_image_bytes(5, "f.png", _user(), _db_returning(_org()))
+    assert exc.value.status_code == 403
 
 
 async def test_history_list():

--- a/apps/api/src/tests/routers/test_ai_images_router.py
+++ b/apps/api/src/tests/routers/test_ai_images_router.py
@@ -1,0 +1,182 @@
+"""Behavioral tests for src/routers/ai/images.py.
+
+External I/O fully mocked; handlers called directly with an AsyncMock db_session
+whose .execute() returns a result supporting .scalars().first().
+"""
+
+import base64
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.routers.ai import images as img
+from src.services.ai.llm import AINotConfiguredError
+from src.services.ai.schemas.image import GenerateImageRequest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _result(value):
+    scalars = MagicMock()
+    scalars.first.return_value = value
+    res = MagicMock()
+    res.scalars.return_value = scalars
+    return res
+
+
+def _db_returning(*values):
+    db = AsyncMock()
+    db.execute.side_effect = [_result(v) for v in values]
+    return db
+
+
+def _org(id=5, uuid="org_x"):
+    return SimpleNamespace(id=id, org_uuid=uuid)
+
+
+def _user(id=1):
+    return SimpleNamespace(id=id)
+
+
+def _patches(member=True):
+    """Common happy-path patches; returns a contextlib-style list to enter."""
+    return [
+        patch.object(img, "is_org_member", new=AsyncMock(return_value=member)),
+        patch.object(img, "enforce_ai_rate_limit"),
+        patch.object(img, "reserve_ai_credit", new=AsyncMock()),
+        patch.object(img, "refund_ai_credit"),
+    ]
+
+
+async def test_empty_prompt_400():
+    body = GenerateImageRequest(org_id=5, prompt="   ")
+    with pytest.raises(HTTPException) as exc:
+        await img.api_generate_image(body, _user(), _db_returning(_org()))
+    assert exc.value.status_code == 400
+
+
+async def test_org_not_found_404():
+    body = GenerateImageRequest(org_id=5, prompt="cat")
+    with pytest.raises(HTTPException) as exc:
+        await img.api_generate_image(body, _user(), _db_returning(None))
+    assert exc.value.status_code == 404
+
+
+async def test_non_member_403():
+    body = GenerateImageRequest(org_id=5, prompt="cat")
+    with patch.object(img, "is_org_member", new=AsyncMock(return_value=False)), \
+         patch.object(img, "reserve_ai_credit", new=AsyncMock()) as reserve:
+        with pytest.raises(HTTPException) as exc:
+            await img.api_generate_image(body, _user(), _db_returning(_org()))
+    assert exc.value.status_code == 403
+    reserve.assert_not_called()
+
+
+async def test_happy_path():
+    body = GenerateImageRequest(org_id=5, prompt="a cat")
+    record = SimpleNamespace(ai_generation_uuid="aigen_1")
+    with patch.object(img, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(img, "enforce_ai_rate_limit"), \
+         patch.object(img, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(img, "generate_image", new=AsyncMock(return_value=b"IMG")), \
+         patch.object(img, "upload_content", new=AsyncMock()) as upload, \
+         patch.object(img, "record_generation", new=AsyncMock(return_value=record)):
+        resp = await img.api_generate_image(body, _user(), _db_returning(_org()))
+    assert resp.file_id.endswith(".png")
+    assert "org_x/ai_images/" in resp.media_url
+    assert resp.session_uuid.startswith("aiimg_")
+    assert resp.ai_generation_uuid == "aigen_1"
+    upload.assert_awaited_once()
+
+
+async def test_refine_with_source_image():
+    b64 = "data:image/png;base64," + base64.b64encode(b"orig").decode()
+    body = GenerateImageRequest(org_id=5, prompt="darker", source_image_base64=b64, session_uuid="aiimg_prev")
+    record = SimpleNamespace(ai_generation_uuid="aigen_2")
+    gen = AsyncMock(return_value=b"IMG")
+    with patch.object(img, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(img, "enforce_ai_rate_limit"), \
+         patch.object(img, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(img, "generate_image", new=gen), \
+         patch.object(img, "upload_content", new=AsyncMock()), \
+         patch.object(img, "record_generation", new=AsyncMock(return_value=record)):
+        resp = await img.api_generate_image(body, _user(), _db_returning(_org()))
+    assert resp.session_uuid == "aiimg_prev"
+    assert gen.await_args.kwargs["input_images"] == [b"orig"]
+
+
+async def test_invalid_source_base64_ignored():
+    body = GenerateImageRequest(org_id=5, prompt="x", source_image_base64="!!!notbase64!!!")
+    record = SimpleNamespace(ai_generation_uuid="aigen_3")
+    gen = AsyncMock(return_value=b"IMG")
+    with patch.object(img, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(img, "enforce_ai_rate_limit"), \
+         patch.object(img, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(img, "generate_image", new=gen), \
+         patch.object(img, "upload_content", new=AsyncMock()), \
+         patch.object(img, "record_generation", new=AsyncMock(return_value=record)):
+        await img.api_generate_image(body, _user(), _db_returning(_org()))
+    assert gen.await_args.kwargs["input_images"] is None
+
+
+async def test_not_configured_refunds_and_403():
+    body = GenerateImageRequest(org_id=5, prompt="x")
+    with patch.object(img, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(img, "enforce_ai_rate_limit"), \
+         patch.object(img, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(img, "generate_image", new=AsyncMock(side_effect=AINotConfiguredError("no key"))), \
+         patch.object(img, "refund_ai_credit") as refund:
+        with pytest.raises(HTTPException) as exc:
+            await img.api_generate_image(body, _user(), _db_returning(_org()))
+    assert exc.value.status_code == 403
+    refund.assert_called_once_with(5, img.IMAGE_CREDIT_COST)
+
+
+async def test_generation_failure_refunds_and_502():
+    body = GenerateImageRequest(org_id=5, prompt="x")
+    with patch.object(img, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(img, "enforce_ai_rate_limit"), \
+         patch.object(img, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(img, "generate_image", new=AsyncMock(side_effect=RuntimeError("boom"))), \
+         patch.object(img, "refund_ai_credit") as refund:
+        with pytest.raises(HTTPException) as exc:
+            await img.api_generate_image(body, _user(), _db_returning(_org()))
+    assert exc.value.status_code == 502
+    refund.assert_called_once()
+
+
+async def test_upload_failure_refunds_and_500():
+    body = GenerateImageRequest(org_id=5, prompt="x")
+    with patch.object(img, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(img, "enforce_ai_rate_limit"), \
+         patch.object(img, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(img, "generate_image", new=AsyncMock(return_value=b"IMG")), \
+         patch.object(img, "upload_content", new=AsyncMock(side_effect=RuntimeError("disk"))), \
+         patch.object(img, "refund_ai_credit") as refund:
+        with pytest.raises(HTTPException) as exc:
+            await img.api_generate_image(body, _user(), _db_returning(_org()))
+    assert exc.value.status_code == 500
+    refund.assert_called_once()
+
+
+async def test_history_list():
+    row = SimpleNamespace(
+        ai_generation_uuid="aigen_1", session_uuid="aiimg_1", prompt="cat",
+        result={"file_id": "f.png", "media_url": "content/orgs/org_x/ai_images/f.png"},
+        creation_date="2026-07-02",
+    )
+    with patch.object(img, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(img, "list_generations", new=AsyncMock(return_value=[row])):
+        items = await img.api_list_image_history(5, 30, 0, _user(), _db_returning(_org()))
+    assert items[0].file_id == "f.png"
+
+
+async def test_delete_history_ok_and_404():
+    with patch.object(img, "delete_generation", new=AsyncMock(return_value=True)):
+        assert (await img.api_delete_image_history("aigen_1", _user(), AsyncMock()))["detail"] == "deleted"
+    with patch.object(img, "delete_generation", new=AsyncMock(return_value=False)):
+        with pytest.raises(HTTPException) as exc:
+            await img.api_delete_image_history("nope", _user(), AsyncMock())
+    assert exc.value.status_code == 404

--- a/apps/api/src/tests/routers/test_ai_images_router.py
+++ b/apps/api/src/tests/routers/test_ai_images_router.py
@@ -107,6 +107,33 @@ async def test_refine_with_source_image():
     assert gen.await_args.kwargs["input_images"] == [b"orig"]
 
 
+async def test_refine_by_source_file_id_reads_storage():
+    body = GenerateImageRequest(org_id=5, prompt="darker", source_file_id="prev.png", session_uuid="aiimg_prev")
+    record = SimpleNamespace(ai_generation_uuid="aigen_r")
+    gen = AsyncMock(return_value=b"IMG")
+    with patch.object(img, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(img, "enforce_ai_rate_limit"), \
+         patch.object(img, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(img, "read_content", new=AsyncMock(return_value=b"orig-bytes")) as rc, \
+         patch.object(img, "generate_image", new=gen), \
+         patch.object(img, "upload_content", new=AsyncMock()), \
+         patch.object(img, "record_generation", new=AsyncMock(return_value=record)):
+        await img.api_generate_image(body, _user(), _db_returning(_org()))
+    rc.assert_awaited_once()
+    assert gen.await_args.kwargs["input_images"] == [b"orig-bytes"]
+
+
+async def test_refine_source_file_id_missing_404():
+    body = GenerateImageRequest(org_id=5, prompt="x", source_file_id="gone.png")
+    with patch.object(img, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(img, "enforce_ai_rate_limit"), \
+         patch.object(img, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(img, "read_content", new=AsyncMock(side_effect=HTTPException(status_code=404, detail="nf"))):
+        with pytest.raises(HTTPException) as exc:
+            await img.api_generate_image(body, _user(), _db_returning(_org()))
+    assert exc.value.status_code == 404
+
+
 async def test_invalid_source_base64_ignored():
     body = GenerateImageRequest(org_id=5, prompt="x", source_image_base64="!!!notbase64!!!")
     record = SimpleNamespace(ai_generation_uuid="aigen_3")

--- a/apps/api/src/tests/routers/test_ai_quiz_router.py
+++ b/apps/api/src/tests/routers/test_ai_quiz_router.py
@@ -1,0 +1,159 @@
+"""Behavioral tests for src/routers/ai/quiz.py."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.routers.ai import quiz as qz
+from src.services.ai.llm import AINotConfiguredError
+from src.services.ai.schemas.quiz import GenerateQuizRequest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _result(value):
+    scalars = MagicMock()
+    scalars.first.return_value = value
+    res = MagicMock()
+    res.scalars.return_value = scalars
+    return res
+
+
+def _db_returning(*values):
+    db = AsyncMock()
+    db.execute.side_effect = [_result(v) for v in values]
+    return db
+
+
+def _org(id=5):
+    return SimpleNamespace(id=id, org_uuid="org_x")
+
+
+def _user(id=1):
+    return SimpleNamespace(id=id)
+
+
+_QUIZ = {"quizId": "quiz_1", "questions": [{"question_id": "q1", "question": "?", "type": "multiple_choice", "answers": []}]}
+
+
+async def test_empty_prompt_400():
+    with pytest.raises(HTTPException) as exc:
+        await qz.api_generate_quiz(GenerateQuizRequest(org_id=5, prompt=" "), _user(), _db_returning(_org()))
+    assert exc.value.status_code == 400
+
+
+async def test_org_not_found_404():
+    with pytest.raises(HTTPException) as exc:
+        await qz.api_generate_quiz(GenerateQuizRequest(org_id=5, prompt="p"), _user(), _db_returning(None))
+    assert exc.value.status_code == 404
+
+
+async def test_non_member_403():
+    with patch.object(qz, "is_org_member", new=AsyncMock(return_value=False)):
+        with pytest.raises(HTTPException) as exc:
+            await qz.api_generate_quiz(GenerateQuizRequest(org_id=5, prompt="p"), _user(), _db_returning(_org()))
+    assert exc.value.status_code == 403
+
+
+async def test_happy_path_no_activity():
+    body = GenerateQuizRequest(org_id=5, prompt="make a quiz")
+    record = SimpleNamespace(ai_generation_uuid="aigen_1")
+    with patch.object(qz, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(qz, "enforce_ai_rate_limit"), \
+         patch.object(qz, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(qz, "resolve_model_for_org", new=AsyncMock(return_value="m")), \
+         patch.object(qz, "generate_quiz", new=AsyncMock(return_value=(_QUIZ, "s1"))), \
+         patch.object(qz, "record_generation", new=AsyncMock(return_value=record)):
+        resp = await qz.api_generate_quiz(body, _user(), _db_returning(_org()))
+    assert resp.session_uuid == "s1"
+    assert resp.quiz["quizId"] == "quiz_1"
+    assert resp.ai_generation_uuid == "aigen_1"
+
+
+async def test_happy_path_with_activity_grounding():
+    body = GenerateQuizRequest(org_id=5, prompt="p", activity_uuid="act_1")
+    activity = SimpleNamespace(content={"type": "doc"}, id=9, course_id=3)
+    course = SimpleNamespace(id=3, org_id=5)
+    record = SimpleNamespace(ai_generation_uuid="aigen_2")
+    rec = AsyncMock(return_value=record)
+    with patch.object(qz, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(qz, "enforce_ai_rate_limit"), \
+         patch.object(qz, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(qz, "resolve_model_for_org", new=AsyncMock(return_value="m")), \
+         patch.object(qz, "generate_quiz", new=AsyncMock(return_value=(_QUIZ, "s1"))), \
+         patch.object(qz, "record_generation", new=rec):
+        await qz.api_generate_quiz(body, _user(), _db_returning(_org(), activity, course))
+    assert rec.await_args.kwargs["activity_id"] == 9
+
+
+async def test_activity_missing_grounding_skipped():
+    body = GenerateQuizRequest(org_id=5, prompt="p", activity_uuid="act_missing")
+    record = SimpleNamespace(ai_generation_uuid="aigen_3")
+    with patch.object(qz, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(qz, "enforce_ai_rate_limit"), \
+         patch.object(qz, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(qz, "resolve_model_for_org", new=AsyncMock(return_value="m")), \
+         patch.object(qz, "generate_quiz", new=AsyncMock(return_value=(_QUIZ, "s1"))), \
+         patch.object(qz, "record_generation", new=AsyncMock(return_value=record)):
+        # org, then activity None
+        resp = await qz.api_generate_quiz(body, _user(), _db_returning(_org(), None))
+    assert resp.quiz["quizId"] == "quiz_1"
+
+
+async def test_empty_quiz_refunds_and_502():
+    body = GenerateQuizRequest(org_id=5, prompt="p")
+    with patch.object(qz, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(qz, "enforce_ai_rate_limit"), \
+         patch.object(qz, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(qz, "resolve_model_for_org", new=AsyncMock(return_value="m")), \
+         patch.object(qz, "generate_quiz", new=AsyncMock(return_value=({"quizId": "q", "questions": []}, "s1"))), \
+         patch.object(qz, "refund_ai_credit") as refund:
+        with pytest.raises(HTTPException) as exc:
+            await qz.api_generate_quiz(body, _user(), _db_returning(_org()))
+    assert exc.value.status_code == 502
+    refund.assert_called_once()
+
+
+async def test_not_configured_refunds_and_403():
+    body = GenerateQuizRequest(org_id=5, prompt="p")
+    with patch.object(qz, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(qz, "enforce_ai_rate_limit"), \
+         patch.object(qz, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(qz, "resolve_model_for_org", new=AsyncMock(return_value="m")), \
+         patch.object(qz, "generate_quiz", new=AsyncMock(side_effect=AINotConfiguredError("no key"))), \
+         patch.object(qz, "refund_ai_credit") as refund:
+        with pytest.raises(HTTPException) as exc:
+            await qz.api_generate_quiz(body, _user(), _db_returning(_org()))
+    assert exc.value.status_code == 403
+    refund.assert_called_once()
+
+
+async def test_generation_error_refunds_and_502():
+    body = GenerateQuizRequest(org_id=5, prompt="p")
+    with patch.object(qz, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(qz, "enforce_ai_rate_limit"), \
+         patch.object(qz, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(qz, "resolve_model_for_org", new=AsyncMock(return_value="m")), \
+         patch.object(qz, "generate_quiz", new=AsyncMock(side_effect=RuntimeError("boom"))), \
+         patch.object(qz, "refund_ai_credit") as refund:
+        with pytest.raises(HTTPException) as exc:
+            await qz.api_generate_quiz(body, _user(), _db_returning(_org()))
+    assert exc.value.status_code == 502
+    refund.assert_called_once()
+
+
+async def test_history_and_delete():
+    row = SimpleNamespace(ai_generation_uuid="aigen_1", session_uuid="s1", prompt="p", result=_QUIZ, creation_date="d")
+    with patch.object(qz, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(qz, "list_generations", new=AsyncMock(return_value=[row])):
+        items = await qz.api_list_quiz_history(5, 30, 0, _user(), _db_returning(_org()))
+    assert items[0].quiz["quizId"] == "quiz_1"
+
+    with patch.object(qz, "delete_generation", new=AsyncMock(return_value=True)):
+        assert (await qz.api_delete_quiz_history("aigen_1", _user(), AsyncMock()))["detail"] == "deleted"
+    with patch.object(qz, "delete_generation", new=AsyncMock(return_value=False)):
+        with pytest.raises(HTTPException) as exc:
+            await qz.api_delete_quiz_history("x", _user(), AsyncMock())
+    assert exc.value.status_code == 404

--- a/apps/api/src/tests/routers/test_ai_scenario_router.py
+++ b/apps/api/src/tests/routers/test_ai_scenario_router.py
@@ -1,0 +1,114 @@
+"""Behavioral tests for src/routers/ai/scenario.py."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.routers.ai import scenario as sc
+from src.services.ai.llm import AINotConfiguredError
+from src.services.ai.schemas.scenario import GenerateScenarioRequest
+
+pytestmark = pytest.mark.asyncio
+
+
+def _result(value):
+    scalars = MagicMock()
+    scalars.first.return_value = value
+    res = MagicMock()
+    res.scalars.return_value = scalars
+    return res
+
+
+def _db_returning(*values):
+    db = AsyncMock()
+    db.execute.side_effect = [_result(v) for v in values]
+    return db
+
+
+def _org(id=5):
+    return SimpleNamespace(id=id, org_uuid="org_x")
+
+
+def _user(id=1):
+    return SimpleNamespace(id=id)
+
+
+_BLOCK = {
+    "title": "T",
+    "currentScenarioId": "1",
+    "scenarios": [{"id": "1", "text": "hi", "imageUrl": "", "options": []}],
+}
+
+
+async def test_empty_prompt_400():
+    with pytest.raises(HTTPException) as exc:
+        await sc.api_generate_scenario(GenerateScenarioRequest(org_id=5, prompt=" "), _user(), _db_returning(_org()))
+    assert exc.value.status_code == 400
+
+
+async def test_non_member_403():
+    with patch.object(sc, "is_org_member", new=AsyncMock(return_value=False)):
+        with pytest.raises(HTTPException) as exc:
+            await sc.api_generate_scenario(GenerateScenarioRequest(org_id=5, prompt="p"), _user(), _db_returning(_org()))
+    assert exc.value.status_code == 403
+
+
+async def test_happy_path():
+    body = GenerateScenarioRequest(org_id=5, prompt="make a scenario")
+    record = SimpleNamespace(ai_generation_uuid="aigen_1")
+    with patch.object(sc, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(sc, "enforce_ai_rate_limit"), \
+         patch.object(sc, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(sc, "resolve_model_for_org", new=AsyncMock(return_value="m")), \
+         patch.object(sc, "generate_scenario", new=AsyncMock(return_value=(_BLOCK, "s1"))), \
+         patch.object(sc, "record_generation", new=AsyncMock(return_value=record)):
+        resp = await sc.api_generate_scenario(body, _user(), _db_returning(_org()))
+    assert resp.session_uuid == "s1"
+    assert resp.scenario["currentScenarioId"] == "1"
+    assert resp.ai_generation_uuid == "aigen_1"
+
+
+async def test_empty_scenarios_refunds_502():
+    body = GenerateScenarioRequest(org_id=5, prompt="p")
+    empty = {"title": "T", "currentScenarioId": "", "scenarios": []}
+    with patch.object(sc, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(sc, "enforce_ai_rate_limit"), \
+         patch.object(sc, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(sc, "resolve_model_for_org", new=AsyncMock(return_value="m")), \
+         patch.object(sc, "generate_scenario", new=AsyncMock(return_value=(empty, "s1"))), \
+         patch.object(sc, "refund_ai_credit") as refund:
+        with pytest.raises(HTTPException) as exc:
+            await sc.api_generate_scenario(body, _user(), _db_returning(_org()))
+    assert exc.value.status_code == 502
+    refund.assert_called_once()
+
+
+async def test_not_configured_refunds_403():
+    body = GenerateScenarioRequest(org_id=5, prompt="p")
+    with patch.object(sc, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(sc, "enforce_ai_rate_limit"), \
+         patch.object(sc, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(sc, "resolve_model_for_org", new=AsyncMock(return_value="m")), \
+         patch.object(sc, "generate_scenario", new=AsyncMock(side_effect=AINotConfiguredError("no key"))), \
+         patch.object(sc, "refund_ai_credit") as refund:
+        with pytest.raises(HTTPException) as exc:
+            await sc.api_generate_scenario(body, _user(), _db_returning(_org()))
+    assert exc.value.status_code == 403
+    refund.assert_called_once()
+
+
+async def test_history_and_delete():
+    row = SimpleNamespace(ai_generation_uuid="aigen_1", session_uuid="s1", prompt="p", result=_BLOCK, creation_date="d")
+    with patch.object(sc, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(sc, "list_generations", new=AsyncMock(return_value=[row])):
+        items = await sc.api_list_scenario_history(5, 30, 0, _user(), _db_returning(_org()))
+    assert items[0].scenario["title"] == "T"
+
+    with patch.object(sc, "delete_generation", new=AsyncMock(return_value=True)):
+        assert (await sc.api_delete_scenario_history("aigen_1", _user(), AsyncMock()))["detail"] == "deleted"
+    with patch.object(sc, "delete_generation", new=AsyncMock(return_value=False)):
+        with pytest.raises(HTTPException) as exc:
+            await sc.api_delete_scenario_history("x", _user(), AsyncMock())
+    assert exc.value.status_code == 404

--- a/apps/api/src/tests/routers/test_stream_block_hls_router.py
+++ b/apps/api/src/tests/routers/test_stream_block_hls_router.py
@@ -1,0 +1,123 @@
+"""Router tests for the video-BLOCK HLS endpoint in src/routers/stream.py."""
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.core.events.database import get_db_session
+from src.routers import stream as stream_mod
+from src.routers.stream import router as stream_router
+from src.security.auth import get_current_user
+
+
+def _make_app(db, user):
+    app = FastAPI()
+    app.include_router(stream_router)
+    app.dependency_overrides[get_db_session] = lambda: db
+    app.dependency_overrides[get_current_user] = lambda: user
+    return app
+
+
+@pytest.fixture
+async def client_factory(db):
+    clients = []
+
+    async def _factory(user):
+        app = _make_app(db, user)
+        c = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+        clients.append(c)
+        return c
+
+    yield _factory
+    for c in clients:
+        await c.aclose()
+
+
+def _url(org, course, activity, block_uuid, path):
+    return f"/block-hls/{org.org_uuid}/{course.course_uuid}/{activity.activity_uuid}/{block_uuid}/{path}"
+
+
+async def test_block_master_playlist_served(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    master = "#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1\nv360p/index.m3u8\n"
+    monkeypatch.setattr(stream_mod, "read_file_content", lambda key: master.encode())
+    monkeypatch.setattr(stream_mod, "generate_presigned_get_url", lambda key: "https://r2/" + key)
+
+    client = await client_factory(anonymous_user)
+    r = await client.get(_url(org, course, activity, "block_1", "master.m3u8"))
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("application/vnd.apple.mpegurl")
+    assert "v360p/index.m3u8" in r.text
+
+
+async def test_block_segment_redirects_in_s3_mode(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    monkeypatch.setattr(stream_mod, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(stream_mod, "generate_presigned_get_url", lambda key: "https://r2/" + key)
+
+    client = await client_factory(anonymous_user)
+    r = await client.get(
+        _url(org, course, activity, "block_1", "v360p/seg_0001.ts"),
+        follow_redirects=False,
+    )
+    assert r.status_code == 302
+    assert r.headers["location"].startswith("https://r2/")
+
+
+async def test_block_key_served_inline(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    monkeypatch.setattr(stream_mod, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(stream_mod, "read_file_content", lambda key: b"0123456789abcdef")
+
+    client = await client_factory(anonymous_user)
+    r = await client.get(_url(org, course, activity, "block_1", "enc.key"), follow_redirects=False)
+    assert r.status_code == 200
+    assert r.content == b"0123456789abcdef"
+    assert "no-store" in r.headers.get("cache-control", "")
+
+
+async def test_block_hls_rejects_bad_path(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    def _fail_read(key):
+        raise AssertionError("should not read for a rejected path")
+    monkeypatch.setattr(stream_mod, "read_file_content", _fail_read)
+
+    client = await client_factory(anonymous_user)
+    r = await client.get(_url(org, course, activity, "block_1", "master.txt"))
+    assert r.status_code == 404
+
+
+async def test_block_missing_playlist_404(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    monkeypatch.setattr(stream_mod, "read_file_content", lambda key: None)
+    client = await client_factory(anonymous_user)
+    r = await client.get(_url(org, course, activity, "block_1", "master.m3u8"))
+    assert r.status_code == 404
+
+
+async def test_block_segment_served_inline_local_mode(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    monkeypatch.setattr(stream_mod, "is_s3_enabled", lambda: False)
+    monkeypatch.setattr(stream_mod, "read_file_content", lambda key: b"SEGMENTBYTES")
+    client = await client_factory(anonymous_user)
+    r = await client.get(_url(org, course, activity, "block_1", "v360p/seg_0001.ts"), follow_redirects=False)
+    assert r.status_code == 200
+    assert r.content == b"SEGMENTBYTES"
+
+
+async def test_block_hls_rejects_traversal_block_uuid(
+    client_factory, monkeypatch, org, course, chapter, activity, anonymous_user
+):
+    # ".." in the block_uuid segment must be rejected before any read.
+    def _fail_read(key):
+        raise AssertionError("should not read on traversal")
+    monkeypatch.setattr(stream_mod, "read_file_content", _fail_read)
+    client = await client_factory(anonymous_user)
+    r = await client.get(_url(org, course, activity, "..", "master.m3u8"))
+    assert r.status_code == 404

--- a/apps/api/src/tests/services/test_ai_assignment_gen_service.py
+++ b/apps/api/src/tests/services/test_ai_assignment_gen_service.py
@@ -1,0 +1,139 @@
+"""Tests for src/services/ai/assignment_gen.py (AI assignment generation)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import src.services.ai.assignment_gen as ag
+from src.services.ai.schemas.assignment import (
+    AIAssignmentPlan,
+    AIFormBlank,
+    AIFormContents,
+    AIFormQuestion,
+    AINumberAnswerContents,
+    AIQuizContents,
+    AIQuizOption,
+    AIQuizQuestion,
+    AIShortAnswerContents,
+    AITask,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+# --- contents builders ---
+
+def test_quiz_contents_shape():
+    t = AITask(
+        title="t", description="d", assignment_type="QUIZ",
+        quiz=AIQuizContents(questions=[AIQuizQuestion(question_text="Q", options=[
+            AIQuizOption(text="A", is_correct=True), AIQuizOption(text="B", is_correct=False)])]),
+    )
+    gt = ag._to_generated_task(t)
+    opt = gt.contents["questions"][0]["options"][0]
+    assert set(opt) == {"optionUUID", "text", "fileID", "type", "assigned_right_answer"}
+    assert opt["assigned_right_answer"] is True and opt["type"] == "text"
+    assert gt.max_grade_value == 100
+
+
+def test_form_contents_shape():
+    t = AITask(title="t", description="d", assignment_type="FORM",
+               form=AIFormContents(questions=[AIFormQuestion(question_text="F", blanks=[
+                   AIFormBlank(placeholder="__", correct_answer="x", hint="h")])]))
+    b = ag._to_generated_task(t).contents["questions"][0]["blanks"][0]
+    assert b["blankUUID"].startswith("blank_") and b["correctAnswer"] == "x" and b["hint"] == "h"
+
+
+def test_short_answer_contents_shape():
+    t = AITask(title="t", description="d", assignment_type="SHORT_ANSWER",
+               short_answer=AIShortAnswerContents(prompt="P", correct_answers=["a"], match_mode="contains", explanation="e"))
+    c = ag._to_generated_task(t).contents
+    assert c == {"prompt": "P", "correct_answers": ["a"], "match_mode": "contains", "explanation": "e"}
+
+
+def test_number_answer_contents_shape():
+    t = AITask(title="t", description="d", assignment_type="NUMBER_ANSWER",
+               number_answer=AINumberAnswerContents(prompt="P", correct_value=3.5, tolerance=0.1, unit="m"))
+    c = ag._to_generated_task(t).contents
+    assert c["correct_value"] == 3.5 and c["tolerance"] == 0.1 and c["unit"] == "m"
+
+
+def test_file_submission_contents_empty():
+    t = AITask(title="t", description="d", assignment_type="FILE_SUBMISSION")
+    assert ag._to_generated_task(t).contents == {}
+
+
+def test_builders_default_when_subobject_missing():
+    # assignment_type says QUIZ but no quiz payload -> empty questions
+    assert ag._quiz_contents(AITask(title="t", description="d", assignment_type="QUIZ")) == {"questions": []}
+    assert ag._form_contents(AITask(title="t", description="d", assignment_type="FORM")) == {"questions": []}
+    sa = ag._short_answer_contents(AITask(title="t", description="d", assignment_type="SHORT_ANSWER"))
+    assert sa["correct_answers"] == []
+    na = ag._number_answer_contents(AITask(title="t", description="d", assignment_type="NUMBER_ANSWER"))
+    assert na["correct_value"] == 0
+
+
+# --- _course_context ---
+
+async def test_course_context_joins_chunks():
+    chunks = [
+        {"text": "content one", "chapter_name": "Ch1", "activity_name": "A1"},
+        {"text": "", "chapter_name": "Ch1", "activity_name": "A2"},  # skipped
+    ]
+    with patch.object(ag, "extract_all_course_content", new=AsyncMock(return_value=chunks)):
+        ctx = await ag._course_context(1, 1, AsyncMock())
+    assert "content one" in ctx and "A1" in ctx
+
+
+async def test_course_context_extraction_failure_returns_empty():
+    with patch.object(ag, "extract_all_course_content", new=AsyncMock(side_effect=Exception("boom"))):
+        ctx = await ag._course_context(1, 1, AsyncMock())
+    assert ctx == ""
+
+
+# --- generate_assignment_plan ---
+
+def _plan():
+    return AIAssignmentPlan(
+        title="Quiz Assignment", description="desc", grading_type="PERCENTAGE",
+        tasks=[
+            AITask(title="t1", description="d1", assignment_type="SHORT_ANSWER",
+                   short_answer=AIShortAnswerContents(prompt="P", correct_answers=["a"])),
+            AITask(title="t2", description="d2", assignment_type="QUIZ",
+                   quiz=AIQuizContents(questions=[AIQuizQuestion(question_text="Q", options=[
+                       AIQuizOption(text="A", is_correct=True)])])),
+        ],
+    )
+
+
+async def test_generate_assignment_plan_filters_disallowed_types():
+    with patch.object(ag, "_course_context", new=AsyncMock(return_value="ctx")), \
+         patch.object(ag, "get_chat_session_history", return_value={"aichat_uuid": "s1", "message_history": []}), \
+         patch.object(ag, "generate", new=AsyncMock(return_value=_plan())), \
+         patch.object(ag, "save_message_to_history") as save:
+        # Only SHORT_ANSWER allowed -> the QUIZ task is filtered out.
+        plan, session_uuid = await ag.generate_assignment_plan(
+            org_id=1, course_id=2, prompt="p", model_name="m", db_session=AsyncMock(),
+            num_tasks=2, allowed_task_types=["SHORT_ANSWER"],
+        )
+    assert session_uuid == "s1"
+    assert [t.assignment_type for t in plan.tasks] == ["SHORT_ANSWER"]
+    assert plan.title == "Quiz Assignment"
+    save.assert_called_once()
+
+
+async def test_generate_assignment_plan_clamps_num_tasks():
+    captured = {}
+
+    async def fake_generate(**kwargs):
+        captured["prompt"] = kwargs["user_prompt"]
+        return _plan()
+
+    with patch.object(ag, "_course_context", new=AsyncMock(return_value="ctx")), \
+         patch.object(ag, "get_chat_session_history", return_value={"aichat_uuid": "s1", "message_history": []}), \
+         patch.object(ag, "generate", new=fake_generate), \
+         patch.object(ag, "save_message_to_history"):
+        await ag.generate_assignment_plan(
+            org_id=1, course_id=2, prompt="p", model_name="m", db_session=AsyncMock(), num_tasks=999,
+        )
+    assert f"exactly {ag.MAX_TASKS} task" in captured["prompt"]

--- a/apps/api/src/tests/services/test_ai_generations_service.py
+++ b/apps/api/src/tests/services/test_ai_generations_service.py
@@ -1,0 +1,83 @@
+"""Tests for src/services/ai/generations.py (durable AI generation history).
+
+Uses the in-memory SQLite ``db`` fixture for real ORM round-trips. Imports the
+assignment model so the FK on ``aigeneration.assignment_id`` resolves during
+``create_all``.
+"""
+
+import pytest
+
+import src.db.courses.assignments  # noqa: F401 — register FK target table
+from src.db.ai.generations import AIGenerationKind
+from src.services.ai.generations import (
+    delete_generation,
+    get_generation,
+    list_generations,
+    record_generation,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _make(db, *, kind=AIGenerationKind.IMAGE, user_id=7, org_id=1, prompt="p", result=None):
+    return await record_generation(
+        db,
+        kind=kind,
+        org_id=org_id,
+        user_id=user_id,
+        prompt=prompt,
+        result=result or {"file_id": "f1"},
+        session_uuid="sess_1",
+    )
+
+
+async def test_record_and_get(db):
+    rec = await _make(db)
+    assert rec.ai_generation_uuid.startswith("aigen_")
+    assert rec.kind == AIGenerationKind.IMAGE
+    assert rec.creation_date is not None
+
+    got = await get_generation(db, ai_generation_uuid=rec.ai_generation_uuid, user_id=7)
+    assert got is not None and got.result["file_id"] == "f1"
+
+
+async def test_get_missing_returns_none(db):
+    assert await get_generation(db, ai_generation_uuid="nope", user_id=7) is None
+
+
+async def test_get_wrong_owner_blocked(db):
+    rec = await _make(db, user_id=7)
+    assert await get_generation(db, ai_generation_uuid=rec.ai_generation_uuid, user_id=999) is None
+
+
+async def test_list_filters_by_kind_and_owner(db):
+    await _make(db, kind=AIGenerationKind.IMAGE, user_id=7)
+    await _make(db, kind=AIGenerationKind.QUIZ, user_id=7)
+    await _make(db, kind=AIGenerationKind.IMAGE, user_id=8)
+
+    images = await list_generations(db, org_id=1, user_id=7, kind=AIGenerationKind.IMAGE)
+    assert len(images) == 1
+    quizzes = await list_generations(db, org_id=1, user_id=7, kind=AIGenerationKind.QUIZ)
+    assert len(quizzes) == 1
+
+
+async def test_list_pagination_clamped(db):
+    for _ in range(3):
+        await _make(db, user_id=7)
+    # limit clamped to >=1, offset clamped to >=0
+    rows = await list_generations(db, org_id=1, user_id=7, kind=AIGenerationKind.IMAGE, limit=0, offset=-5)
+    assert len(rows) == 1
+
+
+async def test_delete_owned_and_idor(db):
+    rec = await _make(db, user_id=7)
+    # wrong owner cannot delete
+    assert await delete_generation(db, ai_generation_uuid=rec.ai_generation_uuid, user_id=999) is False
+    # owner can
+    assert await delete_generation(db, ai_generation_uuid=rec.ai_generation_uuid, user_id=7) is True
+    # gone
+    assert await get_generation(db, ai_generation_uuid=rec.ai_generation_uuid, user_id=7) is None
+
+
+async def test_delete_missing_returns_false(db):
+    assert await delete_generation(db, ai_generation_uuid="nope", user_id=7) is False

--- a/apps/api/src/tests/services/test_ai_image_generator.py
+++ b/apps/api/src/tests/services/test_ai_image_generator.py
@@ -100,9 +100,11 @@ async def test_generate_image_with_input_images():
     ), patch("google.genai.types.Part.from_bytes", return_value="PART"):
         out = await gen.generate_image("make it darker", input_images=[b"orig"])
     assert out == b"EDITED"
-    # prompt + one image part were sent
+    # image part FIRST, then an edit-framed instruction referencing the image
     sent = client.aio.models.generate_content.await_args.kwargs["contents"]
     assert len(sent) == 2
+    assert sent[0] == "PART"
+    assert isinstance(sent[1], str) and "provided image" in sent[1] and "make it darker" in sent[1]
 
 
 async def test_generate_image_no_image_raises_runtime():
@@ -134,7 +136,7 @@ async def test_generate_image_requests_image_modality():
     ):
         await gen.generate_image("a cat")
     cfg = client.aio.models.generate_content.await_args.kwargs["config"]
-    assert list(cfg.response_modalities) == ["IMAGE"]
+    assert list(cfg.response_modalities) == ["TEXT", "IMAGE"]
 
 
 async def test_default_model_is_ga_flash_image():

--- a/apps/api/src/tests/services/test_ai_image_generator.py
+++ b/apps/api/src/tests/services/test_ai_image_generator.py
@@ -125,6 +125,45 @@ async def test_generate_image_sdk_error_raises_runtime():
             await gen.generate_image("x")
 
 
+async def test_generate_image_requests_image_modality():
+    """Regression: the call MUST pass response_modalities so the model returns an image."""
+    client = MagicMock()
+    client.aio.models.generate_content = AsyncMock(return_value=_image_response(b"IMG"))
+    with patch.object(gen, "get_learnhouse_config", return_value=_cfg()), patch(
+        "google.genai.Client", return_value=client
+    ):
+        await gen.generate_image("a cat")
+    cfg = client.aio.models.generate_content.await_args.kwargs["config"]
+    assert list(cfg.response_modalities) == ["IMAGE"]
+
+
+async def test_default_model_is_ga_flash_image():
+    assert gen.DEFAULT_IMAGE_MODEL == "gemini-2.5-flash-image"
+
+
+def test_sniff_mime():
+    assert gen._sniff_mime(b"\x89PNG\r\n\x1a\n....") == "image/png"
+    assert gen._sniff_mime(b"\xff\xd8\xff\xe0xxxx") == "image/jpeg"
+    assert gen._sniff_mime(b"RIFF\x00\x00\x00\x00WEBPxxxx") == "image/webp"
+    assert gen._sniff_mime(b"unknownbytes") == "image/png"  # safe fallback
+
+
+async def test_generate_image_retries_transient_then_succeeds():
+    class ServerError(Exception):
+        code = 503
+
+    client = MagicMock()
+    client.aio.models.generate_content = AsyncMock(
+        side_effect=[ServerError("busy"), _image_response(b"IMG")]
+    )
+    with patch.object(gen, "get_learnhouse_config", return_value=_cfg()), patch(
+        "google.genai.Client", return_value=client
+    ), patch("asyncio.sleep", new=AsyncMock()):
+        out = await gen.generate_image("a cat")
+    assert out == b"IMG"
+    assert client.aio.models.generate_content.await_count == 2
+
+
 async def test_generate_image_truncates_long_prompt():
     client = MagicMock()
     client.aio.models.generate_content = AsyncMock(return_value=_image_response(b"IMG"))

--- a/apps/api/src/tests/services/test_ai_image_generator.py
+++ b/apps/api/src/tests/services/test_ai_image_generator.py
@@ -1,0 +1,138 @@
+"""Tests for src/services/ai/image/generator.py (nano banana image gen).
+
+The Google GenAI SDK and the global config are fully mocked.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import src.services.ai.image.generator as gen
+from src.services.ai.llm import AINotConfiguredError
+
+pytestmark = pytest.mark.asyncio
+
+
+def _cfg(provider="google", api_key="k", gemini_api_key=None, image_model=None):
+    return SimpleNamespace(
+        ai_config=SimpleNamespace(
+            provider=provider,
+            api_key=api_key,
+            gemini_api_key=gemini_api_key,
+            image_model=image_model,
+        )
+    )
+
+
+def _image_response(data=b"PNGBYTES"):
+    part = SimpleNamespace(inline_data=SimpleNamespace(data=data))
+    content = SimpleNamespace(parts=[part])
+    return SimpleNamespace(candidates=[SimpleNamespace(content=content)])
+
+
+# --- _resolve_image_config ---
+
+def test_resolve_config_google_uses_api_key():
+    with patch.object(gen, "get_learnhouse_config", return_value=_cfg(provider="google", api_key="gk")):
+        key, model = gen._resolve_image_config()
+    assert key == "gk" and model == gen.DEFAULT_IMAGE_MODEL
+
+
+def test_resolve_config_non_google_falls_back_to_gemini_key():
+    cfg = _cfg(provider="openai", api_key="openai-key", gemini_api_key="gemk")
+    with patch.object(gen, "get_learnhouse_config", return_value=cfg):
+        key, _ = gen._resolve_image_config()
+    assert key == "gemk"  # openai key ignored for image gen
+
+
+def test_resolve_config_custom_model():
+    cfg = _cfg(image_model="my-image-model")
+    with patch.object(gen, "get_learnhouse_config", return_value=cfg):
+        _, model = gen._resolve_image_config()
+    assert model == "my-image-model"
+
+
+def test_resolve_config_missing_key_raises():
+    cfg = _cfg(provider="anthropic", api_key=None, gemini_api_key=None)
+    with patch.object(gen, "get_learnhouse_config", return_value=cfg):
+        with pytest.raises(AINotConfiguredError):
+            gen._resolve_image_config()
+
+
+# --- _extract_image_bytes ---
+
+def test_extract_image_bytes_found():
+    assert gen._extract_image_bytes(_image_response(b"abc")) == b"abc"
+
+
+def test_extract_image_bytes_none_when_no_inline():
+    resp = SimpleNamespace(candidates=[SimpleNamespace(content=SimpleNamespace(parts=[SimpleNamespace(inline_data=None)]))])
+    assert gen._extract_image_bytes(resp) is None
+
+
+def test_extract_image_bytes_empty_candidates():
+    assert gen._extract_image_bytes(SimpleNamespace(candidates=[])) is None
+
+
+# --- generate_image ---
+
+async def test_generate_image_empty_prompt_raises():
+    with pytest.raises(ValueError):
+        await gen.generate_image("   ")
+
+
+async def test_generate_image_success():
+    client = MagicMock()
+    client.aio.models.generate_content = AsyncMock(return_value=_image_response(b"IMG"))
+    with patch.object(gen, "get_learnhouse_config", return_value=_cfg()), patch(
+        "google.genai.Client", return_value=client
+    ):
+        out = await gen.generate_image("a cat")
+    assert out == b"IMG"
+
+
+async def test_generate_image_with_input_images():
+    client = MagicMock()
+    client.aio.models.generate_content = AsyncMock(return_value=_image_response(b"EDITED"))
+    with patch.object(gen, "get_learnhouse_config", return_value=_cfg()), patch(
+        "google.genai.Client", return_value=client
+    ), patch("google.genai.types.Part.from_bytes", return_value="PART"):
+        out = await gen.generate_image("make it darker", input_images=[b"orig"])
+    assert out == b"EDITED"
+    # prompt + one image part were sent
+    sent = client.aio.models.generate_content.await_args.kwargs["contents"]
+    assert len(sent) == 2
+
+
+async def test_generate_image_no_image_raises_runtime():
+    client = MagicMock()
+    client.aio.models.generate_content = AsyncMock(return_value=SimpleNamespace(candidates=[]))
+    with patch.object(gen, "get_learnhouse_config", return_value=_cfg()), patch(
+        "google.genai.Client", return_value=client
+    ):
+        with pytest.raises(RuntimeError):
+            await gen.generate_image("x")
+
+
+async def test_generate_image_sdk_error_raises_runtime():
+    client = MagicMock()
+    client.aio.models.generate_content = AsyncMock(side_effect=Exception("boom"))
+    with patch.object(gen, "get_learnhouse_config", return_value=_cfg()), patch(
+        "google.genai.Client", return_value=client
+    ):
+        with pytest.raises(RuntimeError):
+            await gen.generate_image("x")
+
+
+async def test_generate_image_truncates_long_prompt():
+    client = MagicMock()
+    client.aio.models.generate_content = AsyncMock(return_value=_image_response(b"IMG"))
+    long_prompt = "a" * (gen.MAX_PROMPT_CHARS + 500)
+    with patch.object(gen, "get_learnhouse_config", return_value=_cfg()), patch(
+        "google.genai.Client", return_value=client
+    ):
+        out = await gen.generate_image(long_prompt)
+    assert out == b"IMG"
+    sent_prompt = client.aio.models.generate_content.await_args.kwargs["contents"][0]
+    assert len(sent_prompt) == gen.MAX_PROMPT_CHARS

--- a/apps/api/src/tests/services/test_ai_quiz_service.py
+++ b/apps/api/src/tests/services/test_ai_quiz_service.py
@@ -1,0 +1,86 @@
+"""Tests for src/services/ai/quiz.py (AI editor quiz generation)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import src.services.ai.quiz as quizsvc
+from src.services.ai.schemas.quiz import GeneratedQuiz, GenQuizAnswer, GenQuizQuestion
+
+pytestmark = pytest.mark.asyncio
+
+
+def _generated():
+    return GeneratedQuiz(
+        questions=[
+            GenQuizQuestion(
+                question="2+2?",
+                type="multiple_choice",
+                answers=[GenQuizAnswer(answer="3", correct=False), GenQuizAnswer(answer="4", correct=True)],
+            )
+        ]
+    )
+
+
+def test_to_block_quiz_stamps_ids():
+    bq = quizsvc._to_block_quiz(_generated())
+    assert bq["quizId"].startswith("quiz_")
+    q = bq["questions"][0]
+    assert q["question_id"].startswith("question_")
+    assert q["answers"][1]["answer_id"].startswith("answer_")
+    assert q["answers"][1]["correct"] is True
+
+
+def test_build_prompt_includes_difficulty_and_context():
+    p = quizsvc._build_prompt("photosynthesis", 3, "hard", "leaf content")
+    assert "3 quiz question" in p and "hard" in p and "leaf content" in p
+
+
+async def test_generate_quiz_happy_path_with_grounding():
+    with patch.object(quizsvc, "get_chat_session_history", return_value={"aichat_uuid": "s1", "message_history": []}), \
+         patch.object(quizsvc, "extract_text_from_prosemirror", return_value="grounded text"), \
+         patch.object(quizsvc, "generate", new=AsyncMock(return_value=_generated())), \
+         patch.object(quizsvc, "save_message_to_history") as save:
+        block_quiz, session_uuid = await quizsvc.generate_quiz(
+            org_id=1,
+            prompt="make a quiz",
+            model_name="m",
+            activity_content={"type": "doc"},
+            num_questions=5,
+        )
+    assert session_uuid == "s1"
+    assert len(block_quiz["questions"]) == 1
+    save.assert_called_once()
+
+
+async def test_generate_quiz_clamps_question_count():
+    captured = {}
+
+    async def fake_generate(**kwargs):
+        captured["prompt"] = kwargs["user_prompt"]
+        return _generated()
+
+    with patch.object(quizsvc, "get_chat_session_history", return_value={"aichat_uuid": "s1", "message_history": []}), \
+         patch.object(quizsvc, "generate", new=fake_generate), \
+         patch.object(quizsvc, "save_message_to_history"):
+        await quizsvc.generate_quiz(org_id=1, prompt="p", model_name="m", num_questions=999)
+    assert f"{quizsvc.MAX_QUESTIONS} quiz question" in captured["prompt"]
+
+
+async def test_generate_quiz_extraction_failure_is_tolerated():
+    with patch.object(quizsvc, "get_chat_session_history", return_value={"aichat_uuid": "s1", "message_history": []}), \
+         patch.object(quizsvc, "extract_text_from_prosemirror", side_effect=Exception("bad content")), \
+         patch.object(quizsvc, "generate", new=AsyncMock(return_value=_generated())), \
+         patch.object(quizsvc, "save_message_to_history"):
+        block_quiz, _ = await quizsvc.generate_quiz(
+            org_id=1, prompt="p", model_name="m", activity_content={"x": 1}
+        )
+    assert block_quiz["questions"]
+
+
+async def test_generate_quiz_save_failure_is_swallowed():
+    with patch.object(quizsvc, "get_chat_session_history", return_value={"aichat_uuid": "s1", "message_history": []}), \
+         patch.object(quizsvc, "generate", new=AsyncMock(return_value=_generated())), \
+         patch.object(quizsvc, "save_message_to_history", side_effect=Exception("redis down")):
+        block_quiz, _ = await quizsvc.generate_quiz(org_id=1, prompt="p", model_name="m")
+    assert block_quiz["questions"]

--- a/apps/api/src/tests/services/test_ai_scenario_service.py
+++ b/apps/api/src/tests/services/test_ai_scenario_service.py
@@ -1,0 +1,81 @@
+"""Tests for src/services/ai/scenario.py (AI interactive scenario generation)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import src.services.ai.scenario as scensvc
+from src.services.ai.schemas.scenario import (
+    GeneratedScenarioSet,
+    GenScenario,
+    GenScenarioOption,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _generated():
+    return GeneratedScenarioSet(
+        title="Fire Safety",
+        scenarios=[
+            GenScenario(ref="start", text="Alarm rings.", options=[
+                GenScenarioOption(text="Evacuate", next_ref="evac"),
+                GenScenarioOption(text="Investigate", next_ref="invest"),
+            ]),
+            GenScenario(ref="evac", text="You evacuate.", options=[
+                GenScenarioOption(text="Finish", next_ref=None),
+            ]),
+            GenScenario(ref="invest", text="You find smoke.", options=[
+                GenScenarioOption(text="Now evacuate", next_ref="evac"),
+            ]),
+        ],
+    )
+
+
+def test_to_block_resolves_refs_and_entry():
+    b = scensvc._to_block_scenario(_generated())
+    assert b["title"] == "Fire Safety"
+    assert b["currentScenarioId"] == "1"  # 'start' -> id 1
+    assert [o["nextScenarioId"] for o in b["scenarios"][0]["options"]] == ["2", "3"]
+    assert b["scenarios"][1]["options"][0]["nextScenarioId"] is None  # ending
+    # every option carries an id + the block shape fields
+    opt = b["scenarios"][0]["options"][0]
+    assert set(opt) == {"id", "text", "nextScenarioId"}
+    assert all("imageUrl" in s for s in b["scenarios"])
+
+
+def test_to_block_empty():
+    b = scensvc._to_block_scenario(GeneratedScenarioSet(title="X", scenarios=[]))
+    assert b["scenarios"] == [] and b["currentScenarioId"] == ""
+
+
+def test_to_block_unknown_next_ref_becomes_none():
+    g = GeneratedScenarioSet(title="T", scenarios=[
+        GenScenario(ref="start", text="hi", options=[GenScenarioOption(text="go", next_ref="missing")]),
+    ])
+    b = scensvc._to_block_scenario(g)
+    assert b["scenarios"][0]["options"][0]["nextScenarioId"] is None
+
+
+async def test_generate_scenario_happy_path():
+    with patch.object(scensvc, "get_chat_session_history", return_value={"aichat_uuid": "s1", "message_history": []}), \
+         patch.object(scensvc, "extract_text_from_prosemirror", return_value="ground"), \
+         patch.object(scensvc, "generate", new=AsyncMock(return_value=_generated())), \
+         patch.object(scensvc, "save_message_to_history") as save:
+        block, session_uuid = await scensvc.generate_scenario(
+            org_id=1, prompt="fire drill", model_name="m", activity_content={"type": "doc"}, num_scenarios=5,
+        )
+    assert session_uuid == "s1"
+    assert len(block["scenarios"]) == 3
+    save.assert_called_once()
+
+
+async def test_generate_scenario_clamps_and_tolerates_extract_failure():
+    with patch.object(scensvc, "get_chat_session_history", return_value={"aichat_uuid": "s1", "message_history": []}), \
+         patch.object(scensvc, "extract_text_from_prosemirror", side_effect=Exception("bad")), \
+         patch.object(scensvc, "generate", new=AsyncMock(return_value=_generated())), \
+         patch.object(scensvc, "save_message_to_history"):
+        block, _ = await scensvc.generate_scenario(
+            org_id=1, prompt="p", model_name="m", activity_content={"x": 1}, num_scenarios=999,
+        )
+    assert block["scenarios"]

--- a/apps/api/src/tests/services/test_hls_jobs_block_service.py
+++ b/apps/api/src/tests/services/test_hls_jobs_block_service.py
@@ -7,7 +7,6 @@ routing, transcode_block, and the reconciler's block pass.
 
 from datetime import datetime
 
-import pytest
 
 from src.db.courses.blocks import Block, BlockTypeEnum
 from src.services.utils import hls_jobs
@@ -141,9 +140,11 @@ async def test_resolve_block_source(monkeypatch, db, org, course, chapter, activ
 async def test_dispatch_routes_block_and_activity(monkeypatch):
     calls = []
     async def fake_block(a, b):
-        calls.append(("block", a, b)); return True
+        calls.append(("block", a, b))
+        return True
     async def fake_activity(a):
-        calls.append(("activity", a)); return True
+        calls.append(("activity", a))
+        return True
     monkeypatch.setattr(hls_jobs, "transcode_block", fake_block)
     monkeypatch.setattr(hls_jobs, "transcode_activity", fake_activity)
     await hls_jobs._dispatch({"kind": "block", "activity_uuid": "a1", "block_uuid": "b1"})

--- a/apps/api/src/tests/services/test_hls_jobs_block_service.py
+++ b/apps/api/src/tests/services/test_hls_jobs_block_service.py
@@ -1,0 +1,219 @@
+"""Tests for the video-BLOCK HLS path in src/services/utils/hls_jobs.py.
+
+The block path reuses the same queue/consumer/reconciler as activities; these
+tests cover queue-item parsing, block status writes, source resolution, dispatch
+routing, transcode_block, and the reconciler's block pass.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from src.db.courses.blocks import Block, BlockTypeEnum
+from src.services.utils import hls_jobs
+
+
+class _FactoryCtx:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _bind_session(monkeypatch, session):
+    monkeypatch.setattr(hls_jobs, "_async_session_factory", lambda: _FactoryCtx(session))
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.pushed = []
+        self.store = {}
+
+    def rpush(self, key, val):
+        self.pushed.append(val)
+
+    def set(self, k, v, ex=None):
+        self.store[k] = v
+
+    def get(self, k):
+        return self.store.get(k)
+
+    def delete(self, *keys):
+        for k in keys:
+            self.store.pop(k, None)
+
+    def exists(self, k):
+        return 1 if k in self.store else 0
+
+    def incr(self, k):
+        self.store[k] = int(self.store.get(k, 0)) + 1
+        return self.store[k]
+
+    def expire(self, k, ttl):
+        return True
+
+    def lrange(self, key, a, b):
+        return []
+
+
+async def _add_video_block(db, org, course, activity, block_uuid, *, file_id="f1", fmt="mp4", hls=None):
+    content = {"file_id": file_id, "file_format": fmt, "activity_uuid": activity.activity_uuid}
+    if hls is not None:
+        content["hls"] = hls
+    b = Block(
+        block_type=BlockTypeEnum.BLOCK_VIDEO,
+        content=content,
+        org_id=org.id,
+        course_id=course.id,
+        activity_id=activity.id,
+        block_uuid=block_uuid,
+        creation_date=str(datetime.now()),
+        update_date=str(datetime.now()),
+    )
+    db.add(b)
+    await db.commit()
+    return b
+
+
+# --- queue item parsing ---
+
+def test_parse_item_block_and_activity():
+    item = hls_jobs._block_item("act_1", "block_1")
+    assert hls_jobs._parse_item(item) == {"kind": "block", "activity_uuid": "act_1", "block_uuid": "block_1"}
+    assert hls_jobs._parse_item("act_uuid") == {"kind": "activity", "activity_uuid": "act_uuid"}
+    # malformed json falls back to activity
+    assert hls_jobs._parse_item("{not json")["kind"] == "activity"
+
+
+def test_enqueue_block_noop_when_disabled(monkeypatch):
+    monkeypatch.setattr(hls_jobs, "hls_enabled", lambda: False)
+    touched = {"redis": False}
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: touched.__setitem__("redis", True))
+    hls_jobs.enqueue_block("act", "block")
+    assert touched["redis"] is False
+
+
+def test_enqueue_block_pushes_json(monkeypatch):
+    monkeypatch.setattr(hls_jobs, "hls_enabled", lambda: True)
+    r = _FakeRedis()
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: r)
+    hls_jobs.enqueue_block("act_1", "block_1")
+    assert r.pushed == [hls_jobs._block_item("act_1", "block_1")]
+
+
+# --- status writes + source resolution (real DB) ---
+
+async def test_set_block_status_writes_content_hls(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    b = await _add_video_block(db, org, course, activity, "block_status")
+    await hls_jobs._set_block_status("block_status", "processing")
+    refreshed = await db.get(Block, b.id)
+    assert refreshed.content["hls"]["status"] == "processing"
+    assert "updated_at" in refreshed.content["hls"]
+
+    await hls_jobs._set_block_status("block_status", "ready", master="master.m3u8", renditions=["720p"])
+    refreshed = await db.get(Block, b.id)
+    assert refreshed.content["hls"]["status"] == "ready"
+    assert refreshed.content["hls"]["renditions"] == ["720p"]
+    # existing block fields preserved
+    assert refreshed.content["file_id"] == "f1"
+
+
+async def test_resolve_block_source(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    await _add_video_block(db, org, course, activity, "block_src", file_id="abc", fmt="mp4")
+    info = await hls_jobs._resolve_block_source("block_src")
+    assert info["org_uuid"] == org.org_uuid
+    assert info["course_uuid"] == course.course_uuid
+    assert info["activity_uuid"] == activity.activity_uuid
+    assert info["filename"] == "abc.mp4"
+
+    # missing block / missing file
+    assert await hls_jobs._resolve_block_source("nope") is None
+
+
+# --- dispatch routing ---
+
+async def test_dispatch_routes_block_and_activity(monkeypatch):
+    calls = []
+    async def fake_block(a, b):
+        calls.append(("block", a, b)); return True
+    async def fake_activity(a):
+        calls.append(("activity", a)); return True
+    monkeypatch.setattr(hls_jobs, "transcode_block", fake_block)
+    monkeypatch.setattr(hls_jobs, "transcode_activity", fake_activity)
+    await hls_jobs._dispatch({"kind": "block", "activity_uuid": "a1", "block_uuid": "b1"})
+    await hls_jobs._dispatch({"kind": "activity", "activity_uuid": "a2"})
+    assert calls == [("block", "a1", "b1"), ("activity", "a2")]
+
+
+# --- transcode_block happy + failure paths (mocked I/O) ---
+
+async def test_transcode_block_happy_path(monkeypatch):
+    statuses = []
+    async def fake_status(uuid, status, **extra):
+        statuses.append((uuid, status, extra))
+    monkeypatch.setattr(hls_jobs, "_set_block_status", fake_status)
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: None)
+    monkeypatch.setattr(hls_jobs, "_resolve_block_source", hls_jobs_aret({
+        "org_uuid": "org_1", "course_uuid": "course_1", "activity_uuid": "act_1", "filename": "v.mp4",
+    }))
+    monkeypatch.setattr(hls_jobs, "_fetch_source", lambda *a, **k: True)
+    async def fake_transcode(src, out):
+        return {"master": "master.m3u8", "renditions": ["720p", "480p"], "thumbnails": {"url": "thumbnails/sprite.jpg"}}
+    monkeypatch.setattr(hls_jobs, "transcode_source_to_hls", fake_transcode)
+    monkeypatch.setattr(hls_jobs, "is_s3_enabled", lambda: False)
+    import shutil
+    monkeypatch.setattr(shutil, "copytree", lambda *a, **k: None)
+
+    ok = await hls_jobs.transcode_block("act_1", "block_1")
+    assert ok is True
+    assert statuses[0][1] == "processing"
+    assert statuses[-1][1] == "ready"
+    assert statuses[-1][2]["renditions"] == ["720p", "480p"]
+
+
+async def test_transcode_block_source_unavailable(monkeypatch):
+    statuses = []
+    async def fake_status(uuid, status, **extra):
+        statuses.append((uuid, status, extra))
+    monkeypatch.setattr(hls_jobs, "_set_block_status", fake_status)
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: None)
+    monkeypatch.setattr(hls_jobs, "_resolve_block_source", hls_jobs_aret({
+        "org_uuid": "o", "course_uuid": "c", "activity_uuid": "a", "filename": "v.mp4",
+    }))
+    monkeypatch.setattr(hls_jobs, "_fetch_source", lambda *a, **k: False)
+    ok = await hls_jobs.transcode_block("a", "b")
+    assert ok is False
+    assert statuses[-1][1] == "failed"
+    assert statuses[-1][2]["error"] == "source_unavailable"
+
+
+async def test_transcode_block_no_source_returns_false(monkeypatch):
+    monkeypatch.setattr(hls_jobs, "_resolve_block_source", hls_jobs_aret(None))
+    assert await hls_jobs.transcode_block("a", "b") is False
+
+
+# --- reconciler block pass ---
+
+async def test_reconcile_requeues_unready_block(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    await _add_video_block(db, org, course, activity, "block_todo")  # no hls -> unready
+    await _add_video_block(db, org, course, activity, "block_ready", file_id="r", hls={"status": "ready"})
+    r = _FakeRedis()
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: r)
+
+    result = await hls_jobs.reconcile_unfinished()
+    # the unready block is requeued as a block job; the ready one is skipped
+    assert hls_jobs._block_item(activity.activity_uuid, "block_todo") in r.pushed
+    assert result["requeued"] >= 1
+
+
+def hls_jobs_aret(value):
+    async def _f(*a, **k):
+        return value
+    return _f

--- a/apps/api/src/tests/services/test_hls_jobs_block_service.py
+++ b/apps/api/src/tests/services/test_hls_jobs_block_service.py
@@ -353,6 +353,10 @@ async def test_resolve_block_source_non_video_and_no_file(monkeypatch, db, org, 
     assert await hls_jobs._resolve_block_source("block_img") is None
     assert await hls_jobs._resolve_block_source("block_nofile") is None
 
+    # unsafe filename (traversal in file_id) is rejected
+    await _add_video_block(db, org, course, activity, "block_badname", file_id="../evil", fmt="mp4")
+    assert await hls_jobs._resolve_block_source("block_badname") is None
+
 
 async def test_reconcile_skips_pending_and_nofile_blocks(monkeypatch, db, org, course, chapter, activity):
     _bind_session(monkeypatch, db)
@@ -365,10 +369,19 @@ async def test_reconcile_skips_pending_and_nofile_blocks(monkeypatch, db, org, c
     )
     db.add(nofile)
     await db.commit()
+    # video block with hls status but NO activity_uuid -> skipped (can't build a job)
+    noact = Block(
+        block_type=BlockTypeEnum.BLOCK_VIDEO, content={"file_id": "z", "file_format": "mp4", "hls": {"status": "failed"}},
+        org_id=org.id, course_id=course.id, activity_id=activity.id, block_uuid="block_noact",
+        creation_date=str(datetime.now()), update_date=str(datetime.now()),
+    )
+    db.add(noact)
+    await db.commit()
     pending_item = hls_jobs._block_item(activity.activity_uuid, "block_pending")
     r = _FakeRedis(pending=[pending_item])
     monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: r)
     result = await hls_jobs.reconcile_unfinished()
-    # already-pending block is not re-pushed
+    # already-pending block is not re-pushed; the no-activity_uuid block isn't queued
     assert pending_item not in r.pushed
+    assert not any("block_noact" in p for p in r.pushed)
     assert result["skipped"] >= 1

--- a/apps/api/src/tests/services/test_hls_jobs_block_service.py
+++ b/apps/api/src/tests/services/test_hls_jobs_block_service.py
@@ -28,9 +28,10 @@ def _bind_session(monkeypatch, session):
 
 
 class _FakeRedis:
-    def __init__(self):
+    def __init__(self, pending=None):
         self.pushed = []
         self.store = {}
+        self._pending = list(pending or [])
 
     def rpush(self, key, val):
         self.pushed.append(val)
@@ -56,7 +57,7 @@ class _FakeRedis:
         return True
 
     def lrange(self, key, a, b):
-        return []
+        return list(self._pending)
 
 
 async def _add_video_block(db, org, course, activity, block_uuid, *, file_id="f1", fmt="mp4", hls=None):
@@ -199,6 +200,83 @@ async def test_transcode_block_no_source_returns_false(monkeypatch):
     assert await hls_jobs.transcode_block("a", "b") is False
 
 
+def _mock_common_transcode(monkeypatch, statuses):
+    async def fake_status(uuid, status, **extra):
+        statuses.append((uuid, status, extra))
+    monkeypatch.setattr(hls_jobs, "_set_block_status", fake_status)
+    monkeypatch.setattr(hls_jobs, "_resolve_block_source", hls_jobs_aret({
+        "org_uuid": "o", "course_uuid": "c", "activity_uuid": "a", "filename": "v.mp4",
+    }))
+    monkeypatch.setattr(hls_jobs, "_fetch_source", lambda *a, **k: True)
+
+
+async def test_transcode_block_with_redis_and_s3(monkeypatch):
+    """Covers the lease/heartbeat + S3 upload branches + success retry-clear."""
+    statuses = []
+    _mock_common_transcode(monkeypatch, statuses)
+    r = _FakeRedis()
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: r)
+
+    async def fake_transcode(src, out):
+        return {"master": "master.m3u8", "renditions": ["720p"], "thumbnails": None}
+    monkeypatch.setattr(hls_jobs, "transcode_source_to_hls", fake_transcode)
+    monkeypatch.setattr(hls_jobs, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(hls_jobs, "upload_directory_to_s3", lambda out, prefix: True)
+
+    ok = await hls_jobs.transcode_block("act_1", "block_1")
+    assert ok is True
+    assert statuses[-1][1] == "ready"
+    # lease was set then cleaned up
+    assert hls_jobs._lease_key("block:block_1") not in r.store
+
+
+async def test_transcode_block_transcode_failed(monkeypatch):
+    statuses = []
+    _mock_common_transcode(monkeypatch, statuses)
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: None)
+    monkeypatch.setattr(hls_jobs, "transcode_source_to_hls", hls_jobs_aret(None))
+    ok = await hls_jobs.transcode_block("a", "b")
+    assert ok is False
+    assert statuses[-1][2]["error"] == "transcode_failed"
+
+
+async def test_transcode_block_upload_failed(monkeypatch):
+    statuses = []
+    _mock_common_transcode(monkeypatch, statuses)
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: None)
+    monkeypatch.setattr(hls_jobs, "transcode_source_to_hls", hls_jobs_aret({"master": "m", "renditions": ["720p"]}))
+    monkeypatch.setattr(hls_jobs, "is_s3_enabled", lambda: True)
+    monkeypatch.setattr(hls_jobs, "upload_directory_to_s3", lambda out, prefix: False)
+    ok = await hls_jobs.transcode_block("a", "b")
+    assert ok is False
+    assert statuses[-1][2]["error"] == "upload_failed"
+
+
+async def test_transcode_block_exception(monkeypatch):
+    statuses = []
+    _mock_common_transcode(monkeypatch, statuses)
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: None)
+    async def boom(src, out):
+        raise RuntimeError("ffmpeg blew up")
+    monkeypatch.setattr(hls_jobs, "transcode_source_to_hls", boom)
+    ok = await hls_jobs.transcode_block("a", "b")
+    assert ok is False
+    assert statuses[-1][2]["error"] == "exception"
+
+
+async def test_mark_failed_routes(monkeypatch):
+    calls = []
+    async def fake_block(uuid, status, **extra):
+        calls.append(("block", uuid, extra.get("error")))
+    async def fake_act(uuid, status, **extra):
+        calls.append(("activity", uuid, extra.get("error")))
+    monkeypatch.setattr(hls_jobs, "_set_block_status", fake_block)
+    monkeypatch.setattr(hls_jobs, "_set_status", fake_act)
+    await hls_jobs._mark_failed({"kind": "block", "block_uuid": "b1"}, "timeout")
+    await hls_jobs._mark_failed({"kind": "activity", "activity_uuid": "a1"}, "timeout")
+    assert calls == [("block", "b1", "timeout"), ("activity", "a1", "timeout")]
+
+
 # --- reconciler block pass ---
 
 async def test_reconcile_requeues_unready_block(monkeypatch, db, org, course, chapter, activity):
@@ -214,7 +292,83 @@ async def test_reconcile_requeues_unready_block(monkeypatch, db, org, course, ch
     assert result["requeued"] >= 1
 
 
+async def test_reconcile_skips_leased_block(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    await _add_video_block(db, org, course, activity, "block_leased")
+    r = _FakeRedis()
+    r.store[hls_jobs._lease_key("block:block_leased")] = "1"  # actively transcoding
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: r)
+    result = await hls_jobs.reconcile_unfinished()
+    assert hls_jobs._block_item(activity.activity_uuid, "block_leased") not in r.pushed
+    assert result["skipped"] >= 1
+
+
+async def test_reconcile_gives_up_block_at_max_retries(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    await _add_video_block(db, org, course, activity, "block_broken")
+    r = _FakeRedis()
+    r.store[hls_jobs._retries_key("block:block_broken")] = hls_jobs.hls_max_retries()
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: r)
+    result = await hls_jobs.reconcile_unfinished()
+    assert hls_jobs._block_item(activity.activity_uuid, "block_broken") not in r.pushed
+    assert result["gaveup"] >= 1
+
+
 def hls_jobs_aret(value):
     async def _f(*a, **k):
         return value
     return _f
+
+
+# --- extra edge coverage ---
+
+def test_enqueue_block_no_redis_is_noop(monkeypatch):
+    monkeypatch.setattr(hls_jobs, "hls_enabled", lambda: True)
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: None)
+    hls_jobs.enqueue_block("a", "b")  # must not raise
+
+
+async def test_set_block_status_missing_block_is_noop(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    await hls_jobs._set_block_status("does_not_exist", "processing")  # no raise
+
+
+async def test_resolve_block_source_non_video_and_no_file(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    # non-video block
+    img = Block(
+        block_type=BlockTypeEnum.BLOCK_IMAGE, content={"file_id": "x", "file_format": "png"},
+        org_id=org.id, course_id=course.id, activity_id=activity.id, block_uuid="block_img",
+        creation_date=str(datetime.now()), update_date=str(datetime.now()),
+    )
+    db.add(img)
+    # video block missing file_id
+    nofile = Block(
+        block_type=BlockTypeEnum.BLOCK_VIDEO, content={"activity_uuid": activity.activity_uuid},
+        org_id=org.id, course_id=course.id, activity_id=activity.id, block_uuid="block_nofile",
+        creation_date=str(datetime.now()), update_date=str(datetime.now()),
+    )
+    db.add(nofile)
+    await db.commit()
+    assert await hls_jobs._resolve_block_source("block_img") is None
+    assert await hls_jobs._resolve_block_source("block_nofile") is None
+
+
+async def test_reconcile_skips_pending_and_nofile_blocks(monkeypatch, db, org, course, chapter, activity):
+    _bind_session(monkeypatch, db)
+    await _add_video_block(db, org, course, activity, "block_pending")
+    # video block with no file_id -> continue (skipped silently)
+    nofile = Block(
+        block_type=BlockTypeEnum.BLOCK_VIDEO, content={"activity_uuid": activity.activity_uuid},
+        org_id=org.id, course_id=course.id, activity_id=activity.id, block_uuid="block_nofile2",
+        creation_date=str(datetime.now()), update_date=str(datetime.now()),
+    )
+    db.add(nofile)
+    await db.commit()
+    pending_item = hls_jobs._block_item(activity.activity_uuid, "block_pending")
+    r = _FakeRedis(pending=[pending_item])
+    monkeypatch.setattr(hls_jobs, "get_redis_client", lambda: r)
+    result = await hls_jobs.reconcile_unfinished()
+    # already-pending block is not re-pushed
+    assert pending_item not in r.pushed
+    assert result["skipped"] >= 1

--- a/apps/api/src/tests/services/test_upload_content_service.py
+++ b/apps/api/src/tests/services/test_upload_content_service.py
@@ -7,7 +7,12 @@ from unittest.mock import Mock, patch
 import pytest
 from fastapi import HTTPException, UploadFile
 
-from src.services.utils.upload_content import ensure_directory_exists, upload_content, upload_file
+from src.services.utils.upload_content import (
+    ensure_directory_exists,
+    read_content,
+    upload_content,
+    upload_file,
+)
 
 
 class TestUploadContentService:
@@ -157,6 +162,86 @@ class TestUploadContentService:
             os.chdir(old_cwd)
 
         assert exc.value.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_read_content_rejects_bad_filename(self):
+        for bad in ("../secret.png", "a/b.png", "x\\y.png", "\x00.png", ""):
+            with pytest.raises(HTTPException) as exc:
+                await read_content("ai_images", "orgs", "org_uuid", bad)
+            assert exc.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_read_content_filesystem_success_and_missing(self, tmp_path):
+        fake_config = SimpleNamespace(
+            hosting_config=SimpleNamespace(
+                content_delivery=SimpleNamespace(type="filesystem")
+            )
+        )
+        file_path = tmp_path / "content" / "orgs" / "org_uuid" / "ai_images" / "img.png"
+        file_path.parent.mkdir(parents=True)
+        file_path.write_bytes(b"PNGDATA")
+
+        import os
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            with patch(
+                "src.services.utils.upload_content.get_learnhouse_config",
+                return_value=fake_config,
+            ):
+                data = await read_content("ai_images", "orgs", "org_uuid", "img.png")
+                assert data == b"PNGDATA"
+
+                # missing file -> 404
+                with pytest.raises(HTTPException) as exc:
+                    await read_content("ai_images", "orgs", "org_uuid", "gone.png")
+                assert exc.value.status_code == 404
+        finally:
+            os.chdir(old_cwd)
+
+    @pytest.mark.asyncio
+    async def test_read_content_s3_success_and_failure(self):
+        fake_config = SimpleNamespace(
+            hosting_config=SimpleNamespace(
+                content_delivery=SimpleNamespace(
+                    type="s3api",
+                    s3api=SimpleNamespace(endpoint_url="https://s3.test", bucket_name="bucket"),
+                )
+            )
+        )
+        body = Mock()
+        body.read.return_value = b"S3BYTES"
+        s3_client = Mock()
+        s3_client.get_object.return_value = {"Body": body}
+
+        with patch(
+            "src.services.utils.upload_content.get_learnhouse_config",
+            return_value=fake_config,
+        ), patch(
+            "src.services.utils.upload_content.boto3.client",
+            return_value=s3_client,
+        ):
+            data = await read_content("ai_images", "orgs", "org_uuid", "img.png")
+        assert data == b"S3BYTES"
+        s3_client.get_object.assert_called_once()
+
+        # missing object -> 404
+        from botocore.exceptions import ClientError
+
+        s3_client = Mock()
+        s3_client.get_object.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchKey", "Message": "nope"}}, "get_object"
+        )
+        with patch(
+            "src.services.utils.upload_content.get_learnhouse_config",
+            return_value=fake_config,
+        ), patch(
+            "src.services.utils.upload_content.boto3.client",
+            return_value=s3_client,
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await read_content("ai_images", "orgs", "org_uuid", "img.png")
+        assert exc.value.status_code == 404
 
     @pytest.mark.asyncio
     async def test_upload_content_s3_cleanup_oserror_is_swallowed(self, tmp_path):

--- a/apps/api/src/tests/test_root_router.py
+++ b/apps/api/src/tests/test_root_router.py
@@ -116,6 +116,7 @@ def _install_stub_modules(monkeypatch: pytest.MonkeyPatch) -> None:
     install_router_module(
         "src.routers.ai.assignment_gen", "src.routers.ai.assignment_gen"
     )
+    install_router_module("src.routers.ai.scenario", "src.routers.ai.scenario")
     sys.modules["src.routers.ai"].ai = sys.modules["src.routers.ai.ai"]
     sys.modules["src.routers.ai"].magicblocks = sys.modules[
         "src.routers.ai.magicblocks"
@@ -129,6 +130,7 @@ def _install_stub_modules(monkeypatch: pytest.MonkeyPatch) -> None:
     sys.modules["src.routers.ai"].assignment_gen = sys.modules[
         "src.routers.ai.assignment_gen"
     ]
+    sys.modules["src.routers.ai"].scenario = sys.modules["src.routers.ai.scenario"]
 
     install_router_module("src.routers.boards.boards", "src.routers.boards.boards")
     install_router_module(

--- a/apps/api/src/tests/test_root_router.py
+++ b/apps/api/src/tests/test_root_router.py
@@ -111,6 +111,11 @@ def _install_stub_modules(monkeypatch: pytest.MonkeyPatch) -> None:
         "src.routers.ai.courseplanning", "src.routers.ai.courseplanning"
     )
     install_router_module("src.routers.ai.rag", "src.routers.ai.rag")
+    install_router_module("src.routers.ai.images", "src.routers.ai.images")
+    install_router_module("src.routers.ai.quiz", "src.routers.ai.quiz")
+    install_router_module(
+        "src.routers.ai.assignment_gen", "src.routers.ai.assignment_gen"
+    )
     sys.modules["src.routers.ai"].ai = sys.modules["src.routers.ai.ai"]
     sys.modules["src.routers.ai"].magicblocks = sys.modules[
         "src.routers.ai.magicblocks"
@@ -119,6 +124,11 @@ def _install_stub_modules(monkeypatch: pytest.MonkeyPatch) -> None:
         "src.routers.ai.courseplanning"
     ]
     sys.modules["src.routers.ai"].rag = sys.modules["src.routers.ai.rag"]
+    sys.modules["src.routers.ai"].images = sys.modules["src.routers.ai.images"]
+    sys.modules["src.routers.ai"].quiz = sys.modules["src.routers.ai.quiz"]
+    sys.modules["src.routers.ai"].assignment_gen = sys.modules[
+        "src.routers.ai.assignment_gen"
+    ]
 
     install_router_module("src.routers.boards.boards", "src.routers.boards.boards")
     install_router_module(

--- a/apps/web/app/embed/[orgslug]/course/[courseuuid]/activity/[activityid]/EmbedActivityClient.tsx
+++ b/apps/web/app/embed/[orgslug]/course/[courseuuid]/activity/[activityid]/EmbedActivityClient.tsx
@@ -228,7 +228,7 @@ function EmbedActivityClient({ activityId, courseuuid, orgslug, bgcolor }: Embed
         return (
           <EmbedCourseProvider course={course}>
             <Suspense fallback={null}>
-              <Canva content={activity.content} activity={activity} hideTableOfContents />
+              <Canva content={activity.content} activity={activity} hideTableOfContents courseUuid={course?.course_uuid} orgUuid={course?.org_uuid} />
             </Suspense>
           </EmbedCourseProvider>
         )

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/course/[courseuuid]/activity/[activityid]/activity.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/course/[courseuuid]/activity/[activityid]/activity.tsx
@@ -312,7 +312,7 @@ function ActivityClient(props: ActivityClientProps) {
         }
         return (
           <Suspense fallback={<LoadingFallback />}>
-            <Canva content={activity.content} activity={activity} />
+            <Canva content={activity.content} activity={activity} courseUuid={course?.course_uuid} orgUuid={org?.org_uuid} />
           </Suspense>
         );
       case 'TYPE_VIDEO':

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/Modals/GenerateTasksAIModal.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/Modals/GenerateTasksAIModal.tsx
@@ -266,6 +266,7 @@ function GenerateTasksAIModal({
     if (tasks.length === 0) return
     setIsSaving(true)
     let saved = 0
+    let failed = 0
     try {
       for (const task of tasks) {
         const body = {
@@ -277,15 +278,24 @@ function GenerateTasksAIModal({
           contents: task.contents ?? {},
           max_grade_value: task.max_grade_value ?? 100,
         }
+        // createAssignmentTask returns { success: false } on non-200 (it does not throw).
         const res = await createAssignmentTask(body, assignment_uuid, access_token)
-        if (res?.success !== false) saved += 1
+        if (res?.success === false) failed += 1
+        else saved += 1
       }
       // Refresh the task list the editor page renders (react-query key used by
       // AssignmentProvider / Tasks list).
       queryClient.invalidateQueries({ queryKey: queryKeys.assignments.tasks(assignment_uuid) })
       queryClient.invalidateQueries({ queryKey: queryKeys.assignments.detail(assignment_uuid) })
-      toast.success(`Added ${saved} task${saved === 1 ? '' : 's'} to the assignment.`)
-      closeModal(false)
+      if (saved > 0) {
+        toast.success(`Added ${saved} task${saved === 1 ? '' : 's'} to the assignment.`)
+      }
+      if (failed > 0) {
+        toast.error(`${failed} task${failed === 1 ? '' : 's'} could not be saved.`)
+      }
+      // Only close when everything saved; otherwise keep the preview so the
+      // teacher can retry the ones that failed.
+      if (failed === 0) closeModal(false)
     } catch {
       toast.error('Some tasks could not be saved.')
     } finally {

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/Modals/GenerateTasksAIModal.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/Modals/GenerateTasksAIModal.tsx
@@ -3,22 +3,7 @@
 import React from 'react'
 import toast from 'react-hot-toast'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import {
-  Check,
-  Clock,
-  FileUp,
-  Hash,
-  History,
-  ListTodo,
-  Loader2,
-  Pencil,
-  Plus,
-  Sparkles,
-  Trash2,
-  Type,
-  X,
-} from 'lucide-react'
-
+import { Check, CircleNotch, Clock, ClockCounterClockwise, FileArrowUp, Hash, ListChecks, PencilSimple, Plus, Sparkle, TextT, Trash, X, type Icon as PhosphorIcon } from '@phosphor-icons/react'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { queryKeys } from '@/lib/query/keys'
@@ -77,13 +62,13 @@ interface HistoryItem {
 
 const TYPE_META: Record<
   string,
-  { label: string; Icon: React.ComponentType<{ size?: number; className?: string }> }
+  { label: string; Icon: PhosphorIcon }
 > = {
-  QUIZ: { label: 'Quiz', Icon: ListTodo },
-  FORM: { label: 'Form', Icon: Type },
-  SHORT_ANSWER: { label: 'Short answer', Icon: Pencil },
+  QUIZ: { label: 'Quiz', Icon: ListChecks },
+  FORM: { label: 'Form', Icon: TextT },
+  SHORT_ANSWER: { label: 'Short answer', Icon: PencilSimple },
   NUMBER_ANSWER: { label: 'Number', Icon: Hash },
-  FILE_SUBMISSION: { label: 'File upload', Icon: FileUp },
+  FILE_SUBMISSION: { label: 'File upload', Icon: FileArrowUp },
 }
 
 const ALL_TYPES: AssignmentTypeValue[] = [
@@ -317,7 +302,7 @@ function GenerateTasksAIModal({
             tab === 'generate' ? 'bg-white text-gray-900 nice-shadow' : 'text-gray-500 hover:text-gray-700'
           }`}
         >
-          <Sparkles size={13} />
+          <Sparkle weight="duotone" size={13} />
           Generate
         </button>
         <button
@@ -327,7 +312,7 @@ function GenerateTasksAIModal({
             tab === 'history' ? 'bg-white text-gray-900 nice-shadow' : 'text-gray-500 hover:text-gray-700'
           }`}
         >
-          <History size={13} />
+          <ClockCounterClockwise weight="duotone" size={13} />
           History
         </button>
       </div>
@@ -395,7 +380,7 @@ function GenerateTasksAIModal({
                             : 'bg-white text-gray-500 border-gray-200 hover:border-gray-300'
                         }`}
                       >
-                        <Icon size={12} />
+                        <Icon weight="duotone" size={12} />
                         {meta.label}
                       </button>
                     )
@@ -411,7 +396,7 @@ function GenerateTasksAIModal({
                 disabled={isGenerating}
                 className="flex items-center gap-1.5 px-4 py-2 bg-gray-900 text-white text-xs font-semibold rounded-lg hover:bg-black transition-colors disabled:opacity-50"
               >
-                {isGenerating ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
+                {isGenerating ? <CircleNotch weight="duotone" size={14} className="animate-spin" /> : <Sparkle weight="duotone" size={14} />}
                 {plan ? 'Regenerate' : 'Generate'}
               </button>
               {plan && (
@@ -431,7 +416,7 @@ function GenerateTasksAIModal({
           {/* Preview */}
           {isGenerating && !plan && (
             <div className="flex items-center justify-center gap-2 py-10 text-sm text-gray-400">
-              <Loader2 size={16} className="animate-spin" />
+              <CircleNotch weight="duotone" size={16} className="animate-spin" />
               Generating tasks…
             </div>
           )}
@@ -483,7 +468,7 @@ function GenerateTasksAIModal({
                   disabled={isSaving || tasks.length === 0}
                   className="flex items-center gap-1.5 px-4 py-2 bg-gray-900 text-white text-xs font-semibold rounded-lg hover:bg-black transition-colors disabled:opacity-50"
                 >
-                  {isSaving ? <Loader2 size={14} className="animate-spin" /> : <Plus size={14} />}
+                  {isSaving ? <CircleNotch weight="duotone" size={14} className="animate-spin" /> : <Plus weight="duotone" size={14} />}
                   Add to assignment
                 </button>
               </div>
@@ -512,7 +497,7 @@ function HistoryList({
   if (isLoading) {
     return (
       <div className="flex items-center justify-center gap-2 py-10 text-sm text-gray-400">
-        <Loader2 size={16} className="animate-spin" />
+        <CircleNotch weight="duotone" size={16} className="animate-spin" />
         Loading history…
       </div>
     )
@@ -541,13 +526,13 @@ function HistoryList({
               <p className="mt-0.5 text-xs text-gray-500 line-clamp-2">{item.prompt}</p>
               <div className="mt-1.5 flex items-center gap-2 text-[11px] text-gray-400">
                 <span className="inline-flex items-center gap-1">
-                  <ListTodo size={11} />
+                  <ListChecks weight="duotone" size={11} />
                   {item.plan?.tasks?.length ?? 0} task
                   {(item.plan?.tasks?.length ?? 0) === 1 ? '' : 's'}
                 </span>
                 {item.creation_date && (
                   <span className="inline-flex items-center gap-1">
-                    <Clock size={11} />
+                    <Clock weight="duotone" size={11} />
                     {new Date(item.creation_date).toLocaleDateString()}
                   </span>
                 )}
@@ -560,7 +545,7 @@ function HistoryList({
               className="flex-none p-1.5 rounded-md text-gray-300 hover:text-rose-500 hover:bg-rose-50 transition-colors"
               title="Delete"
             >
-              <Trash2 size={14} />
+              <Trash weight="duotone" size={14} />
             </span>
           </div>
         </button>
@@ -585,7 +570,7 @@ function TaskPreviewCard({
   onUpdateContents: (_index: number, _mutate: (_contents: any) => void) => void
   onRemove: (_index: number) => void
 }) {
-  const meta = TYPE_META[task.assignment_type] ?? { label: task.assignment_type, Icon: Type }
+  const meta = TYPE_META[task.assignment_type] ?? { label: task.assignment_type, Icon: TextT }
   const Icon = meta.Icon
 
   return (
@@ -596,7 +581,7 @@ function TaskPreviewCard({
           <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-gray-200 text-gray-600 font-bold">
             {index + 1}
           </span>
-          <Icon size={13} className="text-gray-400" />
+          <Icon weight="duotone" size={13} className="text-gray-400" />
           <span>{meta.label}</span>
         </div>
         <button
@@ -605,7 +590,7 @@ function TaskPreviewCard({
           className="p-1 rounded-md text-gray-300 hover:text-rose-500 hover:bg-rose-50 transition-colors"
           title="Remove from preview"
         >
-          <X size={14} />
+          <X weight="duotone" size={14} />
         </button>
       </div>
 
@@ -721,7 +706,7 @@ function TaskContentEditor({
                     }`}
                     title="Toggle correct answer"
                   >
-                    {o.assigned_right_answer ? <Check size={12} /> : <X size={12} />}
+                    {o.assigned_right_answer ? <Check weight="duotone" size={12} /> : <X weight="duotone" size={12} />}
                     {o.assigned_right_answer ? 'Correct' : 'Wrong'}
                   </button>
                 </div>

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/Modals/GenerateTasksAIModal.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/Modals/GenerateTasksAIModal.tsx
@@ -1,0 +1,887 @@
+'use client'
+
+import React from 'react'
+import toast from 'react-hot-toast'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  Check,
+  Clock,
+  FileUp,
+  Hash,
+  History,
+  ListTodo,
+  Loader2,
+  Pencil,
+  Plus,
+  Sparkles,
+  Trash2,
+  Type,
+  X,
+} from 'lucide-react'
+
+import { useLHSession } from '@components/Contexts/LHSessionContext'
+import { useOrg } from '@components/Contexts/OrgContext'
+import { queryKeys } from '@/lib/query/keys'
+import { getAPIUrl } from '@services/config/config'
+import { apiFetch } from '@services/utils/ts/requests'
+import { createAssignmentTask } from '@services/courses/assignments'
+import {
+  generateAIAssignment,
+  fetchAIAssignmentHistory,
+  deleteAIAssignmentHistory,
+} from '@services/ai/generation'
+
+// ---------------------------------------------------------------------------
+// "Generate tasks with AI" — teacher-facing entry point on the assignment
+// editor. Generates tasks grounded on the assignment's course content, lets
+// the teacher preview + edit them, then saves each one to the current
+// assignment via the existing `createAssignmentTask` client.
+//
+// NOTE: strings are hardcoded English here rather than routed through i18n,
+// because the shared locale files live outside the assignments dashboard area
+// (which this task is scoped to). Everything else mirrors the surrounding
+// LearnHouse design language (neutral palette, nice-shadow, rounded-lg,
+// lucide icons — no AI-gradient styling).
+// ---------------------------------------------------------------------------
+
+type AssignmentTypeValue =
+  | 'QUIZ'
+  | 'FORM'
+  | 'SHORT_ANSWER'
+  | 'NUMBER_ANSWER'
+  | 'FILE_SUBMISSION'
+
+interface GeneratedTask {
+  title: string
+  description: string
+  hint: string
+  assignment_type: AssignmentTypeValue
+  contents: any
+  max_grade_value: number
+}
+
+interface AIPlan {
+  title?: string
+  description?: string
+  grading_type?: string
+  tasks: GeneratedTask[]
+}
+
+interface HistoryItem {
+  ai_generation_uuid: string
+  session_uuid?: string
+  prompt: string
+  plan: AIPlan
+  creation_date?: string
+}
+
+const TYPE_META: Record<
+  string,
+  { label: string; Icon: React.ComponentType<{ size?: number; className?: string }> }
+> = {
+  QUIZ: { label: 'Quiz', Icon: ListTodo },
+  FORM: { label: 'Form', Icon: Type },
+  SHORT_ANSWER: { label: 'Short answer', Icon: Pencil },
+  NUMBER_ANSWER: { label: 'Number', Icon: Hash },
+  FILE_SUBMISSION: { label: 'File upload', Icon: FileUp },
+}
+
+const ALL_TYPES: AssignmentTypeValue[] = [
+  'QUIZ',
+  'FORM',
+  'SHORT_ANSWER',
+  'NUMBER_ANSWER',
+  'FILE_SUBMISSION',
+]
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function GenerateTasksAIModal({
+  assignment_uuid,
+  closeModal,
+}: {
+  assignment_uuid: string
+  closeModal: (_open: boolean) => void
+}) {
+  const session = useLHSession() as any
+  const access_token = session?.data?.tokens?.access_token
+  const org = useOrg() as any
+  const queryClient = useQueryClient()
+
+  // Resolve the assignment's course_uuid (used to ground the generation).
+  // Shares react-query cache with AssignmentProvider so this is usually a
+  // cache hit — no extra round trip.
+  const { data: assignment } = useQuery({
+    queryKey: queryKeys.assignments.detail(assignment_uuid),
+    queryFn: () =>
+      apiFetch(`${getAPIUrl()}assignments/${assignment_uuid}`, access_token),
+    enabled: !!(assignment_uuid && access_token),
+    staleTime: 60_000,
+  })
+  const course_uuid: string | undefined = assignment?.course_uuid
+
+  const [tab, setTab] = React.useState<'generate' | 'history'>('generate')
+
+  // --- Generate form state ---
+  const [prompt, setPrompt] = React.useState('')
+  const [numTasks, setNumTasks] = React.useState(3)
+  const [allowedTypes, setAllowedTypes] = React.useState<Set<AssignmentTypeValue>>(
+    new Set(ALL_TYPES)
+  )
+  const [isGenerating, setIsGenerating] = React.useState(false)
+  const [sessionUuid, setSessionUuid] = React.useState<string | undefined>(undefined)
+
+  // --- Preview / editing state ---
+  const [plan, setPlan] = React.useState<AIPlan | null>(null)
+  const [tasks, setTasks] = React.useState<GeneratedTask[]>([])
+  const [isSaving, setIsSaving] = React.useState(false)
+
+  // --- History state ---
+  const [history, setHistory] = React.useState<HistoryItem[]>([])
+  const [isLoadingHistory, setIsLoadingHistory] = React.useState(false)
+
+  const toggleType = (type: AssignmentTypeValue) => {
+    setAllowedTypes((prev) => {
+      const next = new Set(prev)
+      if (next.has(type)) {
+        // Keep at least one type selected.
+        if (next.size > 1) next.delete(type)
+      } else {
+        next.add(type)
+      }
+      return next
+    })
+  }
+
+  async function runGenerate(refine = false) {
+    if (!org?.id) {
+      toast.error('Organization not ready yet, please retry.')
+      return
+    }
+    if (!course_uuid) {
+      toast.error('This assignment is not linked to a course yet.')
+      return
+    }
+    if (!prompt.trim()) {
+      toast.error('Please describe what you want to generate.')
+      return
+    }
+    setIsGenerating(true)
+    try {
+      const allowed_task_types =
+        allowedTypes.size < ALL_TYPES.length ? Array.from(allowedTypes) : undefined
+      const res = await generateAIAssignment(
+        {
+          org_id: org.id,
+          course_uuid,
+          prompt: prompt.trim(),
+          num_tasks: numTasks,
+          allowed_task_types,
+          // Passing the session_uuid back enables multi-turn refinement.
+          session_uuid: refine ? sessionUuid : undefined,
+        },
+        access_token
+      )
+      if (res.success && res.data?.plan) {
+        setSessionUuid(res.data.session_uuid)
+        setPlan(res.data.plan)
+        setTasks(clone(res.data.plan.tasks ?? []))
+        toast.success(
+          refine ? 'Tasks refined.' : `Generated ${res.data.plan.tasks?.length ?? 0} task(s).`
+        )
+      } else {
+        toast.error('Generation failed, please try again.')
+      }
+    } catch {
+      toast.error('Generation failed, please try again.')
+    } finally {
+      setIsGenerating(false)
+    }
+  }
+
+  async function loadHistory() {
+    if (!org?.id) return
+    setIsLoadingHistory(true)
+    try {
+      const res = await fetchAIAssignmentHistory(org.id, access_token)
+      if (res.success && Array.isArray(res.data)) {
+        setHistory(res.data as HistoryItem[])
+      } else {
+        setHistory([])
+      }
+    } catch {
+      setHistory([])
+    } finally {
+      setIsLoadingHistory(false)
+    }
+  }
+
+  function loadFromHistory(item: HistoryItem) {
+    setPrompt(item.prompt || '')
+    setSessionUuid(item.session_uuid)
+    setPlan(item.plan)
+    setTasks(clone(item.plan?.tasks ?? []))
+    setTab('generate')
+    toast.success('Loaded a previous generation.')
+  }
+
+  async function removeHistory(uuid: string, e: React.MouseEvent) {
+    e.stopPropagation()
+    try {
+      await deleteAIAssignmentHistory(uuid, access_token)
+      setHistory((prev) => prev.filter((h) => h.ai_generation_uuid !== uuid))
+    } catch (_e) {
+      toast.error('Could not delete history entry.')
+    }
+  }
+
+  React.useEffect(() => {
+    if (tab === 'history') loadHistory()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab])
+
+  // --- Task editing helpers ---
+  const updateTask = (index: number, patch: Partial<GeneratedTask>) => {
+    setTasks((prev) => prev.map((t, i) => (i === index ? { ...t, ...patch } : t)))
+  }
+
+  const updateContents = (index: number, mutate: (_contents: any) => void) => {
+    setTasks((prev) =>
+      prev.map((t, i) => {
+        if (i !== index) return t
+        const contents = clone(t.contents ?? {})
+        mutate(contents)
+        return { ...t, contents }
+      })
+    )
+  }
+
+  const removeTask = (index: number) => {
+    setTasks((prev) => prev.filter((_, i) => i !== index))
+  }
+
+  async function saveAll() {
+    if (tasks.length === 0) return
+    setIsSaving(true)
+    let saved = 0
+    try {
+      for (const task of tasks) {
+        const body = {
+          title: task.title,
+          description: task.description,
+          hint: task.hint,
+          reference_file: '',
+          assignment_type: task.assignment_type,
+          contents: task.contents ?? {},
+          max_grade_value: task.max_grade_value ?? 100,
+        }
+        const res = await createAssignmentTask(body, assignment_uuid, access_token)
+        if (res?.success !== false) saved += 1
+      }
+      // Refresh the task list the editor page renders (react-query key used by
+      // AssignmentProvider / Tasks list).
+      queryClient.invalidateQueries({ queryKey: queryKeys.assignments.tasks(assignment_uuid) })
+      queryClient.invalidateQueries({ queryKey: queryKeys.assignments.detail(assignment_uuid) })
+      toast.success(`Added ${saved} task${saved === 1 ? '' : 's'} to the assignment.`)
+      closeModal(false)
+    } catch {
+      toast.error('Some tasks could not be saved.')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Render
+  // ------------------------------------------------------------------
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Tabs */}
+      <div className="flex items-center gap-1 p-1 bg-gray-100 rounded-lg w-fit">
+        <button
+          type="button"
+          onClick={() => setTab('generate')}
+          className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-md transition-colors ${
+            tab === 'generate' ? 'bg-white text-gray-900 nice-shadow' : 'text-gray-500 hover:text-gray-700'
+          }`}
+        >
+          <Sparkles size={13} />
+          Generate
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab('history')}
+          className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-md transition-colors ${
+            tab === 'history' ? 'bg-white text-gray-900 nice-shadow' : 'text-gray-500 hover:text-gray-700'
+          }`}
+        >
+          <History size={13} />
+          History
+        </button>
+      </div>
+
+      {tab === 'history' ? (
+        <HistoryList
+          history={history}
+          isLoading={isLoadingHistory}
+          onLoad={loadFromHistory}
+          onRemove={removeHistory}
+        />
+      ) : (
+        <div className="flex flex-col gap-4">
+          {/* Prompt panel */}
+          <div className="flex flex-col gap-3 p-4 rounded-lg border border-gray-100 nice-shadow bg-white">
+            <div>
+              <label className="text-xs font-semibold text-gray-700 mb-1.5 block">
+                What should these tasks cover?
+              </label>
+              <textarea
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                rows={3}
+                placeholder="e.g. Create tasks that test understanding of the key concepts in this course's second chapter."
+                className="w-full px-3 py-2 text-sm text-gray-700 border border-gray-200 rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-gray-900/10 focus:border-gray-300"
+              />
+              <p className="mt-1 text-[11px] text-gray-400">
+                Tasks are grounded on this assignment&apos;s course content.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap items-end gap-4">
+              <div>
+                <label className="text-xs font-semibold text-gray-700 mb-1.5 block">
+                  Number of tasks
+                </label>
+                <input
+                  type="number"
+                  min={1}
+                  max={10}
+                  value={numTasks}
+                  onChange={(e) =>
+                    setNumTasks(Math.min(10, Math.max(1, parseInt(e.target.value || '1', 10))))
+                  }
+                  className="w-20 px-3 py-2 text-sm text-gray-700 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-900/10"
+                />
+              </div>
+              <div className="flex-1 min-w-[240px]">
+                <label className="text-xs font-semibold text-gray-700 mb-1.5 block">
+                  Allowed task types
+                </label>
+                <div className="flex flex-wrap gap-1.5">
+                  {ALL_TYPES.map((type) => {
+                    const meta = TYPE_META[type]
+                    const Icon = meta.Icon
+                    const active = allowedTypes.has(type)
+                    return (
+                      <button
+                        key={type}
+                        type="button"
+                        onClick={() => toggleType(type)}
+                        className={`flex items-center gap-1 px-2.5 py-1 text-[11px] font-medium rounded-full border transition-colors ${
+                          active
+                            ? 'bg-gray-900 text-white border-gray-900'
+                            : 'bg-white text-gray-500 border-gray-200 hover:border-gray-300'
+                        }`}
+                      >
+                        <Icon size={12} />
+                        {meta.label}
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => runGenerate(false)}
+                disabled={isGenerating}
+                className="flex items-center gap-1.5 px-4 py-2 bg-gray-900 text-white text-xs font-semibold rounded-lg hover:bg-black transition-colors disabled:opacity-50"
+              >
+                {isGenerating ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
+                {plan ? 'Regenerate' : 'Generate'}
+              </button>
+              {plan && (
+                <button
+                  type="button"
+                  onClick={() => runGenerate(true)}
+                  disabled={isGenerating}
+                  className="flex items-center gap-1.5 px-4 py-2 bg-white text-gray-700 text-xs font-semibold rounded-lg border border-gray-200 hover:border-gray-300 transition-colors disabled:opacity-50"
+                  title="Refine the current tasks using your latest prompt"
+                >
+                  Refine with prompt
+                </button>
+              )}
+            </div>
+          </div>
+
+          {/* Preview */}
+          {isGenerating && !plan && (
+            <div className="flex items-center justify-center gap-2 py-10 text-sm text-gray-400">
+              <Loader2 size={16} className="animate-spin" />
+              Generating tasks…
+            </div>
+          )}
+
+          {plan && (
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-gray-900">
+                    {plan.title || 'Preview'}
+                  </p>
+                  {plan.description && (
+                    <p className="text-xs text-gray-500">{plan.description}</p>
+                  )}
+                </div>
+                <span className="text-[11px] font-semibold text-gray-400 uppercase tracking-wide">
+                  {tasks.length} task{tasks.length === 1 ? '' : 's'}
+                </span>
+              </div>
+
+              {tasks.map((task, index) => (
+                <TaskPreviewCard
+                  key={index}
+                  task={task}
+                  index={index}
+                  onUpdateTask={updateTask}
+                  onUpdateContents={updateContents}
+                  onRemove={removeTask}
+                />
+              ))}
+
+              {tasks.length === 0 && (
+                <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50/50 px-4 py-8 text-center text-xs text-gray-400">
+                  No tasks left — regenerate to start over.
+                </div>
+              )}
+
+              <div className="flex items-center justify-end gap-2 pt-1">
+                <button
+                  type="button"
+                  onClick={() => closeModal(false)}
+                  className="px-4 py-2 text-xs font-semibold text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={saveAll}
+                  disabled={isSaving || tasks.length === 0}
+                  className="flex items-center gap-1.5 px-4 py-2 bg-gray-900 text-white text-xs font-semibold rounded-lg hover:bg-black transition-colors disabled:opacity-50"
+                >
+                  {isSaving ? <Loader2 size={14} className="animate-spin" /> : <Plus size={14} />}
+                  Add to assignment
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ------------------------------------------------------------------
+// History list
+// ------------------------------------------------------------------
+function HistoryList({
+  history,
+  isLoading,
+  onLoad,
+  onRemove,
+}: {
+  history: HistoryItem[]
+  isLoading: boolean
+  onLoad: (_item: HistoryItem) => void
+  onRemove: (_uuid: string, _e: React.MouseEvent) => void
+}) {
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center gap-2 py-10 text-sm text-gray-400">
+        <Loader2 size={16} className="animate-spin" />
+        Loading history…
+      </div>
+    )
+  }
+  if (history.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50/50 px-4 py-10 text-center text-xs text-gray-400">
+        No previous generations yet.
+      </div>
+    )
+  }
+  return (
+    <div className="flex flex-col gap-2">
+      {history.map((item) => (
+        <button
+          key={item.ai_generation_uuid}
+          type="button"
+          onClick={() => onLoad(item)}
+          className="group text-left rounded-lg border border-gray-100 bg-white nice-shadow px-3.5 py-3 hover:border-gray-200 transition-all"
+        >
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-gray-800 truncate">
+                {item.plan?.title || item.prompt || 'Untitled generation'}
+              </p>
+              <p className="mt-0.5 text-xs text-gray-500 line-clamp-2">{item.prompt}</p>
+              <div className="mt-1.5 flex items-center gap-2 text-[11px] text-gray-400">
+                <span className="inline-flex items-center gap-1">
+                  <ListTodo size={11} />
+                  {item.plan?.tasks?.length ?? 0} task
+                  {(item.plan?.tasks?.length ?? 0) === 1 ? '' : 's'}
+                </span>
+                {item.creation_date && (
+                  <span className="inline-flex items-center gap-1">
+                    <Clock size={11} />
+                    {new Date(item.creation_date).toLocaleDateString()}
+                  </span>
+                )}
+              </div>
+            </div>
+            <span
+              role="button"
+              tabIndex={0}
+              onClick={(e) => onRemove(item.ai_generation_uuid, e)}
+              className="flex-none p-1.5 rounded-md text-gray-300 hover:text-rose-500 hover:bg-rose-50 transition-colors"
+              title="Delete"
+            >
+              <Trash2 size={14} />
+            </span>
+          </div>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+// ------------------------------------------------------------------
+// Per-task editable preview card
+// ------------------------------------------------------------------
+function TaskPreviewCard({
+  task,
+  index,
+  onUpdateTask,
+  onUpdateContents,
+  onRemove,
+}: {
+  task: GeneratedTask
+  index: number
+  onUpdateTask: (_index: number, _patch: Partial<GeneratedTask>) => void
+  onUpdateContents: (_index: number, _mutate: (_contents: any) => void) => void
+  onRemove: (_index: number) => void
+}) {
+  const meta = TYPE_META[task.assignment_type] ?? { label: task.assignment_type, Icon: Type }
+  const Icon = meta.Icon
+
+  return (
+    <div className="rounded-lg border border-gray-100 bg-white nice-shadow overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-2.5 border-b border-gray-50 bg-gray-50/40">
+        <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wide text-gray-500">
+          <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-gray-200 text-gray-600 font-bold">
+            {index + 1}
+          </span>
+          <Icon size={13} className="text-gray-400" />
+          <span>{meta.label}</span>
+        </div>
+        <button
+          type="button"
+          onClick={() => onRemove(index)}
+          className="p-1 rounded-md text-gray-300 hover:text-rose-500 hover:bg-rose-50 transition-colors"
+          title="Remove from preview"
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      {/* Common fields */}
+      <div className="p-4 flex flex-col gap-3">
+        <div>
+          <label className="text-[11px] font-semibold text-gray-500 mb-1 block">Title</label>
+          <input
+            value={task.title}
+            onChange={(e) => onUpdateTask(index, { title: e.target.value })}
+            className="w-full px-3 py-1.5 text-sm font-semibold text-gray-800 border border-gray-200 rounded-md focus:outline-none focus:ring-2 focus:ring-gray-900/10"
+          />
+        </div>
+        <div>
+          <label className="text-[11px] font-semibold text-gray-500 mb-1 block">Description</label>
+          <textarea
+            value={task.description}
+            onChange={(e) => onUpdateTask(index, { description: e.target.value })}
+            rows={2}
+            className="w-full px-3 py-1.5 text-sm text-gray-700 border border-gray-200 rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-gray-900/10"
+          />
+        </div>
+        <div className="flex gap-3">
+          <div className="flex-1">
+            <label className="text-[11px] font-semibold text-gray-500 mb-1 block">Hint</label>
+            <input
+              value={task.hint}
+              onChange={(e) => onUpdateTask(index, { hint: e.target.value })}
+              className="w-full px-3 py-1.5 text-sm text-gray-700 border border-gray-200 rounded-md focus:outline-none focus:ring-2 focus:ring-gray-900/10"
+            />
+          </div>
+          <div className="w-28">
+            <label className="text-[11px] font-semibold text-gray-500 mb-1 block">Max grade</label>
+            <input
+              type="number"
+              min={1}
+              value={task.max_grade_value}
+              onChange={(e) =>
+                onUpdateTask(index, { max_grade_value: parseInt(e.target.value || '0', 10) })
+              }
+              className="w-full px-3 py-1.5 text-sm text-gray-700 border border-gray-200 rounded-md focus:outline-none focus:ring-2 focus:ring-gray-900/10"
+            />
+          </div>
+        </div>
+
+        {/* Type-specific content */}
+        <TaskContentEditor index={index} task={task} onUpdateContents={onUpdateContents} />
+      </div>
+    </div>
+  )
+}
+
+// ------------------------------------------------------------------
+// Type-specific content editors (mirror the shapes the server expects)
+// ------------------------------------------------------------------
+function TaskContentEditor({
+  index,
+  task,
+  onUpdateContents,
+}: {
+  index: number
+  task: GeneratedTask
+  onUpdateContents: (_index: number, _mutate: (_contents: any) => void) => void
+}) {
+  const c = task.contents ?? {}
+  const inputCls =
+    'w-full px-2.5 py-1.5 text-sm text-gray-700 border border-gray-200 rounded-md focus:outline-none focus:ring-2 focus:ring-gray-900/10'
+
+  if (task.assignment_type === 'QUIZ') {
+    const questions: any[] = Array.isArray(c.questions) ? c.questions : []
+    return (
+      <div className="flex flex-col gap-3 pt-1">
+        {questions.map((q, qi) => (
+          <div key={qi} className="rounded-md border border-gray-100 bg-gray-50/40 p-3 flex flex-col gap-2">
+            <input
+              value={q.questionText ?? ''}
+              onChange={(e) =>
+                onUpdateContents(index, (contents) => {
+                  contents.questions[qi].questionText = e.target.value
+                })
+              }
+              placeholder="Question"
+              className={inputCls + ' font-semibold'}
+            />
+            <div className="flex flex-col gap-1.5">
+              {(q.options ?? []).map((o: any, oi: number) => (
+                <div key={oi} className="flex items-center gap-2">
+                  <span className="w-5 text-center text-xs font-bold text-gray-400">
+                    {String.fromCharCode(65 + oi)}
+                  </span>
+                  <input
+                    value={o.text ?? ''}
+                    onChange={(e) =>
+                      onUpdateContents(index, (contents) => {
+                        contents.questions[qi].options[oi].text = e.target.value
+                      })
+                    }
+                    placeholder="Option"
+                    className={inputCls}
+                  />
+                  <button
+                    type="button"
+                    onClick={() =>
+                      onUpdateContents(index, (contents) => {
+                        const opt = contents.questions[qi].options[oi]
+                        opt.assigned_right_answer = !opt.assigned_right_answer
+                      })
+                    }
+                    className={`flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-bold transition-colors ${
+                      o.assigned_right_answer
+                        ? 'bg-lime-100 text-lime-700'
+                        : 'bg-rose-50 text-rose-500'
+                    }`}
+                    title="Toggle correct answer"
+                  >
+                    {o.assigned_right_answer ? <Check size={12} /> : <X size={12} />}
+                    {o.assigned_right_answer ? 'Correct' : 'Wrong'}
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  if (task.assignment_type === 'FORM') {
+    const questions: any[] = Array.isArray(c.questions) ? c.questions : []
+    return (
+      <div className="flex flex-col gap-3 pt-1">
+        {questions.map((q, qi) => (
+          <div key={qi} className="rounded-md border border-gray-100 bg-gray-50/40 p-3 flex flex-col gap-2">
+            <input
+              value={q.questionText ?? ''}
+              onChange={(e) =>
+                onUpdateContents(index, (contents) => {
+                  contents.questions[qi].questionText = e.target.value
+                })
+              }
+              placeholder="Prompt (use ___ for a blank)"
+              className={inputCls + ' font-semibold'}
+            />
+            {(q.blanks ?? []).map((b: any, bi: number) => (
+              <div key={bi} className="flex items-center gap-2">
+                <input
+                  value={b.placeholder ?? ''}
+                  onChange={(e) =>
+                    onUpdateContents(index, (contents) => {
+                      contents.questions[qi].blanks[bi].placeholder = e.target.value
+                    })
+                  }
+                  placeholder="Placeholder"
+                  className={inputCls}
+                />
+                <input
+                  value={b.correctAnswer ?? ''}
+                  onChange={(e) =>
+                    onUpdateContents(index, (contents) => {
+                      contents.questions[qi].blanks[bi].correctAnswer = e.target.value
+                    })
+                  }
+                  placeholder="Correct answer"
+                  className={inputCls + ' font-semibold text-emerald-700'}
+                />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  if (task.assignment_type === 'SHORT_ANSWER') {
+    const answers: string[] = Array.isArray(c.correct_answers) ? c.correct_answers : []
+    return (
+      <div className="flex flex-col gap-2 pt-1">
+        <input
+          value={c.prompt ?? ''}
+          onChange={(e) =>
+            onUpdateContents(index, (contents) => {
+              contents.prompt = e.target.value
+            })
+          }
+          placeholder="Prompt"
+          className={inputCls + ' font-semibold'}
+        />
+        <div className="flex flex-col gap-1.5">
+          <span className="text-[11px] font-semibold text-gray-500">Accepted answers</span>
+          {answers.map((a, ai) => (
+            <input
+              key={ai}
+              value={a}
+              onChange={(e) =>
+                onUpdateContents(index, (contents) => {
+                  contents.correct_answers[ai] = e.target.value
+                })
+              }
+              className={inputCls + ' text-emerald-700 font-medium'}
+            />
+          ))}
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-[11px] font-semibold text-gray-500">Match mode</span>
+          <select
+            value={c.match_mode ?? 'case_insensitive'}
+            onChange={(e) =>
+              onUpdateContents(index, (contents) => {
+                contents.match_mode = e.target.value
+              })
+            }
+            className="px-2.5 py-1.5 text-sm text-gray-700 border border-gray-200 rounded-md bg-white focus:outline-none focus:ring-2 focus:ring-gray-900/10"
+          >
+            <option value="case_insensitive">Case insensitive</option>
+            <option value="exact">Exact</option>
+            <option value="contains">Contains</option>
+            <option value="regex">Regex</option>
+          </select>
+        </div>
+      </div>
+    )
+  }
+
+  if (task.assignment_type === 'NUMBER_ANSWER') {
+    return (
+      <div className="flex flex-col gap-2 pt-1">
+        <input
+          value={c.prompt ?? ''}
+          onChange={(e) =>
+            onUpdateContents(index, (contents) => {
+              contents.prompt = e.target.value
+            })
+          }
+          placeholder="Prompt"
+          className={inputCls + ' font-semibold'}
+        />
+        <div className="flex items-center gap-2">
+          <div className="flex-1">
+            <label className="text-[11px] font-semibold text-gray-500 mb-1 block">Correct value</label>
+            <input
+              type="number"
+              value={c.correct_value ?? 0}
+              onChange={(e) =>
+                onUpdateContents(index, (contents) => {
+                  contents.correct_value = parseFloat(e.target.value || '0')
+                })
+              }
+              className={inputCls + ' text-emerald-700 font-semibold'}
+            />
+          </div>
+          <div className="flex-1">
+            <label className="text-[11px] font-semibold text-gray-500 mb-1 block">Tolerance (±)</label>
+            <input
+              type="number"
+              value={c.tolerance ?? 0}
+              onChange={(e) =>
+                onUpdateContents(index, (contents) => {
+                  contents.tolerance = parseFloat(e.target.value || '0')
+                })
+              }
+              className={inputCls}
+            />
+          </div>
+          <div className="w-24">
+            <label className="text-[11px] font-semibold text-gray-500 mb-1 block">Unit</label>
+            <input
+              value={c.unit ?? ''}
+              onChange={(e) =>
+                onUpdateContents(index, (contents) => {
+                  contents.unit = e.target.value
+                })
+              }
+              className={inputCls}
+            />
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // FILE_SUBMISSION — no content to edit.
+  return (
+    <p className="text-xs text-gray-400 italic pt-1">
+      Students submit a file for this task. No answer key to configure.
+    </p>
+  )
+}
+
+export default GenerateTasksAIModal

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/Tasks.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/Tasks.tsx
@@ -1,8 +1,9 @@
 import { useAssignments } from '@components/Contexts/Assignments/AssignmentContext'
 import Modal from '@components/Objects/StyledElements/Modal/Modal';
-import { Clock, Code2, FileUp, Hash, ListTodo, Pencil, Plus, Type } from 'lucide-react';
+import { Clock, Code2, FileUp, Hash, ListTodo, Pencil, Plus, Sparkles, Type } from 'lucide-react';
 import React from 'react'
 import NewTaskModal from './Modals/NewTaskModal';
+import GenerateTasksAIModal from './Modals/GenerateTasksAIModal';
 import { useAssignmentsTask, useAssignmentsTaskDispatch } from '@components/Contexts/Assignments/AssignmentsTaskContext';
 import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs'
@@ -33,6 +34,7 @@ function AssignmentTasks({ assignment_uuid }: any) {
     const assignmentTask = useAssignmentsTask() as any;
     const assignmentTaskHook = useAssignmentsTaskDispatch() as any;
     const [isNewTaskModalOpen, setIsNewTaskModalOpen] = React.useState(false)
+    const [isGenerateAIModalOpen, setIsGenerateAIModalOpen] = React.useState(false)
 
     async function setSelectTask(task_uuid: string) {
         assignmentTaskHook({ type: 'setSelectedAssignmentTaskUUID', payload: task_uuid })
@@ -61,6 +63,32 @@ function AssignmentTasks({ assignment_uuid }: any) {
                             >
                                 <Plus size={14} className='transition-transform group-hover:scale-110' />
                                 <span>{t('dashboard.assignments.editor.add_task')}</span>
+                            </button>
+                        }
+                    />
+                )}
+
+                {assignments && tasks.length < 10 && (
+                    <Modal
+                        isDialogOpen={isGenerateAIModalOpen}
+                        onOpenChange={setIsGenerateAIModalOpen}
+                        minHeight='no-min'
+                        minWidth='md'
+                        dialogContent={
+                            <GenerateTasksAIModal
+                                assignment_uuid={assignment_uuid}
+                                closeModal={setIsGenerateAIModalOpen}
+                            />
+                        }
+                        dialogTitle={t('dashboard.assignments.editor.generate_ai_modal.title', 'Generate tasks with AI')}
+                        dialogDescription={t('dashboard.assignments.editor.generate_ai_modal.description', 'Describe what you want and preview tasks grounded on the course content before adding them.')}
+                        dialogTrigger={
+                            <button
+                                type='button'
+                                className='group flex items-center justify-center gap-1.5 w-full px-3 py-2.5 bg-white text-gray-700 text-xs font-semibold rounded-lg border border-gray-200 hover:border-gray-300 hover:bg-gray-50 transition-colors nice-shadow'
+                            >
+                                <Sparkles size={14} className='transition-transform group-hover:scale-110' />
+                                <span>{t('dashboard.assignments.editor.generate_ai', 'Generate tasks with AI')}</span>
                             </button>
                         }
                     />

--- a/apps/web/components/Dashboard/Boards/Extensions/ActivityBlockComponent.tsx
+++ b/apps/web/components/Dashboard/Boards/Extensions/ActivityBlockComponent.tsx
@@ -253,7 +253,12 @@ export default function ActivityBlockComponent({ node, updateAttributes, selecte
         return (
           <EmbedCourseProvider courseUuid={cUuid}>
             <Suspense fallback={<LoadingFallback />}>
-              <Canva content={activity.content} activity={activity} />
+              <Canva
+                content={activity.content}
+                activity={activity}
+                courseUuid={courseMeta?.course_uuid || cUuid}
+                orgUuid={courseMeta?.org_uuid}
+              />
             </Suspense>
           </EmbedCourseProvider>
         )

--- a/apps/web/components/Dashboard/Boards/Tabs/BoardThumbnailTab.tsx
+++ b/apps/web/components/Dashboard/Boards/Tabs/BoardThumbnailTab.tsx
@@ -7,6 +7,7 @@ import { useLHSession } from '@components/Contexts/LHSessionContext'
 import { updateBoardThumbnail } from '@services/boards/boards'
 import { getBoardThumbnailMediaDirectory } from '@services/media/media'
 import UnsplashImagePicker from '@components/Dashboard/Pages/Course/EditCourseGeneral/UnsplashImagePicker'
+import AIImageButton from '@components/Objects/AI/AIImageButton'
 import toast from 'react-hot-toast'
 import { useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query/keys'
@@ -157,6 +158,10 @@ function BoardThumbnailTab({ board, boardUuid, orgUuid, boardKey }: BoardThumbna
                 <ImageIcon size={16} />
                 {t('boards.thumbnail.gallery')}
               </button>
+              <AIImageButton
+                onSelect={handleUnsplashSelect}
+                className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+              />
             </div>
           )}
 

--- a/apps/web/components/Dashboard/Boards/Tabs/BoardThumbnailTab.tsx
+++ b/apps/web/components/Dashboard/Boards/Tabs/BoardThumbnailTab.tsx
@@ -23,7 +23,7 @@ interface BoardThumbnailTabProps {
   boardKey: string | null
 }
 
-function BoardThumbnailTab({ board, boardUuid, orgUuid, boardKey }: BoardThumbnailTabProps) {
+function BoardThumbnailTab({ board, boardUuid, orgUuid, boardKey: _boardKey }: BoardThumbnailTabProps) {
   const { t } = useTranslation()
   const org = useOrg() as any
   const session = useLHSession() as any

--- a/apps/web/components/Dashboard/Boards/Tabs/BoardThumbnailTab.tsx
+++ b/apps/web/components/Dashboard/Boards/Tabs/BoardThumbnailTab.tsx
@@ -83,6 +83,12 @@ function BoardThumbnailTab({ board, boardUuid, orgUuid, boardKey: _boardKey }: B
     await uploadFile(file)
   }
 
+  const handleAIImageFile = async (file: File) => {
+    const blobUrl = URL.createObjectURL(file)
+    setLocalThumbnail({ url: blobUrl })
+    await uploadFile(file)
+  }
+
   const handleUnsplashSelect = async (imageUrl: string) => {
     try {
       const url = new URL(imageUrl)
@@ -160,6 +166,7 @@ function BoardThumbnailTab({ board, boardUuid, orgUuid, boardKey: _boardKey }: B
               </button>
               <AIImageButton
                 onSelect={handleUnsplashSelect}
+                onSelectFile={handleAIImageFile}
                 className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
               />
             </div>

--- a/apps/web/components/Dashboard/Pages/Community/CommunityEditThumbnail.tsx
+++ b/apps/web/components/Dashboard/Pages/Community/CommunityEditThumbnail.tsx
@@ -105,6 +105,13 @@ const CommunityEditThumbnail: React.FC = () => {
     }
   }
 
+  const handleAIImageFile = async (file: File) => {
+    if (!validateFile(file)) return
+    const blobUrl = URL.createObjectURL(file)
+    setLocalThumbnail({ file, url: blobUrl })
+    await uploadThumbnail(file)
+  }
+
   const uploadThumbnail = async (file: File) => {
     setIsLoading(true)
     try {
@@ -218,6 +225,7 @@ const CommunityEditThumbnail: React.FC = () => {
                 </Button>
                 <AIImageButton
                   onSelect={handleUnsplashSelect}
+                  onSelectFile={handleAIImageFile}
                   className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium border border-gray-200 rounded-md bg-white hover:bg-gray-50 transition-colors"
                 />
               </div>

--- a/apps/web/components/Dashboard/Pages/Community/CommunityEditThumbnail.tsx
+++ b/apps/web/components/Dashboard/Pages/Community/CommunityEditThumbnail.tsx
@@ -12,6 +12,7 @@ import { revalidateTags } from '@services/utils/ts/requests'
 import { useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query/keys'
 import UnsplashImagePicker from '@components/Dashboard/Pages/Course/EditCourseGeneral/UnsplashImagePicker'
+import AIImageButton from '@components/Objects/AI/AIImageButton'
 import toast from 'react-hot-toast'
 import { Button } from '@components/ui/button'
 import { SafeImage } from '@components/Objects/SafeImage'
@@ -215,6 +216,10 @@ const CommunityEditThumbnail: React.FC = () => {
                   <ImageIcon size={16} />
                   {t('dashboard.courses.communities.thumbnail.browse_unsplash')}
                 </Button>
+                <AIImageButton
+                  onSelect={handleUnsplashSelect}
+                  className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium border border-gray-200 rounded-md bg-white hover:bg-gray-50 transition-colors"
+                />
               </div>
             )}
 

--- a/apps/web/components/Dashboard/Pages/Community/CommunityEditThumbnail.tsx
+++ b/apps/web/components/Dashboard/Pages/Community/CommunityEditThumbnail.tsx
@@ -27,7 +27,7 @@ const CommunityEditThumbnail: React.FC = () => {
   const session = useLHSession() as any
   const org = useOrg() as any
   const communityState = useCommunity()
-  const dispatch = useCommunityDispatch()
+  const _dispatch = useCommunityDispatch()
   const community = communityState?.community
   const accessToken = session?.data?.tokens?.access_token
   const queryClient = useQueryClient()
@@ -99,7 +99,7 @@ const CommunityEditThumbnail: React.FC = () => {
       setLocalThumbnail({ file, url: blobUrl })
       setShowUnsplashPicker(false)
       await uploadThumbnail(file)
-    } catch (err) {
+    } catch (_err) {
       showError(t('dashboard.courses.communities.thumbnail.toasts.update_error'))
       setIsLoading(false)
     }
@@ -127,7 +127,7 @@ const CommunityEditThumbnail: React.FC = () => {
         })
         router.refresh()
       }
-    } catch (err) {
+    } catch (_err) {
       showError(t('dashboard.courses.communities.thumbnail.toasts.update_error'))
     } finally {
       setIsLoading(false)

--- a/apps/web/components/Dashboard/Pages/Course/EditCourseGeneral/ThumbnailUpdate.tsx
+++ b/apps/web/components/Dashboard/Pages/Course/EditCourseGeneral/ThumbnailUpdate.tsx
@@ -39,7 +39,7 @@ function ThumbnailUpdate({ thumbnailType }: ThumbnailUpdateProps) {
   const [isLoading, setIsLoading] = useState(false)
   const [showUnsplashPicker, setShowUnsplashPicker] = useState(false)
   const [activeTab, setActiveTab] = useState<TabType>('image')
-  const withUnpublishedActivities = course ? course.withUnpublishedActivities : false
+  const _withUnpublishedActivities = course ? course.withUnpublishedActivities : false
 
   // Set initial active tab based on thumbnailType
   useEffect(() => {
@@ -129,7 +129,7 @@ function ThumbnailUpdate({ thumbnailType }: ThumbnailUpdateProps) {
       const blobUrl = URL.createObjectURL(file);
       setLocalThumbnail({ file, url: blobUrl, type: 'image' });
       await updateThumbnail(file, 'image');
-    } catch (err) {
+    } catch (_err) {
       showError('Failed to process Unsplash image');
       setIsLoading(false);
     }
@@ -163,7 +163,7 @@ function ThumbnailUpdate({ thumbnailType }: ThumbnailUpdateProps) {
           position: 'top-center',
         });
       }
-    } catch (err) {
+    } catch (_err) {
       showError('Failed to update thumbnail');
     } finally {
       setIsLoading(false);

--- a/apps/web/components/Dashboard/Pages/Course/EditCourseGeneral/ThumbnailUpdate.tsx
+++ b/apps/web/components/Dashboard/Pages/Course/EditCourseGeneral/ThumbnailUpdate.tsx
@@ -135,6 +135,13 @@ function ThumbnailUpdate({ thumbnailType }: ThumbnailUpdateProps) {
     }
   }
 
+  const handleAIImageFile = async (file: File) => {
+    if (!validateFile(file, 'image')) return
+    const blobUrl = URL.createObjectURL(file)
+    setLocalThumbnail({ file, url: blobUrl, type: 'image' })
+    await updateThumbnail(file, 'image')
+  }
+
   const updateThumbnail = async (file: File, type: 'image' | 'video') => {
     setIsLoading(true);
     try {
@@ -281,6 +288,7 @@ function ThumbnailUpdate({ thumbnailType }: ThumbnailUpdateProps) {
           </button>
           <AIImageButton
             onSelect={handleUnsplashSelect}
+            onSelectFile={handleAIImageFile}
             className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
           />
         </div>

--- a/apps/web/components/Dashboard/Pages/Course/EditCourseGeneral/ThumbnailUpdate.tsx
+++ b/apps/web/components/Dashboard/Pages/Course/EditCourseGeneral/ThumbnailUpdate.tsx
@@ -8,6 +8,7 @@ import React, { useState, useEffect, useRef } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@lib/query/keys'
 import UnsplashImagePicker from './UnsplashImagePicker'
+import AIImageButton from '@components/Objects/AI/AIImageButton'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
 import { SafeImage, SafeVideo } from '@components/Objects/SafeImage'
@@ -278,6 +279,10 @@ function ThumbnailUpdate({ thumbnailType }: ThumbnailUpdateProps) {
             <ImageIcon size={16} />
             {t('dashboard.courses.general.thumbnail.gallery')}
           </button>
+          <AIImageButton
+            onSelect={handleUnsplashSelect}
+            className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          />
         </div>
       );
     }

--- a/apps/web/components/Dashboard/Pages/Org/OrgEditBranding/AuthBrandingTab.tsx
+++ b/apps/web/components/Dashboard/Pages/Org/OrgEditBranding/AuthBrandingTab.tsx
@@ -18,6 +18,7 @@ import { revalidateTags } from '@services/utils/ts/requests'
 import { useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query/keys'
 import UnsplashImagePicker, { UnsplashPhotoMeta } from '@components/Dashboard/Pages/Course/EditCourseGeneral/UnsplashImagePicker'
+import AIImageButton from '@components/Objects/AI/AIImageButton'
 import { isOSSMode } from '@services/config/config'
 import { usePlan } from '@components/Hooks/usePlan'
 
@@ -223,6 +224,12 @@ export default function AuthBrandingTab() {
             className="hidden"
             onChange={handleBackgroundUpload}
           />
+          <div className="mt-3">
+            <AIImageButton
+              onSelect={handleUnsplashSelect}
+              className="w-full flex items-center justify-center gap-2 p-3 rounded-xl border-2 border-gray-200 hover:border-gray-300 bg-white text-sm font-medium text-gray-600 transition-all"
+            />
+          </div>
         </div>
 
         {/* Text Color */}

--- a/apps/web/components/Dashboard/Pages/Org/OrgEditBranding/AuthBrandingTab.tsx
+++ b/apps/web/components/Dashboard/Pages/Org/OrgEditBranding/AuthBrandingTab.tsx
@@ -9,7 +9,6 @@ import { toast } from 'react-hot-toast'
 import { constructAcceptValue } from '@/lib/constants'
 import { updateOrgAuthBrandingConfig, uploadOrgAuthBackground, AuthBrandingConfig } from '@services/settings/org'
 import { cn } from '@/lib/utils'
-import { Input } from "@components/ui/input"
 import { Button } from "@components/ui/button"
 import { Label } from "@components/ui/label"
 import { Textarea } from "@components/ui/textarea"
@@ -19,7 +18,6 @@ import { useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query/keys'
 import UnsplashImagePicker, { UnsplashPhotoMeta } from '@components/Dashboard/Pages/Course/EditCourseGeneral/UnsplashImagePicker'
 import AIImageButton from '@components/Objects/AI/AIImageButton'
-import { isOSSMode } from '@services/config/config'
 import { usePlan } from '@components/Hooks/usePlan'
 
 const SUPPORTED_FILES = constructAcceptValue(['png', 'jpg', 'webp'])
@@ -85,7 +83,7 @@ export default function AuthBrandingTab() {
       queryClient.invalidateQueries({ queryKey: queryKeys.org.detail(org.slug) })
       toast.success(t('dashboard.organization.auth_branding.save_success'), { id: loadingToast })
       router.refresh()
-    } catch (err) {
+    } catch (_err) {
       toast.error(t('dashboard.organization.auth_branding.save_error'), { id: loadingToast })
     } finally {
       setIsSaving(false)
@@ -104,7 +102,7 @@ export default function AuthBrandingTab() {
         setBackgroundType('custom')
         toast.success(t('dashboard.organization.auth_branding.upload_success'), { id: loadingToast })
         queryClient.invalidateQueries({ queryKey: queryKeys.org.detail(org.slug) })
-      } catch (err) {
+      } catch (_err) {
         toast.error(t('dashboard.organization.auth_branding.upload_error'), { id: loadingToast })
         setLocalBackgroundPreview(null)
       } finally {

--- a/apps/web/components/Dashboard/Pages/Org/OrgEditImages/OrgEditImages.tsx
+++ b/apps/web/components/Dashboard/Pages/Org/OrgEditImages/OrgEditImages.tsx
@@ -154,6 +154,23 @@ export default function OrgEditImages() {
     }
   }
 
+  const handleLogoAIImageFile = async (file: File) => {
+    setLocalLogo(URL.createObjectURL(file))
+    setIsLogoUploading(true)
+    const loadingToast = toast.loading(t('dashboard.organization.images.uploading_logo'))
+    try {
+      await uploadOrganizationLogo(org.id, file, access_token)
+      await new Promise((r) => setTimeout(r, 1500))
+      toast.success(t('dashboard.organization.images.toasts.logo_success'), { id: loadingToast })
+      queryClient.invalidateQueries({ queryKey: queryKeys.org.detail(org.slug) })
+      router.refresh()
+    } catch {
+      toast.error(t('dashboard.organization.images.toasts.logo_error'), { id: loadingToast })
+    } finally {
+      setIsLogoUploading(false)
+    }
+  }
+
   const handleThumbnailChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files && event.target.files.length > 0) {
       const file = event.target.files[0]
@@ -468,6 +485,7 @@ export default function OrgEditImages() {
 
                   <AIImageButton
                     onSelect={handleLogoAISelect}
+                    onSelectFile={handleLogoAIImageFile}
                     className="font-medium text-sm px-6 py-2.5 rounded-full bg-neutral-900 text-white hover:bg-neutral-800 shadow-xs hover:shadow-sm transition-all duration-300 flex items-center space-x-2"
                   />
 

--- a/apps/web/components/Dashboard/Pages/Org/OrgEditImages/OrgEditImages.tsx
+++ b/apps/web/components/Dashboard/Pages/Org/OrgEditImages/OrgEditImages.tsx
@@ -13,6 +13,7 @@ import { cn } from '@/lib/utils'
 import { Input } from "@components/ui/input"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@components/ui/dialog"
 import { Button } from "@components/ui/button"
+import AIImageButton from '@components/Objects/AI/AIImageButton'
 import { SiLoom, SiYoutube } from '@icons-pack/react-simple-icons'
 import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd'
 import { useTranslation } from 'react-i18next'
@@ -130,6 +131,26 @@ export default function OrgEditImages() {
       } finally {
         setIsLogoUploading(false)
       }
+    }
+  }
+
+  const handleLogoAISelect = async (imageUrl: string) => {
+    setLocalLogo(imageUrl)
+    setIsLogoUploading(true)
+    const loadingToast = toast.loading(t('dashboard.organization.images.uploading_logo'))
+    try {
+      const response = await fetch(imageUrl)
+      const blob = await response.blob()
+      const file = new File([blob], `ai_logo_${Date.now()}.png`, { type: blob.type || 'image/png' })
+      await uploadOrganizationLogo(org.id, file, access_token)
+      await new Promise((r) => setTimeout(r, 1500))
+      toast.success(t('dashboard.organization.images.toasts.logo_success'), { id: loadingToast })
+      queryClient.invalidateQueries({ queryKey: queryKeys.org.detail(org.slug) })
+      router.refresh()
+    } catch {
+      toast.error(t('dashboard.organization.images.toasts.logo_error'), { id: loadingToast })
+    } finally {
+      setIsLogoUploading(false)
     }
   }
 
@@ -444,6 +465,11 @@ export default function OrgEditImages() {
                     <UploadCloud size={18} className={cn("", isLogoUploading && "animate-bounce")} />
                     <span>{isLogoUploading ? t('dashboard.organization.images.uploading') : t('dashboard.organization.images.upload_logo')}</span>
                   </button>
+
+                  <AIImageButton
+                    onSelect={handleLogoAISelect}
+                    className="font-medium text-sm px-6 py-2.5 rounded-full bg-neutral-900 text-white hover:bg-neutral-800 shadow-xs hover:shadow-sm transition-all duration-300 flex items-center space-x-2"
+                  />
 
                   <div className="flex flex-col text-xs space-y-2 items-center text-gray-500">
                     <div className="flex items-center space-x-2 bg-blue-50 text-blue-700 px-3 py-1.5 rounded-full">

--- a/apps/web/components/Dashboard/Pages/Org/OrgEditImages/OrgEditImages.tsx
+++ b/apps/web/components/Dashboard/Pages/Org/OrgEditImages/OrgEditImages.tsx
@@ -126,7 +126,7 @@ export default function OrgEditImages() {
         toast.success(t('dashboard.organization.images.toasts.logo_success'), { id: loadingToast })
         queryClient.invalidateQueries({ queryKey: queryKeys.org.detail(org.slug) })
         router.refresh()
-      } catch (err) {
+      } catch (_err) {
         toast.error(t('dashboard.organization.images.toasts.logo_error'), { id: loadingToast })
       } finally {
         setIsLogoUploading(false)
@@ -166,7 +166,7 @@ export default function OrgEditImages() {
         toast.success(t('dashboard.organization.images.toasts.thumbnail_success'), { id: loadingToast })
         queryClient.invalidateQueries({ queryKey: queryKeys.org.detail(org.slug) })
         router.refresh()
-      } catch (err) {
+      } catch (_err) {
         toast.error(t('dashboard.organization.images.toasts.thumbnail_error'), { id: loadingToast })
       } finally {
         setIsThumbnailUploading(false)
@@ -236,7 +236,7 @@ export default function OrgEditImages() {
           : t('dashboard.organization.images.toasts.preview_added_plural', { count: files.length }), { id: loadingToast })
         queryClient.invalidateQueries({ queryKey: queryKeys.org.detail(org.slug) })
         router.refresh()
-      } catch (err) {
+      } catch (_err) {
         toast.error(t('dashboard.organization.images.toasts.preview_error'), { id: loadingToast })
       } finally {
         setIsPreviewUploading(false)
@@ -260,14 +260,14 @@ export default function OrgEditImages() {
       toast.success(t('dashboard.organization.images.toasts.preview_removed'), { id: loadingToast })
       queryClient.invalidateQueries({ queryKey: queryKeys.org.detail(org.slug) })
       router.refresh()
-    } catch (err) {
+    } catch (_err) {
       toast.error(t('dashboard.organization.images.toasts.preview_remove_error'), { id: loadingToast })
     }
   }
 
   const extractVideoId = (url: string, type: 'youtube' | 'loom'): string | null => {
     if (type === 'youtube') {
-      const regex = /(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/\s]{11})/
+      const regex = /(?:youtube\.com\/(?:[^/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?/\s]{11})/
       const match = url.match(regex)
       return match ? match[1] : null
     } else if (type === 'loom') {
@@ -334,7 +334,7 @@ export default function OrgEditImages() {
       toast.success(t('dashboard.organization.images.toasts.video_preview_added'), { id: loadingToast });
       queryClient.invalidateQueries({ queryKey: queryKeys.org.detail(org.slug) });
       router.refresh();
-    } catch (err) {
+    } catch (_err) {
       toast.error(t('dashboard.organization.images.toasts.video_preview_error'), { id: loadingToast });
     }
   };
@@ -379,7 +379,7 @@ export default function OrgEditImages() {
       toast.success(t('dashboard.organization.images.toasts.order_updated'), { id: loadingToast });
       queryClient.invalidateQueries({ queryKey: queryKeys.org.detail(org.slug) });
       router.refresh();
-    } catch (err) {
+    } catch (_err) {
       toast.error(t('dashboard.organization.images.toasts.order_update_error'), { id: loadingToast });
       setPreviews(previews);
     }

--- a/apps/web/components/Objects/AI/AIImageButton.tsx
+++ b/apps/web/components/Objects/AI/AIImageButton.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react'
+import { Sparkles } from 'lucide-react'
+import AIImagePicker from './AIImagePicker'
+
+// Drop-in trigger for the shared AI image generator. Place next to an existing
+// Unsplash button on any image-upload surface; it manages its own modal state,
+// so wiring a new surface is a single line:
+//   <AIImageButton onSelect={handleSelect} />
+// onSelect receives an absolute image URL (same contract as UnsplashImagePicker).
+interface AIImageButtonProps {
+  onSelect: (_imageUrl: string) => void
+  className?: string
+  label?: string
+  variant?: 'button' | 'chip'
+}
+
+const AIImageButton: React.FC<AIImageButtonProps> = ({
+  onSelect,
+  className,
+  label = 'Generate with AI',
+  variant = 'button',
+}) => {
+  const [open, setOpen] = useState(false)
+
+  const base =
+    variant === 'chip'
+      ? 'px-3 py-1 bg-neutral-100 rounded-lg hover:bg-neutral-200 nice-shadow transition-colors flex items-center gap-1.5 text-sm'
+      : 'px-3 py-2 bg-neutral-900 text-white rounded-lg hover:bg-neutral-800 nice-shadow transition-colors flex items-center gap-1.5 text-sm'
+
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)} className={className || base}>
+        <Sparkles size={15} />
+        {label}
+      </button>
+      {open && (
+        <AIImagePicker
+          isOpen={open}
+          onSelect={onSelect}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  )
+}
+
+export default AIImageButton

--- a/apps/web/components/Objects/AI/AIImageButton.tsx
+++ b/apps/web/components/Objects/AI/AIImageButton.tsx
@@ -9,6 +9,9 @@ import AIImagePicker from './AIImagePicker'
 // onSelect receives an absolute image URL (same contract as UnsplashImagePicker).
 interface AIImageButtonProps {
   onSelect: (_imageUrl: string) => void
+  // Upload surfaces pass this to receive a ready-to-upload File (fetched
+  // same-origin via the API), instead of re-fetching a cross-origin URL.
+  onSelectFile?: (_file: File) => void | Promise<void>
   className?: string
   label?: string
   variant?: 'button' | 'chip'
@@ -16,6 +19,7 @@ interface AIImageButtonProps {
 
 const AIImageButton: React.FC<AIImageButtonProps> = ({
   onSelect,
+  onSelectFile,
   className,
   label = 'Generate with AI',
   variant = 'button',
@@ -37,6 +41,7 @@ const AIImageButton: React.FC<AIImageButtonProps> = ({
         <AIImagePicker
           isOpen={open}
           onSelect={onSelect}
+          onSelectFile={onSelectFile}
           onClose={() => setOpen(false)}
         />
       )}

--- a/apps/web/components/Objects/AI/AIImageButton.tsx
+++ b/apps/web/components/Objects/AI/AIImageButton.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Sparkles } from 'lucide-react'
+import { Sparkle } from '@phosphor-icons/react'
 import AIImagePicker from './AIImagePicker'
 
 // Drop-in trigger for the shared AI image generator. Place next to an existing
@@ -34,7 +34,7 @@ const AIImageButton: React.FC<AIImageButtonProps> = ({
   return (
     <>
       <button type="button" onClick={() => setOpen(true)} className={className || base}>
-        <Sparkles size={15} />
+        <Sparkle weight="duotone" size={15} />
         {label}
       </button>
       {open && (

--- a/apps/web/components/Objects/AI/AIImagePicker.tsx
+++ b/apps/web/components/Objects/AI/AIImagePicker.tsx
@@ -35,23 +35,6 @@ const PROMPT_IDEAS = [
   'A watercolor landscape for a history lesson',
 ]
 
-async function urlToBase64(url: string): Promise<string | undefined> {
-  try {
-    const res = await fetch(url, { credentials: 'include' })
-    if (!res.ok) return undefined
-    const blob = await res.blob()
-    if (!blob.type.startsWith('image/')) return undefined
-    return await new Promise((resolve) => {
-      const reader = new FileReader()
-      reader.onloadend = () => resolve(reader.result as string)
-      reader.onerror = () => resolve(undefined)
-      reader.readAsDataURL(blob)
-    })
-  } catch {
-    return undefined
-  }
-}
-
 const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onClose, isOpen = true }) => {
   const org = useOrg() as any
   const session = useLHSession() as any
@@ -85,20 +68,14 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onClose, isOpen
     setGenerating(true)
     setError(null)
     try {
-      let source_image_base64: string | undefined
-      if (refineFrom) {
-        source_image_base64 = await urlToBase64(refineFrom.url)
-        if (!source_image_base64) {
-          setError('Could not load the source image to refine. Please try again.')
-          return
-        }
-      }
       const res = await generateAIImage(
         {
           org_id: org.id,
           prompt: prompt.trim(),
           session_uuid: sessionUuid,
-          source_image_base64,
+          // Refine by file_id — the backend reads the source image from storage
+          // (no cross-origin fetch), so refinement is reliable.
+          source_file_id: refineFrom?.file_id,
         },
         access_token
       )

--- a/apps/web/components/Objects/AI/AIImagePicker.tsx
+++ b/apps/web/components/Objects/AI/AIImagePicker.tsx
@@ -1,0 +1,303 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { Sparkles, Wand2, History, ArrowUpRight, RefreshCw, X, Trash2 } from 'lucide-react'
+import Modal from '@components/Objects/StyledElements/Modal/Modal'
+import { useOrg } from '@components/Contexts/OrgContext'
+import { useLHSession } from '@components/Contexts/LHSessionContext'
+import {
+  generateAIImage,
+  fetchAIImageHistory,
+  deleteAIImageHistory,
+  aiImageUrl,
+  AIImageHistoryItem,
+} from '@services/ai/generation'
+
+// Shared, Unsplash-style AI image generator (Google "nano banana"). Drops into
+// every image-upload surface via the SAME contract as UnsplashImagePicker, so
+// callers can wire it in identically: onSelect receives an absolute image URL.
+export interface AIImagePickerProps {
+  onSelect: (_imageUrl: string) => void
+  onClose: () => void
+  isOpen?: boolean
+}
+
+interface GeneratedItem {
+  ai_generation_uuid: string
+  file_id: string
+  url: string
+  prompt: string
+}
+
+const PROMPT_IDEAS = [
+  'A minimalist illustration of a lightbulb, soft gradients',
+  'A friendly 3D robot tutor, isometric, pastel colors',
+  'An abstract geometric banner about data science',
+  'A watercolor landscape for a history lesson',
+]
+
+async function urlToBase64(url: string): Promise<string | undefined> {
+  try {
+    const res = await fetch(url)
+    const blob = await res.blob()
+    return await new Promise((resolve) => {
+      const reader = new FileReader()
+      reader.onloadend = () => resolve(reader.result as string)
+      reader.onerror = () => resolve(undefined)
+      reader.readAsDataURL(blob)
+    })
+  } catch {
+    return undefined
+  }
+}
+
+const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onClose, isOpen = true }) => {
+  const org = useOrg() as any
+  const session = useLHSession() as any
+  const access_token = session?.data?.tokens?.access_token
+
+  const [tab, setTab] = useState<'generate' | 'history'>('generate')
+  const [prompt, setPrompt] = useState('')
+  const [generating, setGenerating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [items, setItems] = useState<GeneratedItem[]>([])
+  const [sessionUuid, setSessionUuid] = useState<string | undefined>(undefined)
+  const [refineFrom, setRefineFrom] = useState<GeneratedItem | null>(null)
+
+  const [history, setHistory] = useState<AIImageHistoryItem[]>([])
+  const [historyLoading, setHistoryLoading] = useState(false)
+
+  const loadHistory = useCallback(async () => {
+    if (!org?.id || !access_token) return
+    setHistoryLoading(true)
+    const res = await fetchAIImageHistory(org.id, access_token)
+    if (res.success && Array.isArray(res.data)) setHistory(res.data)
+    setHistoryLoading(false)
+  }, [org?.id, access_token])
+
+  useEffect(() => {
+    if (tab === 'history') loadHistory()
+  }, [tab, loadHistory])
+
+  const handleGenerate = async () => {
+    if (!prompt.trim() || generating || !org?.id) return
+    setGenerating(true)
+    setError(null)
+    try {
+      let source_image_base64: string | undefined
+      if (refineFrom) {
+        source_image_base64 = await urlToBase64(refineFrom.url)
+      }
+      const res = await generateAIImage(
+        {
+          org_id: org.id,
+          prompt: prompt.trim(),
+          session_uuid: sessionUuid,
+          source_image_base64,
+        },
+        access_token
+      )
+      if (!res.success) {
+        setError(res.data?.detail || 'Image generation failed. Please try again.')
+        return
+      }
+      const url = aiImageUrl(org.org_uuid, res.data.file_id)
+      setItems((prev) => [
+        { ai_generation_uuid: res.data.ai_generation_uuid, file_id: res.data.file_id, url, prompt: prompt.trim() },
+        ...prev,
+      ])
+      setSessionUuid(res.data.session_uuid)
+      setRefineFrom(null)
+      setPrompt('')
+    } catch {
+      setError('Image generation failed. Please try again.')
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+      handleGenerate()
+    }
+  }
+
+  const handleDeleteHistory = async (uuid: string) => {
+    if (!access_token) return
+    await deleteAIImageHistory(uuid, access_token)
+    setHistory((prev) => prev.filter((h) => h.ai_generation_uuid !== uuid))
+  }
+
+  const modalContent = (
+    <div className="flex flex-col h-full">
+      {/* Tabs */}
+      <div className="flex items-center gap-1 px-4 pt-3">
+        <button
+          onClick={() => setTab('generate')}
+          className={`px-3 py-1.5 rounded-lg text-sm flex items-center gap-1.5 transition-colors ${
+            tab === 'generate' ? 'bg-neutral-900 text-white' : 'text-neutral-500 hover:bg-neutral-100'
+          }`}
+        >
+          <Wand2 size={15} /> Generate
+        </button>
+        <button
+          onClick={() => setTab('history')}
+          className={`px-3 py-1.5 rounded-lg text-sm flex items-center gap-1.5 transition-colors ${
+            tab === 'history' ? 'bg-neutral-900 text-white' : 'text-neutral-500 hover:bg-neutral-100'
+          }`}
+        >
+          <History size={15} /> History
+        </button>
+      </div>
+
+      {tab === 'generate' ? (
+        <>
+          {/* Prompt composer */}
+          <div className="p-4 space-y-3">
+            {refineFrom && (
+              <div className="flex items-center gap-2 text-xs text-neutral-600 bg-neutral-100 rounded-lg px-2.5 py-1.5 w-fit">
+                <img src={refineFrom.url} alt="" className="w-6 h-6 rounded object-cover" />
+                <span>Refining from this image</span>
+                <button onClick={() => setRefineFrom(null)} className="text-neutral-400 hover:text-neutral-700">
+                  <X size={13} />
+                </button>
+              </div>
+            )}
+            <div className="relative">
+              <textarea
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                onKeyDown={handleKeyDown}
+                rows={2}
+                placeholder={
+                  refineFrom
+                    ? 'Describe how to change the image…'
+                    : 'Describe the image you want to generate…'
+                }
+                className="w-full p-3 pr-28 border border-neutral-200 rounded-xl resize-none focus:outline-hidden focus:ring-2 focus:ring-neutral-900/10 text-sm"
+              />
+              <button
+                onClick={handleGenerate}
+                disabled={generating || !prompt.trim()}
+                className="absolute right-2 bottom-2 px-3 py-1.5 rounded-lg bg-neutral-900 text-white text-sm flex items-center gap-1.5 nice-shadow disabled:opacity-40 transition-opacity"
+              >
+                {generating ? (
+                  <RefreshCw size={15} className="animate-spin" />
+                ) : (
+                  <Sparkles size={15} />
+                )}
+                {generating ? 'Generating' : 'Generate'}
+              </button>
+            </div>
+            {items.length === 0 && !generating && (
+              <div className="flex flex-wrap gap-2">
+                {PROMPT_IDEAS.map((idea) => (
+                  <button
+                    key={idea}
+                    onClick={() => setPrompt(idea)}
+                    className="px-2.5 py-1 bg-neutral-100 rounded-lg hover:bg-neutral-200 nice-shadow transition-colors text-xs text-neutral-600"
+                  >
+                    {idea}
+                  </button>
+                ))}
+              </div>
+            )}
+            {error && <p className="text-xs text-rose-500">{error}</p>}
+            <p className="text-[11px] text-neutral-400">
+              Powered by Google nano banana. Generating an image uses AI credits.
+            </p>
+          </div>
+
+          {/* Generated thread */}
+          <div className="flex-1 overflow-y-auto px-4 pb-4">
+            {generating && (
+              <div className="w-full aspect-video rounded-xl bg-neutral-100 animate-pulse mb-4" />
+            )}
+            <div className="grid grid-cols-2 gap-4">
+              {items.map((item) => (
+                <div key={item.ai_generation_uuid} className="group flex flex-col gap-1.5">
+                  <div className="relative w-full pb-[75%] rounded-xl overflow-hidden nice-shadow">
+                    <img src={item.url} alt={item.prompt} className="absolute inset-0 w-full h-full object-cover" />
+                    <div className="absolute inset-0 bg-neutral-900/0 group-hover:bg-neutral-900/40 transition-colors flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100">
+                      <button
+                        onClick={() => {
+                          onSelect(item.url)
+                          onClose()
+                        }}
+                        className="px-3 py-1.5 rounded-lg bg-white text-neutral-900 text-sm flex items-center gap-1 nice-shadow"
+                      >
+                        <ArrowUpRight size={15} /> Use
+                      </button>
+                      <button
+                        onClick={() => setRefineFrom(item)}
+                        className="px-3 py-1.5 rounded-lg bg-neutral-900 text-white text-sm flex items-center gap-1 nice-shadow"
+                      >
+                        <Wand2 size={15} /> Refine
+                      </button>
+                    </div>
+                  </div>
+                  <p className="text-[11px] text-neutral-500 truncate">{item.prompt}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      ) : (
+        // History tab
+        <div className="flex-1 overflow-y-auto p-4">
+          {historyLoading ? (
+            <p className="text-center text-sm text-neutral-400 mt-6">Loading…</p>
+          ) : history.length === 0 ? (
+            <p className="text-center text-sm text-neutral-400 mt-6">No generated images yet.</p>
+          ) : (
+            <div className="grid grid-cols-3 gap-4">
+              {history.map((h) => {
+                const url = aiImageUrl(org.org_uuid, h.file_id)
+                return (
+                  <div key={h.ai_generation_uuid} className="group flex flex-col gap-1.5">
+                    <div className="relative w-full pb-[75%] rounded-xl overflow-hidden nice-shadow">
+                      <img src={url} alt={h.prompt} className="absolute inset-0 w-full h-full object-cover" />
+                      <div className="absolute inset-0 bg-neutral-900/0 group-hover:bg-neutral-900/40 transition-colors flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100">
+                        <button
+                          onClick={() => {
+                            onSelect(url)
+                            onClose()
+                          }}
+                          className="px-3 py-1.5 rounded-lg bg-white text-neutral-900 text-sm flex items-center gap-1 nice-shadow"
+                        >
+                          <ArrowUpRight size={15} /> Use
+                        </button>
+                        <button
+                          onClick={() => handleDeleteHistory(h.ai_generation_uuid)}
+                          className="p-1.5 rounded-lg bg-neutral-900 text-white nice-shadow"
+                          title="Delete"
+                        >
+                          <Trash2 size={15} />
+                        </button>
+                      </div>
+                    </div>
+                    <p className="text-[11px] text-neutral-500 truncate">{h.prompt}</p>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+
+  return (
+    <Modal
+      dialogTitle="Generate an image with AI"
+      dialogContent={modalContent}
+      onOpenChange={onClose}
+      isDialogOpen={isOpen}
+      minWidth="lg"
+      minHeight="lg"
+      customHeight="h-[80vh]"
+      noPadding
+    />
+  )
+}
+
+export default AIImagePicker

--- a/apps/web/components/Objects/AI/AIImagePicker.tsx
+++ b/apps/web/components/Objects/AI/AIImagePicker.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { Sparkles, Wand2, History, ArrowUpRight, RefreshCw, X, Trash2, ImageIcon, ImageOff } from 'lucide-react'
+import { ArrowUpRight, CircleNotch, ClockCounterClockwise, Image, ImageBroken, MagicWand, Sparkle, Trash, X } from '@phosphor-icons/react'
 import Modal from '@components/Objects/StyledElements/Modal/Modal'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
@@ -165,7 +165,7 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onSelectFile, o
       disabled={usingKey === key}
       className="px-3 py-1.5 rounded-lg bg-white text-neutral-900 text-sm font-medium flex items-center gap-1.5 nice-shadow disabled:opacity-60"
     >
-      {usingKey === key ? <RefreshCw size={15} className="animate-spin" /> : <ArrowUpRight size={15} />}
+      {usingKey === key ? <CircleNotch weight="duotone" size={15} className="animate-spin" /> : <ArrowUpRight weight="duotone" size={15} />}
       Use
     </button>
   )
@@ -174,8 +174,8 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onSelectFile, o
     <div className="flex flex-col h-full bg-white">
       {/* Tabs */}
       <div className="flex items-center gap-1.5 px-5 pt-4 pb-3 border-b border-neutral-100">
-        {tabBtn('generate', <Wand2 size={15} />, 'Generate')}
-        {tabBtn('history', <History size={15} />, 'History')}
+        {tabBtn('generate', <MagicWand weight="duotone" size={15} />, 'Generate')}
+        {tabBtn('history', <ClockCounterClockwise weight="duotone" size={15} />, 'History')}
       </div>
 
       {tab === 'generate' ? (
@@ -187,7 +187,7 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onSelectFile, o
                 <img src={refineFrom.url} alt="" className="w-6 h-6 rounded-full object-cover" />
                 <span className="font-medium">Refining from this image</span>
                 <button onClick={() => setRefineFrom(null)} className="text-neutral-400 hover:text-neutral-700">
-                  <X size={13} />
+                  <X weight="duotone" size={13} />
                 </button>
               </div>
             )}
@@ -213,7 +213,7 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onSelectFile, o
                   disabled={generating || !prompt.trim()}
                   className="ml-auto px-4 py-2 rounded-xl bg-neutral-900 text-white text-sm font-medium flex items-center gap-2 nice-shadow disabled:opacity-40 transition-opacity hover:bg-neutral-800"
                 >
-                  {generating ? <RefreshCw size={15} className="animate-spin" /> : <Sparkles size={15} />}
+                  {generating ? <CircleNotch weight="duotone" size={15} className="animate-spin" /> : <Sparkle weight="duotone" size={15} />}
                   {generating ? 'Generating…' : refineFrom ? 'Refine' : 'Generate'}
                 </button>
               </div>
@@ -231,7 +231,7 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onSelectFile, o
               <div className="relative w-full aspect-[4/3] rounded-2xl bg-gradient-to-br from-neutral-100 to-neutral-200 overflow-hidden mb-4">
                 <div className="absolute inset-0 animate-pulse" />
                 <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-neutral-500">
-                  <Sparkles size={22} className="animate-pulse" />
+                  <Sparkle weight="duotone" size={22} className="animate-pulse" />
                   <span className="text-sm font-medium">Creating your image…</span>
                 </div>
               </div>
@@ -240,7 +240,7 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onSelectFile, o
             {!generating && items.length === 0 ? (
               <div className="flex flex-col items-center text-center gap-3 py-10">
                 <div className="w-12 h-12 rounded-2xl bg-neutral-100 flex items-center justify-center text-neutral-400">
-                  <ImageIcon size={22} />
+                  <Image weight="duotone" size={22} />
                 </div>
                 <div>
                   <p className="text-sm font-semibold text-neutral-700">Describe an image to get started</p>
@@ -265,7 +265,7 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onSelectFile, o
                     <div className="relative w-full pb-[75%] rounded-2xl overflow-hidden nice-shadow bg-neutral-100">
                       {item.failed ? (
                         <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 text-[11px] text-neutral-400 px-2 text-center">
-                          <ImageOff size={18} />
+                          <ImageBroken weight="duotone" size={18} />
                           Image failed to load
                         </div>
                       ) : (
@@ -289,7 +289,7 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onSelectFile, o
                             onClick={() => stageRefine(item)}
                             className="px-3 py-1.5 rounded-lg bg-neutral-900 text-white text-sm font-medium flex items-center gap-1.5 nice-shadow"
                           >
-                            <Wand2 size={15} /> Refine
+                            <MagicWand weight="duotone" size={15} /> Refine
                           </button>
                         </div>
                       )}
@@ -306,11 +306,11 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onSelectFile, o
         <div className="flex-1 overflow-y-auto p-5">
           {historyLoading ? (
             <div className="flex items-center justify-center gap-2 text-sm text-neutral-400 mt-8">
-              <RefreshCw size={15} className="animate-spin" /> Loading…
+              <CircleNotch weight="duotone" size={15} className="animate-spin" /> Loading…
             </div>
           ) : history.length === 0 ? (
             <div className="flex flex-col items-center text-center gap-2 py-12 text-neutral-400">
-              <History size={22} />
+              <ClockCounterClockwise weight="duotone" size={22} />
               <p className="text-sm">No generated images yet.</p>
             </div>
           ) : (
@@ -328,7 +328,7 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onSelectFile, o
                           className="p-1.5 rounded-lg bg-neutral-900 text-white nice-shadow"
                           title="Delete"
                         >
-                          <Trash2 size={15} />
+                          <Trash weight="duotone" size={15} />
                         </button>
                       </div>
                     </div>

--- a/apps/web/components/Objects/AI/AIImagePicker.tsx
+++ b/apps/web/components/Objects/AI/AIImagePicker.tsx
@@ -25,6 +25,7 @@ interface GeneratedItem {
   file_id: string
   url: string
   prompt: string
+  failed?: boolean
 }
 
 const PROMPT_IDEAS = [
@@ -36,8 +37,10 @@ const PROMPT_IDEAS = [
 
 async function urlToBase64(url: string): Promise<string | undefined> {
   try {
-    const res = await fetch(url)
+    const res = await fetch(url, { credentials: 'include' })
+    if (!res.ok) return undefined
     const blob = await res.blob()
+    if (!blob.type.startsWith('image/')) return undefined
     return await new Promise((resolve) => {
       const reader = new FileReader()
       reader.onloadend = () => resolve(reader.result as string)
@@ -85,6 +88,10 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onClose, isOpen
       let source_image_base64: string | undefined
       if (refineFrom) {
         source_image_base64 = await urlToBase64(refineFrom.url)
+        if (!source_image_base64) {
+          setError('Could not load the source image to refine. Please try again.')
+          return
+        }
       }
       const res = await generateAIImage(
         {
@@ -95,8 +102,11 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onClose, isOpen
         },
         access_token
       )
-      if (!res.success) {
-        setError(res.data?.detail || 'Image generation failed. Please try again.')
+      // detail can be a string (our HTTPException) or an array (422) — only show strings.
+      const detail = res.data?.detail
+      const message = typeof detail === 'string' ? detail : 'Image generation failed. Please try again.'
+      if (!res.success || !res.data?.file_id || !res.data?.ai_generation_uuid) {
+        setError(message)
         return
       }
       const url = aiImageUrl(org.org_uuid, res.data.file_id)
@@ -215,25 +225,44 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onClose, isOpen
             <div className="grid grid-cols-2 gap-4">
               {items.map((item) => (
                 <div key={item.ai_generation_uuid} className="group flex flex-col gap-1.5">
-                  <div className="relative w-full pb-[75%] rounded-xl overflow-hidden nice-shadow">
-                    <img src={item.url} alt={item.prompt} className="absolute inset-0 w-full h-full object-cover" />
-                    <div className="absolute inset-0 bg-neutral-900/0 group-hover:bg-neutral-900/40 transition-colors flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100">
-                      <button
-                        onClick={() => {
-                          onSelect(item.url)
-                          onClose()
-                        }}
-                        className="px-3 py-1.5 rounded-lg bg-white text-neutral-900 text-sm flex items-center gap-1 nice-shadow"
-                      >
-                        <ArrowUpRight size={15} /> Use
-                      </button>
-                      <button
-                        onClick={() => setRefineFrom(item)}
-                        className="px-3 py-1.5 rounded-lg bg-neutral-900 text-white text-sm flex items-center gap-1 nice-shadow"
-                      >
-                        <Wand2 size={15} /> Refine
-                      </button>
-                    </div>
+                  <div className="relative w-full pb-[75%] rounded-xl overflow-hidden nice-shadow bg-neutral-100">
+                    {item.failed ? (
+                      <div className="absolute inset-0 flex items-center justify-center text-[11px] text-neutral-400 px-2 text-center">
+                        Image failed to load
+                      </div>
+                    ) : (
+                      <img
+                        src={item.url}
+                        alt={item.prompt}
+                        className="absolute inset-0 w-full h-full object-cover"
+                        onError={() =>
+                          setItems((prev) =>
+                            prev.map((i) =>
+                              i.ai_generation_uuid === item.ai_generation_uuid ? { ...i, failed: true } : i
+                            )
+                          )
+                        }
+                      />
+                    )}
+                    {!item.failed && (
+                      <div className="absolute inset-0 bg-neutral-900/0 group-hover:bg-neutral-900/40 transition-colors flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100">
+                        <button
+                          onClick={() => {
+                            onSelect(item.url)
+                            onClose()
+                          }}
+                          className="px-3 py-1.5 rounded-lg bg-white text-neutral-900 text-sm flex items-center gap-1 nice-shadow"
+                        >
+                          <ArrowUpRight size={15} /> Use
+                        </button>
+                        <button
+                          onClick={() => setRefineFrom(item)}
+                          className="px-3 py-1.5 rounded-lg bg-neutral-900 text-white text-sm flex items-center gap-1 nice-shadow"
+                        >
+                          <Wand2 size={15} /> Refine
+                        </button>
+                      </div>
+                    )}
                   </div>
                   <p className="text-[11px] text-neutral-500 truncate">{item.prompt}</p>
                 </div>

--- a/apps/web/components/Objects/AI/AIImagePicker.tsx
+++ b/apps/web/components/Objects/AI/AIImagePicker.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { Sparkles, Wand2, History, ArrowUpRight, RefreshCw, X, Trash2 } from 'lucide-react'
+import { Sparkles, Wand2, History, ArrowUpRight, RefreshCw, X, Trash2, ImageIcon, ImageOff } from 'lucide-react'
 import Modal from '@components/Objects/StyledElements/Modal/Modal'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
@@ -7,15 +7,19 @@ import {
   generateAIImage,
   fetchAIImageHistory,
   deleteAIImageHistory,
+  fetchAIImageFile,
   aiImageUrl,
   AIImageHistoryItem,
 } from '@services/ai/generation'
 
-// Shared, Unsplash-style AI image generator (Google "nano banana"). Drops into
-// every image-upload surface via the SAME contract as UnsplashImagePicker, so
-// callers can wire it in identically: onSelect receives an absolute image URL.
+// Shared AI image generator (Google "nano banana"). Drops into every image-upload
+// surface via the same contract as UnsplashImagePicker (onSelect(url)). Upload
+// surfaces can additionally pass onSelectFile to receive a ready-to-upload File
+// fetched SAME-ORIGIN via the API (avoids the cross-origin CORS fetch that left
+// the surface stuck "processing").
 export interface AIImagePickerProps {
   onSelect: (_imageUrl: string) => void
+  onSelectFile?: (_file: File) => void | Promise<void>
   onClose: () => void
   isOpen?: boolean
 }
@@ -35,7 +39,7 @@ const PROMPT_IDEAS = [
   'A watercolor landscape for a history lesson',
 ]
 
-const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onClose, isOpen = true }) => {
+const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onSelectFile, onClose, isOpen = true }) => {
   const org = useOrg() as any
   const session = useLHSession() as any
   const access_token = session?.data?.tokens?.access_token
@@ -47,6 +51,7 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onClose, isOpen
   const [items, setItems] = useState<GeneratedItem[]>([])
   const [sessionUuid, setSessionUuid] = useState<string | undefined>(undefined)
   const [refineFrom, setRefineFrom] = useState<GeneratedItem | null>(null)
+  const [usingKey, setUsingKey] = useState<string | null>(null)
 
   const [history, setHistory] = useState<AIImageHistoryItem[]>([])
   const [historyLoading, setHistoryLoading] = useState(false)
@@ -101,6 +106,28 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onClose, isOpen
     }
   }
 
+  // Apply a picked image. When the caller needs an uploadable File (thumbnails,
+  // avatars, logos), fetch the bytes SAME-ORIGIN via the API; otherwise hand back
+  // the URL (editor image block stores it directly).
+  const handleUse = async (key: string, fileId: string, url: string) => {
+    if (!onSelectFile) {
+      onSelect(url)
+      onClose()
+      return
+    }
+    try {
+      setUsingKey(key)
+      setError(null)
+      const file = await fetchAIImageFile(org.id, fileId, access_token)
+      await onSelectFile(file)
+      onClose()
+    } catch {
+      setError('Could not use this image. Please try again.')
+    } finally {
+      setUsingKey(null)
+    }
+  }
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
       e.preventDefault()
@@ -114,164 +141,180 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onClose, isOpen
     setHistory((prev) => prev.filter((h) => h.ai_generation_uuid !== uuid))
   }
 
+  const tabBtn = (id: 'generate' | 'history', icon: React.ReactNode, label: string) => (
+    <button
+      onClick={() => setTab(id)}
+      className={`px-3.5 py-1.5 rounded-full text-sm font-medium flex items-center gap-1.5 transition-colors ${
+        tab === id ? 'bg-neutral-900 text-white nice-shadow' : 'text-neutral-500 hover:bg-neutral-100'
+      }`}
+    >
+      {icon} {label}
+    </button>
+  )
+
+  const renderUseButton = (key: string, fileId: string, url: string) => (
+    <button
+      onClick={() => handleUse(key, fileId, url)}
+      disabled={usingKey === key}
+      className="px-3 py-1.5 rounded-lg bg-white text-neutral-900 text-sm font-medium flex items-center gap-1.5 nice-shadow disabled:opacity-60"
+    >
+      {usingKey === key ? <RefreshCw size={15} className="animate-spin" /> : <ArrowUpRight size={15} />}
+      Use
+    </button>
+  )
+
   const modalContent = (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full bg-white">
       {/* Tabs */}
-      <div className="flex items-center gap-1 px-4 pt-3">
-        <button
-          onClick={() => setTab('generate')}
-          className={`px-3 py-1.5 rounded-lg text-sm flex items-center gap-1.5 transition-colors ${
-            tab === 'generate' ? 'bg-neutral-900 text-white' : 'text-neutral-500 hover:bg-neutral-100'
-          }`}
-        >
-          <Wand2 size={15} /> Generate
-        </button>
-        <button
-          onClick={() => setTab('history')}
-          className={`px-3 py-1.5 rounded-lg text-sm flex items-center gap-1.5 transition-colors ${
-            tab === 'history' ? 'bg-neutral-900 text-white' : 'text-neutral-500 hover:bg-neutral-100'
-          }`}
-        >
-          <History size={15} /> History
-        </button>
+      <div className="flex items-center gap-1.5 px-5 pt-4 pb-3 border-b border-neutral-100">
+        {tabBtn('generate', <Wand2 size={15} />, 'Generate')}
+        {tabBtn('history', <History size={15} />, 'History')}
       </div>
 
       {tab === 'generate' ? (
         <>
           {/* Prompt composer */}
-          <div className="p-4 space-y-3">
+          <div className="px-5 pt-4 pb-3 space-y-3">
             {refineFrom && (
-              <div className="flex items-center gap-2 text-xs text-neutral-600 bg-neutral-100 rounded-lg px-2.5 py-1.5 w-fit">
-                <img src={refineFrom.url} alt="" className="w-6 h-6 rounded object-cover" />
-                <span>Refining from this image</span>
+              <div className="flex items-center gap-2 text-xs text-neutral-600 bg-neutral-100 rounded-full pl-1.5 pr-2.5 py-1 w-fit">
+                <img src={refineFrom.url} alt="" className="w-6 h-6 rounded-full object-cover" />
+                <span className="font-medium">Refining from this image</span>
                 <button onClick={() => setRefineFrom(null)} className="text-neutral-400 hover:text-neutral-700">
                   <X size={13} />
                 </button>
               </div>
             )}
-            <div className="relative">
+            <div className="rounded-2xl border border-neutral-200 focus-within:border-neutral-300 focus-within:ring-4 focus-within:ring-neutral-900/5 transition-all bg-neutral-50/50">
               <textarea
                 value={prompt}
                 onChange={(e) => setPrompt(e.target.value)}
                 onKeyDown={handleKeyDown}
-                rows={2}
+                rows={3}
+                autoFocus
                 placeholder={
                   refineFrom
-                    ? 'Describe how to change the image…'
-                    : 'Describe the image you want to generate…'
+                    ? 'Describe how to change the image…  (e.g. make it darker, add a diagram)'
+                    : 'Describe the image you want to create…'
                 }
-                className="w-full p-3 pr-28 border border-neutral-200 rounded-xl resize-none focus:outline-hidden focus:ring-2 focus:ring-neutral-900/10 text-sm"
+                className="w-full p-3.5 bg-transparent resize-none focus:outline-hidden text-sm placeholder:text-neutral-400"
               />
-              <button
-                onClick={handleGenerate}
-                disabled={generating || !prompt.trim()}
-                className="absolute right-2 bottom-2 px-3 py-1.5 rounded-lg bg-neutral-900 text-white text-sm flex items-center gap-1.5 nice-shadow disabled:opacity-40 transition-opacity"
-              >
-                {generating ? (
-                  <RefreshCw size={15} className="animate-spin" />
-                ) : (
-                  <Sparkles size={15} />
-                )}
-                {generating ? 'Generating' : 'Generate'}
-              </button>
+              <div className="flex items-center justify-between px-3 pb-3">
+                <span className="text-[11px] text-neutral-400 hidden sm:block">⌘↵ to generate · uses AI credits</span>
+                <button
+                  onClick={handleGenerate}
+                  disabled={generating || !prompt.trim()}
+                  className="ml-auto px-4 py-2 rounded-xl bg-neutral-900 text-white text-sm font-medium flex items-center gap-2 nice-shadow disabled:opacity-40 transition-opacity hover:bg-neutral-800"
+                >
+                  {generating ? <RefreshCw size={15} className="animate-spin" /> : <Sparkles size={15} />}
+                  {generating ? 'Generating…' : refineFrom ? 'Refine' : 'Generate'}
+                </button>
+              </div>
             </div>
-            {items.length === 0 && !generating && (
-              <div className="flex flex-wrap gap-2">
-                {PROMPT_IDEAS.map((idea) => (
-                  <button
-                    key={idea}
-                    onClick={() => setPrompt(idea)}
-                    className="px-2.5 py-1 bg-neutral-100 rounded-lg hover:bg-neutral-200 nice-shadow transition-colors text-xs text-neutral-600"
-                  >
-                    {idea}
-                  </button>
+            {error && (
+              <div className="text-xs text-rose-600 bg-rose-50 border border-rose-100 rounded-lg px-3 py-2">
+                {error}
+              </div>
+            )}
+          </div>
+
+          {/* Results / empty / loading */}
+          <div className="flex-1 overflow-y-auto px-5 pb-5">
+            {generating && (
+              <div className="relative w-full aspect-[4/3] rounded-2xl bg-gradient-to-br from-neutral-100 to-neutral-200 overflow-hidden mb-4">
+                <div className="absolute inset-0 animate-pulse" />
+                <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-neutral-500">
+                  <Sparkles size={22} className="animate-pulse" />
+                  <span className="text-sm font-medium">Creating your image…</span>
+                </div>
+              </div>
+            )}
+
+            {!generating && items.length === 0 ? (
+              <div className="flex flex-col items-center text-center gap-3 py-10">
+                <div className="w-12 h-12 rounded-2xl bg-neutral-100 flex items-center justify-center text-neutral-400">
+                  <ImageIcon size={22} />
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-neutral-700">Describe an image to get started</p>
+                  <p className="text-xs text-neutral-400 mt-0.5">or try one of these ideas</p>
+                </div>
+                <div className="flex flex-wrap gap-2 justify-center max-w-md">
+                  {PROMPT_IDEAS.map((idea) => (
+                    <button
+                      key={idea}
+                      onClick={() => setPrompt(idea)}
+                      className="px-3 py-1.5 bg-neutral-100 rounded-full hover:bg-neutral-200 transition-colors text-xs text-neutral-600"
+                    >
+                      {idea}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 gap-4">
+                {items.map((item) => (
+                  <div key={item.ai_generation_uuid} className="group flex flex-col gap-1.5">
+                    <div className="relative w-full pb-[75%] rounded-2xl overflow-hidden nice-shadow bg-neutral-100">
+                      {item.failed ? (
+                        <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 text-[11px] text-neutral-400 px-2 text-center">
+                          <ImageOff size={18} />
+                          Image failed to load
+                        </div>
+                      ) : (
+                        <img
+                          src={item.url}
+                          alt={item.prompt}
+                          className="absolute inset-0 w-full h-full object-cover"
+                          onError={() =>
+                            setItems((prev) =>
+                              prev.map((i) =>
+                                i.ai_generation_uuid === item.ai_generation_uuid ? { ...i, failed: true } : i
+                              )
+                            )
+                          }
+                        />
+                      )}
+                      {!item.failed && (
+                        <div className="absolute inset-0 bg-neutral-900/0 group-hover:bg-neutral-900/45 transition-colors flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100">
+                          {renderUseButton(item.ai_generation_uuid, item.file_id, item.url)}
+                          <button
+                            onClick={() => setRefineFrom(item)}
+                            className="px-3 py-1.5 rounded-lg bg-neutral-900 text-white text-sm font-medium flex items-center gap-1.5 nice-shadow"
+                          >
+                            <Wand2 size={15} /> Refine
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                    <p className="text-[11px] text-neutral-500 truncate px-0.5">{item.prompt}</p>
+                  </div>
                 ))}
               </div>
             )}
-            {error && <p className="text-xs text-rose-500">{error}</p>}
-            <p className="text-[11px] text-neutral-400">
-              Powered by Google nano banana. Generating an image uses AI credits.
-            </p>
-          </div>
-
-          {/* Generated thread */}
-          <div className="flex-1 overflow-y-auto px-4 pb-4">
-            {generating && (
-              <div className="w-full aspect-video rounded-xl bg-neutral-100 animate-pulse mb-4" />
-            )}
-            <div className="grid grid-cols-2 gap-4">
-              {items.map((item) => (
-                <div key={item.ai_generation_uuid} className="group flex flex-col gap-1.5">
-                  <div className="relative w-full pb-[75%] rounded-xl overflow-hidden nice-shadow bg-neutral-100">
-                    {item.failed ? (
-                      <div className="absolute inset-0 flex items-center justify-center text-[11px] text-neutral-400 px-2 text-center">
-                        Image failed to load
-                      </div>
-                    ) : (
-                      <img
-                        src={item.url}
-                        alt={item.prompt}
-                        className="absolute inset-0 w-full h-full object-cover"
-                        onError={() =>
-                          setItems((prev) =>
-                            prev.map((i) =>
-                              i.ai_generation_uuid === item.ai_generation_uuid ? { ...i, failed: true } : i
-                            )
-                          )
-                        }
-                      />
-                    )}
-                    {!item.failed && (
-                      <div className="absolute inset-0 bg-neutral-900/0 group-hover:bg-neutral-900/40 transition-colors flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100">
-                        <button
-                          onClick={() => {
-                            onSelect(item.url)
-                            onClose()
-                          }}
-                          className="px-3 py-1.5 rounded-lg bg-white text-neutral-900 text-sm flex items-center gap-1 nice-shadow"
-                        >
-                          <ArrowUpRight size={15} /> Use
-                        </button>
-                        <button
-                          onClick={() => setRefineFrom(item)}
-                          className="px-3 py-1.5 rounded-lg bg-neutral-900 text-white text-sm flex items-center gap-1 nice-shadow"
-                        >
-                          <Wand2 size={15} /> Refine
-                        </button>
-                      </div>
-                    )}
-                  </div>
-                  <p className="text-[11px] text-neutral-500 truncate">{item.prompt}</p>
-                </div>
-              ))}
-            </div>
           </div>
         </>
       ) : (
         // History tab
-        <div className="flex-1 overflow-y-auto p-4">
+        <div className="flex-1 overflow-y-auto p-5">
           {historyLoading ? (
-            <p className="text-center text-sm text-neutral-400 mt-6">Loading…</p>
+            <div className="flex items-center justify-center gap-2 text-sm text-neutral-400 mt-8">
+              <RefreshCw size={15} className="animate-spin" /> Loading…
+            </div>
           ) : history.length === 0 ? (
-            <p className="text-center text-sm text-neutral-400 mt-6">No generated images yet.</p>
+            <div className="flex flex-col items-center text-center gap-2 py-12 text-neutral-400">
+              <History size={22} />
+              <p className="text-sm">No generated images yet.</p>
+            </div>
           ) : (
             <div className="grid grid-cols-3 gap-4">
               {history.map((h) => {
                 const url = aiImageUrl(org.org_uuid, h.file_id)
                 return (
                   <div key={h.ai_generation_uuid} className="group flex flex-col gap-1.5">
-                    <div className="relative w-full pb-[75%] rounded-xl overflow-hidden nice-shadow">
+                    <div className="relative w-full pb-[75%] rounded-2xl overflow-hidden nice-shadow bg-neutral-100">
                       <img src={url} alt={h.prompt} className="absolute inset-0 w-full h-full object-cover" />
-                      <div className="absolute inset-0 bg-neutral-900/0 group-hover:bg-neutral-900/40 transition-colors flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100">
-                        <button
-                          onClick={() => {
-                            onSelect(url)
-                            onClose()
-                          }}
-                          className="px-3 py-1.5 rounded-lg bg-white text-neutral-900 text-sm flex items-center gap-1 nice-shadow"
-                        >
-                          <ArrowUpRight size={15} /> Use
-                        </button>
+                      <div className="absolute inset-0 bg-neutral-900/0 group-hover:bg-neutral-900/45 transition-colors flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100">
+                        {renderUseButton(h.ai_generation_uuid, h.file_id, url)}
                         <button
                           onClick={() => handleDeleteHistory(h.ai_generation_uuid)}
                           className="p-1.5 rounded-lg bg-neutral-900 text-white nice-shadow"
@@ -281,7 +324,7 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onClose, isOpen
                         </button>
                       </div>
                     </div>
-                    <p className="text-[11px] text-neutral-500 truncate">{h.prompt}</p>
+                    <p className="text-[11px] text-neutral-500 truncate px-0.5">{h.prompt}</p>
                   </div>
                 )
               })}
@@ -300,7 +343,7 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onClose, isOpen
       isDialogOpen={isOpen}
       minWidth="lg"
       minHeight="lg"
-      customHeight="h-[80vh]"
+      customHeight="h-[82vh]"
       noPadding
     />
   )

--- a/apps/web/components/Objects/AI/AIImagePicker.tsx
+++ b/apps/web/components/Objects/AI/AIImagePicker.tsx
@@ -52,6 +52,13 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onSelectFile, o
   const [sessionUuid, setSessionUuid] = useState<string | undefined>(undefined)
   const [refineFrom, setRefineFrom] = useState<GeneratedItem | null>(null)
   const [usingKey, setUsingKey] = useState<string | null>(null)
+  const promptRef = React.useRef<HTMLTextAreaElement>(null)
+
+  const stageRefine = (item: GeneratedItem) => {
+    setRefineFrom(item)
+    setPrompt('')
+    requestAnimationFrame(() => promptRef.current?.focus())
+  }
 
   const [history, setHistory] = useState<AIImageHistoryItem[]>([])
   const [historyLoading, setHistoryLoading] = useState(false)
@@ -186,6 +193,7 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onSelectFile, o
             )}
             <div className="rounded-2xl border border-neutral-200 focus-within:border-neutral-300 focus-within:ring-4 focus-within:ring-neutral-900/5 transition-all bg-neutral-50/50">
               <textarea
+                ref={promptRef}
                 value={prompt}
                 onChange={(e) => setPrompt(e.target.value)}
                 onKeyDown={handleKeyDown}
@@ -278,7 +286,7 @@ const AIImagePicker: React.FC<AIImagePickerProps> = ({ onSelect, onSelectFile, o
                         <div className="absolute inset-0 bg-neutral-900/0 group-hover:bg-neutral-900/45 transition-colors flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100">
                           {renderUseButton(item.ai_generation_uuid, item.file_id, item.url)}
                           <button
-                            onClick={() => setRefineFrom(item)}
+                            onClick={() => stageRefine(item)}
                             className="px-3 py-1.5 rounded-lg bg-neutral-900 text-white text-sm font-medium flex items-center gap-1.5 nice-shadow"
                           >
                             <Wand2 size={15} /> Refine

--- a/apps/web/components/Objects/AI/AIQuizGeneratorModal.tsx
+++ b/apps/web/components/Objects/AI/AIQuizGeneratorModal.tsx
@@ -1,0 +1,362 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { Sparkles, Wand2, History, RefreshCw, Check, Trash2, CornerDownLeft } from 'lucide-react'
+import Modal from '@components/Objects/StyledElements/Modal/Modal'
+import { useOrg } from '@components/Contexts/OrgContext'
+import { useLHSession } from '@components/Contexts/LHSessionContext'
+import {
+  generateAIQuiz,
+  fetchAIQuizHistory,
+  deleteAIQuizHistory,
+} from '@services/ai/generation'
+
+// AI quiz generator for the editor's blockQuiz. Generates a schema-valid quiz,
+// lets the author preview & edit, then inserts it into the Quiz block. Styled to
+// match the QuizBlockComponent so the preview reads as the real thing.
+interface BlockQuizAnswer {
+  answer_id: string
+  answer: string
+  correct: boolean
+}
+interface BlockQuizQuestion {
+  question_id: string
+  question: string
+  type: 'multiple_choice' | 'custom_answer'
+  answers: BlockQuizAnswer[]
+}
+interface BlockQuiz {
+  quizId: string
+  questions: BlockQuizQuestion[]
+}
+
+interface AIQuizGeneratorModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onInsert: (_quiz: BlockQuiz) => void
+  activityUuid?: string
+}
+
+interface QuizHistoryItem {
+  ai_generation_uuid: string
+  session_uuid?: string
+  prompt: string
+  quiz: BlockQuiz
+  creation_date?: string
+}
+
+const AIQuizGeneratorModal: React.FC<AIQuizGeneratorModalProps> = ({
+  isOpen,
+  onClose,
+  onInsert,
+  activityUuid,
+}) => {
+  const org = useOrg() as any
+  const session = useLHSession() as any
+  const access_token = session?.data?.tokens?.access_token
+
+  const [tab, setTab] = useState<'generate' | 'history'>('generate')
+  const [prompt, setPrompt] = useState('')
+  const [numQuestions, setNumQuestions] = useState(5)
+  const [difficulty, setDifficulty] = useState<'easy' | 'medium' | 'hard'>('medium')
+  const [generating, setGenerating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [quiz, setQuiz] = useState<BlockQuiz | null>(null)
+  const [sessionUuid, setSessionUuid] = useState<string | undefined>(undefined)
+
+  const [history, setHistory] = useState<QuizHistoryItem[]>([])
+  const [historyLoading, setHistoryLoading] = useState(false)
+
+  const loadHistory = useCallback(async () => {
+    if (!org?.id || !access_token) return
+    setHistoryLoading(true)
+    const res = await fetchAIQuizHistory(org.id, access_token)
+    if (res.success && Array.isArray(res.data)) setHistory(res.data)
+    setHistoryLoading(false)
+  }, [org?.id, access_token])
+
+  useEffect(() => {
+    if (tab === 'history') loadHistory()
+  }, [tab, loadHistory])
+
+  const handleGenerate = async () => {
+    if (!prompt.trim() || generating || !org?.id) return
+    setGenerating(true)
+    setError(null)
+    try {
+      const res = await generateAIQuiz(
+        {
+          org_id: org.id,
+          prompt: prompt.trim(),
+          activity_uuid: activityUuid,
+          session_uuid: sessionUuid,
+          num_questions: numQuestions,
+          difficulty,
+        },
+        access_token
+      )
+      if (!res.success) {
+        setError(res.data?.detail || 'Quiz generation failed. Please try again.')
+        return
+      }
+      setQuiz(res.data.quiz)
+      setSessionUuid(res.data.session_uuid)
+    } catch {
+      setError('Quiz generation failed. Please try again.')
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  // --- Editable preview helpers ---
+  const updateQuestionText = (qid: string, value: string) => {
+    if (!quiz) return
+    setQuiz({
+      ...quiz,
+      questions: quiz.questions.map((q) =>
+        q.question_id === qid ? { ...q, question: value } : q
+      ),
+    })
+  }
+  const updateAnswerText = (qid: string, aid: string, value: string) => {
+    if (!quiz) return
+    setQuiz({
+      ...quiz,
+      questions: quiz.questions.map((q) =>
+        q.question_id === qid
+          ? {
+              ...q,
+              answers: q.answers.map((a) =>
+                a.answer_id === aid ? { ...a, answer: value } : a
+              ),
+            }
+          : q
+      ),
+    })
+  }
+  const toggleCorrect = (qid: string, aid: string) => {
+    if (!quiz) return
+    setQuiz({
+      ...quiz,
+      questions: quiz.questions.map((q) =>
+        q.question_id === qid
+          ? {
+              ...q,
+              answers: q.answers.map((a) =>
+                a.answer_id === aid ? { ...a, correct: !a.correct } : a
+              ),
+            }
+          : q
+      ),
+    })
+  }
+
+  const handleInsert = () => {
+    if (!quiz) return
+    onInsert(quiz)
+    onClose()
+  }
+
+  const handleDeleteHistory = async (uuid: string) => {
+    if (!access_token) return
+    await deleteAIQuizHistory(uuid, access_token)
+    setHistory((prev) => prev.filter((h) => h.ai_generation_uuid !== uuid))
+  }
+
+  const modalContent = (
+    <div className="flex flex-col h-full">
+      {/* Tabs */}
+      <div className="flex items-center gap-1 px-4 pt-3">
+        <button
+          onClick={() => setTab('generate')}
+          className={`px-3 py-1.5 rounded-lg text-sm flex items-center gap-1.5 transition-colors ${
+            tab === 'generate' ? 'bg-neutral-900 text-white' : 'text-neutral-500 hover:bg-neutral-100'
+          }`}
+        >
+          <Wand2 size={15} /> Generate
+        </button>
+        <button
+          onClick={() => setTab('history')}
+          className={`px-3 py-1.5 rounded-lg text-sm flex items-center gap-1.5 transition-colors ${
+            tab === 'history' ? 'bg-neutral-900 text-white' : 'text-neutral-500 hover:bg-neutral-100'
+          }`}
+        >
+          <History size={15} /> History
+        </button>
+      </div>
+
+      {tab === 'generate' ? (
+        <>
+          {/* Composer */}
+          <div className="p-4 space-y-3 border-b border-neutral-100">
+            <textarea
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              rows={2}
+              placeholder={
+                activityUuid
+                  ? 'What should the quiz cover? (grounded on this activity)'
+                  : 'What should the quiz cover?'
+              }
+              className="w-full p-3 border border-neutral-200 rounded-xl resize-none focus:outline-hidden focus:ring-2 focus:ring-neutral-900/10 text-sm"
+            />
+            <div className="flex flex-wrap items-center gap-3">
+              <label className="flex items-center gap-1.5 text-xs text-neutral-500">
+                Questions
+                <input
+                  type="number"
+                  min={1}
+                  max={20}
+                  value={numQuestions}
+                  onChange={(e) => setNumQuestions(Number(e.target.value))}
+                  className="w-16 p-1.5 border border-neutral-200 rounded-lg text-sm"
+                />
+              </label>
+              <div className="flex items-center gap-1">
+                {(['easy', 'medium', 'hard'] as const).map((d) => (
+                  <button
+                    key={d}
+                    onClick={() => setDifficulty(d)}
+                    className={`px-2.5 py-1 rounded-lg text-xs capitalize transition-colors ${
+                      difficulty === d ? 'bg-neutral-900 text-white' : 'bg-neutral-100 text-neutral-600 hover:bg-neutral-200'
+                    }`}
+                  >
+                    {d}
+                  </button>
+                ))}
+              </div>
+              <div className="grow" />
+              <button
+                onClick={handleGenerate}
+                disabled={generating || !prompt.trim()}
+                className="px-3 py-2 rounded-lg bg-neutral-900 text-white text-sm flex items-center gap-1.5 nice-shadow disabled:opacity-40 transition-opacity"
+              >
+                {generating ? <RefreshCw size={15} className="animate-spin" /> : <Sparkles size={15} />}
+                {quiz ? 'Regenerate' : generating ? 'Generating' : 'Generate'}
+              </button>
+            </div>
+            {error && <p className="text-xs text-rose-500">{error}</p>}
+            <p className="text-[11px] text-neutral-400">Generating a quiz uses AI credits.</p>
+          </div>
+
+          {/* Editable preview */}
+          <div className="flex-1 overflow-y-auto p-4 bg-neutral-50/50">
+            {!quiz && !generating && (
+              <p className="text-center text-sm text-neutral-400 mt-6">
+                Your generated quiz will appear here to review before inserting.
+              </p>
+            )}
+            {generating && <div className="w-full h-24 rounded-xl bg-neutral-100 animate-pulse" />}
+            {quiz && (
+              <div className="space-y-4">
+                {quiz.questions.map((q, qi) => (
+                  <div key={q.question_id} className="bg-white rounded-lg p-4 nice-shadow">
+                    <div className="flex items-center gap-2 mb-2">
+                      <span className="text-xs font-bold text-neutral-400">Q{qi + 1}</span>
+                    </div>
+                    <input
+                      value={q.question}
+                      onChange={(e) => updateQuestionText(q.question_id, e.target.value)}
+                      className="text-neutral-800 bg-transparent border-2 border-dashed border-neutral-200 rounded-lg text-base font-semibold w-full p-2 focus:border-neutral-300 outline-none transition-colors mb-2"
+                    />
+                    <div className="space-y-2">
+                      {q.answers.map((a) => (
+                        <div
+                          key={a.answer_id}
+                          className={`flex items-center gap-2 rounded-lg border-2 px-2 py-1.5 transition-colors ${
+                            a.correct ? 'border-emerald-400 bg-emerald-50' : 'border-neutral-200 bg-neutral-50'
+                          }`}
+                        >
+                          <button
+                            onClick={() => toggleCorrect(q.question_id, a.answer_id)}
+                            className={`w-7 h-7 flex items-center justify-center rounded-lg transition-colors ${
+                              a.correct ? 'bg-emerald-400 text-white' : 'bg-neutral-100 text-neutral-500 hover:bg-neutral-200'
+                            }`}
+                            title={a.correct ? 'Marked correct' : 'Mark correct'}
+                          >
+                            <Check size={14} />
+                          </button>
+                          <input
+                            value={a.answer}
+                            onChange={(e) => updateAnswerText(q.question_id, a.answer_id, e.target.value)}
+                            className="flex-1 text-neutral-700 bg-transparent border-0 text-sm font-medium outline-none"
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Footer */}
+          {quiz && (
+            <div className="border-t border-neutral-100 p-3 flex justify-end">
+              <button
+                onClick={handleInsert}
+                className="px-4 py-2 rounded-lg bg-neutral-900 text-white text-sm flex items-center gap-1.5 nice-shadow"
+              >
+                <CornerDownLeft size={15} /> Insert into editor
+              </button>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="flex-1 overflow-y-auto p-4">
+          {historyLoading ? (
+            <p className="text-center text-sm text-neutral-400 mt-6">Loading…</p>
+          ) : history.length === 0 ? (
+            <p className="text-center text-sm text-neutral-400 mt-6">No generated quizzes yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {history.map((h) => (
+                <div
+                  key={h.ai_generation_uuid}
+                  className="flex items-center gap-3 bg-white rounded-lg p-3 nice-shadow"
+                >
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-neutral-700 truncate">{h.prompt}</p>
+                    <p className="text-[11px] text-neutral-400">
+                      {h.quiz?.questions?.length || 0} question(s)
+                    </p>
+                  </div>
+                  <button
+                    onClick={() => {
+                      setQuiz(h.quiz)
+                      setSessionUuid(h.session_uuid)
+                      setTab('generate')
+                    }}
+                    className="px-3 py-1.5 rounded-lg bg-neutral-100 hover:bg-neutral-200 text-sm text-neutral-700"
+                  >
+                    Load
+                  </button>
+                  <button
+                    onClick={() => handleDeleteHistory(h.ai_generation_uuid)}
+                    className="p-1.5 rounded-lg hover:bg-neutral-100 text-neutral-400"
+                    title="Delete"
+                  >
+                    <Trash2 size={15} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+
+  return (
+    <Modal
+      dialogTitle="Generate a quiz with AI"
+      dialogContent={modalContent}
+      onOpenChange={onClose}
+      isDialogOpen={isOpen}
+      minWidth="lg"
+      minHeight="lg"
+      customHeight="h-[80vh]"
+      noPadding
+    />
+  )
+}
+
+export default AIQuizGeneratorModal

--- a/apps/web/components/Objects/AI/AIQuizGeneratorModal.tsx
+++ b/apps/web/components/Objects/AI/AIQuizGeneratorModal.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { Sparkles, Wand2, History, RefreshCw, Check, Trash2, CornerDownLeft } from 'lucide-react'
+import { ArrowElbowDownLeft, Check, CircleNotch, ClockCounterClockwise, MagicWand, Sparkle, Trash } from '@phosphor-icons/react'
 import Modal from '@components/Objects/StyledElements/Modal/Modal'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
@@ -171,7 +171,7 @@ const AIQuizGeneratorModal: React.FC<AIQuizGeneratorModalProps> = ({
             tab === 'generate' ? 'bg-neutral-900 text-white' : 'text-neutral-500 hover:bg-neutral-100'
           }`}
         >
-          <Wand2 size={15} /> Generate
+          <MagicWand weight="duotone" size={15} /> Generate
         </button>
         <button
           onClick={() => setTab('history')}
@@ -179,7 +179,7 @@ const AIQuizGeneratorModal: React.FC<AIQuizGeneratorModalProps> = ({
             tab === 'history' ? 'bg-neutral-900 text-white' : 'text-neutral-500 hover:bg-neutral-100'
           }`}
         >
-          <History size={15} /> History
+          <ClockCounterClockwise weight="duotone" size={15} /> History
         </button>
       </div>
 
@@ -229,7 +229,7 @@ const AIQuizGeneratorModal: React.FC<AIQuizGeneratorModalProps> = ({
                 disabled={generating || !prompt.trim()}
                 className="px-3 py-2 rounded-lg bg-neutral-900 text-white text-sm flex items-center gap-1.5 nice-shadow disabled:opacity-40 transition-opacity"
               >
-                {generating ? <RefreshCw size={15} className="animate-spin" /> : <Sparkles size={15} />}
+                {generating ? <CircleNotch weight="duotone" size={15} className="animate-spin" /> : <Sparkle weight="duotone" size={15} />}
                 {quiz ? 'Regenerate' : generating ? 'Generating' : 'Generate'}
               </button>
             </div>
@@ -272,7 +272,7 @@ const AIQuizGeneratorModal: React.FC<AIQuizGeneratorModalProps> = ({
                             }`}
                             title={a.correct ? 'Marked correct' : 'Mark correct'}
                           >
-                            <Check size={14} />
+                            <Check weight="duotone" size={14} />
                           </button>
                           <input
                             value={a.answer}
@@ -295,7 +295,7 @@ const AIQuizGeneratorModal: React.FC<AIQuizGeneratorModalProps> = ({
                 onClick={handleInsert}
                 className="px-4 py-2 rounded-lg bg-neutral-900 text-white text-sm flex items-center gap-1.5 nice-shadow"
               >
-                <CornerDownLeft size={15} /> Insert into editor
+                <ArrowElbowDownLeft weight="duotone" size={15} /> Insert into editor
               </button>
             </div>
           )}
@@ -334,7 +334,7 @@ const AIQuizGeneratorModal: React.FC<AIQuizGeneratorModalProps> = ({
                     className="p-1.5 rounded-lg hover:bg-neutral-100 text-neutral-400"
                     title="Delete"
                   >
-                    <Trash2 size={15} />
+                    <Trash weight="duotone" size={15} />
                   </button>
                 </div>
               ))}

--- a/apps/web/components/Objects/AI/AIScenarioGeneratorModal.tsx
+++ b/apps/web/components/Objects/AI/AIScenarioGeneratorModal.tsx
@@ -1,0 +1,318 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { Sparkles, Wand2, History, RefreshCw, Trash2, CornerDownLeft, GitBranch, ArrowRight } from 'lucide-react'
+import Modal from '@components/Objects/StyledElements/Modal/Modal'
+import { useOrg } from '@components/Contexts/OrgContext'
+import { useLHSession } from '@components/Contexts/LHSessionContext'
+import {
+  generateAIScenario,
+  fetchAIScenarioHistory,
+  deleteAIScenarioHistory,
+} from '@services/ai/generation'
+
+// AI generator for the editor's `scenarios` (branching interactive) block.
+// Generates a schema-valid decision tree, lets the author preview & tweak node
+// text, then inserts it. Styled to match the ScenariosExtension.
+interface ScenarioOption {
+  id: string
+  text: string
+  nextScenarioId: string | null
+}
+interface Scenario {
+  id: string
+  text: string
+  imageUrl?: string
+  options: ScenarioOption[]
+}
+interface ScenarioBlock {
+  title: string
+  scenarios: Scenario[]
+  currentScenarioId: string
+}
+
+interface AIScenarioGeneratorModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onInsert: (_block: ScenarioBlock) => void
+  activityUuid?: string
+}
+
+interface ScenarioHistoryItem {
+  ai_generation_uuid: string
+  session_uuid?: string
+  prompt: string
+  scenario: ScenarioBlock
+  creation_date?: string
+}
+
+const AIScenarioGeneratorModal: React.FC<AIScenarioGeneratorModalProps> = ({
+  isOpen,
+  onClose,
+  onInsert,
+  activityUuid,
+}) => {
+  const org = useOrg() as any
+  const session = useLHSession() as any
+  const access_token = session?.data?.tokens?.access_token
+
+  const [tab, setTab] = useState<'generate' | 'history'>('generate')
+  const [prompt, setPrompt] = useState('')
+  const [numScenarios, setNumScenarios] = useState(5)
+  const [generating, setGenerating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [block, setBlock] = useState<ScenarioBlock | null>(null)
+  const [sessionUuid, setSessionUuid] = useState<string | undefined>(undefined)
+
+  const [history, setHistory] = useState<ScenarioHistoryItem[]>([])
+  const [historyLoading, setHistoryLoading] = useState(false)
+
+  const loadHistory = useCallback(async () => {
+    if (!org?.id || !access_token) return
+    setHistoryLoading(true)
+    const res = await fetchAIScenarioHistory(org.id, access_token)
+    if (res.success && Array.isArray(res.data)) setHistory(res.data)
+    setHistoryLoading(false)
+  }, [org?.id, access_token])
+
+  useEffect(() => {
+    if (tab === 'history') loadHistory()
+  }, [tab, loadHistory])
+
+  const handleGenerate = async () => {
+    if (!prompt.trim() || generating || !org?.id) return
+    setGenerating(true)
+    setError(null)
+    try {
+      const res = await generateAIScenario(
+        {
+          org_id: org.id,
+          prompt: prompt.trim(),
+          activity_uuid: activityUuid,
+          session_uuid: sessionUuid,
+          num_scenarios: numScenarios,
+        },
+        access_token
+      )
+      const detail = res.data?.detail
+      const message = typeof detail === 'string' ? detail : 'Scenario generation failed. Please try again.'
+      if (!res.success || !res.data?.scenario) {
+        setError(message)
+        return
+      }
+      setBlock(res.data.scenario)
+      setSessionUuid(res.data.session_uuid)
+    } catch {
+      setError('Scenario generation failed. Please try again.')
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  const updateNodeText = (id: string, value: string) => {
+    if (!block) return
+    setBlock({ ...block, scenarios: block.scenarios.map((s) => (s.id === id ? { ...s, text: value } : s)) })
+  }
+  const updateOptionText = (nodeId: string, optId: string, value: string) => {
+    if (!block) return
+    setBlock({
+      ...block,
+      scenarios: block.scenarios.map((s) =>
+        s.id === nodeId
+          ? { ...s, options: s.options.map((o) => (o.id === optId ? { ...o, text: value } : o)) }
+          : s
+      ),
+    })
+  }
+
+  const handleInsert = () => {
+    if (!block) return
+    onInsert(block)
+    onClose()
+  }
+
+  const handleDeleteHistory = async (uuid: string) => {
+    if (!access_token) return
+    await deleteAIScenarioHistory(uuid, access_token)
+    setHistory((prev) => prev.filter((h) => h.ai_generation_uuid !== uuid))
+  }
+
+  const nodeLabel = (id: string, target: string | null) => {
+    if (!target) return 'End'
+    const idx = block?.scenarios.findIndex((s) => s.id === target)
+    return idx != null && idx >= 0 ? `Node ${idx + 1}` : 'End'
+  }
+
+  const modalContent = (
+    <div className="flex flex-col h-full">
+      {/* Tabs */}
+      <div className="flex items-center gap-1 px-4 pt-3">
+        <button
+          onClick={() => setTab('generate')}
+          className={`px-3 py-1.5 rounded-lg text-sm flex items-center gap-1.5 transition-colors ${
+            tab === 'generate' ? 'bg-neutral-900 text-white' : 'text-neutral-500 hover:bg-neutral-100'
+          }`}
+        >
+          <Wand2 size={15} /> Generate
+        </button>
+        <button
+          onClick={() => setTab('history')}
+          className={`px-3 py-1.5 rounded-lg text-sm flex items-center gap-1.5 transition-colors ${
+            tab === 'history' ? 'bg-neutral-900 text-white' : 'text-neutral-500 hover:bg-neutral-100'
+          }`}
+        >
+          <History size={15} /> History
+        </button>
+      </div>
+
+      {tab === 'generate' ? (
+        <>
+          <div className="p-4 space-y-3 border-b border-neutral-100">
+            <textarea
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              rows={2}
+              placeholder={
+                activityUuid
+                  ? 'What should the scenario be about? (grounded on this activity)'
+                  : 'What should the interactive scenario be about?'
+              }
+              className="w-full p-3 border border-neutral-200 rounded-xl resize-none focus:outline-hidden focus:ring-2 focus:ring-neutral-900/10 text-sm"
+            />
+            <div className="flex flex-wrap items-center gap-3">
+              <label className="flex items-center gap-1.5 text-xs text-neutral-500">
+                Nodes
+                <input
+                  type="number"
+                  min={2}
+                  max={40}
+                  value={numScenarios}
+                  onChange={(e) => setNumScenarios(Number(e.target.value))}
+                  className="w-16 p-1.5 border border-neutral-200 rounded-lg text-sm"
+                />
+              </label>
+              <div className="grow" />
+              <button
+                onClick={handleGenerate}
+                disabled={generating || !prompt.trim()}
+                className="px-3 py-2 rounded-lg bg-neutral-900 text-white text-sm flex items-center gap-1.5 nice-shadow disabled:opacity-40 transition-opacity"
+              >
+                {generating ? <RefreshCw size={15} className="animate-spin" /> : <Sparkles size={15} />}
+                {block ? 'Regenerate' : generating ? 'Generating' : 'Generate'}
+              </button>
+            </div>
+            {error && <p className="text-xs text-rose-500">{error}</p>}
+            <p className="text-[11px] text-neutral-400">Generating a scenario uses AI credits.</p>
+          </div>
+
+          {/* Editable preview */}
+          <div className="flex-1 overflow-y-auto p-4 bg-neutral-50/50">
+            {!block && !generating && (
+              <p className="text-center text-sm text-neutral-400 mt-6">
+                Your branching scenario will appear here to review before inserting.
+              </p>
+            )}
+            {generating && <div className="w-full h-24 rounded-xl bg-neutral-100 animate-pulse" />}
+            {block && (
+              <div className="space-y-4">
+                <p className="text-sm font-semibold text-neutral-700 flex items-center gap-1.5">
+                  <GitBranch size={15} className="text-neutral-400" /> {block.title}
+                </p>
+                {block.scenarios.map((node, ni) => (
+                  <div key={node.id} className="bg-white rounded-lg p-4 nice-shadow">
+                    <div className="flex items-center gap-2 mb-2">
+                      <span className="text-xs font-bold text-neutral-400">
+                        Node {ni + 1}
+                        {block.currentScenarioId === node.id && ' · start'}
+                      </span>
+                    </div>
+                    <textarea
+                      value={node.text}
+                      onChange={(e) => updateNodeText(node.id, e.target.value)}
+                      rows={2}
+                      className="text-neutral-800 bg-transparent border-2 border-dashed border-neutral-200 rounded-lg text-sm w-full p-2 focus:border-neutral-300 outline-none transition-colors mb-2 resize-none"
+                    />
+                    <div className="space-y-1.5">
+                      {node.options.map((opt) => (
+                        <div key={opt.id} className="flex items-center gap-2 bg-neutral-50 border border-neutral-200 rounded-lg px-2 py-1.5">
+                          <input
+                            value={opt.text}
+                            onChange={(e) => updateOptionText(node.id, opt.id, e.target.value)}
+                            className="flex-1 text-neutral-700 bg-transparent border-0 text-sm outline-none"
+                          />
+                          <span className="text-[11px] text-neutral-400 flex items-center gap-1 whitespace-nowrap">
+                            <ArrowRight size={12} /> {nodeLabel(node.id, opt.nextScenarioId)}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {block && (
+            <div className="border-t border-neutral-100 p-3 flex justify-end">
+              <button
+                onClick={handleInsert}
+                className="px-4 py-2 rounded-lg bg-neutral-900 text-white text-sm flex items-center gap-1.5 nice-shadow"
+              >
+                <CornerDownLeft size={15} /> Insert into editor
+              </button>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="flex-1 overflow-y-auto p-4">
+          {historyLoading ? (
+            <p className="text-center text-sm text-neutral-400 mt-6">Loading…</p>
+          ) : history.length === 0 ? (
+            <p className="text-center text-sm text-neutral-400 mt-6">No generated scenarios yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {history.map((h) => (
+                <div key={h.ai_generation_uuid} className="flex items-center gap-3 bg-white rounded-lg p-3 nice-shadow">
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-neutral-700 truncate">{h.prompt}</p>
+                    <p className="text-[11px] text-neutral-400">{h.scenario?.scenarios?.length || 0} node(s)</p>
+                  </div>
+                  <button
+                    onClick={() => {
+                      setBlock(h.scenario)
+                      setSessionUuid(h.session_uuid)
+                      setTab('generate')
+                    }}
+                    className="px-3 py-1.5 rounded-lg bg-neutral-100 hover:bg-neutral-200 text-sm text-neutral-700"
+                  >
+                    Load
+                  </button>
+                  <button
+                    onClick={() => handleDeleteHistory(h.ai_generation_uuid)}
+                    className="p-1.5 rounded-lg hover:bg-neutral-100 text-neutral-400"
+                    title="Delete"
+                  >
+                    <Trash2 size={15} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+
+  return (
+    <Modal
+      dialogTitle="Generate a scenario with AI"
+      dialogContent={modalContent}
+      onOpenChange={onClose}
+      isDialogOpen={isOpen}
+      minWidth="lg"
+      minHeight="lg"
+      customHeight="h-[80vh]"
+      noPadding
+    />
+  )
+}
+
+export default AIScenarioGeneratorModal

--- a/apps/web/components/Objects/AI/AIScenarioGeneratorModal.tsx
+++ b/apps/web/components/Objects/AI/AIScenarioGeneratorModal.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { Sparkles, Wand2, History, RefreshCw, Trash2, CornerDownLeft, GitBranch, ArrowRight } from 'lucide-react'
+import { ArrowElbowDownLeft, ArrowRight, CircleNotch, ClockCounterClockwise, GitBranch, MagicWand, Sparkle, Trash } from '@phosphor-icons/react'
 import Modal from '@components/Objects/StyledElements/Modal/Modal'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
@@ -151,7 +151,7 @@ const AIScenarioGeneratorModal: React.FC<AIScenarioGeneratorModalProps> = ({
             tab === 'generate' ? 'bg-neutral-900 text-white' : 'text-neutral-500 hover:bg-neutral-100'
           }`}
         >
-          <Wand2 size={15} /> Generate
+          <MagicWand weight="duotone" size={15} /> Generate
         </button>
         <button
           onClick={() => setTab('history')}
@@ -159,7 +159,7 @@ const AIScenarioGeneratorModal: React.FC<AIScenarioGeneratorModalProps> = ({
             tab === 'history' ? 'bg-neutral-900 text-white' : 'text-neutral-500 hover:bg-neutral-100'
           }`}
         >
-          <History size={15} /> History
+          <ClockCounterClockwise weight="duotone" size={15} /> History
         </button>
       </div>
 
@@ -195,7 +195,7 @@ const AIScenarioGeneratorModal: React.FC<AIScenarioGeneratorModalProps> = ({
                 disabled={generating || !prompt.trim()}
                 className="px-3 py-2 rounded-lg bg-neutral-900 text-white text-sm flex items-center gap-1.5 nice-shadow disabled:opacity-40 transition-opacity"
               >
-                {generating ? <RefreshCw size={15} className="animate-spin" /> : <Sparkles size={15} />}
+                {generating ? <CircleNotch weight="duotone" size={15} className="animate-spin" /> : <Sparkle weight="duotone" size={15} />}
                 {block ? 'Regenerate' : generating ? 'Generating' : 'Generate'}
               </button>
             </div>
@@ -214,7 +214,7 @@ const AIScenarioGeneratorModal: React.FC<AIScenarioGeneratorModalProps> = ({
             {block && (
               <div className="space-y-4">
                 <p className="text-sm font-semibold text-neutral-700 flex items-center gap-1.5">
-                  <GitBranch size={15} className="text-neutral-400" /> {block.title}
+                  <GitBranch weight="duotone" size={15} className="text-neutral-400" /> {block.title}
                 </p>
                 {block.scenarios.map((node, ni) => (
                   <div key={node.id} className="bg-white rounded-lg p-4 nice-shadow">
@@ -239,7 +239,7 @@ const AIScenarioGeneratorModal: React.FC<AIScenarioGeneratorModalProps> = ({
                             className="flex-1 text-neutral-700 bg-transparent border-0 text-sm outline-none"
                           />
                           <span className="text-[11px] text-neutral-400 flex items-center gap-1 whitespace-nowrap">
-                            <ArrowRight size={12} /> {nodeLabel(node.id, opt.nextScenarioId)}
+                            <ArrowRight weight="duotone" size={12} /> {nodeLabel(node.id, opt.nextScenarioId)}
                           </span>
                         </div>
                       ))}
@@ -256,7 +256,7 @@ const AIScenarioGeneratorModal: React.FC<AIScenarioGeneratorModalProps> = ({
                 onClick={handleInsert}
                 className="px-4 py-2 rounded-lg bg-neutral-900 text-white text-sm flex items-center gap-1.5 nice-shadow"
               >
-                <CornerDownLeft size={15} /> Insert into editor
+                <ArrowElbowDownLeft weight="duotone" size={15} /> Insert into editor
               </button>
             </div>
           )}
@@ -290,7 +290,7 @@ const AIScenarioGeneratorModal: React.FC<AIScenarioGeneratorModalProps> = ({
                     className="p-1.5 rounded-lg hover:bg-neutral-100 text-neutral-400"
                     title="Delete"
                   >
-                    <Trash2 size={15} />
+                    <Trash weight="duotone" size={15} />
                   </button>
                 </div>
               ))}

--- a/apps/web/components/Objects/Account/subpages/AccountGeneral.tsx
+++ b/apps/web/components/Objects/Account/subpages/AccountGeneral.tsx
@@ -254,6 +254,7 @@ const UserEditForm = ({
     localAvatar: File | null;
     handleFileChange: (_event: any) => Promise<void>;
     handleAISelect: (_imageUrl: string) => Promise<void>;
+    handleAIImageFile: (_file: File) => Promise<void>;
   };
 }) => {
   const { t } = useTranslation();
@@ -505,6 +506,7 @@ const UserEditForm = ({
                     </Button>
                     <AIImageButton
                       onSelect={profilePicture.handleAISelect}
+                      onSelectFile={profilePicture.handleAIImageFile}
                       className="w-full inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium border border-gray-200 rounded-md bg-white hover:bg-gray-50 transition-colors"
                     />
                   </>
@@ -600,6 +602,26 @@ function AccountGeneral() {
     }
   }
 
+  const handleAIImageFile = async (file: File) => {
+    try {
+      setLocalAvatar(file)
+      setIsLoading(true)
+      const res = await updateUserAvatar(session.data.user.id, file, access_token)
+      if (res.success === false) {
+        setError(res.HTTPmessage)
+      } else {
+        // Force refresh session to pick up the new avatar filename
+        await session.update(true)
+        setIsLoading(false)
+        setError('')
+        setSuccess(t('user.settings.general.avatar_updated'))
+      }
+    } catch {
+      setError('Failed to process AI image')
+      setIsLoading(false)
+    }
+  }
+
   const handleEmailChange = async (newEmail: string) => {
     toast.success(t('user.settings.general.profile_updated'), { duration: 4000 })
 
@@ -674,7 +696,8 @@ function AccountGeneral() {
               isLoading,
               localAvatar,
               handleFileChange,
-              handleAISelect
+              handleAISelect,
+              handleAIImageFile
             }}
           />
         )}

--- a/apps/web/components/Objects/Account/subpages/AccountGeneral.tsx
+++ b/apps/web/components/Objects/Account/subpages/AccountGeneral.tsx
@@ -25,6 +25,7 @@ import {
   Lightbulb
 } from 'lucide-react'
 import UserAvatar from '@components/Objects/UserAvatar'
+import AIImageButton from '@components/Objects/AI/AIImageButton'
 import { updateUserAvatar } from '@services/users/users'
 import { constructAcceptValue } from '@/lib/constants'
 import * as Yup from 'yup'
@@ -252,6 +253,7 @@ const UserEditForm = ({
     isLoading: boolean;
     localAvatar: File | null;
     handleFileChange: (_event: any) => Promise<void>;
+    handleAISelect: (_imageUrl: string) => Promise<void>;
   };
 }) => {
   const { t } = useTranslation();
@@ -501,6 +503,10 @@ const UserEditForm = ({
                       <UploadCloud size={16} className="mr-2" />
                       {t('user.settings.general.change_avatar')}
                     </Button>
+                    <AIImageButton
+                      onSelect={profilePicture.handleAISelect}
+                      className="w-full inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium border border-gray-200 rounded-md bg-white hover:bg-gray-50 transition-colors"
+                    />
                   </>
                 )}
                 <div className="flex items-center text-xs text-gray-500">
@@ -568,6 +574,29 @@ function AccountGeneral() {
       setIsLoading(false)
       setError('')
       setSuccess(t('user.settings.general.avatar_updated'))
+    }
+  }
+
+  const handleAISelect = async (imageUrl: string) => {
+    try {
+      const response = await fetch(imageUrl)
+      const blob = await response.blob()
+      const file = new File([blob], `ai_avatar_${Date.now()}.jpg`, { type: blob.type || 'image/jpeg' })
+      setLocalAvatar(file)
+      setIsLoading(true)
+      const res = await updateUserAvatar(session.data.user.id, file, access_token)
+      if (res.success === false) {
+        setError(res.HTTPmessage)
+      } else {
+        // Force refresh session to pick up the new avatar filename
+        await session.update(true)
+        setIsLoading(false)
+        setError('')
+        setSuccess(t('user.settings.general.avatar_updated'))
+      }
+    } catch (_error) {
+      setError('Failed to process AI image')
+      setIsLoading(false)
     }
   }
 
@@ -644,7 +673,8 @@ function AccountGeneral() {
               success,
               isLoading,
               localAvatar,
-              handleFileChange
+              handleFileChange,
+              handleAISelect
             }}
           />
         )}

--- a/apps/web/components/Objects/Activities/DynamicCanva/DynamicCanva.tsx
+++ b/apps/web/components/Objects/Activities/DynamicCanva/DynamicCanva.tsx
@@ -62,6 +62,10 @@ interface Editor {
   content: string
   activity: any
   hideTableOfContents?: boolean
+  // Passed by the activity/embed/board renderers so the video block can build
+  // stream URLs even where the Org/Course React contexts aren't populated.
+  courseUuid?: string
+  orgUuid?: string
 }
 
 
@@ -82,7 +86,7 @@ function Canva(props: Editor) {
         ? JSON.parse(props.content)
         : props.content;
       return normalizeMarkTypes(parsed);
-    } catch (e) {
+    } catch {
       return props.content;
     }
   }, [props.content]);
@@ -122,6 +126,8 @@ function Canva(props: Editor) {
       VideoBlock.configure({
         editable: true,
         activity: props.activity,
+        orgUuid: props.orgUuid,
+        courseUuid: props.courseUuid,
       }),
       AudioBlock.configure({
         editable: true,

--- a/apps/web/components/Objects/Activities/Video/videoSource.ts
+++ b/apps/web/components/Objects/Activities/Video/videoSource.ts
@@ -80,10 +80,12 @@ export function resolveActivityVideoSource(args: VideoSourceArgs): VideoSource {
  * must stay uncredentialed (R2 CORS rejects credentialed wildcard requests).
  */
 export function shouldSendHlsCredentials(url: string): boolean {
-  // Our authed playlist/key endpoint — but NEVER a presigned object-storage URL
-  // (those always carry X-Amz-* query params). Sending the cookie cross-origin
-  // to R2 would fail CORS and leak the cookie to storage.
-  return url.includes('/api/v1/stream/hls/') && !url.includes('X-Amz-')
+  // Our authed playlist/key endpoints (activity + video block) — but NEVER a
+  // presigned object-storage URL (those always carry X-Amz-* query params).
+  // Sending the cookie cross-origin to R2 would fail CORS and leak the cookie.
+  const isApiPlaylist =
+    url.includes('/api/v1/stream/hls/') || url.includes('/api/v1/stream/block-hls/')
+  return isApiPlaylist && !url.includes('X-Amz-')
 }
 
 export interface ThumbnailArgs {

--- a/apps/web/components/Objects/Editor/Editor.tsx
+++ b/apps/web/components/Objects/Editor/Editor.tsx
@@ -167,7 +167,7 @@ function Editor(props: EditorProps) {
       InfoCallout.configure({ editable: true }),
       WarningCallout.configure({ editable: true }),
       ImageBlock.configure({ editable: true, activity: stableActivity }),
-      VideoBlock.configure({ editable: true, activity: stableActivity }),
+      VideoBlock.configure({ editable: true, activity: stableActivity, orgUuid: props.org?.org_uuid, courseUuid: props.course?.course_uuid }),
       AudioBlock.configure({ editable: true, activity: stableActivity }),
       MathEquationBlock.configure({ editable: true, activity: stableActivity }),
       PDFBlock.configure({ editable: true, activity: stableActivity }),

--- a/apps/web/components/Objects/Editor/Extensions/Image/ImageBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Image/ImageBlockComponent.tsx
@@ -13,6 +13,7 @@ import { constructAcceptValue } from '@/lib/constants';
 import Modal from '@components/Objects/StyledElements/Modal/Modal'
 import { useTranslation } from 'react-i18next'
 import UnsplashImagePicker, { UnsplashPhotoMeta } from '@components/Dashboard/Pages/Course/EditCourseGeneral/UnsplashImagePicker'
+import AIImageButton from '@components/Objects/AI/AIImageButton'
 
 const SUPPORTED_FILES = constructAcceptValue(['jpg', 'png', 'webp', 'gif'])
 const UNSPLASH_UTM = '?utm_source=LearnHouse&utm_medium=referral'
@@ -283,7 +284,7 @@ function ImageBlockComponent(props: any) {
 
           {/* Upload Zone - shown when no image */}
           {!blockObject && !unsplashUrl && isEditable && (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
               <div
                 onClick={() => fileInputRef.current?.click()}
                 onDragEnter={handleDragEnter}
@@ -347,6 +348,10 @@ function ImageBlockComponent(props: any) {
                   </div>
                 </div>
               </button>
+              <AIImageButton
+                onSelect={handleUnsplashSelect}
+                className="border border-neutral-200 rounded-lg text-center cursor-pointer transition-all flex flex-col gap-2 items-center justify-center min-h-[160px] p-6 bg-white hover:border-neutral-400 hover:bg-neutral-50 disabled:opacity-50 disabled:cursor-not-allowed outline-none text-sm font-medium text-neutral-700"
+              />
             </div>
           )}
 

--- a/apps/web/components/Objects/Editor/Extensions/Quiz/QuizBlock.ts
+++ b/apps/web/components/Objects/Editor/Extensions/Quiz/QuizBlock.ts
@@ -15,7 +15,7 @@ export default Node.create({
   addAttributes() {
     return {
       quizId: {
-        value: null,
+        default: null,
       },
       questions: {
         default: [],

--- a/apps/web/components/Objects/Editor/Extensions/Quiz/QuizBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Quiz/QuizBlockComponent.tsx
@@ -2,9 +2,10 @@ import { NodeViewWrapper } from '@tiptap/react'
 import { v4 as uuidv4 } from 'uuid'
 import { cn } from '@/lib/utils'
 import React from 'react'
-import { BadgeHelp, Check, Minus, Plus, RefreshCcw } from 'lucide-react'
+import { BadgeHelp, Check, Minus, Plus, RefreshCcw, Sparkles } from 'lucide-react'
 import dynamic from 'next/dynamic'
 const ReactConfetti = dynamic(() => import('react-confetti'), { ssr: false })
+const AIQuizGeneratorModal = dynamic(() => import('@components/Objects/AI/AIQuizGeneratorModal'), { ssr: false })
 import { useEditorProvider } from '@components/Contexts/Editor/EditorContext'
 import { useTranslation } from 'react-i18next'
 
@@ -33,6 +34,18 @@ function QuizBlockComponent(props: any) {
   ]
   const editorState = useEditorProvider() as any
   const isEditable = editorState.isEditable
+  const [showAIGenerator, setShowAIGenerator] = React.useState(false)
+  const activityUuid = props.extension?.options?.activity?.activity_uuid
+
+  const applyGeneratedQuiz = (quiz: { quizId: string; questions: Question[] }) => {
+    // Append the generated questions to whatever is already in the block.
+    const merged = [...questions, ...quiz.questions]
+    props.updateAttributes({
+      quizId: props.node.attrs.quizId || quiz.quizId,
+      questions: merged,
+    })
+    setQuestions(merged)
+  }
 
   const handleAnswerClick = (question_id: string, answer_id: string) => {
     if (submitted) return;
@@ -233,12 +246,21 @@ function QuizBlockComponent(props: any) {
 
           {/* Action buttons */}
           {isEditable ? (
-            <button
-              onClick={addSampleQuestion}
-              className="bg-neutral-200 hover:bg-neutral-300 text-neutral-700 font-medium py-1.5 px-3 rounded-lg text-xs transition-colors outline-none"
-            >
-              {t('editor.blocks.quiz_block.add_question')}
-            </button>
+            <div className="flex items-center gap-1.5">
+              <button
+                onClick={() => setShowAIGenerator(true)}
+                className="bg-neutral-900 hover:bg-neutral-800 text-white font-medium py-1.5 px-3 rounded-lg text-xs transition-colors outline-none flex items-center gap-1.5 nice-shadow"
+              >
+                <Sparkles size={13} />
+                {t('editor.blocks.quiz_block.generate_with_ai', 'Generate with AI')}
+              </button>
+              <button
+                onClick={addSampleQuestion}
+                className="bg-neutral-200 hover:bg-neutral-300 text-neutral-700 font-medium py-1.5 px-3 rounded-lg text-xs transition-colors outline-none"
+              >
+                {t('editor.blocks.quiz_block.add_question')}
+              </button>
+            </div>
           ) : (
             <div className="flex items-center gap-1">
               <button
@@ -412,6 +434,14 @@ function QuizBlockComponent(props: any) {
           ))}
         </div>
       </div>
+      {showAIGenerator && (
+        <AIQuizGeneratorModal
+          isOpen={showAIGenerator}
+          onClose={() => setShowAIGenerator(false)}
+          onInsert={applyGeneratedQuiz}
+          activityUuid={activityUuid}
+        />
+      )}
     </NodeViewWrapper>
   )
 }

--- a/apps/web/components/Objects/Editor/Extensions/Quiz/QuizBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Quiz/QuizBlockComponent.tsx
@@ -2,7 +2,8 @@ import { NodeViewWrapper } from '@tiptap/react'
 import { v4 as uuidv4 } from 'uuid'
 import { cn } from '@/lib/utils'
 import React from 'react'
-import { BadgeHelp, Check, Minus, Plus, RefreshCcw, Sparkles } from 'lucide-react'
+import { BadgeHelp, Check, Minus, Plus, RefreshCcw } from 'lucide-react'
+import { Sparkle } from '@phosphor-icons/react'
 import dynamic from 'next/dynamic'
 const ReactConfetti = dynamic(() => import('react-confetti'), { ssr: false })
 const AIQuizGeneratorModal = dynamic(() => import('@components/Objects/AI/AIQuizGeneratorModal'), { ssr: false })
@@ -251,7 +252,7 @@ function QuizBlockComponent(props: any) {
                 onClick={() => setShowAIGenerator(true)}
                 className="bg-neutral-900 hover:bg-neutral-800 text-white font-medium py-1.5 px-3 rounded-lg text-xs transition-colors outline-none flex items-center gap-1.5 nice-shadow"
               >
-                <Sparkles size={13} />
+                <Sparkle weight="duotone" size={13} />
                 {t('editor.blocks.quiz_block.generate_with_ai', 'Generate with AI')}
               </button>
               <button

--- a/apps/web/components/Objects/Editor/Extensions/Scenarios/ScenariosExtension.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Scenarios/ScenariosExtension.tsx
@@ -1,6 +1,7 @@
 import { NodeViewWrapper } from '@tiptap/react'
 import React, { useState } from 'react'
-import { RotateCcw, ArrowRight, CheckCircle, GitBranch, RefreshCcw, Sparkles } from 'lucide-react'
+import { RotateCcw, ArrowRight, CheckCircle, GitBranch, RefreshCcw } from 'lucide-react'
+import { Sparkle } from '@phosphor-icons/react'
 import dynamic from 'next/dynamic'
 import { useEditorProvider } from '@components/Contexts/Editor/EditorContext'
 import ScenariosModal from './ScenariosModal'
@@ -96,7 +97,7 @@ const ScenariosExtension: React.FC = (props: any) => {
                 onClick={() => setShowAIGenerator(true)}
                 className="bg-neutral-900 hover:bg-neutral-800 text-white font-medium py-1.5 px-3 rounded-lg text-xs transition-colors outline-none flex items-center gap-1.5 nice-shadow"
               >
-                <Sparkles size={13} />
+                <Sparkle weight="duotone" size={13} />
                 Generate with AI
               </button>
               <button

--- a/apps/web/components/Objects/Editor/Extensions/Scenarios/ScenariosExtension.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Scenarios/ScenariosExtension.tsx
@@ -1,8 +1,10 @@
 import { NodeViewWrapper } from '@tiptap/react'
 import React, { useState } from 'react'
-import { RotateCcw, ArrowRight, CheckCircle, GitBranch, RefreshCcw } from 'lucide-react'
+import { RotateCcw, ArrowRight, CheckCircle, GitBranch, RefreshCcw, Sparkles } from 'lucide-react'
+import dynamic from 'next/dynamic'
 import { useEditorProvider } from '@components/Contexts/Editor/EditorContext'
 import ScenariosModal from './ScenariosModal'
+const AIScenarioGeneratorModal = dynamic(() => import('@components/Objects/AI/AIScenarioGeneratorModal'), { ssr: false })
 
 interface ScenarioOption {
   id: string
@@ -22,9 +24,15 @@ const ScenariosExtension: React.FC = (props: any) => {
   const [scenarios, setScenarios] = useState<Scenario[]>(props.node.attrs.scenarios)
   const [currentScenarioId, setCurrentScenarioId] = useState(props.node.attrs.currentScenarioId)
   const [isModalOpen, setIsModalOpen] = useState(false)
+  const [showAIGenerator, setShowAIGenerator] = useState(false)
   const [scenarioComplete, setScenarioComplete] = useState(false)
   const editorState = useEditorProvider() as any
   const isEditable = editorState?.isEditable ?? true
+  const activityUuid = props.extension?.options?.activity?.activity_uuid
+
+  const applyGeneratedScenario = (block: { title: string; scenarios: Scenario[]; currentScenarioId: string }) => {
+    handleSave(block.title, block.scenarios, block.currentScenarioId)
+  }
 
   const getCurrentScenario = (scenarioId: string = currentScenarioId): Scenario | null => {
     return scenarios.find(s => s.id === scenarioId) || null
@@ -83,12 +91,21 @@ const ScenariosExtension: React.FC = (props: any) => {
 
           {/* Action buttons */}
           {isEditable ? (
-            <button
-              onClick={() => setIsModalOpen(true)}
-              className="bg-neutral-200 hover:bg-neutral-300 text-neutral-700 font-medium py-1.5 px-3 rounded-lg text-xs transition-colors outline-none"
-            >
-              Edit Scenarios
-            </button>
+            <div className="flex items-center gap-1.5">
+              <button
+                onClick={() => setShowAIGenerator(true)}
+                className="bg-neutral-900 hover:bg-neutral-800 text-white font-medium py-1.5 px-3 rounded-lg text-xs transition-colors outline-none flex items-center gap-1.5 nice-shadow"
+              >
+                <Sparkles size={13} />
+                Generate with AI
+              </button>
+              <button
+                onClick={() => setIsModalOpen(true)}
+                className="bg-neutral-200 hover:bg-neutral-300 text-neutral-700 font-medium py-1.5 px-3 rounded-lg text-xs transition-colors outline-none"
+              >
+                Edit Scenarios
+              </button>
+            </div>
           ) : (
             <button
               onClick={resetScenario}
@@ -213,6 +230,14 @@ const ScenariosExtension: React.FC = (props: any) => {
           onSave={handleSave}
         />
       </div>
+      {showAIGenerator && (
+        <AIScenarioGeneratorModal
+          isOpen={showAIGenerator}
+          onClose={() => setShowAIGenerator(false)}
+          onInsert={applyGeneratedScenario}
+          activityUuid={activityUuid}
+        />
+      )}
     </NodeViewWrapper>
   )
 }

--- a/apps/web/components/Objects/Editor/Extensions/Video/VideoBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Video/VideoBlockComponent.tsx
@@ -6,8 +6,8 @@ import {
 } from 'lucide-react'
 import React from 'react'
 import toast from 'react-hot-toast'
-import { uploadNewVideoFileWithProgress } from '../../../../../services/blocks/Video/video'
-import { getVideoBlockStreamUrl } from '@services/media/media'
+import { uploadNewVideoFileWithProgress, getVideoBlock } from '../../../../../services/blocks/Video/video'
+import { getVideoBlockStreamUrl, getVideoBlockHlsMasterUrl, getVideoBlockHlsThumbnailsUrl } from '@services/media/media'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { useCourse } from '@components/Contexts/CourseContext'
 import { useEditorProvider } from '@components/Contexts/Editor/EditorContext'
@@ -139,6 +139,11 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
   const [blockObject, setBlockObject] = React.useState<VideoBlockObject | null>(initialBlockObject)
   const [selectedSize, setSelectedSize] = React.useState<VideoSize>(initialBlockObject?.size || 'medium')
   const [isModalOpen, setIsModalOpen] = React.useState(false)
+  // Fresh HLS transcode status for this block (the Tiptap blockObject is an
+  // upload-time snapshot and never reflects later HLS-ready updates).
+  const [hlsMeta, setHlsMeta] = React.useState<any>(
+    (initialBlockObject as any)?.content?.hls ?? null
+  )
 
   // Update block object when size changes
   React.useEffect(() => {
@@ -253,9 +258,44 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
   const courseUuid = extension.options.courseUuid || course?.courseStructure?.course_uuid
   const activityUuid = blockObject?.content?.activity_uuid || extension.options.activity?.activity_uuid
 
-  const videoUrl = blockObject && orgUuid && courseUuid && activityUuid && fileId
+  const mp4Url = blockObject && orgUuid && courseUuid && activityUuid && fileId
     ? getVideoBlockStreamUrl(orgUuid, courseUuid, activityUuid, blockObject.block_uuid, fileId)
     : null
+
+  // Fetch the fresh block once we have its uuid, to learn whether HLS is ready.
+  const blockUuid = blockObject?.block_uuid
+  React.useEffect(() => {
+    if (!blockUuid || !access_token) return
+    let cancelled = false
+    getVideoBlock(blockUuid, access_token).then((fresh) => {
+      if (!cancelled && fresh?.content?.hls) setHlsMeta(fresh.content.hls)
+    })
+    return () => { cancelled = true }
+  }, [blockUuid, access_token])
+
+  const hlsReady = hlsMeta?.status === 'ready'
+  const hlsMasterUrl = hlsReady && blockObject && orgUuid && courseUuid && activityUuid
+    ? getVideoBlockHlsMasterUrl(orgUuid, courseUuid, activityUuid, blockObject.block_uuid)
+    : null
+
+  // Adaptive HLS when ready (with the MP4 as fallback), else the progressive MP4.
+  const videoUrl = hlsMasterUrl || mp4Url
+  const playerProps = {
+    src: videoUrl || '',
+    isHls: !!hlsMasterUrl,
+    fallbackSrc: hlsMasterUrl && mp4Url ? mp4Url : undefined,
+    thumbnails:
+      hlsReady && hlsMeta?.thumbnails?.url && blockObject && orgUuid && courseUuid && activityUuid
+        ? {
+            url: getVideoBlockHlsThumbnailsUrl(orgUuid, courseUuid, activityUuid, blockObject.block_uuid, hlsMeta.thumbnails.url),
+            interval: hlsMeta.thumbnails.interval,
+            width: hlsMeta.thumbnails.width,
+            height: hlsMeta.thumbnails.height,
+            columns: hlsMeta.thumbnails.columns,
+            rows: hlsMeta.thumbnails.rows ?? 1,
+          }
+        : null,
+  }
 
   const handleExpand = () => {
     setIsModalOpen(true);
@@ -275,7 +315,7 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
               }}
             >
               <div className="relative group">
-                <LearnHousePlayer src={videoUrl} />
+                <LearnHousePlayer {...playerProps} />
                 <div className="absolute top-2 right-2 z-40 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
                   <button
                     onClick={handleExpand}
@@ -300,7 +340,7 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
             <div className="w-full">
               <LearnHousePlayer
                 key={isModalOpen ? videoUrl : undefined}
-                src={videoUrl}
+                {...playerProps}
                 details={{ autoplay: true }}
               />
             </div>
@@ -439,7 +479,7 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
                       <Loader2 className="w-8 h-8 animate-spin text-white" />
                     </div>
                   )}
-                  <LearnHousePlayer src={videoUrl} />
+                  <LearnHousePlayer {...playerProps} />
                   <div className="absolute top-2 right-2 z-40 flex gap-1">
                     <button
                       onClick={handleExpand}
@@ -467,7 +507,7 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
             <div className="w-full">
               <LearnHousePlayer
                 key={isModalOpen ? videoUrl : undefined}
-                src={videoUrl}
+                {...playerProps}
                 details={{ autoplay: true }}
               />
             </div>

--- a/apps/web/components/Objects/Editor/Extensions/Video/VideoBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Video/VideoBlockComponent.tsx
@@ -314,7 +314,7 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
                 width: '100%'
               }}
             >
-              <div className="relative group">
+              <div className="relative group w-full aspect-video overflow-hidden rounded-lg bg-black">
                 <LearnHousePlayer {...playerProps} />
                 <div className="absolute top-2 right-2 z-40 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
                   <button
@@ -337,7 +337,7 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
           minWidth="lg"
           minHeight="lg"
           dialogContent={
-            <div className="w-full">
+            <div className="w-full aspect-video overflow-hidden rounded-lg bg-black">
               <LearnHousePlayer
                 key={isModalOpen ? videoUrl : undefined}
                 {...playerProps}
@@ -473,7 +473,7 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
                   width: '100%'
                 }}
               >
-                <div className="relative rounded-lg overflow-hidden bg-black/5 nice-shadow">
+                <div className="relative w-full aspect-video rounded-lg overflow-hidden bg-black nice-shadow">
                   {isLoading && (
                     <div className="absolute inset-0 z-40 flex items-center justify-center bg-black/10 backdrop-blur-sm">
                       <Loader2 className="w-8 h-8 animate-spin text-white" />
@@ -504,7 +504,7 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
           minWidth="lg"
           minHeight="lg"
           dialogContent={
-            <div className="w-full">
+            <div className="w-full aspect-video overflow-hidden rounded-lg bg-black">
               <LearnHousePlayer
                 key={isModalOpen ? videoUrl : undefined}
                 {...playerProps}

--- a/apps/web/components/Objects/Editor/Extensions/Video/VideoBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Video/VideoBlockComponent.tsx
@@ -6,7 +6,7 @@ import {
 } from 'lucide-react'
 import React from 'react'
 import toast from 'react-hot-toast'
-import { uploadNewVideoFile } from '../../../../../services/blocks/Video/video'
+import { uploadNewVideoFileWithProgress } from '../../../../../services/blocks/Video/video'
 import { getVideoBlockStreamUrl } from '@services/media/media'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { useCourse } from '@components/Contexts/CourseContext'
@@ -91,6 +91,10 @@ interface ExtendedNodeViewProps extends Omit<NodeViewProps, 'extension'> {
       activity: {
         activity_uuid: string
       }
+      // Passed at configure() time so playback ids resolve reliably even where
+      // the Org/Course React contexts aren't populated (e.g. the student page).
+      orgUuid?: string
+      courseUuid?: string
     }
   }
 }
@@ -200,17 +204,14 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
       setError(null)
       setUploadProgress(0)
 
-      const progressInterval = setInterval(() => {
-        setUploadProgress(prev => Math.min(prev + 10, 90))
-      }, 200)
-
-      const object = await uploadNewVideoFile(
+      // Real byte-accurate progress (XHR), same as the video-activity upload.
+      const object = await uploadNewVideoFileWithProgress(
         file,
         extension.options.activity.activity_uuid,
-        access_token
+        access_token,
+        (percent) => setUploadProgress(Math.round(percent))
       )
 
-      clearInterval(progressInterval)
       setUploadProgress(100)
 
       const newBlockObject = {
@@ -245,13 +246,16 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
     setSelectedSize(size)
   }
 
-  const videoUrl = blockObject && org?.org_uuid && course?.courseStructure.course_uuid ? getVideoBlockStreamUrl(
-    org.org_uuid,
-    course.courseStructure.course_uuid,
-    blockObject.content.activity_uuid || extension.options.activity.activity_uuid,
-    blockObject.block_uuid,
-    fileId || ''
-  ) : null
+  // Resolve ids preferring what was passed at configure() time (reliable on the
+  // student page), falling back to the Org/Course contexts. This is what makes
+  // the player actually render there (previously videoUrl went null).
+  const orgUuid = extension.options.orgUuid || org?.org_uuid
+  const courseUuid = extension.options.courseUuid || course?.courseStructure?.course_uuid
+  const activityUuid = blockObject?.content?.activity_uuid || extension.options.activity?.activity_uuid
+
+  const videoUrl = blockObject && orgUuid && courseUuid && activityUuid && fileId
+    ? getVideoBlockStreamUrl(orgUuid, courseUuid, activityUuid, blockObject.block_uuid, fileId)
+    : null
 
   const handleExpand = () => {
     setIsModalOpen(true);
@@ -431,20 +435,12 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
               >
                 <div className="relative rounded-lg overflow-hidden bg-black/5 nice-shadow">
                   {isLoading && (
-                    <div className="absolute inset-0 flex items-center justify-center bg-black/10 backdrop-blur-sm">
+                    <div className="absolute inset-0 z-40 flex items-center justify-center bg-black/10 backdrop-blur-sm">
                       <Loader2 className="w-8 h-8 animate-spin text-white" />
                     </div>
                   )}
-                  <video
-                    controls
-                    preload="metadata"
-                    className={cn(
-                      "w-full aspect-video object-contain bg-black/95 transition-all duration-200",
-                      isLoading && "opacity-50 blur-sm"
-                    )}
-                    src={videoUrl}
-                  />
-                  <div className="absolute top-2 right-2 flex gap-1">
+                  <LearnHousePlayer src={videoUrl} />
+                  <div className="absolute top-2 right-2 z-40 flex gap-1">
                     <button
                       onClick={handleExpand}
                       className="p-2 outline-none bg-black/50 hover:bg-black/70 rounded-lg transition-colors"
@@ -469,13 +465,10 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
           minHeight="lg"
           dialogContent={
             <div className="w-full">
-              <video
+              <LearnHousePlayer
                 key={isModalOpen ? videoUrl : undefined}
-                controls
-                autoPlay
-                preload="metadata"
-                className="w-full aspect-video object-contain rounded-lg shadow-lg bg-black"
                 src={videoUrl}
+                details={{ autoplay: true }}
               />
             </div>
           }

--- a/apps/web/components/Objects/Modals/Communities/CommunityThumbnailModal.tsx
+++ b/apps/web/components/Objects/Modals/Communities/CommunityThumbnailModal.tsx
@@ -114,6 +114,13 @@ export function CommunityThumbnailModal({
     }
   }
 
+  const handleAIImageFile = async (file: File) => {
+    if (!validateFile(file)) return
+    const blobUrl = URL.createObjectURL(file)
+    setLocalThumbnail({ file, url: blobUrl })
+    await uploadThumbnail(file)
+  }
+
   const uploadThumbnail = async (file: File) => {
     setIsLoading(true)
     try {
@@ -230,6 +237,7 @@ export function CommunityThumbnailModal({
                 </button>
                 <AIImageButton
                   onSelect={handleUnsplashSelect}
+                  onSelectFile={handleAIImageFile}
                   className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
                 />
               </div>

--- a/apps/web/components/Objects/Modals/Communities/CommunityThumbnailModal.tsx
+++ b/apps/web/components/Objects/Modals/Communities/CommunityThumbnailModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 import React, { useState, useRef } from 'react'
-import { UploadCloud, Image as ImageIcon, ArrowBigUpDash, X, Loader2 } from 'lucide-react'
+import { UploadCloud, Image as ImageIcon, ArrowBigUpDash } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
 import { useOrg } from '@components/Contexts/OrgContext'
@@ -108,7 +108,7 @@ export function CommunityThumbnailModal({
       setLocalThumbnail({ file, url: blobUrl })
       setShowUnsplashPicker(false)
       await uploadThumbnail(file)
-    } catch (err) {
+    } catch (_err) {
       showError('Failed to process Unsplash image')
       setIsLoading(false)
     }
@@ -141,7 +141,7 @@ export function CommunityThumbnailModal({
         router.refresh()
         onClose()
       }
-    } catch (err) {
+    } catch (_err) {
       showError('Failed to update thumbnail')
     } finally {
       setIsLoading(false)

--- a/apps/web/components/Objects/Modals/Communities/CommunityThumbnailModal.tsx
+++ b/apps/web/components/Objects/Modals/Communities/CommunityThumbnailModal.tsx
@@ -16,6 +16,7 @@ import {
   DialogTitle,
 } from '@components/ui/dialog'
 import UnsplashImagePicker from '@components/Dashboard/Pages/Course/EditCourseGeneral/UnsplashImagePicker'
+import AIImageButton from '@components/Objects/AI/AIImageButton'
 import toast from 'react-hot-toast'
 import { SafeImage } from '@components/Objects/SafeImage'
 
@@ -227,6 +228,10 @@ export function CommunityThumbnailModal({
                   <ImageIcon size={16} />
                   Browse Unsplash
                 </button>
+                <AIImageButton
+                  onSelect={handleUnsplashSelect}
+                  className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+                />
               </div>
             )}
 

--- a/apps/web/components/Objects/Modals/Course/Create/CreateCourse.tsx
+++ b/apps/web/components/Objects/Modals/Course/Create/CreateCourse.tsx
@@ -21,6 +21,7 @@ import { useFormik } from 'formik'
 import * as Yup from 'yup'
 import {  UploadCloud, Image as ImageIcon } from 'lucide-react'
 import UnsplashImagePicker from "@components/Dashboard/Pages/Course/EditCourseGeneral/UnsplashImagePicker"
+import AIImageButton from '@components/Objects/AI/AIImageButton'
 import FormTagInput from "@components/Objects/StyledElements/Form/TagInput"
 import { useTranslation } from "react-i18next"
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
@@ -232,6 +233,10 @@ function CreateCourseModal({ closeModal, orgslug }: any) {
                   <ImageIcon size={16} className="mr-2" />
                   <span>{t('courses.choose_from_gallery')}</span>
                 </button>
+                <AIImageButton
+                  onSelect={handleUnsplashSelect}
+                  className="font-bold antialiased items-center text-gray text-sm rounded-md px-4 mt-6 flex gap-2"
+                />
               </div>
             </div>
           </div>

--- a/apps/web/components/Objects/Modals/Course/Create/CreateCourse.tsx
+++ b/apps/web/components/Objects/Modals/Course/Create/CreateCourse.tsx
@@ -159,6 +159,10 @@ function CreateCourseModal({ closeModal, orgslug }: any) {
     setIsUploading(false)
   }
 
+  const handleAIImageFile = async (file: File) => {
+    formik.setFieldValue('thumbnail', file)
+  }
+
   return (
     <FormLayout onSubmit={formik.handleSubmit} >
       <FormField name="name">
@@ -235,6 +239,7 @@ function CreateCourseModal({ closeModal, orgslug }: any) {
                 </button>
                 <AIImageButton
                   onSelect={handleUnsplashSelect}
+                  onSelectFile={handleAIImageFile}
                   className="font-bold antialiased items-center text-gray text-sm rounded-md px-4 mt-6 flex gap-2"
                 />
               </div>

--- a/apps/web/components/Objects/Modals/Podcast/Create/CreatePodcast.tsx
+++ b/apps/web/components/Objects/Modals/Podcast/Create/CreatePodcast.tsx
@@ -22,6 +22,7 @@ import { useFormik } from 'formik'
 import * as Yup from 'yup'
 import { UploadCloud, Image as ImageIcon } from 'lucide-react'
 import UnsplashImagePicker from "@components/Dashboard/Pages/Course/EditCourseGeneral/UnsplashImagePicker"
+import AIImageButton from '@components/Objects/AI/AIImageButton'
 import FormTagInput from "@components/Objects/StyledElements/Form/TagInput"
 import { useTranslation } from "react-i18next"
 
@@ -211,6 +212,10 @@ function CreatePodcastModal({ closeModal, orgslug }: any) {
                   <ImageIcon size={16} className="mr-2" />
                   <span>{t('courses.choose_from_gallery')}</span>
                 </button>
+                <AIImageButton
+                  onSelect={handleUnsplashSelect}
+                  className="font-bold antialiased items-center text-gray text-sm rounded-md px-4 mt-6 flex gap-2"
+                />
               </div>
             </div>
           </div>

--- a/apps/web/components/Objects/Modals/Podcast/Create/CreatePodcast.tsx
+++ b/apps/web/components/Objects/Modals/Podcast/Create/CreatePodcast.tsx
@@ -139,6 +139,10 @@ function CreatePodcastModal({ closeModal, orgslug }: any) {
     setIsUploading(false)
   }
 
+  const handleAIImageFile = async (file: File) => {
+    formik.setFieldValue('thumbnail', file)
+  }
+
   return (
     <FormLayout onSubmit={formik.handleSubmit} >
       <FormField name="name">
@@ -214,6 +218,7 @@ function CreatePodcastModal({ closeModal, orgslug }: any) {
                 </button>
                 <AIImageButton
                   onSelect={handleUnsplashSelect}
+                  onSelectFile={handleAIImageFile}
                   className="font-bold antialiased items-center text-gray text-sm rounded-md px-4 mt-6 flex gap-2"
                 />
               </div>

--- a/apps/web/components/Playground/PlaygroundOptionsModal.tsx
+++ b/apps/web/components/Playground/PlaygroundOptionsModal.tsx
@@ -39,10 +39,10 @@ type Tab = 'general' | 'access' | 'thumbnail'
 
 interface PlaygroundOptionsModalProps {
   open: boolean
-  onOpenChange: (open: boolean) => void
+  onOpenChange: (_open: boolean) => void
   playground: Playground
   orgslug: string
-  onUpdated: (updated: Playground) => void
+  onUpdated: (_updated: Playground) => void
 }
 
 export default function PlaygroundOptionsModal({
@@ -121,7 +121,7 @@ function GeneralTab({
 }: {
   playground: Playground
   orgslug: string
-  onUpdated: (p: Playground) => void
+  onUpdated: (_p: Playground) => void
 }) {
   const session = useLHSession() as any
   const access_token = session?.data?.tokens?.access_token
@@ -216,7 +216,7 @@ function AccessTab({
   playground: Playground
   orgslug: string
   orgId: number
-  onUpdated: (p: Playground) => void
+  onUpdated: (_p: Playground) => void
 }) {
   const session = useLHSession() as any
   const access_token = session?.data?.tokens?.access_token
@@ -423,7 +423,7 @@ function ThumbnailTab({
 }: {
   playground: Playground
   orgslug: string
-  onUpdated: (p: Playground) => void
+  onUpdated: (_p: Playground) => void
 }) {
   const session = useLHSession() as any
   const access_token = session?.data?.tokens?.access_token

--- a/apps/web/components/Playground/PlaygroundOptionsModal.tsx
+++ b/apps/web/components/Playground/PlaygroundOptionsModal.tsx
@@ -31,6 +31,7 @@ import {
 import { getPlaygroundThumbnailMediaDirectory } from '@services/media/media'
 import Modal from '@components/Objects/StyledElements/Modal/Modal'
 import UnsplashImagePicker from '@components/Dashboard/Pages/Course/EditCourseGeneral/UnsplashImagePicker'
+import AIImageButton from '@components/Objects/AI/AIImageButton'
 import toast from 'react-hot-toast'
 import Link from 'next/link'
 
@@ -558,6 +559,10 @@ function ThumbnailTab({
             <Image size={14} weight="bold" />
             Unsplash
           </button>
+          <AIImageButton
+            onSelect={handleUnsplashSelect}
+            className="flex items-center gap-1.5 h-9 px-4 rounded-lg border border-gray-200 bg-white hover:bg-gray-50 text-sm font-medium text-gray-700 transition-all nice-shadow"
+          />
         </div>
       )}
       <p className="text-xs text-gray-400">PNG or JPG · Max 8MB</p>

--- a/apps/web/services/ai/generation.ts
+++ b/apps/web/services/ai/generation.ts
@@ -139,6 +139,29 @@ export async function deleteAIQuizHistory(uuid: string, access_token: string) {
   return del(`ai/quiz/history/${uuid}`, access_token)
 }
 
+// --- Scenario generation (editor scenarios block) ---
+
+export async function generateAIScenario(
+  params: {
+    org_id: number
+    prompt: string
+    activity_uuid?: string
+    session_uuid?: string
+    num_scenarios?: number
+  },
+  access_token: string
+) {
+  return postJSON('ai/scenario/generate', params, access_token)
+}
+
+export async function fetchAIScenarioHistory(org_id: number, access_token: string, limit = 30) {
+  return getJSON(`ai/scenario/history?org_id=${org_id}&limit=${limit}`, access_token)
+}
+
+export async function deleteAIScenarioHistory(uuid: string, access_token: string) {
+  return del(`ai/scenario/history/${uuid}`, access_token)
+}
+
 // --- Assignment generation ---
 
 export async function generateAIAssignment(

--- a/apps/web/services/ai/generation.ts
+++ b/apps/web/services/ai/generation.ts
@@ -1,0 +1,138 @@
+import { getAPIUrl } from '@services/config/config'
+import { RequestBodyWithAuthHeader } from '@services/utils/ts/requests'
+import { getAIImageMediaDirectory } from '@services/media/media'
+
+// ---------------------------------------------------------------------------
+// AI generation clients (image / quiz / assignment) + durable history.
+// Non-streaming, structured endpoints — the backend guarantees schema-valid
+// output so the UI can preview/insert directly. See src/routers/ai/{images,
+// quiz,assignment_gen}.py.
+// ---------------------------------------------------------------------------
+
+async function postJSON(path: string, data: any, access_token: string) {
+  const res = await fetch(
+    `${getAPIUrl()}${path}`,
+    RequestBodyWithAuthHeader('POST', data, null, access_token)
+  )
+  const json = await res.json().catch(() => ({}))
+  return { success: res.status === 200, status: res.status, data: json }
+}
+
+async function getJSON(path: string, access_token: string) {
+  const res = await fetch(`${getAPIUrl()}${path}`, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${access_token}` },
+    cache: 'no-store',
+  })
+  const json = await res.json().catch(() => ([]))
+  return { success: res.status === 200, status: res.status, data: json }
+}
+
+async function del(path: string, access_token: string) {
+  const res = await fetch(`${getAPIUrl()}${path}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${access_token}` },
+    cache: 'no-store',
+  })
+  return { success: res.status === 200, status: res.status }
+}
+
+// --- Types ---
+
+export interface AIImageResult {
+  ai_generation_uuid: string
+  session_uuid: string
+  file_id: string
+  media_url: string // relative content path; use getAIImageMediaDirectory for absolute
+  prompt: string
+}
+
+export interface AIImageHistoryItem {
+  ai_generation_uuid: string
+  session_uuid?: string
+  prompt: string
+  file_id: string
+  media_url: string
+  creation_date?: string
+}
+
+// --- Image generation ---
+
+export async function generateAIImage(
+  params: {
+    org_id: number
+    prompt: string
+    session_uuid?: string
+    source_image_base64?: string
+    course_id?: number
+    activity_id?: number
+  },
+  access_token: string
+) {
+  return postJSON('ai/images/generate', params, access_token)
+}
+
+export async function fetchAIImageHistory(
+  org_id: number,
+  access_token: string,
+  limit = 30
+) {
+  return getJSON(`ai/images/history?org_id=${org_id}&limit=${limit}`, access_token)
+}
+
+export async function deleteAIImageHistory(uuid: string, access_token: string) {
+  return del(`ai/images/history/${uuid}`, access_token)
+}
+
+/** Build the absolute URL for a generated image from its file_id. */
+export function aiImageUrl(orgUUID: string, fileId: string) {
+  return getAIImageMediaDirectory(orgUUID, fileId)
+}
+
+// --- Quiz generation ---
+
+export async function generateAIQuiz(
+  params: {
+    org_id: number
+    prompt: string
+    activity_uuid?: string
+    session_uuid?: string
+    num_questions?: number
+    difficulty?: 'easy' | 'medium' | 'hard'
+  },
+  access_token: string
+) {
+  return postJSON('ai/quiz/generate', params, access_token)
+}
+
+export async function fetchAIQuizHistory(org_id: number, access_token: string, limit = 30) {
+  return getJSON(`ai/quiz/history?org_id=${org_id}&limit=${limit}`, access_token)
+}
+
+export async function deleteAIQuizHistory(uuid: string, access_token: string) {
+  return del(`ai/quiz/history/${uuid}`, access_token)
+}
+
+// --- Assignment generation ---
+
+export async function generateAIAssignment(
+  params: {
+    org_id: number
+    course_uuid: string
+    prompt: string
+    session_uuid?: string
+    num_tasks?: number
+    allowed_task_types?: string[]
+  },
+  access_token: string
+) {
+  return postJSON('ai/assignments/generate', params, access_token)
+}
+
+export async function fetchAIAssignmentHistory(org_id: number, access_token: string, limit = 30) {
+  return getJSON(`ai/assignments/history?org_id=${org_id}&limit=${limit}`, access_token)
+}
+
+export async function deleteAIAssignmentHistory(uuid: string, access_token: string) {
+  return del(`ai/assignments/history/${uuid}`, access_token)
+}

--- a/apps/web/services/ai/generation.ts
+++ b/apps/web/services/ai/generation.ts
@@ -63,6 +63,8 @@ export async function generateAIImage(
     org_id: number
     prompt: string
     session_uuid?: string
+    // Preferred way to refine: the file_id of a prior AI image in this org.
+    source_file_id?: string
     source_image_base64?: string
     course_id?: number
     activity_id?: number

--- a/apps/web/services/ai/generation.ts
+++ b/apps/web/services/ai/generation.ts
@@ -86,9 +86,33 @@ export async function deleteAIImageHistory(uuid: string, access_token: string) {
   return del(`ai/images/history/${uuid}`, access_token)
 }
 
-/** Build the absolute URL for a generated image from its file_id. */
+/** Build the absolute URL for a generated image from its file_id (for <img> display). */
 export function aiImageUrl(orgUUID: string, fileId: string) {
   return getAIImageMediaDirectory(orgUUID, fileId)
+}
+
+/**
+ * Fetch a generated AI image's bytes SAME-ORIGIN (via the API, not the public
+ * media URL) and return a ready-to-upload File. Upload surfaces use this instead
+ * of cross-origin fetching getAIImageMediaDirectory(...), which is CORS-gated and
+ * fails on custom domains — leaving the surface stuck "processing".
+ */
+export async function fetchAIImageFile(
+  orgId: number,
+  fileId: string,
+  access_token: string
+): Promise<File> {
+  const res = await fetch(
+    `${getAPIUrl()}ai/images/${orgId}/${encodeURIComponent(fileId)}/bytes`,
+    {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${access_token}` },
+      cache: 'no-store',
+    }
+  )
+  if (!res.ok) throw new Error(`Failed to load AI image (${res.status})`)
+  const blob = await res.blob()
+  return new File([blob], `ai_generated_${Date.now()}.png`, { type: blob.type || 'image/png' })
 }
 
 // --- Quiz generation ---

--- a/apps/web/services/blocks/Video/video.ts
+++ b/apps/web/services/blocks/Video/video.ts
@@ -86,6 +86,20 @@ export function uploadNewVideoFileWithProgress(
   })
 }
 
+/**
+ * Fetch a fresh video block by its UUID (BlockRead). Used to read the current
+ * `content.hls` transcode status — the Tiptap-stored blockObject is an
+ * upload-time snapshot and never sees later HLS-ready updates.
+ */
+export async function getVideoBlock(block_uuid: string, access_token: string) {
+  const res = await fetch(
+    `${getAPIUrl()}blocks/video?block_uuid=${encodeURIComponent(block_uuid)}`,
+    RequestBodyWithAuthHeader('GET', null, null, access_token)
+  )
+  if (!res.ok) return null
+  return res.json().catch(() => null)
+}
+
 export async function getVideoFile(file_id: string, access_token: string) {
   return fetch(
     `${getAPIUrl()}blocks/video?file_id=${file_id}`,

--- a/apps/web/services/blocks/Video/video.ts
+++ b/apps/web/services/blocks/Video/video.ts
@@ -33,6 +33,59 @@ export async function uploadNewVideoFile(
   return data
 }
 
+/**
+ * Upload a video block with REAL upload progress (XHR — fetch can't report upload
+ * progress). Mirrors createVideoActivityWithProgress so the block gets the same
+ * accurate progress the video-activity flow has. Resolves with the created
+ * BlockRead JSON.
+ */
+export function uploadNewVideoFileWithProgress(
+  file: File,
+  activity_uuid: string,
+  access_token: string,
+  onProgress: (_percent: number) => void
+): Promise<any> {
+  const formData = new FormData()
+  formData.append('file_object', file)
+  formData.append('activity_uuid', activity_uuid)
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest()
+    xhr.open('POST', `${getAPIUrl()}blocks/video`)
+    xhr.withCredentials = true
+    xhr.setRequestHeader('Authorization', `Bearer ${access_token}`)
+    xhr.upload.onprogress = (e) => {
+      if (e.lengthComputable) onProgress((e.loaded / e.total) * 100)
+    }
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          resolve(JSON.parse(xhr.responseText))
+        } catch {
+          resolve({})
+        }
+      } else if (xhr.status === 413) {
+        reject(new Error('The file is too large to upload.'))
+      } else {
+        let detail: string | undefined
+        try {
+          const body = JSON.parse(xhr.responseText)
+          detail = typeof body?.detail === 'string'
+            ? body.detail
+            : Array.isArray(body?.detail)
+              ? body.detail.map((e: any) => e.msg).join(', ')
+              : undefined
+        } catch {
+          /* non-JSON error body */
+        }
+        reject(new Error(detail || `Upload failed (HTTP ${xhr.status})`))
+      }
+    }
+    xhr.onerror = () => reject(new Error('Network error during upload'))
+    xhr.onabort = () => reject(new Error('Upload cancelled'))
+    xhr.send(formData)
+  })
+}
+
 export async function getVideoFile(file_id: string, access_token: string) {
   return fetch(
     `${getAPIUrl()}blocks/video?file_id=${file_id}`,

--- a/apps/web/services/media/media.ts
+++ b/apps/web/services/media/media.ts
@@ -1,12 +1,10 @@
 import { getBackendUrl, getConfig } from '@services/config/config'
 
 function getMediaUrl() {
-  const mediaUrl = getConfig('NEXT_PUBLIC_LEARNHOUSE_MEDIA_URL');
-  if (mediaUrl) {
-    return mediaUrl;
-  } else {
-    return getBackendUrl();
-  }
+  const raw = getConfig('NEXT_PUBLIC_LEARNHOUSE_MEDIA_URL') || getBackendUrl();
+  // Guarantee a trailing slash so callers can concatenate "content/..." without
+  // producing "https://api.example.iocontent/..." when the base lacks a slash.
+  return raw.endsWith('/') ? raw : `${raw}/`;
 }
 
 function getApiUrl() {

--- a/apps/web/services/media/media.ts
+++ b/apps/web/services/media/media.ts
@@ -105,6 +105,14 @@ export function getCourseThumbnailMediaDirectory(
   return uri
 }
 
+/**
+ * Absolute URL for an AI-generated image (nano banana). Stored per-org under
+ * content/orgs/{orgUUID}/ai_images/{fileId}, mirroring the other media helpers.
+ */
+export function getAIImageMediaDirectory(orgUUID: string, fileId: string) {
+  return `${getMediaUrl()}content/orgs/${orgUUID}/ai_images/${fileId}`
+}
+
 export function getFolderThumbnailMediaDirectory(
   orgUUID: string,
   folderUUID: string,

--- a/apps/web/services/media/media.ts
+++ b/apps/web/services/media/media.ts
@@ -81,6 +81,30 @@ export function getVideoBlockStreamUrl(
 }
 
 /**
+ * HLS master-playlist URL for a video BLOCK (adaptive streaming). The API
+ * presigns segment URLs to R2 — same pipeline as activity videos.
+ */
+export function getVideoBlockHlsMasterUrl(
+  orgUUID: string,
+  courseUUID: string,
+  activityUUID: string,
+  blockUUID: string
+) {
+  return `${getApiUrl()}api/v1/stream/block-hls/${orgUUID}/${courseUUID}/${activityUUID}/${blockUUID}/master.m3u8`
+}
+
+/** URL of a video block's HLS hover-preview sprite sheet. */
+export function getVideoBlockHlsThumbnailsUrl(
+  orgUUID: string,
+  courseUUID: string,
+  activityUUID: string,
+  blockUUID: string,
+  spritePath: string
+) {
+  return `${getApiUrl()}api/v1/stream/block-hls/${orgUUID}/${courseUUID}/${activityUUID}/${blockUUID}/${spritePath}`
+}
+
+/**
  * Get the streaming URL for an audio block.
  * Uses the optimized streaming endpoint with proper Range request support.
  */


### PR DESCRIPTION
Adds three AI authoring features:

- **Image generation** — a shared nano-banana image picker (Unsplash-style) wired into image-upload surfaces, with refine + history.
- **Quiz generation** — generate a quiz inside the editor, preview/edit, insert.
- **Assignment generation** — generate graded tasks from course content, preview/edit, save.

Reuses the existing AI credit / rate-limit / feature-flag guards. Adds a durable `AIGeneration` history table (migration also merges the open Alembic heads).