### PR TITLE
fix: hide hint and reference document buttons when empty

### DIFF
--- a/apps/web/components/Objects/Activities/Assignment/AssignmentStudentActivity.tsx
+++ b/apps/web/components/Objects/Activities/Assignment/AssignmentStudentActivity.tsx
@@ -121,13 +121,13 @@ function AssignmentStudentActivity() {
                 <p className='text-slate-500 break-words'>{task.description}</p>
               </div>
               <div className='flex flex-wrap gap-2'>
-                <div
+                {task.hint && <div
                   onClick={() => toast(task.hint, { icon: 'ℹ️' })}
                   className='px-3 py-1 flex items-center nice-shadow bg-amber-50/40 text-amber-900 rounded-full space-x-2 cursor-pointer'>
                   <Info size={13} />
                   <p className='text-xs font-semibold'>{t('assignments.hint')}</p>
-                </div>
-                <Link
+                </div>}
+                {task.reference_file && <Link
                   href={getTaskRefFileDir(
                     org?.org_uuid,
                     assignments?.course_object.course_uuid,
@@ -148,7 +148,7 @@ function AssignmentStudentActivity() {
                     )}
                     <p className='text-xs font-semibold'>{t('assignments.reference_document')}</p>
                   </div>
-                </Link>
+                </Link>}
               </div>
             </div>
             {isGraded && taskSubmission && (


### PR DESCRIPTION

https://github.com/user-attachments/assets/9b6fe97c-fe20-459f-98c0-81be7438ab6f

## The problems:

- When an assignment has an empty hint, the button still appears and shows a toast with just the ℹ️ icon, so the button is not really useful for the student.
- When an assignment has an empty reference document, the button still appears and it leads to a 404 page, so the button is also not useful for the student.

## How this PR attempts to resolve the issues:

This PR attempts to simply hide these buttons when no hint or no reference document is provided.