### PR TITLE
fix(scorm): make 5GB uploads work + fix SCORM player iframe

### DIFF
--- a/apps/web/app/api/v1/[...path]/route.ts
+++ b/apps/web/app/api/v1/[...path]/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getBackendUrl } from '@services/config/config'
 
-// Allow large file uploads (videos, SCORM packages) to pass through
-export const maxDuration = 300 // 5 minutes
+// Allow large file uploads (videos, SCORM packages up to 5GB) to pass through
+export const maxDuration = 3600 // 60 minutes
 export const dynamic = 'force-dynamic'
 export const fetchCache = 'force-no-store'
 
@@ -31,7 +31,9 @@ async function proxyToBackend(request: NextRequest): Promise<Response> {
     : undefined
 
   const controller = new AbortController()
-  const timeoutId = setTimeout(() => controller.abort(), 290_000)
+  // Just under maxDuration so large uploads (e.g. 5GB SCORM packages on slow
+  // connections) can complete before the request is aborted with a 504.
+  const timeoutId = setTimeout(() => controller.abort(), 3_590_000)
 
   try {
     const backendResponse = await fetch(backendUrl, {

--- a/apps/web/ee/components/Modals/ScormActivityModal.tsx
+++ b/apps/web/ee/components/Modals/ScormActivityModal.tsx
@@ -277,7 +277,7 @@ function ScormActivityModal({ course, closeModal, onImportComplete }: ScormActiv
                     <Upload size={36} className="text-gray-400" />
                     <div>
                       <p className="text-gray-600 font-medium">Click to upload or drag and drop</p>
-                      <p className="text-sm text-gray-400 mt-1">SCORM 1.2 or SCORM 2004 package (max 200MB)</p>
+                      <p className="text-sm text-gray-400 mt-1">SCORM 1.2 or SCORM 2004 package (max 5GB)</p>
                     </div>
                   </>
                 )}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -49,6 +49,19 @@ const nextConfig = {
           },
         ],
       },
+      {
+        // SCORM packages are served same-origin through /api/scorm and rendered
+        // inside an iframe by the player. The global frame-ancestors 'none' /
+        // X-Frame-Options: DENY above blocks even same-origin framing, so the
+        // player shows "refused to connect". Allow the content to be framed by
+        // its own origin (the player also needs same-origin contentDocument
+        // access to inject the SCORM API and styles).
+        source: '/api/scorm/:path*',
+        headers: [
+          { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+          { key: 'Content-Security-Policy', value: "frame-ancestors 'self'" },
+        ],
+      },
     ]
   },
   reactStrictMode: false,

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -52,8 +52,9 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout 600s;
-        proxy_send_timeout 600s;
+        # Long timeouts to allow large uploads (e.g. SCORM packages up to 5GB)
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
     }
 
     # Backend Static Content


### PR DESCRIPTION
Frontend half of the SCORM fixes. Companion to **learnhouse/ee#2** (backend 5GB limit + streaming) and **learnhouse/infra#5** (ingress timeouts). These are separate repos, so they can't be one PR; this is the single frontend PR.

## 1. SCORM player iframe was blocked (the "refused to connect" bug)
`next.config.js` set `X-Frame-Options: DENY` + CSP `frame-ancestors 'none'` on every route. The player serves package content same-origin via `/api/scorm/...` and renders it in an iframe, so even same-origin framing was blocked and the activity showed "<domain> refused to connect". Added a header override for `/api/scorm/:path*` → `X-Frame-Options: SAMEORIGIN` + `frame-ancestors 'self'` (the player also needs same-origin `contentDocument` access to inject the SCORM API and styles).

## 2. Proxy timeout capped uploads at ~5 min
On custom domains the upload streams through `app/api/v1/[...path]/route.ts`, which capped `maxDuration` at 300s and aborted after 290s → a 5GB upload was killed with a `504` mid-transfer. Raised `maxDuration` to 3600s and the abort to 3590s.

## 3. Internal nginx timeout
`docker/nginx.conf` `/api/v1` `proxy_read/send_timeout` 600s → 3600s.

## 4. Stale UI copy
`ScormActivityModal` hardcoded `(max 200MB)` → `(max 5GB)`.

Body-size caps are already `6G` everywhere, so size was never the blocker — only time and framing.