### PR TITLE
chore: show Get Started on mobile for unauthenticated users

### DIFF
--- a/apps/web/components/Objects/Courses/CourseActions/CourseActionsMobile.tsx
+++ b/apps/web/components/Objects/Courses/CourseActions/CourseActionsMobile.tsx
@@ -13,6 +13,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query/keys'
 import Link from 'next/link'
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
+import { useTranslation } from 'react-i18next'
 
 interface Author {
   user: {
@@ -138,6 +139,7 @@ const CourseActionsMobile = ({ courseuuid, orgslug, course, trailData }: CourseA
   // Clean up course UUID by removing 'course_' prefix if it exists
   const cleanCourseUuid = course.course_uuid?.replace('course_', '');
   const resourceUuid = cleanCourseUuid ? `course_${cleanCourseUuid}` : null;
+    const { t } = useTranslation()
 
   const isStarted = trailData?.runs?.find(
     (run: any) => {
@@ -224,10 +226,10 @@ const CourseActionsMobile = ({ courseuuid, orgslug, course, trailData }: CourseA
           <div className="p-3 bg-amber-50 border border-amber-200 rounded-lg">
             <div className="flex items-center gap-2">
               <UserPlus className="w-4 h-4 text-amber-800" />
-              <span className="text-amber-800 text-sm font-semibold">Organization Membership Required</span>
+              <span className="text-amber-800 text-sm font-semibold">{t('courses.join_org_required')}</span>
             </div>
             <p className="text-amber-700 text-xs mt-1">
-              You need to join this organization to enroll in courses.
+              {t('courses.join_org_required_description')}
             </p>
           </div>
           <a
@@ -235,7 +237,7 @@ const CourseActionsMobile = ({ courseuuid, orgslug, course, trailData }: CourseA
             className="w-full py-2 px-4 rounded-lg bg-neutral-900 text-white font-semibold text-sm hover:bg-neutral-800 transition-colors flex items-center justify-center gap-2"
           >
             <UserPlus className="w-4 h-4" />
-            Join Organization
+            {t('courses.join_organization')}
           </a>
         </div>
       </div>
@@ -274,7 +276,7 @@ const CourseActionsMobile = ({ courseuuid, orgslug, course, trailData }: CourseA
                   <div className="p-3 bg-green-50 border border-green-200 rounded-lg">
                     <div className="flex items-center gap-2">
                       <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
-                      <span className="text-green-800 text-sm font-semibold">You Own This Course</span>
+                      <span className="text-green-800 text-sm font-semibold">{t('courses.you_own_this_course')}</span>
                     </div>
                   </div>
                   <button
@@ -287,7 +289,7 @@ const CourseActionsMobile = ({ courseuuid, orgslug, course, trailData }: CourseA
                     ) : (
                       <>
                         <LogOut className="w-4 h-4" />
-                        Leave Course
+                        {t('courses.leave_course')}
                       </>
                     )}
                   </button>
@@ -338,17 +340,17 @@ const CourseActionsMobile = ({ courseuuid, orgslug, course, trailData }: CourseA
             ) : !session.data?.user ? (
               <>
                 <LogIn className="w-4 h-4" />
-                Get Started
+                {t('onboarding.welcome.get_started')}
               </>
             ) : isStarted ? (
               <>
                 <LogOut className="w-4 h-4" />
-                Leave Course
+                {t('courses.leave_course')}
               </>
             ) : (
               <>
                 <LogIn className="w-4 h-4" />
-                Start Course
+                {t('courses.start_course')}
               </>
             )}
           </button>

--- a/apps/web/components/Objects/Courses/CourseActions/CourseActionsMobile.tsx
+++ b/apps/web/components/Objects/Courses/CourseActions/CourseActionsMobile.tsx
@@ -338,7 +338,7 @@ const CourseActionsMobile = ({ courseuuid, orgslug, course, trailData }: CourseA
             ) : !session.data?.user ? (
               <>
                 <LogIn className="w-4 h-4" />
-                Sign In
+                Get Started
               </>
             ) : isStarted ? (
               <>


### PR DESCRIPTION
As per https://github.com/learnhouse/learnhouse/discussions/896, when users are not authenticated, they may be potential new students viewing the course website on a mobile device. Clicking the "Sign In" button leads to the `/signup` page so this button instead says `Get Started` to better match the actual behavior of the button.

| Before | After |
| --- | --- |
| <img width="588" height="644" alt="image" src="https://github.com/user-attachments/assets/637e98eb-a549-48e4-846e-f3b713b044a6" /> | <img width="592" height="646" alt="image" src="https://github.com/user-attachments/assets/15ed687b-b247-4abd-9c4e-d3b94a8d160b" /> |

> Side note: Personally not sure why this button is in a card right below the author name. Perhaps it should be separated?
