### PR TITLE
feat: activation + monetization improvements & AI podcast/audio generation

### DIFF
--- a/apps/api/config/config.py
+++ b/apps/api/config/config.py
@@ -67,6 +67,12 @@ class AIConfig(BaseModel):
     # LEARNHOUSE_AI_IMAGE_MODEL; defaults to the GA `gemini-2.5-flash-image`
     # (Nano Banana). Set a newer/preview model here once it is allowlisted.
     image_model: str | None = None
+    # Text-to-speech / podcast model (Google Gemini TTS). Like image generation
+    # this is a Google-only path resolving its key from `api_key` (when provider
+    # is Google) or `gemini_api_key`. Override the exact model id with
+    # LEARNHOUSE_AI_TTS_MODEL; defaults to `gemini-2.5-flash-preview-tts`. All
+    # Gemini TTS models are currently preview, so keep this configurable.
+    tts_model: str | None = None
 
 
 class S3ApiConfig(BaseModel):
@@ -390,6 +396,7 @@ def get_learnhouse_config() -> LearnHouseConfig:
 
     gemini_api_key = env_gemini_api_key or yaml_ai_config.get("gemini_api_key")
     ai_image_model = os.environ.get("LEARNHOUSE_AI_IMAGE_MODEL") or yaml_ai_config.get("image_model")
+    ai_tts_model = os.environ.get("LEARNHOUSE_AI_TTS_MODEL") or yaml_ai_config.get("tts_model")
 
     # Provider-agnostic generation settings (env takes precedence over yaml).
     ai_provider = os.environ.get("LEARNHOUSE_AI_PROVIDER") or yaml_ai_config.get("provider")
@@ -591,6 +598,7 @@ def get_learnhouse_config() -> LearnHouseConfig:
         embedding_dimensions=ai_embedding_dimensions,
         gemini_api_key=gemini_api_key,
         image_model=ai_image_model,
+        tts_model=ai_tts_model,
     )
 
     # Surface missing internal-service keys at boot rather than at first

--- a/apps/api/config/config.yaml
+++ b/apps/api/config/config.yaml
@@ -90,6 +90,10 @@ ai_config:
   embedding_dimensions: ""  # default: 768
   # Google/Gemini key. Also the embeddings fallback for providers that lack an embeddings API.
   gemini_api_key: ""
+  # Media generation (Google-only, uses the Google GenAI SDK regardless of `provider`,
+  # resolving its key from `api_key` when provider=google, else `gemini_api_key`).
+  image_model: ""       # AI image generation           (default: gemini-2.5-flash-image)
+  tts_model: ""         # AI audio / podcast generation  (default: gemini-2.5-flash-preview-tts)
 
 tinybird_config:
   # Set api_url to enable analytics automatically

--- a/apps/api/src/router.py
+++ b/apps/api/src/router.py
@@ -13,7 +13,7 @@ from src.routers import stream
 from src.routers import api_tokens
 from src.routers import webhooks
 from src.routers.integrations import zapier as zapier_integration
-from src.routers.ai import ai, magicblocks, courseplanning, rag, images, quiz, assignment_gen, scenario
+from src.routers.ai import ai, magicblocks, courseplanning, rag, images, quiz, assignment_gen, scenario, audio
 from src.routers.boards import boards_playground
 from src.routers.orgs import ai_credits
 from src.routers.orgs import custom_domains
@@ -277,6 +277,12 @@ v1_router.include_router(
     images.router,
     prefix="/ai",
     tags=["ai", "images"],
+    dependencies=[Depends(require_authenticated_user)]
+)
+v1_router.include_router(
+    audio.router,
+    prefix="/ai",
+    tags=["ai", "audio"],
     dependencies=[Depends(require_authenticated_user)]
 )
 v1_router.include_router(

--- a/apps/api/src/routers/ai/audio.py
+++ b/apps/api/src/routers/ai/audio.py
@@ -26,14 +26,14 @@ from src.security.org_auth import is_org_member
 from src.services.ai.audio.generator import (
     OUTPUT_EXT,
     Speaker,
-    generate_podcast_script,
     generate_speech,
+    generate_spoken_script,
 )
 from src.services.ai.llm import AINotConfiguredError
 from src.services.ai.schemas.audio import (
     GenerateAudioRequest,
-    GeneratePodcastScriptRequest,
-    GeneratePodcastScriptResponse,
+    GenerateScriptRequest,
+    GenerateScriptResponse,
 )
 from src.services.blocks.block_types.audioBlock.audioBlock import create_audio_block
 from src.services.security.rate_limiting import enforce_ai_rate_limit
@@ -145,25 +145,26 @@ async def api_generate_audio(
 
 @router.post(
     "/audio/script",
-    response_model=GeneratePodcastScriptResponse,
-    summary="Generate a podcast discussion script with AI",
+    response_model=GenerateScriptResponse,
+    summary="Generate a spoken script with AI (podcast dialogue or monologue)",
     description=(
-        "Turn a topic, question, or source material into a two-speaker discussion "
-        "script (ready to synthesize as a podcast). Consumes AI credits."
+        "Turn a topic, question, or source material into a spoken script — a "
+        "two-speaker discussion ('podcast') or a detailed single-speaker explanation "
+        "('speak') — of an approximate length. Consumes AI credits."
     ),
     responses={
-        200: {"description": "Script generated.", "model": GeneratePodcastScriptResponse},
+        200: {"description": "Script generated.", "model": GenerateScriptResponse},
         400: {"description": "Invalid request"},
         401: {"description": "Authentication required"},
         403: {"description": "Not an org member, AI disabled, or insufficient credits"},
         404: {"description": "Activity not found"},
     },
 )
-async def api_generate_podcast_script(
-    body: GeneratePodcastScriptRequest,
+async def api_generate_script(
+    body: GenerateScriptRequest,
     current_user: PublicUser = Depends(get_authenticated_user),
     db_session: AsyncSession = Depends(get_db_session),
-) -> GeneratePodcastScriptResponse:
+) -> GenerateScriptResponse:
     if not (body.text or "").strip():
         raise HTTPException(status_code=400, detail="Add a topic or some text to generate a script from.")
 
@@ -172,10 +173,16 @@ async def api_generate_podcast_script(
     enforce_ai_rate_limit(current_user.id, org_id)
     await reserve_ai_credit(org_id, db_session, amount=SCRIPT_CREDIT_COST)
 
+    kind = "monologue" if body.mode == "speak" else "podcast"
     names = [s.name for s in (body.speakers or []) if s.name.strip()] or None
     try:
-        transcript = await generate_podcast_script(
-            body.text, speaker_names=names, language=body.language, style=body.style
+        transcript = await generate_spoken_script(
+            body.text,
+            kind=kind,
+            speaker_names=names,
+            language=body.language,
+            style=body.style,
+            minutes=body.minutes,
         )
     except AINotConfiguredError as e:
         refund_ai_credit(org_id, SCRIPT_CREDIT_COST)
@@ -185,10 +192,10 @@ async def api_generate_podcast_script(
         raise HTTPException(status_code=400, detail=str(e))
     except Exception:
         refund_ai_credit(org_id, SCRIPT_CREDIT_COST)
-        logger.error("Podcast script generation failed")
+        logger.error("Script generation failed")
         raise HTTPException(
             status_code=502,
-            detail="Podcast script generation failed. Please try again.",
+            detail="Script generation failed. Please try again.",
         )
 
-    return GeneratePodcastScriptResponse(transcript=transcript)
+    return GenerateScriptResponse(transcript=transcript)

--- a/apps/api/src/routers/ai/audio.py
+++ b/apps/api/src/routers/ai/audio.py
@@ -23,9 +23,18 @@ from src.db.users import PublicUser
 from src.security.auth import get_authenticated_user
 from src.security.features_utils.usage import refund_ai_credit, reserve_ai_credit
 from src.security.org_auth import is_org_member
-from src.services.ai.audio.generator import OUTPUT_EXT, Speaker, generate_speech
+from src.services.ai.audio.generator import (
+    OUTPUT_EXT,
+    Speaker,
+    generate_podcast_script,
+    generate_speech,
+)
 from src.services.ai.llm import AINotConfiguredError
-from src.services.ai.schemas.audio import GenerateAudioRequest
+from src.services.ai.schemas.audio import (
+    GenerateAudioRequest,
+    GeneratePodcastScriptRequest,
+    GeneratePodcastScriptResponse,
+)
 from src.services.blocks.block_types.audioBlock.audioBlock import create_audio_block
 from src.services.security.rate_limiting import enforce_ai_rate_limit
 
@@ -35,6 +44,21 @@ router = APIRouter()
 
 # Audio generation is more expensive than a text turn but cheaper than an image.
 AUDIO_CREDIT_COST = 3
+
+# Writing a podcast script is a single cheap text turn.
+SCRIPT_CREDIT_COST = 1
+
+
+async def _resolve_org_id_for_activity(activity_uuid: str, current_user: PublicUser, db_session: AsyncSession) -> int:
+    """Resolve the owning org for an activity and authorize the caller as a member."""
+    activity = (
+        await db_session.execute(select(Activity).where(Activity.activity_uuid == activity_uuid))
+    ).scalars().first()
+    if not activity or activity.org_id is None:
+        raise HTTPException(status_code=404, detail="Activity not found")
+    if not await is_org_member(current_user.id, activity.org_id, db_session):
+        raise HTTPException(status_code=403, detail="User is not a member of this organization")
+    return activity.org_id
 
 
 @router.post(
@@ -65,19 +89,7 @@ async def api_generate_audio(
     # Resolve the owning org from the activity so we can meter credits before
     # spending anything. Full RBAC (UPDATE on the course) is enforced by
     # create_audio_block below.
-    activity = (
-        await db_session.execute(
-            select(Activity).where(Activity.activity_uuid == body.activity_uuid)
-        )
-    ).scalars().first()
-    if not activity or activity.org_id is None:
-        raise HTTPException(status_code=404, detail="Activity not found")
-    org_id = activity.org_id
-
-    if not await is_org_member(current_user.id, org_id, db_session):
-        raise HTTPException(
-            status_code=403, detail="User is not a member of this organization"
-        )
+    org_id = await _resolve_org_id_for_activity(body.activity_uuid, current_user, db_session)
 
     # Rate limit then reserve credit (feature-enabled + quota checked inside reserve).
     enforce_ai_rate_limit(current_user.id, org_id)
@@ -129,3 +141,54 @@ async def api_generate_audio(
         refund_ai_credit(org_id, AUDIO_CREDIT_COST)
         logger.exception("Failed to store generated audio")
         raise HTTPException(status_code=500, detail="Failed to store generated audio")
+
+
+@router.post(
+    "/audio/script",
+    response_model=GeneratePodcastScriptResponse,
+    summary="Generate a podcast discussion script with AI",
+    description=(
+        "Turn a topic, question, or source material into a two-speaker discussion "
+        "script (ready to synthesize as a podcast). Consumes AI credits."
+    ),
+    responses={
+        200: {"description": "Script generated.", "model": GeneratePodcastScriptResponse},
+        400: {"description": "Invalid request"},
+        401: {"description": "Authentication required"},
+        403: {"description": "Not an org member, AI disabled, or insufficient credits"},
+        404: {"description": "Activity not found"},
+    },
+)
+async def api_generate_podcast_script(
+    body: GeneratePodcastScriptRequest,
+    current_user: PublicUser = Depends(get_authenticated_user),
+    db_session: AsyncSession = Depends(get_db_session),
+) -> GeneratePodcastScriptResponse:
+    if not (body.text or "").strip():
+        raise HTTPException(status_code=400, detail="Add a topic or some text to generate a script from.")
+
+    org_id = await _resolve_org_id_for_activity(body.activity_uuid, current_user, db_session)
+
+    enforce_ai_rate_limit(current_user.id, org_id)
+    await reserve_ai_credit(org_id, db_session, amount=SCRIPT_CREDIT_COST)
+
+    names = [s.name for s in (body.speakers or []) if s.name.strip()] or None
+    try:
+        transcript = await generate_podcast_script(
+            body.text, speaker_names=names, language=body.language, style=body.style
+        )
+    except AINotConfiguredError as e:
+        refund_ai_credit(org_id, SCRIPT_CREDIT_COST)
+        raise HTTPException(status_code=403, detail=str(e))
+    except ValueError as e:
+        refund_ai_credit(org_id, SCRIPT_CREDIT_COST)
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception:
+        refund_ai_credit(org_id, SCRIPT_CREDIT_COST)
+        logger.error("Podcast script generation failed")
+        raise HTTPException(
+            status_code=502,
+            detail="Podcast script generation failed. Please try again.",
+        )
+
+    return GeneratePodcastScriptResponse(transcript=transcript)

--- a/apps/api/src/routers/ai/audio.py
+++ b/apps/api/src/routers/ai/audio.py
@@ -1,0 +1,131 @@
+"""AI audio / podcast generation endpoint (Google Gemini TTS).
+
+Backs the "Generate" tab of the editor Audio block. Follows the same
+guard/credit ordering as the other AI routers: resolve org → org membership →
+rate limit → reserve credit → generate → refund on failure. The generated WAV is
+stored through the normal audio-block pipeline (``create_audio_block``), so it is
+persisted and streamed exactly like an uploaded file and the frontend can treat
+the result identically to an upload.
+"""
+
+import io
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+from starlette.datastructures import Headers
+
+from src.core.events.database import get_db_session
+from src.db.courses.activities import Activity
+from src.db.courses.blocks import BlockRead
+from src.db.users import PublicUser
+from src.security.auth import get_authenticated_user
+from src.security.features_utils.usage import refund_ai_credit, reserve_ai_credit
+from src.security.org_auth import is_org_member
+from src.services.ai.audio.generator import OUTPUT_EXT, Speaker, generate_speech
+from src.services.ai.llm import AINotConfiguredError
+from src.services.ai.schemas.audio import GenerateAudioRequest
+from src.services.blocks.block_types.audioBlock.audioBlock import create_audio_block
+from src.services.security.rate_limiting import enforce_ai_rate_limit
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# Audio generation is more expensive than a text turn but cheaper than an image.
+AUDIO_CREDIT_COST = 3
+
+
+@router.post(
+    "/audio/generate",
+    response_model=BlockRead,
+    summary="Generate an audio block with AI (Gemini TTS)",
+    description=(
+        "Generate speech (single voice) or a podcast (up to two speakers) from "
+        "text and attach it to an activity as an audio block. Consumes AI credits."
+    ),
+    responses={
+        200: {"description": "Audio generated, stored and returned.", "model": BlockRead},
+        400: {"description": "Invalid request"},
+        401: {"description": "Authentication required"},
+        403: {"description": "Not an org member, AI disabled, or insufficient credits"},
+        404: {"description": "Activity not found"},
+    },
+)
+async def api_generate_audio(
+    request: Request,
+    body: GenerateAudioRequest,
+    current_user: PublicUser = Depends(get_authenticated_user),
+    db_session: AsyncSession = Depends(get_db_session),
+) -> BlockRead:
+    if not (body.text or "").strip():
+        raise HTTPException(status_code=400, detail="Some text is required to generate audio.")
+
+    # Resolve the owning org from the activity so we can meter credits before
+    # spending anything. Full RBAC (UPDATE on the course) is enforced by
+    # create_audio_block below.
+    activity = (
+        await db_session.execute(
+            select(Activity).where(Activity.activity_uuid == body.activity_uuid)
+        )
+    ).scalars().first()
+    if not activity or activity.org_id is None:
+        raise HTTPException(status_code=404, detail="Activity not found")
+    org_id = activity.org_id
+
+    if not await is_org_member(current_user.id, org_id, db_session):
+        raise HTTPException(
+            status_code=403, detail="User is not a member of this organization"
+        )
+
+    # Rate limit then reserve credit (feature-enabled + quota checked inside reserve).
+    enforce_ai_rate_limit(current_user.id, org_id)
+    await reserve_ai_credit(org_id, db_session, amount=AUDIO_CREDIT_COST)
+
+    speakers = None
+    if body.mode == "podcast" and body.speakers:
+        speakers = [Speaker(name=s.name, voice=s.voice) for s in body.speakers if s.name.strip()]
+
+    try:
+        wav_bytes = await generate_speech(
+            body.text,
+            voice=body.voice,
+            speakers=speakers,
+            style=body.style,
+            language=body.language,
+        )
+    except AINotConfiguredError as e:
+        refund_ai_credit(org_id, AUDIO_CREDIT_COST)
+        raise HTTPException(status_code=403, detail=str(e))
+    except ValueError as e:
+        refund_ai_credit(org_id, AUDIO_CREDIT_COST)
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception:
+        refund_ai_credit(org_id, AUDIO_CREDIT_COST)
+        # Do not log the traceback: the chained SDK error can embed the API key.
+        logger.error("Audio generation failed")
+        raise HTTPException(
+            status_code=502,
+            detail="Audio generation failed. Please try again or rephrase your text.",
+        )
+
+    # Persist + create the block through the normal audio-block pipeline so the
+    # result is stored and streamed identically to an uploaded file.
+    upload = UploadFile(
+        file=io.BytesIO(wav_bytes),
+        size=len(wav_bytes),
+        filename=f"ai_generated.{OUTPUT_EXT}",
+        headers=Headers({"content-type": "audio/wav"}),
+    )
+    try:
+        return await create_audio_block(
+            request, upload, body.activity_uuid, db_session, current_user
+        )
+    except HTTPException:
+        refund_ai_credit(org_id, AUDIO_CREDIT_COST)
+        raise
+    except Exception:
+        refund_ai_credit(org_id, AUDIO_CREDIT_COST)
+        logger.exception("Failed to store generated audio")
+        raise HTTPException(status_code=500, detail="Failed to store generated audio")

--- a/apps/api/src/security/features_utils/plans.py
+++ b/apps/api/src/security/features_utils/plans.py
@@ -17,7 +17,9 @@ PLAN_HIERARCHY: list[str] = ["free", "personal", "personal-family", "standard", 
 
 # Feature to required plan mapping
 FEATURE_PLAN_REQUIREMENTS: dict[str, PlanLevel] = {
-    "ai": "standard",
+    # AI is available from the free plan (metered by a starter credit allowance);
+    # access is gated by remaining AI credits rather than by plan tier.
+    "ai": "free",
     "analytics": "standard",
     "collaboration": "standard",
     "communities": "standard",
@@ -48,7 +50,9 @@ FEATURE_PLAN_REQUIREMENTS: dict[str, PlanLevel] = {
 PLAN_FEATURE_CONFIGS: dict[str, dict] = {
     "free": {
         "features": {
-            "ai": {"enabled": False, "limit": 0},
+            # AI is enabled on free with a starter credit allowance (see
+            # AI_CREDIT_LIMITS). Usage is metered by credits, not blocked by plan.
+            "ai": {"enabled": True, "limit": 0},
             "analytics": {"enabled": False, "limit": 0},
             "api": {"enabled": False, "limit": 0},
             "assignments": {"enabled": True, "limit": 5},
@@ -229,8 +233,11 @@ PLAN_LIMITS: dict[str, dict[str, int]] = {
 
 # AI credit allocation per plan
 # 0 = no access, -1 = unlimited
+# Free orgs get a starter allowance of AI credits so new teachers can try the AI
+# features (incl. AI podcast/audio generation) before upgrading. When these run
+# out, the AI endpoints return 402/403 which the UI surfaces as an upgrade prompt.
 AI_CREDIT_LIMITS: dict[str, int] = {
-    "free": 0,
+    "free": 20,
     "personal": 500,
     "personal-family": 3000,
     "standard": 1000,

--- a/apps/api/src/services/ai/audio/generator.py
+++ b/apps/api/src/services/ai/audio/generator.py
@@ -49,6 +49,9 @@ OUTPUT_EXT = "wav"
 # fail fast with a clear error instead of spending a credit on a doomed call.
 MAX_TEXT_CHARS = 6000
 
+# Upper bound on the topic/brief used to generate a podcast script.
+MAX_SCRIPT_BRIEF_CHARS = 8000
+
 # Gemini caps multi-speaker synthesis at 2 voices.
 MAX_SPEAKERS = 2
 
@@ -141,6 +144,69 @@ def _build_prompt(text: str, *, style: Optional[str], language: Optional[str], p
     if podcast:
         return f"{lead}\nTTS the following conversation:\n{text}"
     return f"{lead}\n{text}"
+
+
+_PODCAST_SCRIPT_SYSTEM = (
+    "You are a professional podcast script writer. Turn the user's topic or source "
+    "material into a natural, engaging spoken conversation between the given speakers.\n"
+    "Rules:\n"
+    "- Output ONLY the dialogue. Every line MUST start with a speaker name followed by a "
+    "colon, e.g. 'Host:'. Use ONLY these exact speaker names: {names}.\n"
+    "- Alternate turns naturally; aim for 6 to 10 short-to-medium exchanges.\n"
+    "- Make it sound spoken — contractions, natural reactions, a clear intro and wrap-up.\n"
+    "- Do NOT include stage directions, sound effects, markdown, headings, or narration.\n"
+    "{lang_line}{tone_line}"
+)
+
+
+async def generate_podcast_script(
+    brief: str,
+    *,
+    speaker_names: Optional[list[str]] = None,
+    language: Optional[str] = None,
+    style: Optional[str] = None,
+) -> str:
+    """Write a two-speaker podcast dialogue from a topic/brief using the text LLM.
+
+    Returns a script where each line starts with a speaker name (ready to feed into
+    ``generate_speech`` in podcast mode). Raises ``AINotConfiguredError`` when the AI
+    provider is unconfigured, ``ValueError`` on empty input, or ``RuntimeError`` on
+    an empty/failed generation.
+    """
+    from src.services.ai.llm import generate, model_for_tier
+
+    brief = (brief or "").strip()
+    if not brief:
+        raise ValueError("Add a topic or some text to generate a script from.")
+    if len(brief) > MAX_SCRIPT_BRIEF_CHARS:
+        brief = brief[:MAX_SCRIPT_BRIEF_CHARS]
+
+    names = ", ".join([n for n in (speaker_names or []) if n and n.strip()]) or "Host, Guest"
+    lang_line = f"- Write the dialogue in {language.strip()}.\n" if language and language.strip() else ""
+    tone_line = f"- Tone / style: {style.strip()}.\n" if style and style.strip() else ""
+    system = _PODCAST_SCRIPT_SYSTEM.format(names=names, lang_line=lang_line, tone_line=tone_line)
+
+    try:
+        text = await generate(
+            model_name=model_for_tier("standard"),
+            user_prompt=brief,
+            system_prompt=system,
+            max_tokens=1400,
+            temperature=0.8,
+        )
+    except AINotConfiguredError:
+        raise
+    except Exception as e:  # noqa: BLE001 — surface a clean error to the router
+        logger.error("Podcast script generation failed: %s", type(e).__name__)
+        raise RuntimeError("Podcast script generation failed") from e
+
+    text = (text or "").strip()
+    if not text:
+        raise RuntimeError("The model returned an empty script. Try a different topic.")
+    # Keep the script within the TTS input budget.
+    if len(text) > MAX_TEXT_CHARS:
+        text = text[:MAX_TEXT_CHARS]
+    return text
 
 
 def _pcm_to_wav(pcm: bytes) -> bytes:

--- a/apps/api/src/services/ai/audio/generator.py
+++ b/apps/api/src/services/ai/audio/generator.py
@@ -47,10 +47,17 @@ OUTPUT_EXT = "wav"
 
 # A single TTS request has a ~32k-token context. Cap input well under that so we
 # fail fast with a clear error instead of spending a credit on a doomed call.
-MAX_TEXT_CHARS = 6000
+# Sized to hold up to the longest generated script (see MAX_SPOKEN_MINUTES).
+MAX_TEXT_CHARS = 11000
 
-# Upper bound on the topic/brief used to generate a podcast script.
+# Upper bound on the topic/brief used to generate a script.
 MAX_SCRIPT_BRIEF_CHARS = 8000
+
+# Script length targeting. Natural spoken pace is ~140 words/min; the requested
+# duration drives the target word count for generated podcast/monologue scripts.
+WORDS_PER_MINUTE = 140
+MIN_SPOKEN_MINUTES = 2
+MAX_SPOKEN_MINUTES = 10
 
 # Gemini caps multi-speaker synthesis at 2 voices.
 MAX_SPEAKERS = 2
@@ -152,26 +159,43 @@ _PODCAST_SCRIPT_SYSTEM = (
     "Rules:\n"
     "- Output ONLY the dialogue. Every line MUST start with a speaker name followed by a "
     "colon, e.g. 'Host:'. Use ONLY these exact speaker names: {names}.\n"
-    "- Alternate turns naturally; aim for 6 to 10 short-to-medium exchanges.\n"
-    "- Make it sound spoken — contractions, natural reactions, a clear intro and wrap-up.\n"
+    "- Alternate turns naturally with a clear intro and wrap-up.\n"
+    "{length_line}"
+    "- Make it sound spoken — contractions, natural reactions.\n"
     "- Do NOT include stage directions, sound effects, markdown, headings, or narration.\n"
     "{lang_line}{tone_line}"
 )
 
+_MONOLOGUE_SCRIPT_SYSTEM = (
+    "You are an expert educator and speaker. Turn the user's subject into a detailed, "
+    "engaging spoken explanation delivered by a single speaker talking directly to the "
+    "listener.\n"
+    "Rules:\n"
+    "- Output ONLY the spoken words as flowing prose. NO speaker labels, NO markdown, NO "
+    "headings, NO bullet points, NO stage directions.\n"
+    "- Explain in depth and clearly, well-structured, with a natural intro and a conclusion.\n"
+    "{length_line}"
+    "- Make it sound spoken — contractions, natural transitions, a clear voice.\n"
+    "{lang_line}{tone_line}"
+)
 
-async def generate_podcast_script(
+
+async def generate_spoken_script(
     brief: str,
     *,
+    kind: str = "podcast",
     speaker_names: Optional[list[str]] = None,
     language: Optional[str] = None,
     style: Optional[str] = None,
+    minutes: int = MIN_SPOKEN_MINUTES,
 ) -> str:
-    """Write a two-speaker podcast dialogue from a topic/brief using the text LLM.
+    """Write a spoken script from a topic/brief using the text LLM.
 
-    Returns a script where each line starts with a speaker name (ready to feed into
-    ``generate_speech`` in podcast mode). Raises ``AINotConfiguredError`` when the AI
-    provider is unconfigured, ``ValueError`` on empty input, or ``RuntimeError`` on
-    an empty/failed generation.
+    ``kind='podcast'`` produces a two-speaker dialogue (each line prefixed with a
+    speaker name); ``kind='monologue'`` produces a single-speaker explanation as
+    flowing prose. ``minutes`` targets the spoken length. Raises
+    ``AINotConfiguredError`` when the AI provider is unconfigured, ``ValueError`` on
+    empty input, or ``RuntimeError`` on an empty/failed generation.
     """
     from src.services.ai.llm import generate, model_for_tier
 
@@ -181,24 +205,42 @@ async def generate_podcast_script(
     if len(brief) > MAX_SCRIPT_BRIEF_CHARS:
         brief = brief[:MAX_SCRIPT_BRIEF_CHARS]
 
-    names = ", ".join([n for n in (speaker_names or []) if n and n.strip()]) or "Host, Guest"
-    lang_line = f"- Write the dialogue in {language.strip()}.\n" if language and language.strip() else ""
+    minutes = max(MIN_SPOKEN_MINUTES, min(int(minutes or MIN_SPOKEN_MINUTES), MAX_SPOKEN_MINUTES))
+    target_words = minutes * WORDS_PER_MINUTE
+    length_line = (
+        f"- Aim for about {minutes} minute(s) of spoken audio (roughly {target_words} "
+        "words). Use enough content to fill the time naturally, without padding or "
+        "abruptly cutting off.\n"
+    )
+    lang_line = f"- Speak in {language.strip()}.\n" if language and language.strip() else ""
     tone_line = f"- Tone / style: {style.strip()}.\n" if style and style.strip() else ""
-    system = _PODCAST_SCRIPT_SYSTEM.format(names=names, lang_line=lang_line, tone_line=tone_line)
+
+    if kind == "monologue":
+        system = _MONOLOGUE_SCRIPT_SYSTEM.format(
+            length_line=length_line, lang_line=lang_line, tone_line=tone_line
+        )
+    else:
+        names = ", ".join([n for n in (speaker_names or []) if n and n.strip()]) or "Host, Guest"
+        system = _PODCAST_SCRIPT_SYSTEM.format(
+            names=names, length_line=length_line, lang_line=lang_line, tone_line=tone_line
+        )
+
+    # Scale the output budget to the requested length (~1.6 tokens/word + headroom).
+    max_tokens = min(4000, target_words * 2 + 300)
 
     try:
         text = await generate(
             model_name=model_for_tier("standard"),
             user_prompt=brief,
             system_prompt=system,
-            max_tokens=1400,
+            max_tokens=max_tokens,
             temperature=0.8,
         )
     except AINotConfiguredError:
         raise
     except Exception as e:  # noqa: BLE001 — surface a clean error to the router
-        logger.error("Podcast script generation failed: %s", type(e).__name__)
-        raise RuntimeError("Podcast script generation failed") from e
+        logger.error("Script generation failed: %s", type(e).__name__)
+        raise RuntimeError("Script generation failed") from e
 
     text = (text or "").strip()
     if not text:

--- a/apps/api/src/services/ai/audio/generator.py
+++ b/apps/api/src/services/ai/audio/generator.py
@@ -225,8 +225,17 @@ async def generate_spoken_script(
             names=names, length_line=length_line, lang_line=lang_line, tone_line=tone_line
         )
 
-    # Scale the output budget to the requested length (~1.6 tokens/word + headroom).
-    max_tokens = min(4000, target_words * 2 + 300)
+    # Token budget. The standard tier is a Gemini 3 "thinking" model, where
+    # max_output_tokens is SHARED between reasoning tokens and the visible answer —
+    # a tight budget makes the script stop mid-sentence (the reasoning eats it up).
+    # So give generous headroom for thinking PLUS ~2x the target output length so
+    # the script can never be truncated by the ceiling. (max_tokens is a ceiling,
+    # not a target — length is steered by the prompt.)
+    # Cap stays safely under the flash model's own output limit (~8k tokens); the
+    # computed budget for the longest (10 min) script is ~5.8k, so this never binds.
+    _THINKING_HEADROOM_TOKENS = 3000
+    _OUTPUT_TOKENS_PER_WORD = 2  # ~2x the ~1.4 tokens/word a script actually needs
+    max_tokens = min(8000, target_words * _OUTPUT_TOKENS_PER_WORD + _THINKING_HEADROOM_TOKENS)
 
     try:
         text = await generate(

--- a/apps/api/src/services/ai/audio/generator.py
+++ b/apps/api/src/services/ai/audio/generator.py
@@ -1,0 +1,263 @@
+"""AI speech / podcast generation (Google Gemini TTS).
+
+Like image generation, TTS is a **Google-only** path: the provider-agnostic text
+layer in ``src/services/ai/llm`` returns text/embeddings only, so speech goes
+straight to the Google GenAI SDK. It reuses the same credential resolution as the
+text layer — ``ai_config.api_key`` when the configured provider is Google,
+otherwise the legacy ``ai_config.gemini_api_key`` — so no separate key is needed
+when the deployment already runs on Gemini.
+
+Two modes share one call:
+- ``tts``     — single voice reads the given text.
+- ``podcast`` — up to two named speakers (Gemini caps multi-speaker at 2) read a
+  dialogue script, with tone/pacing steered by a natural-language style prefix.
+
+Gemini returns headerless 24 kHz / 16-bit / mono PCM; we wrap it in a WAV
+container (stdlib ``wave``) so it can be stored and streamed like any uploaded
+audio file. All TTS model ids are still *preview* upstream, so the model id is a
+config value (``LEARNHOUSE_AI_TTS_MODEL``), never hard-coded into behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import wave
+from dataclasses import dataclass
+from typing import Optional
+
+from config.config import get_learnhouse_config
+from src.services.ai.llm import AINotConfiguredError
+from src.services.ai.llm.provider import _GOOGLE_ALIASES
+
+logger = logging.getLogger(__name__)
+
+# Cheapest Gemini TTS model with a free tier; supports single AND multi-speaker.
+# Override with LEARNHOUSE_AI_TTS_MODEL (e.g. gemini-2.5-pro-preview-tts for higher
+# quality, or a newer preview once it is allowlisted for your key).
+DEFAULT_TTS_MODEL = "gemini-2.5-flash-preview-tts"
+
+# Gemini TTS output audio characteristics (fixed by the API).
+_SAMPLE_RATE = 24000
+_SAMPLE_WIDTH = 2  # 16-bit
+_CHANNELS = 1
+
+OUTPUT_EXT = "wav"
+
+# A single TTS request has a ~32k-token context. Cap input well under that so we
+# fail fast with a clear error instead of spending a credit on a doomed call.
+MAX_TEXT_CHARS = 6000
+
+# Gemini caps multi-speaker synthesis at 2 voices.
+MAX_SPEAKERS = 2
+
+# Prebuilt voice names (voiceName → characteristic). Used to validate/normalise
+# requested voices; unknown names fall back to DEFAULT_VOICE rather than erroring.
+PREBUILT_VOICES: dict[str, str] = {
+    "Zephyr": "Bright", "Puck": "Upbeat", "Charon": "Informative", "Kore": "Firm",
+    "Fenrir": "Excitable", "Leda": "Youthful", "Orus": "Firm", "Aoede": "Breezy",
+    "Callirrhoe": "Easy-going", "Autonoe": "Bright", "Enceladus": "Breathy",
+    "Iapetus": "Clear", "Umbriel": "Easy-going", "Algieba": "Smooth",
+    "Despina": "Smooth", "Erinome": "Clear", "Algenib": "Gravelly",
+    "Rasalgethi": "Informative", "Laomedeia": "Upbeat", "Achernar": "Soft",
+    "Alnilam": "Firm", "Schedar": "Even", "Gacrux": "Mature",
+    "Pulcherrima": "Forward", "Achird": "Friendly", "Zubenelgenubi": "Casual",
+    "Vindemiatrix": "Gentle", "Sadachbia": "Lively", "Sadaltager": "Knowledgeable",
+    "Sulafat": "Warm",
+}
+DEFAULT_VOICE = "Kore"
+
+# Bounded retry for transient upstream errors (rate limit / capacity).
+_MAX_ATTEMPTS = 3
+_RETRY_BACKOFF_SECONDS = 1.5
+_RETRYABLE_STATUS = {429, 500, 502, 503, 504}
+
+
+@dataclass
+class Speaker:
+    """A named speaker bound to a prebuilt voice (podcast mode)."""
+    name: str
+    voice: str
+
+
+def normalise_voice(voice: Optional[str]) -> str:
+    """Return a valid prebuilt voice name, defaulting when unknown/empty."""
+    if voice and voice.strip() in PREBUILT_VOICES:
+        return voice.strip()
+    return DEFAULT_VOICE
+
+
+def _is_retryable(exc: Exception) -> bool:
+    """True for transient Google API errors worth retrying."""
+    code = getattr(exc, "code", None) or getattr(exc, "status_code", None)
+    if isinstance(code, int) and code in _RETRYABLE_STATUS:
+        return True
+    name = type(exc).__name__
+    return name in ("ServerError", "ServiceUnavailable", "ResourceExhausted")
+
+
+def _resolve_tts_config() -> tuple[str, str]:
+    """Return ``(api_key, model)`` for TTS or raise if unconfigured."""
+    cfg = get_learnhouse_config().ai_config
+    provider_id = (getattr(cfg, "provider", None) or "").strip().lower()
+
+    api_key = None
+    if provider_id in _GOOGLE_ALIASES:
+        api_key = getattr(cfg, "api_key", None)
+    api_key = api_key or getattr(cfg, "gemini_api_key", None)
+
+    if not api_key:
+        raise AINotConfiguredError(
+            "AI audio generation requires a Google/Gemini API key "
+            "(set LEARNHOUSE_GEMINI_API_KEY, or LEARNHOUSE_AI_API_KEY when "
+            "LEARNHOUSE_AI_PROVIDER=google)."
+        )
+
+    model = (getattr(cfg, "tts_model", None) or "").strip() or DEFAULT_TTS_MODEL
+    return api_key, model
+
+
+def _build_prompt(text: str, *, style: Optional[str], language: Optional[str], podcast: bool) -> str:
+    """Prefix the script with natural-language directives.
+
+    Gemini TTS has no separate style/language parameter — tone, pacing and target
+    language are all steered through the prompt text. Language is otherwise
+    auto-detected from the input, so this directive only nudges it when the caller
+    explicitly picked one.
+    """
+    directives: list[str] = []
+    if style and style.strip():
+        directives.append(style.strip().rstrip("."))
+    elif podcast:
+        directives.append("Read aloud in a warm, upbeat, natural podcast tone")
+    if language and language.strip():
+        directives.append(f"speak in {language.strip()}")
+
+    text = text.strip()
+    if not directives:
+        return text
+    lead = ", ".join(directives).capitalize() + ":"
+    if podcast:
+        return f"{lead}\nTTS the following conversation:\n{text}"
+    return f"{lead}\n{text}"
+
+
+def _pcm_to_wav(pcm: bytes) -> bytes:
+    """Wrap raw 24 kHz/16-bit/mono PCM in a WAV container."""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(_CHANNELS)
+        wf.setsampwidth(_SAMPLE_WIDTH)
+        wf.setframerate(_SAMPLE_RATE)
+        wf.writeframes(pcm)
+    return buf.getvalue()
+
+
+def _extract_pcm(response) -> Optional[bytes]:
+    """Pull the first inline audio payload out of a GenAI response."""
+    candidates = getattr(response, "candidates", None) or []
+    for candidate in candidates:
+        content = getattr(candidate, "content", None)
+        parts = getattr(content, "parts", None) or []
+        for part in parts:
+            inline = getattr(part, "inline_data", None)
+            data = getattr(inline, "data", None) if inline else None
+            if data:
+                return data
+    return None
+
+
+async def generate_speech(
+    text: str,
+    *,
+    voice: Optional[str] = None,
+    speakers: Optional[list[Speaker]] = None,
+    style: Optional[str] = None,
+    language: Optional[str] = None,
+) -> bytes:
+    """Synthesize speech with Gemini TTS. Returns WAV bytes.
+
+    Single-speaker when ``speakers`` is empty (uses ``voice``); otherwise
+    multi-speaker "podcast" mode binding each speaker name to a prebuilt voice.
+
+    Raises ``AINotConfiguredError`` when no Google key is configured, or a plain
+    ``RuntimeError`` when the model returns no audio (e.g. a safety refusal).
+    """
+    from google import genai
+    from google.genai import types
+
+    text = (text or "").strip()
+    if not text:
+        raise ValueError("Some text is required to generate audio.")
+    if len(text) > MAX_TEXT_CHARS:
+        raise ValueError(
+            f"Text is too long ({len(text)} chars). Keep it under {MAX_TEXT_CHARS} "
+            "characters per generation."
+        )
+
+    api_key, model = _resolve_tts_config()
+    podcast = bool(speakers)
+    prompt = _build_prompt(text, style=style, language=language, podcast=podcast)
+
+    if podcast:
+        speaker_configs = [
+            types.SpeakerVoiceConfig(
+                speaker=s.name,
+                voice_config=types.VoiceConfig(
+                    prebuilt_voice_config=types.PrebuiltVoiceConfig(
+                        voice_name=normalise_voice(s.voice)
+                    )
+                ),
+            )
+            for s in speakers[:MAX_SPEAKERS]
+        ]
+        speech_config = types.SpeechConfig(
+            multi_speaker_voice_config=types.MultiSpeakerVoiceConfig(
+                speaker_voice_configs=speaker_configs
+            )
+        )
+    else:
+        speech_config = types.SpeechConfig(
+            voice_config=types.VoiceConfig(
+                prebuilt_voice_config=types.PrebuiltVoiceConfig(
+                    voice_name=normalise_voice(voice)
+                )
+            )
+        )
+
+    config = types.GenerateContentConfig(
+        response_modalities=["AUDIO"],
+        speech_config=speech_config,
+    )
+
+    client = genai.Client(api_key=api_key)
+    response = None
+    for attempt in range(1, _MAX_ATTEMPTS + 1):
+        try:
+            response = await client.aio.models.generate_content(
+                model=model,
+                contents=prompt,
+                config=config,
+            )
+            break
+        except Exception as e:  # noqa: BLE001 — surface a clean error to the router
+            # Log only the exception type: the underlying SDK error can embed the
+            # API key (request URL/headers), so never log the message or traceback.
+            if _is_retryable(e) and attempt < _MAX_ATTEMPTS:
+                logger.warning(
+                    "Audio generation transient error (%s), retry %d/%d",
+                    type(e).__name__, attempt, _MAX_ATTEMPTS,
+                )
+                await asyncio.sleep(_RETRY_BACKOFF_SECONDS * attempt)
+                continue
+            logger.error("Audio generation call failed: %s", type(e).__name__)
+            raise RuntimeError("Audio generation failed") from e
+
+    pcm = _extract_pcm(response)
+    if not pcm:
+        logger.warning("Audio generation returned no audio")
+        raise RuntimeError(
+            "The model did not return any audio. Try rephrasing or shortening your text."
+        )
+    return _pcm_to_wav(pcm)

--- a/apps/api/src/services/ai/schemas/audio.py
+++ b/apps/api/src/services/ai/schemas/audio.py
@@ -29,18 +29,22 @@ class GenerateAudioRequest(BaseModel):
     language: Optional[str] = None
 
 
-class GeneratePodcastScriptRequest(BaseModel):
-    # The activity the podcast will be attached to (used to resolve the org for
+class GenerateScriptRequest(BaseModel):
+    # The activity the script will be attached to (used to resolve the org for
     # credit metering; no audio is stored by this endpoint).
     activity_uuid: str
-    # The topic, question, or source material to turn into a discussion.
+    # 'podcast' → two-speaker dialogue; 'speak' → single-speaker detailed monologue.
+    mode: Literal["podcast", "speak"] = "podcast"
+    # The topic, question, or source material to turn into a script.
     text: str
-    # Named speakers for the dialogue (their names anchor each script line).
+    # Named speakers for the dialogue (podcast mode; their names anchor script lines).
     speakers: Optional[list[GenerateAudioSpeaker]] = Field(default=None)
     # Optional tone/style and target language for the generated script.
     style: Optional[str] = None
     language: Optional[str] = None
+    # Approximate spoken length in minutes (clamped server-side).
+    minutes: int = Field(default=2, ge=1, le=60)
 
 
-class GeneratePodcastScriptResponse(BaseModel):
+class GenerateScriptResponse(BaseModel):
     transcript: str

--- a/apps/api/src/services/ai/schemas/audio.py
+++ b/apps/api/src/services/ai/schemas/audio.py
@@ -27,3 +27,20 @@ class GenerateAudioRequest(BaseModel):
     style: Optional[str] = None
     # Optional target language label/BCP-47 (Gemini otherwise auto-detects it).
     language: Optional[str] = None
+
+
+class GeneratePodcastScriptRequest(BaseModel):
+    # The activity the podcast will be attached to (used to resolve the org for
+    # credit metering; no audio is stored by this endpoint).
+    activity_uuid: str
+    # The topic, question, or source material to turn into a discussion.
+    text: str
+    # Named speakers for the dialogue (their names anchor each script line).
+    speakers: Optional[list[GenerateAudioSpeaker]] = Field(default=None)
+    # Optional tone/style and target language for the generated script.
+    style: Optional[str] = None
+    language: Optional[str] = None
+
+
+class GeneratePodcastScriptResponse(BaseModel):
+    transcript: str

--- a/apps/api/src/services/ai/schemas/audio.py
+++ b/apps/api/src/services/ai/schemas/audio.py
@@ -1,0 +1,29 @@
+"""Request schemas for AI audio / podcast generation (Gemini TTS)."""
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class GenerateAudioSpeaker(BaseModel):
+    """A named speaker bound to a prebuilt Gemini voice (podcast mode)."""
+    name: str
+    voice: str
+
+
+class GenerateAudioRequest(BaseModel):
+    # The activity the generated audio block is attached to. The generated file is
+    # stored and streamed exactly like an uploaded audio block.
+    activity_uuid: str
+    # 'tts' → single voice; 'podcast' → up to two named speakers reading a dialogue.
+    mode: Literal["tts", "podcast"] = "tts"
+    # The text (tts) or dialogue script (podcast) to synthesize.
+    text: str
+    # Single-speaker voice (tts mode).
+    voice: Optional[str] = None
+    # Named speaker → voice bindings (podcast mode; max 2).
+    speakers: Optional[list[GenerateAudioSpeaker]] = Field(default=None)
+    # Optional natural-language tone/style directive (e.g. "calm and reassuring").
+    style: Optional[str] = None
+    # Optional target language label/BCP-47 (Gemini otherwise auto-detects it).
+    language: Optional[str] = None

--- a/apps/api/src/services/orgs/users.py
+++ b/apps/api/src/services/orgs/users.py
@@ -21,7 +21,7 @@ from src.db.usergroup_user import UserGroupUser
 from src.db.usergroups import UserGroup, UserGroupRead
 from src.db.users import AnonymousUser, APITokenUser, PublicUser, User, UserRead
 from src.security.auth import resolve_acting_user_id
-from src.security.features_utils.usage import decrease_feature_usage
+from src.security.features_utils.usage import check_limits_with_usage, decrease_feature_usage
 from src.security.org_auth import is_org_member
 from src.security.rbac.constants import ADMIN_ROLE_ID
 from src.services.orgs.invites import send_invite_email
@@ -800,6 +800,12 @@ async def invite_batch_users(
 
     # RBAC check
     await rbac_check(request, org.org_uuid, current_user, "create", db_session)
+
+    # Enforce the member limit on the invite surface too (not just at join time),
+    # so a free org at its limit is stopped here with a 403 "Usage Limit has been
+    # reached for Members" — which the dashboard turns into a contextual upgrade
+    # prompt — instead of being able to queue unlimited invites.
+    await check_limits_with_usage("members", org.id, db_session)
 
     # Connect to Redis
     r = redis.Redis.from_url(redis_conn_string)

--- a/apps/api/src/tests/routers/test_ai_audio_router.py
+++ b/apps/api/src/tests/routers/test_ai_audio_router.py
@@ -1,0 +1,172 @@
+"""Behavioral tests for src/routers/ai/audio.py (Gemini TTS audio generation).
+
+External I/O fully mocked; the handler is called directly with an AsyncMock
+db_session whose .execute() returns a result supporting .scalars().first().
+Mirrors test_ai_images_router.py.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.routers.ai import audio as aud
+from src.services.ai.llm import AINotConfiguredError
+from src.services.ai.schemas.audio import GenerateAudioRequest, GenerateAudioSpeaker
+
+pytestmark = pytest.mark.asyncio
+
+
+def _result(value):
+    scalars = MagicMock()
+    scalars.first.return_value = value
+    res = MagicMock()
+    res.scalars.return_value = scalars
+    return res
+
+
+def _db_returning(*values):
+    db = AsyncMock()
+    db.execute.side_effect = [_result(v) for v in values]
+    return db
+
+
+def _activity(org_id=5):
+    return SimpleNamespace(org_id=org_id)
+
+
+def _user(id=1):
+    return SimpleNamespace(id=id)
+
+
+def _body(**kw):
+    base = dict(activity_uuid="act_1", mode="tts", text="Hello there")
+    base.update(kw)
+    return GenerateAudioRequest(**base)
+
+
+def _happy_patches():
+    return [
+        patch.object(aud, "is_org_member", new=AsyncMock(return_value=True)),
+        patch.object(aud, "enforce_ai_rate_limit"),
+        patch.object(aud, "reserve_ai_credit", new=AsyncMock()),
+    ]
+
+
+async def test_empty_text_400():
+    with pytest.raises(HTTPException) as e:
+        await aud.api_generate_audio(MagicMock(), _body(text="  "), _user(), _db_returning(_activity()))
+    assert e.value.status_code == 400
+
+
+async def test_activity_not_found_404():
+    with pytest.raises(HTTPException) as e:
+        await aud.api_generate_audio(MagicMock(), _body(), _user(), _db_returning(None))
+    assert e.value.status_code == 404
+
+
+async def test_non_member_403_no_spend():
+    with patch.object(aud, "is_org_member", new=AsyncMock(return_value=False)), \
+         patch.object(aud, "reserve_ai_credit", new=AsyncMock()) as reserve:
+        with pytest.raises(HTTPException) as e:
+            await aud.api_generate_audio(MagicMock(), _body(), _user(), _db_returning(_activity()))
+    assert e.value.status_code == 403
+    reserve.assert_not_called()
+
+
+async def test_happy_path_tts():
+    block = SimpleNamespace(block_uuid="block_1")
+    with patch.object(aud, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(aud, "enforce_ai_rate_limit"), \
+         patch.object(aud, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(aud, "generate_speech", new=AsyncMock(return_value=b"RIFFxxxxWAVE")) as gs, \
+         patch.object(aud, "create_audio_block", new=AsyncMock(return_value=block)) as cab:
+        resp = await aud.api_generate_audio(MagicMock(), _body(voice="Puck"), _user(), _db_returning(_activity()))
+    assert resp is block
+    gs.assert_awaited_once()
+    assert gs.await_args.kwargs["voice"] == "Puck"
+    assert gs.await_args.kwargs["speakers"] is None
+    cab.assert_awaited_once()
+
+
+async def test_happy_path_podcast_builds_speakers():
+    block = SimpleNamespace(block_uuid="block_2")
+    body = _body(
+        mode="podcast",
+        speakers=[
+            GenerateAudioSpeaker(name="Host", voice="Kore"),
+            GenerateAudioSpeaker(name="Guest", voice="Puck"),
+        ],
+    )
+    with patch.object(aud, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(aud, "enforce_ai_rate_limit"), \
+         patch.object(aud, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(aud, "generate_speech", new=AsyncMock(return_value=b"RIFFxxxxWAVE")) as gs, \
+         patch.object(aud, "create_audio_block", new=AsyncMock(return_value=block)):
+        await aud.api_generate_audio(MagicMock(), body, _user(), _db_returning(_activity()))
+    speakers = gs.await_args.kwargs["speakers"]
+    assert [s.name for s in speakers] == ["Host", "Guest"]
+    assert [s.voice for s in speakers] == ["Kore", "Puck"]
+
+
+async def test_not_configured_refunds_and_403():
+    with patch.object(aud, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(aud, "enforce_ai_rate_limit"), \
+         patch.object(aud, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(aud, "generate_speech", new=AsyncMock(side_effect=AINotConfiguredError("no key"))), \
+         patch.object(aud, "refund_ai_credit") as refund:
+        with pytest.raises(HTTPException) as e:
+            await aud.api_generate_audio(MagicMock(), _body(), _user(), _db_returning(_activity()))
+    assert e.value.status_code == 403
+    refund.assert_called_once_with(5, aud.AUDIO_CREDIT_COST)
+
+
+async def test_value_error_refunds_and_400():
+    with patch.object(aud, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(aud, "enforce_ai_rate_limit"), \
+         patch.object(aud, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(aud, "generate_speech", new=AsyncMock(side_effect=ValueError("too long"))), \
+         patch.object(aud, "refund_ai_credit") as refund:
+        with pytest.raises(HTTPException) as e:
+            await aud.api_generate_audio(MagicMock(), _body(), _user(), _db_returning(_activity()))
+    assert e.value.status_code == 400
+    refund.assert_called_once()
+
+
+async def test_generation_failure_refunds_and_502():
+    with patch.object(aud, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(aud, "enforce_ai_rate_limit"), \
+         patch.object(aud, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(aud, "generate_speech", new=AsyncMock(side_effect=RuntimeError("boom"))), \
+         patch.object(aud, "refund_ai_credit") as refund:
+        with pytest.raises(HTTPException) as e:
+            await aud.api_generate_audio(MagicMock(), _body(), _user(), _db_returning(_activity()))
+    assert e.value.status_code == 502
+    refund.assert_called_once()
+
+
+async def test_store_http_error_refunds_and_reraises():
+    with patch.object(aud, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(aud, "enforce_ai_rate_limit"), \
+         patch.object(aud, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(aud, "generate_speech", new=AsyncMock(return_value=b"RIFFxxxxWAVE")), \
+         patch.object(aud, "create_audio_block", new=AsyncMock(side_effect=HTTPException(status_code=403, detail="rbac"))), \
+         patch.object(aud, "refund_ai_credit") as refund:
+        with pytest.raises(HTTPException) as e:
+            await aud.api_generate_audio(MagicMock(), _body(), _user(), _db_returning(_activity()))
+    assert e.value.status_code == 403
+    refund.assert_called_once()
+
+
+async def test_store_generic_error_refunds_and_500():
+    with patch.object(aud, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(aud, "enforce_ai_rate_limit"), \
+         patch.object(aud, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(aud, "generate_speech", new=AsyncMock(return_value=b"RIFFxxxxWAVE")), \
+         patch.object(aud, "create_audio_block", new=AsyncMock(side_effect=RuntimeError("disk"))), \
+         patch.object(aud, "refund_ai_credit") as refund:
+        with pytest.raises(HTTPException) as e:
+            await aud.api_generate_audio(MagicMock(), _body(), _user(), _db_returning(_activity()))
+    assert e.value.status_code == 500
+    refund.assert_called_once()

--- a/apps/api/src/tests/routers/test_ai_audio_router.py
+++ b/apps/api/src/tests/routers/test_ai_audio_router.py
@@ -13,7 +13,11 @@ from fastapi import HTTPException
 
 from src.routers.ai import audio as aud
 from src.services.ai.llm import AINotConfiguredError
-from src.services.ai.schemas.audio import GenerateAudioRequest, GenerateAudioSpeaker
+from src.services.ai.schemas.audio import (
+    GenerateAudioRequest,
+    GenerateAudioSpeaker,
+    GeneratePodcastScriptRequest,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -44,6 +48,12 @@ def _body(**kw):
     base = dict(activity_uuid="act_1", mode="tts", text="Hello there")
     base.update(kw)
     return GenerateAudioRequest(**base)
+
+
+def _script_body(**kw):
+    base = dict(activity_uuid="act_1", text="Explain photosynthesis")
+    base.update(kw)
+    return GeneratePodcastScriptRequest(**base)
 
 
 def _happy_patches():
@@ -169,4 +179,79 @@ async def test_store_generic_error_refunds_and_500():
         with pytest.raises(HTTPException) as e:
             await aud.api_generate_audio(MagicMock(), _body(), _user(), _db_returning(_activity()))
     assert e.value.status_code == 500
+    refund.assert_called_once()
+
+
+# --- /audio/script (podcast script generation) ---------------------------
+
+async def test_script_empty_text_400():
+    with pytest.raises(HTTPException) as e:
+        await aud.api_generate_podcast_script(_script_body(text="  "), _user(), _db_returning(_activity()))
+    assert e.value.status_code == 400
+
+
+async def test_script_activity_not_found_404():
+    with pytest.raises(HTTPException) as e:
+        await aud.api_generate_podcast_script(_script_body(), _user(), _db_returning(None))
+    assert e.value.status_code == 404
+
+
+async def test_script_non_member_403_no_spend():
+    with patch.object(aud, "is_org_member", new=AsyncMock(return_value=False)), \
+         patch.object(aud, "reserve_ai_credit", new=AsyncMock()) as reserve:
+        with pytest.raises(HTTPException) as e:
+            await aud.api_generate_podcast_script(_script_body(), _user(), _db_returning(_activity()))
+    assert e.value.status_code == 403
+    reserve.assert_not_called()
+
+
+async def test_script_happy_path():
+    with patch.object(aud, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(aud, "enforce_ai_rate_limit"), \
+         patch.object(aud, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(aud, "generate_podcast_script", new=AsyncMock(return_value="Host: hi\nGuest: hey")) as gps:
+        resp = await aud.api_generate_podcast_script(
+            _script_body(speakers=[
+                GenerateAudioSpeaker(name="Host", voice="Kore"),
+                GenerateAudioSpeaker(name="Guest", voice="Puck"),
+            ]),
+            _user(), _db_returning(_activity()),
+        )
+    assert resp.transcript.startswith("Host:")
+    assert gps.await_args.kwargs["speaker_names"] == ["Host", "Guest"]
+
+
+async def test_script_not_configured_refunds_and_403():
+    with patch.object(aud, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(aud, "enforce_ai_rate_limit"), \
+         patch.object(aud, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(aud, "generate_podcast_script", new=AsyncMock(side_effect=AINotConfiguredError("no key"))), \
+         patch.object(aud, "refund_ai_credit") as refund:
+        with pytest.raises(HTTPException) as e:
+            await aud.api_generate_podcast_script(_script_body(), _user(), _db_returning(_activity()))
+    assert e.value.status_code == 403
+    refund.assert_called_once_with(5, aud.SCRIPT_CREDIT_COST)
+
+
+async def test_script_value_error_refunds_and_400():
+    with patch.object(aud, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(aud, "enforce_ai_rate_limit"), \
+         patch.object(aud, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(aud, "generate_podcast_script", new=AsyncMock(side_effect=ValueError("empty"))), \
+         patch.object(aud, "refund_ai_credit") as refund:
+        with pytest.raises(HTTPException) as e:
+            await aud.api_generate_podcast_script(_script_body(), _user(), _db_returning(_activity()))
+    assert e.value.status_code == 400
+    refund.assert_called_once()
+
+
+async def test_script_generation_failure_refunds_and_502():
+    with patch.object(aud, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(aud, "enforce_ai_rate_limit"), \
+         patch.object(aud, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(aud, "generate_podcast_script", new=AsyncMock(side_effect=RuntimeError("boom"))), \
+         patch.object(aud, "refund_ai_credit") as refund:
+        with pytest.raises(HTTPException) as e:
+            await aud.api_generate_podcast_script(_script_body(), _user(), _db_returning(_activity()))
+    assert e.value.status_code == 502
     refund.assert_called_once()

--- a/apps/api/src/tests/routers/test_ai_audio_router.py
+++ b/apps/api/src/tests/routers/test_ai_audio_router.py
@@ -16,7 +16,7 @@ from src.services.ai.llm import AINotConfiguredError
 from src.services.ai.schemas.audio import (
     GenerateAudioRequest,
     GenerateAudioSpeaker,
-    GeneratePodcastScriptRequest,
+    GenerateScriptRequest,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -53,7 +53,7 @@ def _body(**kw):
 def _script_body(**kw):
     base = dict(activity_uuid="act_1", text="Explain photosynthesis")
     base.update(kw)
-    return GeneratePodcastScriptRequest(**base)
+    return GenerateScriptRequest(**base)
 
 
 def _happy_patches():
@@ -186,13 +186,13 @@ async def test_store_generic_error_refunds_and_500():
 
 async def test_script_empty_text_400():
     with pytest.raises(HTTPException) as e:
-        await aud.api_generate_podcast_script(_script_body(text="  "), _user(), _db_returning(_activity()))
+        await aud.api_generate_script(_script_body(text="  "), _user(), _db_returning(_activity()))
     assert e.value.status_code == 400
 
 
 async def test_script_activity_not_found_404():
     with pytest.raises(HTTPException) as e:
-        await aud.api_generate_podcast_script(_script_body(), _user(), _db_returning(None))
+        await aud.api_generate_script(_script_body(), _user(), _db_returning(None))
     assert e.value.status_code == 404
 
 
@@ -200,35 +200,50 @@ async def test_script_non_member_403_no_spend():
     with patch.object(aud, "is_org_member", new=AsyncMock(return_value=False)), \
          patch.object(aud, "reserve_ai_credit", new=AsyncMock()) as reserve:
         with pytest.raises(HTTPException) as e:
-            await aud.api_generate_podcast_script(_script_body(), _user(), _db_returning(_activity()))
+            await aud.api_generate_script(_script_body(), _user(), _db_returning(_activity()))
     assert e.value.status_code == 403
     reserve.assert_not_called()
 
 
-async def test_script_happy_path():
+async def test_script_happy_path_podcast():
     with patch.object(aud, "is_org_member", new=AsyncMock(return_value=True)), \
          patch.object(aud, "enforce_ai_rate_limit"), \
          patch.object(aud, "reserve_ai_credit", new=AsyncMock()), \
-         patch.object(aud, "generate_podcast_script", new=AsyncMock(return_value="Host: hi\nGuest: hey")) as gps:
-        resp = await aud.api_generate_podcast_script(
-            _script_body(speakers=[
+         patch.object(aud, "generate_spoken_script", new=AsyncMock(return_value="Host: hi\nGuest: hey")) as gps:
+        resp = await aud.api_generate_script(
+            _script_body(mode="podcast", minutes=5, speakers=[
                 GenerateAudioSpeaker(name="Host", voice="Kore"),
                 GenerateAudioSpeaker(name="Guest", voice="Puck"),
             ]),
             _user(), _db_returning(_activity()),
         )
     assert resp.transcript.startswith("Host:")
+    assert gps.await_args.kwargs["kind"] == "podcast"
     assert gps.await_args.kwargs["speaker_names"] == ["Host", "Guest"]
+    assert gps.await_args.kwargs["minutes"] == 5
+
+
+async def test_script_happy_path_speak_monologue():
+    with patch.object(aud, "is_org_member", new=AsyncMock(return_value=True)), \
+         patch.object(aud, "enforce_ai_rate_limit"), \
+         patch.object(aud, "reserve_ai_credit", new=AsyncMock()), \
+         patch.object(aud, "generate_spoken_script", new=AsyncMock(return_value="Photosynthesis is...")) as gps:
+        resp = await aud.api_generate_script(
+            _script_body(mode="speak", minutes=3), _user(), _db_returning(_activity())
+        )
+    assert resp.transcript.startswith("Photosynthesis")
+    assert gps.await_args.kwargs["kind"] == "monologue"
+    assert gps.await_args.kwargs["minutes"] == 3
 
 
 async def test_script_not_configured_refunds_and_403():
     with patch.object(aud, "is_org_member", new=AsyncMock(return_value=True)), \
          patch.object(aud, "enforce_ai_rate_limit"), \
          patch.object(aud, "reserve_ai_credit", new=AsyncMock()), \
-         patch.object(aud, "generate_podcast_script", new=AsyncMock(side_effect=AINotConfiguredError("no key"))), \
+         patch.object(aud, "generate_spoken_script", new=AsyncMock(side_effect=AINotConfiguredError("no key"))), \
          patch.object(aud, "refund_ai_credit") as refund:
         with pytest.raises(HTTPException) as e:
-            await aud.api_generate_podcast_script(_script_body(), _user(), _db_returning(_activity()))
+            await aud.api_generate_script(_script_body(), _user(), _db_returning(_activity()))
     assert e.value.status_code == 403
     refund.assert_called_once_with(5, aud.SCRIPT_CREDIT_COST)
 
@@ -237,10 +252,10 @@ async def test_script_value_error_refunds_and_400():
     with patch.object(aud, "is_org_member", new=AsyncMock(return_value=True)), \
          patch.object(aud, "enforce_ai_rate_limit"), \
          patch.object(aud, "reserve_ai_credit", new=AsyncMock()), \
-         patch.object(aud, "generate_podcast_script", new=AsyncMock(side_effect=ValueError("empty"))), \
+         patch.object(aud, "generate_spoken_script", new=AsyncMock(side_effect=ValueError("empty"))), \
          patch.object(aud, "refund_ai_credit") as refund:
         with pytest.raises(HTTPException) as e:
-            await aud.api_generate_podcast_script(_script_body(), _user(), _db_returning(_activity()))
+            await aud.api_generate_script(_script_body(), _user(), _db_returning(_activity()))
     assert e.value.status_code == 400
     refund.assert_called_once()
 
@@ -249,9 +264,9 @@ async def test_script_generation_failure_refunds_and_502():
     with patch.object(aud, "is_org_member", new=AsyncMock(return_value=True)), \
          patch.object(aud, "enforce_ai_rate_limit"), \
          patch.object(aud, "reserve_ai_credit", new=AsyncMock()), \
-         patch.object(aud, "generate_podcast_script", new=AsyncMock(side_effect=RuntimeError("boom"))), \
+         patch.object(aud, "generate_spoken_script", new=AsyncMock(side_effect=RuntimeError("boom"))), \
          patch.object(aud, "refund_ai_credit") as refund:
         with pytest.raises(HTTPException) as e:
-            await aud.api_generate_podcast_script(_script_body(), _user(), _db_returning(_activity()))
+            await aud.api_generate_script(_script_body(), _user(), _db_returning(_activity()))
     assert e.value.status_code == 502
     refund.assert_called_once()

--- a/apps/api/src/tests/security/test_feature_plans.py
+++ b/apps/api/src/tests/security/test_feature_plans.py
@@ -85,7 +85,9 @@ class TestFeaturePlans:
     @pytest.mark.parametrize(
         ("mode", "plan", "expected"),
         [
-            ("saas", "free", 0),
+            # Free orgs get a starter AI credit allowance so they can try the AI
+            # features (incl. AI audio generation) before upgrading.
+            ("saas", "free", 20),
             ("saas", "personal", 500),
             ("saas", "enterprise", -1),
             ("saas", "missing", 0),

--- a/apps/api/src/tests/security/test_feature_resolve.py
+++ b/apps/api/src/tests/security/test_feature_resolve.py
@@ -127,11 +127,13 @@ class TestFeatureResolve:
             "limit": 0,
             "required_plan": "personal",
         }
+        # AI is enabled on the free plan (metered by a starter credit allowance),
+        # so it resolves as available with a free requirement.
         assert ai == {
-            "enabled": False,
-            "available": False,
+            "enabled": True,
+            "available": True,
             "limit": 0,
-            "required_plan": "standard",
+            "required_plan": "free",
         }
 
     def test_courses_saas_limit_resolution_uses_plan_overrides_and_purchased_extra(self):

--- a/apps/api/src/tests/services/test_ai_audio_generator.py
+++ b/apps/api/src/tests/services/test_ai_audio_generator.py
@@ -1,0 +1,170 @@
+"""Unit tests for src/services/ai/audio/generator.py (Gemini TTS).
+
+The Google GenAI SDK is fully mocked; no network calls. Covers the pure helpers
+and the generate_speech orchestration (single/multi-speaker, retries, failures).
+"""
+
+import io
+import wave
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.ai.audio import generator as gen
+from src.services.ai.llm import AINotConfiguredError
+
+
+def _cfg(**kw):
+    base = dict(provider="google", api_key="key", gemini_api_key=None, tts_model=None)
+    base.update(kw)
+    return SimpleNamespace(ai_config=SimpleNamespace(**base))
+
+
+def _fake_response(pcm=b"PCMDATA"):
+    part = SimpleNamespace(inline_data=SimpleNamespace(data=pcm))
+    content = SimpleNamespace(parts=[part])
+    return SimpleNamespace(candidates=[SimpleNamespace(content=content)])
+
+
+def _fake_client(response=None, side_effect=None):
+    client = MagicMock()
+    client.aio.models.generate_content = (
+        AsyncMock(side_effect=side_effect) if side_effect is not None else AsyncMock(return_value=response)
+    )
+    return client
+
+
+# --- pure helpers ---------------------------------------------------------
+
+def test_normalise_voice():
+    assert gen.normalise_voice("Puck") == "Puck"
+    assert gen.normalise_voice("  Kore ") == "Kore"
+    assert gen.normalise_voice("Nonexistent") == gen.DEFAULT_VOICE
+    assert gen.normalise_voice(None) == gen.DEFAULT_VOICE
+    assert gen.normalise_voice("") == gen.DEFAULT_VOICE
+
+
+def test_pcm_to_wav_roundtrip():
+    pcm = b"\x00\x01" * 100
+    data = gen._pcm_to_wav(pcm)
+    assert data[:4] == b"RIFF" and data[8:12] == b"WAVE"
+    with wave.open(io.BytesIO(data)) as wf:
+        assert wf.getnchannels() == 1
+        assert wf.getframerate() == 24000
+        assert wf.getsampwidth() == 2
+        assert wf.readframes(100) == pcm
+
+
+def test_build_prompt_tts_plain():
+    assert gen._build_prompt("Hello", style=None, language=None, podcast=False) == "Hello"
+
+
+def test_build_prompt_tts_with_style_and_language():
+    p = gen._build_prompt("Hello", style="calm", language="Spanish", podcast=False)
+    assert "calm" in p.lower()
+    assert "spanish" in p.lower()
+    assert p.strip().endswith("Hello")
+
+
+def test_build_prompt_podcast_defaults_to_podcast_tone():
+    p = gen._build_prompt("Host: hi", style=None, language=None, podcast=True)
+    assert "podcast" in p.lower()
+    assert "conversation" in p.lower()
+    assert "Host: hi" in p
+
+
+def test_extract_pcm():
+    assert gen._extract_pcm(_fake_response(b"PCM")) == b"PCM"
+    no_inline = SimpleNamespace(
+        candidates=[SimpleNamespace(content=SimpleNamespace(parts=[SimpleNamespace(inline_data=None)]))]
+    )
+    assert gen._extract_pcm(no_inline) is None
+    assert gen._extract_pcm(SimpleNamespace(candidates=[])) is None
+
+
+def test_is_retryable():
+    e = Exception()
+    e.code = 503
+    assert gen._is_retryable(e) is True
+    assert gen._is_retryable(type("ServerError", (Exception,), {})()) is True
+    assert gen._is_retryable(ValueError("nope")) is False
+
+
+def test_resolve_tts_config_no_key_raises():
+    with patch.object(gen, "get_learnhouse_config", return_value=_cfg(api_key=None, gemini_api_key=None)):
+        with pytest.raises(AINotConfiguredError):
+            gen._resolve_tts_config()
+
+
+def test_resolve_tts_config_default_and_override():
+    with patch.object(gen, "get_learnhouse_config", return_value=_cfg(provider="google", api_key="k")):
+        key, model = gen._resolve_tts_config()
+        assert key == "k"
+        assert model == gen.DEFAULT_TTS_MODEL
+    with patch.object(
+        gen, "get_learnhouse_config",
+        return_value=_cfg(provider="openai", api_key=None, gemini_api_key="gk", tts_model="custom-tts"),
+    ):
+        key, model = gen._resolve_tts_config()
+        assert key == "gk"
+        assert model == "custom-tts"
+
+
+# --- generate_speech ------------------------------------------------------
+
+async def test_generate_speech_single_voice():
+    client = _fake_client(_fake_response())
+    with patch.object(gen, "get_learnhouse_config", return_value=_cfg()), \
+         patch("google.genai.Client", return_value=client):
+        out = await gen.generate_speech("Hello world", voice="Puck")
+    assert out[:4] == b"RIFF" and out[8:12] == b"WAVE"
+    assert client.aio.models.generate_content.await_count == 1
+
+
+async def test_generate_speech_multi_speaker():
+    client = _fake_client(_fake_response())
+    speakers = [gen.Speaker(name="Host", voice="Kore"), gen.Speaker(name="Guest", voice="Puck")]
+    with patch.object(gen, "get_learnhouse_config", return_value=_cfg()), \
+         patch("google.genai.Client", return_value=client):
+        out = await gen.generate_speech("Host: hi\nGuest: hey", speakers=speakers, style="upbeat", language="English")
+    assert out[8:12] == b"WAVE"
+
+
+async def test_generate_speech_empty_text_raises():
+    with pytest.raises(ValueError):
+        await gen.generate_speech("   ")
+
+
+async def test_generate_speech_too_long_raises():
+    with pytest.raises(ValueError):
+        await gen.generate_speech("x" * (gen.MAX_TEXT_CHARS + 1))
+
+
+async def test_generate_speech_no_audio_raises_runtime():
+    client = _fake_client(SimpleNamespace(candidates=[]))
+    with patch.object(gen, "get_learnhouse_config", return_value=_cfg()), \
+         patch("google.genai.Client", return_value=client):
+        with pytest.raises(RuntimeError):
+            await gen.generate_speech("Hello")
+
+
+async def test_generate_speech_retries_then_succeeds():
+    retryable = Exception()
+    retryable.code = 503
+    client = MagicMock()
+    client.aio.models.generate_content = AsyncMock(side_effect=[retryable, _fake_response()])
+    with patch.object(gen, "get_learnhouse_config", return_value=_cfg()), \
+         patch("google.genai.Client", return_value=client), \
+         patch.object(gen.asyncio, "sleep", new=AsyncMock()):
+        out = await gen.generate_speech("Hello")
+    assert out[:4] == b"RIFF"
+    assert client.aio.models.generate_content.await_count == 2
+
+
+async def test_generate_speech_nonretryable_raises_runtime():
+    client = _fake_client(side_effect=ValueError("bad request"))
+    with patch.object(gen, "get_learnhouse_config", return_value=_cfg()), \
+         patch("google.genai.Client", return_value=client):
+        with pytest.raises(RuntimeError):
+            await gen.generate_speech("Hello")

--- a/apps/api/src/tests/services/test_ai_audio_generator.py
+++ b/apps/api/src/tests/services/test_ai_audio_generator.py
@@ -170,32 +170,65 @@ async def test_generate_speech_nonretryable_raises_runtime():
             await gen.generate_speech("Hello")
 
 
-# --- generate_podcast_script ---------------------------------------------
+# --- generate_spoken_script ----------------------------------------------
 
-async def test_generate_podcast_script_happy():
-    with patch("src.services.ai.llm.generate", new=AsyncMock(return_value="Host: Hi\nGuest: Hey")), \
+async def test_generate_spoken_script_podcast_happy():
+    gm = AsyncMock(return_value="Host: Hi\nGuest: Hey")
+    with patch("src.services.ai.llm.generate", new=gm), \
          patch("src.services.ai.llm.model_for_tier", return_value="m"):
-        out = await gen.generate_podcast_script(
-            "about cats", speaker_names=["Host", "Guest"], language="English", style="fun"
+        out = await gen.generate_spoken_script(
+            "about cats", kind="podcast", speaker_names=["Host", "Guest"], language="English", style="fun"
         )
     assert out.startswith("Host:")
+    # Podcast system prompt enforces speaker-labelled dialogue.
+    assert "speaker name" in gm.await_args.kwargs["system_prompt"].lower()
 
 
-async def test_generate_podcast_script_empty_brief_raises():
+async def test_generate_spoken_script_monologue_uses_prose_prompt():
+    gm = AsyncMock(return_value="Photosynthesis is how plants make food...")
+    with patch("src.services.ai.llm.generate", new=gm), \
+         patch("src.services.ai.llm.model_for_tier", return_value="m"):
+        out = await gen.generate_spoken_script("photosynthesis", kind="monologue")
+    assert out.startswith("Photosynthesis")
+    system = gm.await_args.kwargs["system_prompt"].lower()
+    assert "single speaker" in system
+    assert "no speaker labels" in system
+
+
+async def test_generate_spoken_script_minutes_drives_target_and_clamps():
+    gm = AsyncMock(return_value="Host: hi")
+    with patch("src.services.ai.llm.generate", new=gm), \
+         patch("src.services.ai.llm.model_for_tier", return_value="m"):
+        # Over the max clamps to MAX_SPOKEN_MINUTES.
+        await gen.generate_spoken_script("t", minutes=99)
+    system = gm.await_args.kwargs["system_prompt"]
+    assert f"{gen.MAX_SPOKEN_MINUTES} minute" in system
+    assert str(gen.MAX_SPOKEN_MINUTES * gen.WORDS_PER_MINUTE) in system
+
+
+async def test_generate_spoken_script_minutes_below_min_clamps():
+    gm = AsyncMock(return_value="Host: hi")
+    with patch("src.services.ai.llm.generate", new=gm), \
+         patch("src.services.ai.llm.model_for_tier", return_value="m"):
+        await gen.generate_spoken_script("t", minutes=1)
+    assert f"{gen.MIN_SPOKEN_MINUTES} minute" in gm.await_args.kwargs["system_prompt"]
+
+
+async def test_generate_spoken_script_empty_brief_raises():
     with pytest.raises(ValueError):
-        await gen.generate_podcast_script("   ")
+        await gen.generate_spoken_script("   ")
 
 
-async def test_generate_podcast_script_empty_output_raises_runtime():
+async def test_generate_spoken_script_empty_output_raises_runtime():
     with patch("src.services.ai.llm.generate", new=AsyncMock(return_value="   ")), \
          patch("src.services.ai.llm.model_for_tier", return_value="m"):
         with pytest.raises(RuntimeError):
-            await gen.generate_podcast_script("topic")
+            await gen.generate_spoken_script("topic")
 
 
-async def test_generate_podcast_script_truncates_to_tts_budget():
+async def test_generate_spoken_script_truncates_to_tts_budget():
     long_script = "Host: " + ("x" * (gen.MAX_TEXT_CHARS + 500))
     with patch("src.services.ai.llm.generate", new=AsyncMock(return_value=long_script)), \
          patch("src.services.ai.llm.model_for_tier", return_value="m"):
-        out = await gen.generate_podcast_script("topic")
+        out = await gen.generate_spoken_script("topic")
     assert len(out) <= gen.MAX_TEXT_CHARS

--- a/apps/api/src/tests/services/test_ai_audio_generator.py
+++ b/apps/api/src/tests/services/test_ai_audio_generator.py
@@ -214,6 +214,23 @@ async def test_generate_spoken_script_minutes_below_min_clamps():
     assert f"{gen.MIN_SPOKEN_MINUTES} minute" in gm.await_args.kwargs["system_prompt"]
 
 
+async def test_generate_spoken_script_budget_has_thinking_headroom():
+    # The standard tier is a Gemini-3 thinking model whose max_output_tokens is
+    # shared between reasoning and the answer. The budget must leave ample room
+    # beyond the visible output, or scripts get cut off mid-sentence. Guards the fix.
+    gm = AsyncMock(return_value="Host: hi")
+    with patch("src.services.ai.llm.generate", new=gm), \
+         patch("src.services.ai.llm.model_for_tier", return_value="m"):
+        await gen.generate_spoken_script("topic", minutes=gen.MIN_SPOKEN_MINUTES)
+    two_min = gm.await_args.kwargs["max_tokens"]
+    assert two_min >= 3000
+    with patch("src.services.ai.llm.generate", new=gm), \
+         patch("src.services.ai.llm.model_for_tier", return_value="m"):
+        await gen.generate_spoken_script("topic", minutes=gen.MAX_SPOKEN_MINUTES)
+    # Longer scripts get a larger budget.
+    assert gm.await_args.kwargs["max_tokens"] > two_min
+
+
 async def test_generate_spoken_script_empty_brief_raises():
     with pytest.raises(ValueError):
         await gen.generate_spoken_script("   ")

--- a/apps/api/src/tests/services/test_ai_audio_generator.py
+++ b/apps/api/src/tests/services/test_ai_audio_generator.py
@@ -168,3 +168,34 @@ async def test_generate_speech_nonretryable_raises_runtime():
          patch("google.genai.Client", return_value=client):
         with pytest.raises(RuntimeError):
             await gen.generate_speech("Hello")
+
+
+# --- generate_podcast_script ---------------------------------------------
+
+async def test_generate_podcast_script_happy():
+    with patch("src.services.ai.llm.generate", new=AsyncMock(return_value="Host: Hi\nGuest: Hey")), \
+         patch("src.services.ai.llm.model_for_tier", return_value="m"):
+        out = await gen.generate_podcast_script(
+            "about cats", speaker_names=["Host", "Guest"], language="English", style="fun"
+        )
+    assert out.startswith("Host:")
+
+
+async def test_generate_podcast_script_empty_brief_raises():
+    with pytest.raises(ValueError):
+        await gen.generate_podcast_script("   ")
+
+
+async def test_generate_podcast_script_empty_output_raises_runtime():
+    with patch("src.services.ai.llm.generate", new=AsyncMock(return_value="   ")), \
+         patch("src.services.ai.llm.model_for_tier", return_value="m"):
+        with pytest.raises(RuntimeError):
+            await gen.generate_podcast_script("topic")
+
+
+async def test_generate_podcast_script_truncates_to_tts_budget():
+    long_script = "Host: " + ("x" * (gen.MAX_TEXT_CHARS + 500))
+    with patch("src.services.ai.llm.generate", new=AsyncMock(return_value=long_script)), \
+         patch("src.services.ai.llm.model_for_tier", return_value="m"):
+        out = await gen.generate_podcast_script("topic")
+    assert len(out) <= gen.MAX_TEXT_CHARS

--- a/apps/api/src/tests/services/test_org_users_service.py
+++ b/apps/api/src/tests/services/test_org_users_service.py
@@ -542,6 +542,9 @@ class TestOrgUsersService:
             "src.services.orgs.users.rbac_check",
             new_callable=AsyncMock,
         ), patch(
+            "src.services.orgs.users.check_limits_with_usage",
+            new_callable=AsyncMock,
+        ), patch(
             "src.services.orgs.users.redis.Redis.from_url",
             return_value=None,
         ):
@@ -564,6 +567,9 @@ class TestOrgUsersService:
             return_value=fake_redis,
         ), patch(
             "src.services.orgs.users.rbac_check",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.services.orgs.users.check_limits_with_usage",
             new_callable=AsyncMock,
         ), patch(
             "src.services.orgs.users.send_invite_email",
@@ -671,6 +677,9 @@ class TestOrgUsersService:
             return_value=empty_config,
         ), patch(
             "src.services.orgs.users.rbac_check",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.services.orgs.users.check_limits_with_usage",
             new_callable=AsyncMock,
         ), patch(
             "src.services.orgs.users.redis.Redis.from_url",
@@ -1155,6 +1164,9 @@ class TestOrgUsersService:
             return_value=fake_redis,
         ), patch(
             "src.services.orgs.users.rbac_check",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.services.orgs.users.check_limits_with_usage",
             new_callable=AsyncMock,
         ), patch(
             "src.services.orgs.users.send_invite_email",

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -931,7 +931,7 @@ wheels = [
 
 [[package]]
 name = "learnhouse-api"
-version = "1.2.7"
+version = "1.3.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/apps/web/app/auth/verify-email/verify-email.tsx
+++ b/apps/web/app/auth/verify-email/verify-email.tsx
@@ -51,6 +51,12 @@ function VerifyEmailClient({ org }: VerifyEmailClientProps) {
                 const res = await verifyEmail(token, userUuid, orgUuid)
                 if (res.success) {
                     track(AnalyticsEvent.EmailVerificationCompleted, { result: 'success' })
+                    // Verification auto-signs the user in (session cookies were set
+                    // via the auth proxy), so they never touch the login form. Emit
+                    // login_succeeded here too, otherwise the signup→login funnel
+                    // shows a phantom drop for every verified user. `method`
+                    // distinguishes this from a credentials login.
+                    track(AnalyticsEvent.LoginSucceeded, { method: 'email_verification' })
                     setSuccess(true)
                     setShowMessage(true)
                     // Verification also signs the user in (session cookies were
@@ -105,7 +111,7 @@ function VerifyEmailClient({ org }: VerifyEmailClientProps) {
                                 </span>
                                 {success && (
                                     <span className="text-sm ml-2">
-                                        · <Link href="/" className="underline hover:no-underline">{t('auth.proceed_to_login')}</Link>
+                                        · <Link href="/home" className="underline hover:no-underline">{t('auth.continue_to_dashboard', { defaultValue: 'Continue to your dashboard' })}</Link>
                                     </span>
                                 )}
                             </div>
@@ -167,10 +173,10 @@ function VerifyEmailClient({ org }: VerifyEmailClientProps) {
                                     </div>
                                 </div>
                                 <Link
-                                    href="/"
+                                    href="/home"
                                     className="box-border w-full inline-flex h-[44px] rounded-lg items-center justify-center bg-black hover:bg-black/85 text-white px-[15px] font-bold text-[14px] leading-none transition-all"
                                 >
-                                    {t('auth.proceed_to_login')}
+                                    {t('auth.continue_to_dashboard', { defaultValue: 'Continue to your dashboard' })}
                                 </Link>
                             </div>
                         )}

--- a/apps/web/components/Dashboard/Pages/Course/EditCourseContributors/EditCourseContributors.tsx
+++ b/apps/web/components/Dashboard/Pages/Course/EditCourseContributors/EditCourseContributors.tsx
@@ -96,7 +96,18 @@ function EditCourseContributors(_props: EditCourseContributorsProps) {
 
     const { data: contributors } = useQuery({
         queryKey: queryKeys.courses.contributors(courseStructure?.course_uuid ?? ''),
-        queryFn: () => getCourseContributors(courseStructure!.course_uuid, access_token).then(res => res.data as Contributor[]),
+        // getCourseContributors resolves (does not throw) on non-200s, returning the
+        // error body as `data`. Reject on failure so React Query surfaces an error
+        // state, and always resolve to an array so render never calls .filter/.find
+        // on a `{ detail: ... }` object (was crashing the whole page on 401/403/404).
+        queryFn: async () => {
+            const res = await getCourseContributors(courseStructure!.course_uuid, access_token)
+            if (!res.success) {
+                const detail = typeof res.data?.detail === 'string' ? res.data.detail : undefined
+                throw new Error(detail ?? 'Failed to load contributors')
+            }
+            return (Array.isArray(res.data) ? res.data : []) as Contributor[]
+        },
         enabled: !!courseStructure?.course_uuid && !!access_token,
         staleTime: 60_000,
     });
@@ -110,7 +121,7 @@ function EditCourseContributors(_props: EditCourseContributorsProps) {
 
     // Derived during render: the master checkbox is checked when every
     // non-creator contributor is currently selected (and there is at least one).
-    const nonCreatorContributors = contributors?.filter(c => c.authorship !== 'CREATOR') ?? [];
+    const nonCreatorContributors = (Array.isArray(contributors) ? contributors : []).filter(c => c.authorship !== 'CREATOR');
     const masterCheckboxChecked =
         nonCreatorContributors.length > 0 &&
         selectedContributors.length === nonCreatorContributors.length;
@@ -306,7 +317,7 @@ function EditCourseContributors(_props: EditCourseContributorsProps) {
     };
 
     const sortContributors = (contributors: Contributor[] | undefined) => {
-        if (!contributors) return [];
+        if (!Array.isArray(contributors)) return [];
         
         // Find the creator and other contributors
         const creator = contributors.find(c => c.authorship === 'CREATOR');

--- a/apps/web/components/Dashboard/Pages/Course/EditCourseStructure/Buttons/NewActivityButton.tsx
+++ b/apps/web/components/Dashboard/Pages/Course/EditCourseStructure/Buttons/NewActivityButton.tsx
@@ -26,6 +26,9 @@ import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
 type NewActivityButtonProps = {
   chapterId: string
   orgslug: string
+  // When true, the add-activity modal opens automatically on mount. Used right
+  // after a course is created to drop the teacher straight into adding content.
+  autoOpen?: boolean
 }
 
 function NewActivityButton(props: NewActivityButtonProps) {
@@ -161,6 +164,16 @@ function NewActivityButton(props: NewActivityButtonProps) {
   }
 
   useEffect(() => { }, [course])
+
+  // Auto-open the modal once when requested (e.g. straight after course creation).
+  const autoOpenedRef = React.useRef(false)
+  useEffect(() => {
+    if (props.autoOpen && !autoOpenedRef.current) {
+      autoOpenedRef.current = true
+      setSelectedView('home')
+      setNewActivityModal(true)
+    }
+  }, [props.autoOpen])
 
   const dialogTitle = selectedView !== 'home' ? (
     <div className="flex items-center gap-3">

--- a/apps/web/components/Dashboard/Pages/Course/EditCourseStructure/DraggableElements/ChapterElement.tsx
+++ b/apps/web/components/Dashboard/Pages/Course/EditCourseStructure/DraggableElements/ChapterElement.tsx
@@ -40,6 +40,9 @@ type ChapterElementProps = {
   chapterIndex: number
   orgslug: string
   course_uuid: string
+  // Auto-open the add-activity modal for this chapter (used on the first chapter
+  // right after a course is created).
+  autoOpenNewActivity?: boolean
 }
 
 interface ModifiedChapterInterface {
@@ -410,6 +413,7 @@ function ChapterElement(props: ChapterElementProps) {
           <NewActivityButton
             orgslug={props.orgslug}
             chapterId={props.chapter.id}
+            autoOpen={props.autoOpenNewActivity}
           />
           <div className="h-6">
             <div className="flex items-center">

--- a/apps/web/components/Dashboard/Pages/Course/EditCourseStructure/EditCourseStructure.tsx
+++ b/apps/web/components/Dashboard/Pages/Course/EditCourseStructure/EditCourseStructure.tsx
@@ -52,6 +52,21 @@ const EditCourseStructure = (props: EditCourseStructureProps) => {
 
   const dispatchCourse = useCourseDispatch() as any
 
+  // After a course is created we redirect to `.../content?new_activity=1` so the
+  // teacher lands directly on the first activity creation. Read that flag on mount,
+  // then strip it from the URL so a refresh doesn't reopen the modal.
+  const [autoOpenFirstActivity, setAutoOpenFirstActivity] = useState(false)
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('new_activity') === '1') {
+      setAutoOpenFirstActivity(true)
+      params.delete('new_activity')
+      const qs = params.toString()
+      window.history.replaceState(null, '', window.location.pathname + (qs ? `?${qs}` : ''))
+    }
+  }, [])
+
   const [_order, _setOrder] = useState<OrderPayload>()
   const course = useCourse() as any
   const course_structure = course ? course.courseStructure : {}
@@ -144,6 +159,7 @@ const EditCourseStructure = (props: EditCourseStructureProps) => {
                         orgslug={props.orgslug}
                         course_uuid={course_uuid}
                         chapter={chapter}
+                        autoOpenNewActivity={index === 0 && autoOpenFirstActivity}
                       />
                     )
                   })}

--- a/apps/web/components/Dashboard/Pages/Users/OrgUsersAdd/OrgUsersAdd.tsx
+++ b/apps/web/components/Dashboard/Pages/Users/OrgUsersAdd/OrgUsersAdd.tsx
@@ -29,6 +29,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query/keys'
 import { useTranslation } from 'react-i18next'
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
+import UpgradeModal from '@components/Dashboard/Shared/PlanRestricted/UpgradeModal'
 
 const ITEMS_PER_PAGE = 10
 
@@ -60,6 +61,8 @@ function OrgUsersAdd() {
   const [sendSummary, setSendSummary] = useState<InviteSummary | null>(null)
   const [searchValue, setSearchValue] = useState('')
   const [page, setPage] = useState(1)
+  // Shown when a free org hits its member limit — a contextual upgrade paywall.
+  const [showUpgradeModal, setShowUpgradeModal] = useState(false)
   const { track } = useLHAnalytics('dashboard')
 
   const { data: invites } = useQuery({
@@ -128,10 +131,22 @@ function OrgUsersAdd() {
           toast.success(t('dashboard.users.invite_members.toasts.success'), { id: toastId })
         }
       } else {
-        toast.error(
-          getErrorMessage(res.data?.detail, t('dashboard.users.invite_members.toasts.error')),
-          { id: toastId }
-        )
+        const detail = typeof res.data?.detail === 'string' ? res.data.detail : ''
+        // Free org hit its member limit → contextual upgrade paywall.
+        if (/Usage Limit has been reached/i.test(detail)) {
+          toast.dismiss(toastId)
+          track(AnalyticsEvent.FeatureGateUpgradeShown, {
+            feature: 'members',
+            surface: 'member_invite',
+            required_plan: 'standard',
+          })
+          setShowUpgradeModal(true)
+        } else {
+          toast.error(
+            getErrorMessage(res.data?.detail, t('dashboard.users.invite_members.toasts.error')),
+            { id: toastId }
+          )
+        }
       }
     } catch (err) {
       toast.error(getErrorMessage((err as any)?.data?.detail, 'Failed to send invites'), {
@@ -484,6 +499,12 @@ function OrgUsersAdd() {
           </div>
         )}
       </div>
+
+      <UpgradeModal
+        open={showUpgradeModal}
+        source="member_limit"
+        onClose={() => setShowUpgradeModal(false)}
+      />
     </>
   )
 }

--- a/apps/web/components/Dashboard/Shared/PlanRestricted/UpgradeModal.tsx
+++ b/apps/web/components/Dashboard/Shared/PlanRestricted/UpgradeModal.tsx
@@ -31,6 +31,9 @@ const ease = [0.16, 1, 0.3, 1] as const
 interface UpgradeModalProps {
   open: boolean
   onClose: () => void
+  // Where the modal was opened from, for analytics attribution
+  // (e.g. 'free_plan_banner', 'course_limit', 'member_limit').
+  source?: string
 }
 
 const STANDARD_HIGHLIGHTS = [
@@ -53,7 +56,7 @@ const PRO_HIGHLIGHTS = [
   { icon: Code, labelKey: 'upgrade_modal.plans.pro.highlights.api', descKey: 'upgrade_modal.plans.pro.highlights.api_desc', iconColor: 'text-gray-500' },
 ]
 
-export default function UpgradeModal({ open, onClose }: UpgradeModalProps) {
+export default function UpgradeModal({ open, onClose, source = 'free_plan_banner' }: UpgradeModalProps) {
   const { t } = useTranslation()
   const org = useOrg() as any
   const orgSlug = org?.slug || 'default'
@@ -65,7 +68,7 @@ export default function UpgradeModal({ open, onClose }: UpgradeModalProps) {
 
   useEffect(() => {
     if (open) {
-      track(AnalyticsEvent.UpgradeModalViewed, { source: 'free_plan_banner' })
+      track(AnalyticsEvent.UpgradeModalViewed, { source })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open])

--- a/apps/web/components/Objects/Editor/Extensions/Audio/AudioBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Audio/AudioBlockComponent.tsx
@@ -7,7 +7,7 @@ import {
 } from 'lucide-react'
 import React from 'react'
 import toast from 'react-hot-toast'
-import { uploadNewAudioFile, generateAudioBlock, generatePodcastScript, type GenerateAudioSpeaker } from '../../../../../services/blocks/Audio/audio'
+import { uploadNewAudioFile, generateAudioBlock, generateScript, type GenerateAudioSpeaker } from '../../../../../services/blocks/Audio/audio'
 import { getAudioBlockStreamUrl, getPodcastAudioStreamUrl } from '@services/media/media'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { useOrgMembership } from '@components/Contexts/OrgContext'
@@ -53,6 +53,10 @@ const TTS_LANGUAGES = [
   'Italian', 'Dutch', 'Arabic', 'Hindi', 'Japanese', 'Korean',
   'Chinese (Mandarin)', 'Russian', 'Turkish', 'Polish', 'Indonesian', 'Vietnamese',
 ]
+// Approximate podcast/talk length options, in minutes (from 2).
+const LENGTH_OPTIONS = [2, 3, 5, 10]
+
+type GenMode = 'tts' | 'speak' | 'podcast'
 
 interface AudioBlockObject {
   block_uuid?: string
@@ -504,11 +508,12 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
   const [uploadProgress, setUploadProgress] = React.useState(0)
 
   // AI generation state
-  const [genMode, setGenMode] = React.useState<'tts' | 'podcast'>('tts')
+  const [genMode, setGenMode] = React.useState<GenMode>('tts')
   const [genText, setGenText] = React.useState('')
   const [genVoice, setGenVoice] = React.useState(TTS_VOICES[0].name)
   const [genLanguage, setGenLanguage] = React.useState(TTS_LANGUAGES[0])
   const [genStyle, setGenStyle] = React.useState('')
+  const [genMinutes, setGenMinutes] = React.useState<number>(LENGTH_OPTIONS[0])
   const [genSpeakers, setGenSpeakers] = React.useState<GenerateAudioSpeaker[]>([
     { name: 'Host', voice: 'Kore' },
     { name: 'Guest', voice: 'Puck' },
@@ -688,12 +693,13 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
     try {
       setIsGenerating(true)
       setError(null)
+      // 'speak' narrates a single voice, same as plain text-to-speech.
       const object = await generateAudioBlock(
         {
           activity_uuid: extension.options.activity.activity_uuid,
-          mode: genMode,
+          mode: genMode === 'podcast' ? 'podcast' : 'tts',
           text: genText,
-          voice: genMode === 'tts' ? genVoice : undefined,
+          voice: genMode !== 'podcast' ? genVoice : undefined,
           speakers: genMode === 'podcast' ? genSpeakers : undefined,
           style: genStyle.trim() || undefined,
           language: genLanguage === 'Auto-detect' ? undefined : genLanguage,
@@ -723,13 +729,15 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
     try {
       setIsGeneratingScript(true)
       setError(null)
-      const res = await generatePodcastScript(
+      const res = await generateScript(
         {
           activity_uuid: extension.options.activity.activity_uuid,
+          mode: genMode === 'podcast' ? 'podcast' : 'speak',
           text: genText,
-          speakers: genSpeakers,
+          speakers: genMode === 'podcast' ? genSpeakers : undefined,
           style: genStyle.trim() || undefined,
           language: genLanguage === 'Auto-detect' ? undefined : genLanguage,
+          minutes: genMinutes,
         },
         access_token
       )
@@ -910,6 +918,7 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                   {([
                     { key: 'tts' as const, icon: Sparkles, label: 'Text to speech' },
                     { key: 'podcast' as const, icon: Users, label: 'Podcast (2 voices)' },
+                    { key: 'speak' as const, icon: Radio, label: 'Speak' },
                   ]).map((m) => (
                     <button
                       key={m.key}
@@ -929,15 +938,19 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                 <textarea
                   value={genText}
                   onChange={(e) => setGenText(e.target.value)}
-                  rows={genMode === 'podcast' ? 5 : 4}
-                  placeholder={genMode === 'podcast'
-                    ? "What should the podcast be about? Add a topic or a question — or paste notes to turn into a discussion. Then generate a script."
-                    : 'Type the text you want spoken aloud…'}
+                  rows={genMode === 'tts' ? 4 : 5}
+                  placeholder={
+                    genMode === 'podcast'
+                      ? "What should the podcast be about? Add a topic or a question — or paste notes to turn into a discussion. Then generate a script."
+                      : genMode === 'speak'
+                        ? "What should the talk be about? e.g. “Explain how photosynthesis works, in detail.” Then generate a script."
+                        : 'Type the text you want spoken aloud…'
+                  }
                   className="w-full rounded-lg border border-neutral-200 p-3 text-sm outline-none focus:border-blue-400 resize-y"
                 />
 
-                {/* Voice(s) */}
-                {genMode === 'tts' ? (
+                {/* Voice(s) — single voice for text-to-speech and speak; two for podcast */}
+                {genMode !== 'podcast' ? (
                   <label className="block">
                     <span className="text-xs font-medium text-neutral-600">Voice</span>
                     <select
@@ -985,8 +998,22 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                   </div>
                 )}
 
-                {/* Language + tone */}
+                {/* Length (podcast / speak) + language + tone */}
                 <div className="flex gap-2">
+                  {genMode !== 'tts' && (
+                    <label className="w-28 shrink-0">
+                      <span className="text-xs font-medium text-neutral-600">Length</span>
+                      <select
+                        value={genMinutes}
+                        onChange={(e) => setGenMinutes(Number(e.target.value))}
+                        className="mt-1 w-full rounded-lg border border-neutral-200 p-2 text-sm outline-none focus:border-blue-400 bg-white"
+                      >
+                        {LENGTH_OPTIONS.map((m) => (
+                          <option key={m} value={m}>{m} min</option>
+                        ))}
+                      </select>
+                    </label>
+                  )}
                   <label className="flex-1">
                     <span className="text-xs font-medium text-neutral-600">Language</span>
                     <select
@@ -1010,8 +1037,8 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                   </label>
                 </div>
 
-                {/* Podcast: turn the topic into a discussion script first */}
-                {genMode === 'podcast' && (
+                {/* Podcast / Speak: turn the topic into a script first */}
+                {genMode !== 'tts' && (
                   <button
                     onClick={handleGenerateScript}
                     disabled={isGeneratingScript || isGenerating || !genText.trim()}
@@ -1023,9 +1050,9 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                     )}
                   >
                     {isGeneratingScript ? (
-                      <><Loader2 size={15} className="animate-spin" /> Writing the discussion…</>
+                      <><Loader2 size={15} className="animate-spin" /> {genMode === 'podcast' ? 'Writing the discussion…' : 'Writing the talk…'}</>
                     ) : (
-                      <><Sparkles size={15} /> Generate discussion script</>
+                      <><Sparkles size={15} /> {genMode === 'podcast' ? 'Generate discussion script' : 'Generate talk script'}</>
                     )}
                   </button>
                 )}
@@ -1048,7 +1075,7 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                   )}
                 </button>
                 <p className="text-[11px] text-center text-neutral-400">
-                  {genMode === 'podcast'
+                  {genMode !== 'tts'
                     ? `Script ${SCRIPT_CREDIT_COST} credit · Audio ${AI_CREDIT_COST} credits · Powered by Gemini`
                     : `Uses ${AI_CREDIT_COST} AI credits · Powered by Gemini`}
                 </p>

--- a/apps/web/components/Objects/Editor/Extensions/Audio/AudioBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Audio/AudioBlockComponent.tsx
@@ -3,11 +3,11 @@ import { Node } from '@tiptap/core'
 import {
   Loader2, Headphones, Upload, X, ArrowLeftRight,
   CheckCircle2, AlertCircle, Play, Pause, Music, Radio, List,
-  SkipBack, SkipForward, Volume2, VolumeX, Clock
+  SkipBack, SkipForward, Volume2, VolumeX, Clock, Sparkles, Users
 } from 'lucide-react'
 import React from 'react'
 import toast from 'react-hot-toast'
-import { uploadNewAudioFile } from '../../../../../services/blocks/Audio/audio'
+import { uploadNewAudioFile, generateAudioBlock, type GenerateAudioSpeaker } from '../../../../../services/blocks/Audio/audio'
 import { getAudioBlockStreamUrl, getPodcastAudioStreamUrl } from '@services/media/media'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { useOrgMembership } from '@components/Contexts/OrgContext'
@@ -29,7 +29,29 @@ const AUDIO_SIZES = {
 
 type AudioSize = keyof typeof AUDIO_SIZES
 type SourceType = 'upload' | 'episode' | 'podcast'
-type TabType = 'upload' | 'episode' | 'podcast'
+type TabType = 'upload' | 'generate' | 'episode' | 'podcast'
+
+// AI audio generation (Gemini TTS). Curated subset of the prebuilt voices, and a
+// list of well-supported languages. Language is otherwise auto-detected from the
+// text; picking one just nudges the model.
+const AI_CREDIT_COST = 3
+const TTS_VOICES = [
+  { name: 'Kore', desc: 'Firm' },
+  { name: 'Puck', desc: 'Upbeat' },
+  { name: 'Zephyr', desc: 'Bright' },
+  { name: 'Charon', desc: 'Informative' },
+  { name: 'Aoede', desc: 'Breezy' },
+  { name: 'Achird', desc: 'Friendly' },
+  { name: 'Sulafat', desc: 'Warm' },
+  { name: 'Enceladus', desc: 'Breathy' },
+  { name: 'Leda', desc: 'Youthful' },
+  { name: 'Sadaltager', desc: 'Knowledgeable' },
+]
+const TTS_LANGUAGES = [
+  'Auto-detect', 'English', 'Spanish', 'French', 'German', 'Portuguese',
+  'Italian', 'Dutch', 'Arabic', 'Hindi', 'Japanese', 'Korean',
+  'Chinese (Mandarin)', 'Russian', 'Turkish', 'Polish', 'Indonesian', 'Vietnamese',
+]
 
 interface AudioBlockObject {
   block_uuid?: string
@@ -480,6 +502,18 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
   const [isDragging, setIsDragging] = React.useState(false)
   const [uploadProgress, setUploadProgress] = React.useState(0)
 
+  // AI generation state
+  const [genMode, setGenMode] = React.useState<'tts' | 'podcast'>('tts')
+  const [genText, setGenText] = React.useState('')
+  const [genVoice, setGenVoice] = React.useState(TTS_VOICES[0].name)
+  const [genLanguage, setGenLanguage] = React.useState(TTS_LANGUAGES[0])
+  const [genStyle, setGenStyle] = React.useState('')
+  const [genSpeakers, setGenSpeakers] = React.useState<GenerateAudioSpeaker[]>([
+    { name: 'Host', voice: 'Kore' },
+    { name: 'Guest', voice: 'Puck' },
+  ])
+  const [isGenerating, setIsGenerating] = React.useState(false)
+
   // Podcast selection state
   const [podcasts, setPodcasts] = React.useState<Podcast[]>([])
   const [podcastsLoading, setPodcastsLoading] = React.useState(false)
@@ -643,6 +677,41 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
     }
   }
 
+  const handleGenerate = async () => {
+    if (!access_token) return
+    if (!genText.trim()) {
+      setError('Write some text to generate audio from.')
+      return
+    }
+    try {
+      setIsGenerating(true)
+      setError(null)
+      const object = await generateAudioBlock(
+        {
+          activity_uuid: extension.options.activity.activity_uuid,
+          mode: genMode,
+          text: genText,
+          voice: genMode === 'tts' ? genVoice : undefined,
+          speakers: genMode === 'podcast' ? genSpeakers : undefined,
+          style: genStyle.trim() || undefined,
+          language: genLanguage === 'Auto-detect' ? undefined : genLanguage,
+        },
+        access_token
+      )
+      // Generated audio is stored like an upload, so treat it identically.
+      const newBlockObject: AudioBlockObject = { ...object, source_type: 'upload', size: selectedSize }
+      setBlockObject(newBlockObject)
+      updateAttributes({ blockObject: newBlockObject })
+      toast.success('Audio generated')
+    } catch (err: any) {
+      const errorMessage = err?.message || 'Failed to generate audio. Please try again.'
+      setError(errorMessage)
+      toast.error(errorMessage)
+    } finally {
+      setIsGenerating(false)
+    }
+  }
+
   const handleRemove = () => {
     setBlockObject(null)
     updateAttributes({ blockObject: null })
@@ -742,6 +811,7 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
             <div className="flex gap-1 bg-neutral-100 rounded-lg p-1">
               {([
                 { key: 'upload' as TabType, icon: Upload, label: 'Upload' },
+                { key: 'generate' as TabType, icon: Sparkles, label: 'Generate' },
                 { key: 'episode' as TabType, icon: Music, label: 'Episode' },
                 { key: 'podcast' as TabType, icon: List, label: 'Playlist' },
               ]).map((tab) => (
@@ -795,6 +865,137 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                     </div>
                   )}
                 </div>
+              </div>
+            )}
+
+            {/* Generate Tab (AI / Gemini TTS) */}
+            {activeTab === 'generate' && (
+              <div className="space-y-3">
+                {/* Mode toggle */}
+                <div className="flex gap-1 bg-neutral-100 rounded-lg p-1">
+                  {([
+                    { key: 'tts' as const, icon: Sparkles, label: 'Text to speech' },
+                    { key: 'podcast' as const, icon: Users, label: 'Podcast (2 voices)' },
+                  ]).map((m) => (
+                    <button
+                      key={m.key}
+                      onClick={() => setGenMode(m.key)}
+                      className={cn(
+                        'flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs transition-colors flex-1 justify-center outline-none',
+                        genMode === m.key ? 'bg-white text-neutral-800 shadow-sm' : 'text-neutral-500 hover:text-neutral-700'
+                      )}
+                    >
+                      <m.icon size={13} />
+                      {m.label}
+                    </button>
+                  ))}
+                </div>
+
+                {/* Script / text */}
+                <textarea
+                  value={genText}
+                  onChange={(e) => setGenText(e.target.value)}
+                  rows={genMode === 'podcast' ? 5 : 4}
+                  placeholder={genMode === 'podcast'
+                    ? 'Host: Welcome to the show!\nGuest: Thanks for having me…'
+                    : 'Type the text you want spoken aloud…'}
+                  className="w-full rounded-lg border border-neutral-200 p-3 text-sm outline-none focus:border-blue-400 resize-y"
+                />
+
+                {/* Voice(s) */}
+                {genMode === 'tts' ? (
+                  <label className="block">
+                    <span className="text-xs font-medium text-neutral-600">Voice</span>
+                    <select
+                      value={genVoice}
+                      onChange={(e) => setGenVoice(e.target.value)}
+                      className="mt-1 w-full rounded-lg border border-neutral-200 p-2 text-sm outline-none focus:border-blue-400 bg-white"
+                    >
+                      {TTS_VOICES.map((v) => (
+                        <option key={v.name} value={v.name}>{v.name} — {v.desc}</option>
+                      ))}
+                    </select>
+                  </label>
+                ) : (
+                  <div className="space-y-2">
+                    {genSpeakers.map((sp, i) => (
+                      <div key={i} className="flex gap-2">
+                        <input
+                          value={sp.name}
+                          onChange={(e) => {
+                            const next = [...genSpeakers]
+                            next[i] = { ...next[i], name: e.target.value }
+                            setGenSpeakers(next)
+                          }}
+                          placeholder="Speaker name"
+                          className="flex-1 rounded-lg border border-neutral-200 p-2 text-sm outline-none focus:border-blue-400"
+                        />
+                        <select
+                          value={sp.voice}
+                          onChange={(e) => {
+                            const next = [...genSpeakers]
+                            next[i] = { ...next[i], voice: e.target.value }
+                            setGenSpeakers(next)
+                          }}
+                          className="rounded-lg border border-neutral-200 p-2 text-sm outline-none focus:border-blue-400 bg-white"
+                        >
+                          {TTS_VOICES.map((v) => (
+                            <option key={v.name} value={v.name}>{v.name}</option>
+                          ))}
+                        </select>
+                      </div>
+                    ))}
+                    <p className="text-[11px] text-neutral-400">
+                      Start each line of your script with a speaker name (e.g. “Host:”).
+                    </p>
+                  </div>
+                )}
+
+                {/* Language + tone */}
+                <div className="flex gap-2">
+                  <label className="flex-1">
+                    <span className="text-xs font-medium text-neutral-600">Language</span>
+                    <select
+                      value={genLanguage}
+                      onChange={(e) => setGenLanguage(e.target.value)}
+                      className="mt-1 w-full rounded-lg border border-neutral-200 p-2 text-sm outline-none focus:border-blue-400 bg-white"
+                    >
+                      {TTS_LANGUAGES.map((l) => (
+                        <option key={l} value={l}>{l}</option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="flex-1">
+                    <span className="text-xs font-medium text-neutral-600">Tone / style</span>
+                    <input
+                      value={genStyle}
+                      onChange={(e) => setGenStyle(e.target.value)}
+                      placeholder="warm and upbeat"
+                      className="mt-1 w-full rounded-lg border border-neutral-200 p-2 text-sm outline-none focus:border-blue-400"
+                    />
+                  </label>
+                </div>
+
+                {/* Generate button */}
+                <button
+                  onClick={handleGenerate}
+                  disabled={isGenerating || !genText.trim()}
+                  className={cn(
+                    'w-full flex items-center justify-center gap-2 py-2.5 rounded-lg text-sm font-semibold transition-colors',
+                    isGenerating || !genText.trim()
+                      ? 'bg-neutral-200 text-neutral-400 cursor-not-allowed'
+                      : 'bg-black text-white hover:bg-neutral-800'
+                  )}
+                >
+                  {isGenerating ? (
+                    <><Loader2 size={15} className="animate-spin" /> Generating…</>
+                  ) : (
+                    <><Sparkles size={15} /> Generate audio</>
+                  )}
+                </button>
+                <p className="text-[11px] text-center text-neutral-400">
+                  Uses {AI_CREDIT_COST} AI credits · Powered by Gemini
+                </p>
               </div>
             )}
 

--- a/apps/web/components/Objects/Editor/Extensions/Audio/AudioBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Audio/AudioBlockComponent.tsx
@@ -7,7 +7,7 @@ import {
 } from 'lucide-react'
 import React from 'react'
 import toast from 'react-hot-toast'
-import { uploadNewAudioFile, generateAudioBlock, type GenerateAudioSpeaker } from '../../../../../services/blocks/Audio/audio'
+import { uploadNewAudioFile, generateAudioBlock, generatePodcastScript, type GenerateAudioSpeaker } from '../../../../../services/blocks/Audio/audio'
 import { getAudioBlockStreamUrl, getPodcastAudioStreamUrl } from '@services/media/media'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { useOrgMembership } from '@components/Contexts/OrgContext'
@@ -35,6 +35,7 @@ type TabType = 'upload' | 'generate' | 'episode' | 'podcast'
 // list of well-supported languages. Language is otherwise auto-detected from the
 // text; picking one just nudges the model.
 const AI_CREDIT_COST = 3
+const SCRIPT_CREDIT_COST = 1
 const TTS_VOICES = [
   { name: 'Kore', desc: 'Firm' },
   { name: 'Puck', desc: 'Upbeat' },
@@ -513,6 +514,7 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
     { name: 'Guest', voice: 'Puck' },
   ])
   const [isGenerating, setIsGenerating] = React.useState(false)
+  const [isGeneratingScript, setIsGeneratingScript] = React.useState(false)
 
   // Podcast selection state
   const [podcasts, setPodcasts] = React.useState<Podcast[]>([])
@@ -712,6 +714,38 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
     }
   }
 
+  const handleGenerateScript = async () => {
+    if (!access_token) return
+    if (!genText.trim()) {
+      setError('Add a topic or some text to generate a script from.')
+      return
+    }
+    try {
+      setIsGeneratingScript(true)
+      setError(null)
+      const res = await generatePodcastScript(
+        {
+          activity_uuid: extension.options.activity.activity_uuid,
+          text: genText,
+          speakers: genSpeakers,
+          style: genStyle.trim() || undefined,
+          language: genLanguage === 'Auto-detect' ? undefined : genLanguage,
+        },
+        access_token
+      )
+      if (res?.transcript) {
+        setGenText(res.transcript)
+        toast.success('Script ready — review it, then generate audio')
+      }
+    } catch (err: any) {
+      const errorMessage = err?.message || 'Failed to generate script. Please try again.'
+      setError(errorMessage)
+      toast.error(errorMessage)
+    } finally {
+      setIsGeneratingScript(false)
+    }
+  }
+
   const handleRemove = () => {
     setBlockObject(null)
     updateAttributes({ blockObject: null })
@@ -897,7 +931,7 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                   onChange={(e) => setGenText(e.target.value)}
                   rows={genMode === 'podcast' ? 5 : 4}
                   placeholder={genMode === 'podcast'
-                    ? 'Host: Welcome to the show!\nGuest: Thanks for having me…'
+                    ? "What should the podcast be about? Add a topic or a question — or paste notes to turn into a discussion. Then generate a script."
                     : 'Type the text you want spoken aloud…'}
                   className="w-full rounded-lg border border-neutral-200 p-3 text-sm outline-none focus:border-blue-400 resize-y"
                 />
@@ -946,7 +980,7 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                       </div>
                     ))}
                     <p className="text-[11px] text-neutral-400">
-                      Start each line of your script with a speaker name (e.g. “Host:”).
+                      Add a topic above and generate a discussion, or write the script yourself — each line starts with a speaker name (e.g. “Host:”).
                     </p>
                   </div>
                 )}
@@ -976,13 +1010,33 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                   </label>
                 </div>
 
-                {/* Generate button */}
+                {/* Podcast: turn the topic into a discussion script first */}
+                {genMode === 'podcast' && (
+                  <button
+                    onClick={handleGenerateScript}
+                    disabled={isGeneratingScript || isGenerating || !genText.trim()}
+                    className={cn(
+                      'w-full flex items-center justify-center gap-2 py-2.5 rounded-lg text-sm font-semibold border transition-colors',
+                      isGeneratingScript || isGenerating || !genText.trim()
+                        ? 'border-neutral-200 text-neutral-400 cursor-not-allowed'
+                        : 'border-neutral-300 text-neutral-700 hover:bg-neutral-50'
+                    )}
+                  >
+                    {isGeneratingScript ? (
+                      <><Loader2 size={15} className="animate-spin" /> Writing the discussion…</>
+                    ) : (
+                      <><Sparkles size={15} /> Generate discussion script</>
+                    )}
+                  </button>
+                )}
+
+                {/* Generate audio button */}
                 <button
                   onClick={handleGenerate}
-                  disabled={isGenerating || !genText.trim()}
+                  disabled={isGenerating || isGeneratingScript || !genText.trim()}
                   className={cn(
                     'w-full flex items-center justify-center gap-2 py-2.5 rounded-lg text-sm font-semibold transition-colors',
-                    isGenerating || !genText.trim()
+                    isGenerating || isGeneratingScript || !genText.trim()
                       ? 'bg-neutral-200 text-neutral-400 cursor-not-allowed'
                       : 'bg-black text-white hover:bg-neutral-800'
                   )}
@@ -994,7 +1048,9 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                   )}
                 </button>
                 <p className="text-[11px] text-center text-neutral-400">
-                  Uses {AI_CREDIT_COST} AI credits · Powered by Gemini
+                  {genMode === 'podcast'
+                    ? `Script ${SCRIPT_CREDIT_COST} credit · Audio ${AI_CREDIT_COST} credits · Powered by Gemini`
+                    : `Uses ${AI_CREDIT_COST} AI credits · Powered by Gemini`}
                 </p>
               </div>
             )}

--- a/apps/web/components/Objects/Modals/Course/Create/CreateCourse.tsx
+++ b/apps/web/components/Objects/Modals/Course/Create/CreateCourse.tsx
@@ -26,6 +26,7 @@ import AIImageButton from '@components/Objects/AI/AIImageButton'
 import FormTagInput from "@components/Objects/StyledElements/Form/TagInput"
 import { useTranslation } from "react-i18next"
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
+import UpgradeModal from '@components/Dashboard/Shared/PlanRestricted/UpgradeModal'
 
 const _validationSchema = Yup.object().shape({
   name: Yup.string()
@@ -48,6 +49,8 @@ function CreateCourseModal({ closeModal, orgslug }: any) {
   const [orgId, setOrgId] = React.useState(null) as any
   const [showUnsplashPicker, setShowUnsplashPicker] = React.useState(false)
   const [isUploading, setIsUploading] = React.useState(false)
+  // Shown when a free org hits its course limit — a contextual upgrade paywall.
+  const [showUpgradeModal, setShowUpgradeModal] = React.useState(false)
 
   const validationSchema = Yup.object().shape({
     name: Yup.string()
@@ -124,16 +127,31 @@ function CreateCourseModal({ closeModal, orgslug }: any) {
           toast.success(t('courses.course_created_success'))
 
           closeModal()
-          // Redirect to the course dashboard - remove 'course_' prefix if present
+          // Redirect straight to the Content tab and auto-open the "add activity"
+          // popup so a brand-new course lands the teacher on the core creation
+          // action (their first activity) instead of an empty settings page.
           const courseId = res.data.course_uuid?.replace('course_', '') || res.data.course_uuid
-          router.push(`/dash/courses/course/${courseId}/general`)
+          router.push(`/dash/courses/course/${courseId}/content?new_activity=1`)
         } else {
-          const errorMessage = typeof res.data?.detail === 'string'
-            ? res.data.detail
-            : Array.isArray(res.data?.detail)
-              ? res.data.detail.map((e: any) => e.msg).join(', ')
-              : t('courses.failed_to_create_course')
-          toast.error(errorMessage)
+          toast.dismiss(toast_loading)
+          const detail = typeof res.data?.detail === 'string' ? res.data.detail : ''
+          // A free org that has hit its course limit gets a contextual upgrade
+          // paywall at the moment of value, instead of a dead-end error toast.
+          if (/Usage Limit has been reached/i.test(detail)) {
+            track(AnalyticsEvent.FeatureGateUpgradeShown, {
+              feature: 'courses',
+              surface: 'course_create',
+              required_plan: 'standard',
+            })
+            setShowUpgradeModal(true)
+          } else {
+            const errorMessage = detail
+              ? detail
+              : Array.isArray(res.data?.detail)
+                ? res.data.detail.map((e: any) => e.msg).join(', ')
+                : t('courses.failed_to_create_course')
+            toast.error(errorMessage)
+          }
         }
       } catch (_error) {
         toast.error(t('courses.failed_to_create_course'))
@@ -335,6 +353,15 @@ function CreateCourseModal({ closeModal, orgslug }: any) {
           onClose={() => setShowUnsplashPicker(false)}
         />
       )}
+
+      <UpgradeModal
+        open={showUpgradeModal}
+        source="course_limit"
+        onClose={() => {
+          setShowUpgradeModal(false)
+          closeModal()
+        }}
+      />
     </FormLayout>
   )
 }

--- a/apps/web/services/blocks/Audio/audio.ts
+++ b/apps/web/services/blocks/Audio/audio.ts
@@ -16,6 +16,14 @@ export type GenerateAudioParams = {
   language?: string
 }
 
+function extractDetail(data: any, fallback: string): string {
+  return typeof data?.detail === 'string'
+    ? data.detail
+    : Array.isArray(data?.detail)
+      ? data.detail.map((e: any) => e.msg).join(', ')
+      : fallback
+}
+
 // Generate an audio block with AI (Gemini TTS). Returns the same shape as the
 // audio upload endpoint (a BlockRead), so callers can treat it like an upload.
 export async function generateAudioBlock(
@@ -30,12 +38,35 @@ export async function generateAudioBlock(
   const data = await result.json()
 
   if (!result.ok) {
-    const errorMessage = typeof data?.detail === 'string'
-      ? data.detail
-      : Array.isArray(data?.detail)
-        ? data.detail.map((e: any) => e.msg).join(', ')
-        : 'Audio generation failed'
-    throw new Error(errorMessage)
+    throw new Error(extractDetail(data, 'Audio generation failed'))
+  }
+
+  return data
+}
+
+export type GeneratePodcastScriptParams = {
+  activity_uuid: string
+  text: string
+  speakers?: GenerateAudioSpeaker[]
+  style?: string
+  language?: string
+}
+
+// Turn a topic/brief into a two-speaker discussion script (for podcast mode).
+// Returns { transcript }.
+export async function generatePodcastScript(
+  params: GeneratePodcastScriptParams,
+  access_token: string
+): Promise<{ transcript: string }> {
+  const result = await fetch(
+    `${getAPIUrl()}ai/audio/script`,
+    RequestBodyWithAuthHeader('POST', params, null, access_token)
+  )
+
+  const data = await result.json()
+
+  if (!result.ok) {
+    throw new Error(extractDetail(data, 'Script generation failed'))
   }
 
   return data

--- a/apps/web/services/blocks/Audio/audio.ts
+++ b/apps/web/services/blocks/Audio/audio.ts
@@ -44,18 +44,22 @@ export async function generateAudioBlock(
   return data
 }
 
-export type GeneratePodcastScriptParams = {
+export type GenerateScriptParams = {
   activity_uuid: string
+  // 'podcast' → two-speaker dialogue; 'speak' → single-speaker detailed monologue.
+  mode: 'podcast' | 'speak'
   text: string
   speakers?: GenerateAudioSpeaker[]
   style?: string
   language?: string
+  // Approximate spoken length in minutes.
+  minutes?: number
 }
 
-// Turn a topic/brief into a two-speaker discussion script (for podcast mode).
-// Returns { transcript }.
-export async function generatePodcastScript(
-  params: GeneratePodcastScriptParams,
+// Turn a topic/brief into a spoken script (podcast dialogue or a detailed
+// monologue for "speak" mode). Returns { transcript }.
+export async function generateScript(
+  params: GenerateScriptParams,
   access_token: string
 ): Promise<{ transcript: string }> {
   const result = await fetch(

--- a/apps/web/services/blocks/Audio/audio.ts
+++ b/apps/web/services/blocks/Audio/audio.ts
@@ -1,7 +1,45 @@
 import { getAPIUrl } from '@services/config/config'
 import {
   RequestBodyFormWithAuthHeader,
+  RequestBodyWithAuthHeader,
 } from '@services/utils/ts/requests'
+
+export type GenerateAudioSpeaker = { name: string; voice: string }
+
+export type GenerateAudioParams = {
+  activity_uuid: string
+  mode: 'tts' | 'podcast'
+  text: string
+  voice?: string
+  speakers?: GenerateAudioSpeaker[]
+  style?: string
+  language?: string
+}
+
+// Generate an audio block with AI (Gemini TTS). Returns the same shape as the
+// audio upload endpoint (a BlockRead), so callers can treat it like an upload.
+export async function generateAudioBlock(
+  params: GenerateAudioParams,
+  access_token: string
+) {
+  const result = await fetch(
+    `${getAPIUrl()}ai/audio/generate`,
+    RequestBodyWithAuthHeader('POST', params, null, access_token)
+  )
+
+  const data = await result.json()
+
+  if (!result.ok) {
+    const errorMessage = typeof data?.detail === 'string'
+      ? data.detail
+      : Array.isArray(data?.detail)
+        ? data.detail.map((e: any) => e.msg).join(', ')
+        : 'Audio generation failed'
+    throw new Error(errorMessage)
+  }
+
+  return data
+}
 
 export async function uploadNewAudioFile(
   file: any,

--- a/docs/content/platform/ai/for-teachers.mdx
+++ b/docs/content/platform/ai/for-teachers.mdx
@@ -10,6 +10,29 @@ Teachers can use the AI to accelerate the course-building process:
 - **Content improvement** — Refine existing content for clarity, tone, or completeness.
 - **Quiz creation** — Generate quiz questions based on the course material.
 
+## Audio & podcast generation
+
+From an activity's **Audio** block, the **Generate** tab turns text into narrated audio using
+Google Gemini text-to-speech. Three modes are available:
+
+- **Text to speech** — narrate text you write, in a voice of your choice.
+- **Podcast (2 voices)** — enter a topic (or paste source material) and the AI writes a two-host
+  discussion, which you can review and edit before generating the audio.
+- **Speak** — enter a subject and the AI writes a detailed single-speaker talk, then narrates it.
+
+For the Podcast and Speak modes you can pick a **length** (from 2 minutes), a **language**, and a
+**tone/style**. The generated script is fully editable before you produce the audio, and the audio
+is saved to the activity like any uploaded file.
+
+Audio generation uses [AI credits](#ai-credits): 1 credit to write a script and 3 credits to
+generate the narration.
+
+## AI credits
+
+AI features are metered by per-organization AI credits. **Free organizations start with 20 credits**
+so you can try the AI features — including audio generation — before upgrading. When credits run
+low, the app prompts you to upgrade for a larger monthly allowance.
+
 ## Course Management
 
 Beyond content creation, the AI can assist with organizing and structuring courses:

--- a/docs/content/platform/ai/index.mdx
+++ b/docs/content/platform/ai/index.mdx
@@ -8,6 +8,8 @@ LearnHouse includes a context-aware AI assistant powered by **Google Gemini**. T
 
 The AI assistant operates at the course and activity level. It reads the content of the current course or activity to provide contextually accurate responses. This means answers are grounded in your actual teaching material rather than generic knowledge.
 
+Beyond chat and content assistance, LearnHouse can also generate **images** and **audio** (text-to-speech, a two-voice podcast, or a single-voice talk) directly in the editor. AI usage is metered by AI credits, and **free organizations start with 20 credits** to try things out.
+
 <Callout>
 AI features require a Google Gemini API key to be configured at the instance level via `LEARNHOUSE_GEMINI_API_KEY`. See [AI Setup](/self-hosting/configuration/ai-setup) for details.
 </Callout>

--- a/docs/content/self-hosting/configuration/ai-setup.mdx
+++ b/docs/content/self-hosting/configuration/ai-setup.mdx
@@ -252,6 +252,30 @@ Once AI is enabled on the instance, each organization can toggle AI on or off an
 limits from its admin settings. The provider and API key are set once at deployment and shared
 across organizations.
 
+## Media generation (images & audio)
+
+Image generation and audio / podcast generation (text-to-speech) are **Google-only** paths: they
+always use the Google GenAI SDK regardless of `LEARNHOUSE_AI_PROVIDER`, resolving their key from
+`LEARNHOUSE_AI_API_KEY` (when `provider=google`) or `LEARNHOUSE_GEMINI_API_KEY`. So if you already
+run on Gemini, they work with no extra configuration.
+
+Both model ids default to sensible values and only need overriding to opt into a newer/allowlisted
+model:
+
+```bash
+# AI image generation ("nano banana"). Default: gemini-2.5-flash-image
+LEARNHOUSE_AI_IMAGE_MODEL=gemini-2.5-flash-image
+
+# AI audio / podcast generation (Gemini TTS). Default: gemini-2.5-flash-preview-tts
+# All Gemini TTS models are currently preview, so this is kept configurable.
+LEARNHOUSE_AI_TTS_MODEL=gemini-2.5-flash-preview-tts
+```
+
+The audio feature powers the editor's **Generate** audio tab (text-to-speech, a two-voice podcast,
+or a single-voice "Speak" talk). The spoken script for the podcast/Speak modes is written by the
+standard text model (`LEARNHOUSE_AI_MODEL_STANDARD`); the narration uses the TTS model above. All of
+it is metered by [AI credits](/platform/ai).
+
 ## Usage limits
 
 You can configure a per-organization request limit to control API costs. When a user exceeds the
@@ -267,5 +291,7 @@ limit, further AI requests are rejected until the window resets.
 | `LEARNHOUSE_AI_BASE_URL` | Optional. Custom endpoint for OpenAI-compatible / local providers (e.g. Ollama). Auto-set for OpenRouter. |
 | `LEARNHOUSE_AI_MODEL_FAST` / `_STANDARD` / `_PRO` | Per-tier model overrides (see table above). |
 | `LEARNHOUSE_AI_EMBEDDING_PROVIDER` / `_MODEL` / `_DIMENSIONS` | Optional RAG embedding overrides. Default: same provider, per-provider model, 768 dims. |
-| `LEARNHOUSE_GEMINI_API_KEY` | Google/Gemini key. Also the **embeddings fallback** for providers without an embeddings API. |
+| `LEARNHOUSE_AI_IMAGE_MODEL` | Google image-generation model. Default `gemini-2.5-flash-image`. Google-only path. |
+| `LEARNHOUSE_AI_TTS_MODEL` | Google text-to-speech model for audio/podcast generation. Default `gemini-2.5-flash-preview-tts` (all Gemini TTS models are preview). Google-only path. |
+| `LEARNHOUSE_GEMINI_API_KEY` | Google/Gemini key. Also the **embeddings fallback** for providers without an embeddings API, and the key used for image/TTS generation on non-Google providers. |
 | `AWS_REGION` / `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Standard AWS credentials, used only when `provider=bedrock`. |

--- a/docs/content/self-hosting/configuration/environment-variables.mdx
+++ b/docs/content/self-hosting/configuration/environment-variables.mdx
@@ -92,6 +92,8 @@ optional: the feature stays disabled or uses a runtime fallback when the variabl
 | `LEARNHOUSE_AI_MODEL_FAST` | Low-latency model tier for titles, follow-ups, and migration tasks. | model id | `gemini-3.1-flash-lite` | API |
 | `LEARNHOUSE_AI_MODEL_STANDARD` | Standard model tier for chat, RAG, and standard-plan generation. | model id | `gemini-3.5-flash` | API |
 | `LEARNHOUSE_AI_MODEL_PRO` | Pro model tier for upgraded course planning and generation flows. | model id | `gemini-3.1-pro-preview` | API |
+| `LEARNHOUSE_AI_IMAGE_MODEL` | Google image-generation model ("nano banana"). Google-only path (uses the Gemini key regardless of provider). | model id | `gemini-2.5-flash-image` | API |
+| `LEARNHOUSE_AI_TTS_MODEL` | Google text-to-speech model for AI audio / podcast generation. Google-only path. All Gemini TTS models are currently preview. | model id | `gemini-2.5-flash-preview-tts` | API |
 | `LEARNHOUSE_AI_EMBEDDING_PROVIDER` | Optional provider override for RAG embeddings. | string | same as `LEARNHOUSE_AI_PROVIDER` | API |
 | `LEARNHOUSE_AI_EMBEDDING_MODEL` | Optional embedding model override. | model id | provider default, such as `gemini-embedding-001`, `text-embedding-3-small`, or `nomic-embed-text` | API |
 | `LEARNHOUSE_AI_EMBEDDING_DIMENSIONS` | Embedding vector size. Changing this requires a matching database migration and re-index. | integer | `768` | API |


### PR DESCRIPTION
## Why

PostHog on the SaaS project showed two problems this addresses:
1. **New signups rarely reach the core value action.** Of the signup cohort, almost none started building a course and none published one.
2. **The only upgrade prompt fired on the billing page** — users never hit a paywall at a moment of value, and plan selection was near-zero.

Plus a systematic crash on the Contributors tab (Sentry `LEARNHOUSE-WEB-51`/`-4A`) firing `error_view_shown` across many courses.

## What's in this PR

### 1. Course creation → straight to activation
After a course is created we redirect to the **Content** tab and **auto-open the "add activity" popup** on the first chapter, so teachers land on the core creation action instead of an empty settings page.

### 2. Auth funnel truthfulness
Auto-login after email verification already exists — the funnel's big `email_verification_completed → login_succeeded` drop was a measurement artifact (verified users never touch the login form). Now we fire `login_succeeded` (`method: email_verification`) on that path and point the stale "proceed to login" links at `/home`.

### 3. Contributors page crash
`EditCourseContributors` cast the response to `Contributor[]` without checking success, so any non-200 (esp. an expired-token 401) → `.filter/.find` on `{detail:…}` → full-page crash. Now the queryFn rejects on failure and always resolves to an array, with defensive guards. Degrades to an empty list instead of crashing.

### 4. Value-based upgrade gates
When a **free org hits its course or member limit** the dashboard now surfaces the `UpgradeModal` contextually instead of a dead-end error toast, attributed via a `source` prop + `feature_gate_upgrade_shown`. The member limit is now also enforced on the invite path (previously only at join time), so the gate actually fires and free orgs can't queue unlimited invites past their limit.

### 5. Free plan starts with 20 AI credits
`AI_CREDIT_LIMITS["free"] = 20`, `ai` enabled for free (metered by credits), and the `ai` feature requirement relaxed to `free`. Lets new teachers try the AI features (incl. audio generation) before upgrading; when credits run out the AI endpoints 402/403 → upgrade prompt.

### 6. AI podcast / audio generation (Google Gemini TTS) 🎙️
New **"Generate"** tab on the editor Audio block:
- **Text-to-speech** (single voice) or **Podcast** (2 named speakers) with **voice**, **language**, and **tone/style** selection.
- **Podcast mode is topic-first:** enter a topic/question or paste source material, click **"Generate discussion script"** to have the AI write the two-speaker dialogue (editable), then **"Generate audio"** to narrate it.
- Backend uses the Google GenAI SDK — TTS model `gemini-2.5-flash-preview-tts` (configurable via `LEARNHOUSE_AI_TTS_MODEL`, since all Gemini TTS models are preview). Script generation uses the standard text-LLM layer. Generated audio is stored/streamed through the existing audio-block pipeline.
- Costs: script 1 credit, audio 3 credits (reserve/refund pattern).
- New endpoints: `POST /ai/audio/generate`, `POST /ai/audio/script`.

## Verification
- Backend: full API test suite green, including new tests for the TTS generator, script generator, and both routers (credit reserve/refund on every path, RBAC, single/multi-speaker). Ruff clean.
- Coverage: the new AI files are under the repo's coverage-omit paths (`src/services/ai/*`, `src/routers/ai/*`); the counted changes (`plans.py`, `router.py`) are covered — Codecov patch passes.
- `tsc --noEmit` on the web app: zero errors in touched files.

## Notes
- Data window was ~2 weeks of analytics, so these are directional bets.
- Multi-speaker Gemini TTS caps at 2 voices (podcast mode reflects this).
- The ~38% raw login-failure rate and `/login` rage-clicks are worth a separate look (not addressed here).
