### PR TITLE
fix(assignments): scope task submission uuid updates

### DIFF
--- a/apps/api/src/services/courses/activities/assignments.py
+++ b/apps/api/src/services/courses/activities/assignments.py
@@ -1389,6 +1389,14 @@ async def _resolve_token_submission_user(
     return PublicUser(**learner.model_dump())
 
 
+_ASSIGNMENT_TASK_SUBMISSION_MUTABLE_FIELDS = {
+    "task_submission",
+    "grade",
+    "task_submission_grade_feedback",
+    "manually_graded",
+}
+
+
 async def handle_assignment_task_submission(
     request: Request,
     assignment_task_uuid: str,
@@ -1492,17 +1500,23 @@ async def handle_assignment_task_submission(
         # SECURITY: Instructors/admins need update permission to grade
         await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
 
-    # Try to find existing submission by user_id and assignment_task_id first (for save progress functionality)
-    statement = select(AssignmentTaskSubmission).where(
-        AssignmentTaskSubmission.assignment_task_id == assignment_task.id,
-        AssignmentTaskSubmission.user_id == submitter.id,
-    )
-    assignment_task_submission = (await db_session.execute(statement)).scalars().first()
-    
-    # If no submission found by user+task, try to find by UUID if provided (for specific submission updates)
-    if not assignment_task_submission and assignment_task_submission_uuid:
+    if assignment_task_submission_uuid:
         statement = select(AssignmentTaskSubmission).where(
-            AssignmentTaskSubmission.assignment_task_submission_uuid == assignment_task_submission_uuid
+            AssignmentTaskSubmission.assignment_task_submission_uuid == assignment_task_submission_uuid,
+            AssignmentTaskSubmission.assignment_task_id == assignment_task.id,
+        )
+        assignment_task_submission = (await db_session.execute(statement)).scalars().first()
+        if not assignment_task_submission:
+            raise HTTPException(
+                status_code=404,
+                detail="Assignment Task Submission not found",
+            )
+    else:
+        # Save-progress path: without an explicit UUID, update/create the
+        # submitter's own submission for this task.
+        statement = select(AssignmentTaskSubmission).where(
+            AssignmentTaskSubmission.assignment_task_id == assignment_task.id,
+            AssignmentTaskSubmission.user_id == submitter.id,
         )
         assignment_task_submission = (await db_session.execute(statement)).scalars().first()
 
@@ -1518,7 +1532,7 @@ async def handle_assignment_task_submission(
 
         # Update only the fields that were passed in
         for var, value in vars(assignment_task_submission_object).items():
-            if value is not None:
+            if value is not None and var in _ASSIGNMENT_TASK_SUBMISSION_MUTABLE_FIELDS:
                 setattr(assignment_task_submission, var, value)
         assignment_task_submission.update_date = str(datetime.now())
 

--- a/apps/api/src/tests/services/test_assignments_service.py
+++ b/apps/api/src/tests/services/test_assignments_service.py
@@ -26,6 +26,7 @@ from src.db.courses.assignments import (
     Assignment,
     AssignmentCreate,
     AssignmentRead,
+    AssignmentTask,
     AssignmentTaskCreate,
     AssignmentTaskRead,
     AssignmentTaskSubmission,
@@ -1187,10 +1188,10 @@ class TestHandleAssignmentTaskSubmissionUuidBranch:
     async def test_finds_submission_by_uuid_when_user_task_not_found(
         self, mock_request, db, admin_user, assignment_task, task_submission
     ):
-        """Covers line 1342: submission not found by (user, task), found by UUID.
+        """Covers the UUID-specific lookup branch.
 
         `task_submission` belongs to `regular_user` (id=2). Calling as `admin_user`
-        (id=1) means the first lookup returns None; the UUID fallback finds it."""
+        (id=1) still updates the submission identified by UUID."""
         payload = AssignmentTaskSubmissionUpdate(
             assignment_task_submission_uuid=task_submission.assignment_task_submission_uuid,
             task_submission={"answer": "updated"},
@@ -1205,6 +1206,90 @@ class TestHandleAssignmentTaskSubmissionUuidBranch:
                 db,
             )
         assert result is not None
+
+    async def test_explicit_uuid_updates_target_submission_when_submitter_has_own_row(
+        self, mock_request, db, admin_user, assignment_task, task_submission
+    ):
+        admin_submission = AssignmentTaskSubmission(
+            id=41,
+            assignment_task_submission_uuid="ats_admin_same_task",
+            task_submission={"answer": "admin original"},
+            grade=0,
+            task_submission_grade_feedback="",
+            assignment_type=AssignmentTaskTypeEnum.SHORT_ANSWER,
+            user_id=admin_user.id,
+            activity_id=assignment_task.activity_id,
+            course_id=assignment_task.course_id,
+            chapter_id=assignment_task.chapter_id,
+            assignment_task_id=assignment_task.id,
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(admin_submission)
+        await db.commit()
+
+        payload = AssignmentTaskSubmissionUpdate(
+            assignment_task_submission_uuid=task_submission.assignment_task_submission_uuid,
+            task_submission={"answer": "teacher update for learner"},
+        )
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, return_value=True):
+            result = await handle_assignment_task_submission(
+                mock_request,
+                assignment_task.assignment_task_uuid,
+                payload,
+                admin_user,
+                db,
+            )
+
+        await db.refresh(task_submission)
+        await db.refresh(admin_submission)
+        assert result.assignment_task_submission_uuid == task_submission.assignment_task_submission_uuid
+        assert task_submission.task_submission == {"answer": "teacher update for learner"}
+        assert admin_submission.task_submission == {"answer": "admin original"}
+
+    async def test_uuid_lookup_is_scoped_to_route_task(
+        self, mock_request, db, admin_user, assignment, assignment_task, task_submission
+    ):
+        other_task = AssignmentTask(
+            id=21,
+            title="Other task",
+            description="A second task for scoping checks",
+            hint="",
+            reference_file=None,
+            assignment_type=AssignmentTaskTypeEnum.SHORT_ANSWER,
+            contents={"prompt": "What is 3+3?"},
+            max_grade_value=100,
+            assignment_id=assignment.id,
+            org_id=assignment_task.org_id,
+            course_id=assignment_task.course_id,
+            chapter_id=assignment_task.chapter_id,
+            activity_id=assignment_task.activity_id,
+            assignment_task_uuid="assignmenttask_other",
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(other_task)
+        await db.commit()
+
+        payload = AssignmentTaskSubmissionUpdate(
+            assignment_task_submission_uuid=task_submission.assignment_task_submission_uuid,
+            task_submission={"answer": "wrong task update"},
+        )
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, return_value=True):
+            with pytest.raises(HTTPException) as exc:
+                await handle_assignment_task_submission(
+                    mock_request,
+                    other_task.assignment_task_uuid,
+                    payload,
+                    admin_user,
+                    db,
+                )
+
+        await db.refresh(task_submission)
+        assert exc.value.status_code == 404
+        assert task_submission.task_submission == {"answer": "4"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this does

Fixes `handle_assignment_task_submission` so an explicit `assignment_task_submission_uuid` actually targets that submission row.

Today the handler first looks up a row by `(assignment_task_id, submitter.id)` and only falls back to the UUID if that lookup misses. That means a teacher/API actor who already has a submission row for the same task can update their own row instead of the requested learner submission. The UUID fallback also is not scoped to the route task.

This PR changes the lookup order and scope:

- if `assignment_task_submission_uuid` is provided, lookup by `(assignment_task_submission_uuid, assignment_task_id)`;
- if that scoped lookup misses, return `404`;
- only use the `(assignment_task_id, submitter.id)` save-progress lookup when no explicit UUID was provided;
- only apply mutable submission fields during updates, so payload identity/scope fields cannot overwrite the row's UUID, task id, or assignment type.

Closes #924.

## Why this matters

Assignment submission updates should be deterministic. When a caller provides a submission UUID, the handler should update that exact submission and only within the task named by the route. Without this, grading or headless assignment flows can mutate the wrong row or cross task boundaries.

## Testing

- `UV_PROJECT_ENVIRONMENT=/tmp/learnhouse-upstream-api-uv-env uv run pytest src/tests/services/test_assignments_service.py::TestHandleAssignmentTaskSubmissionUuidBranch -q`
- `UV_PROJECT_ENVIRONMENT=/tmp/learnhouse-upstream-api-uv-env uv run pytest src/tests/services/test_assignments_service.py src/tests/services/test_assignment_manual_grading.py src/tests/services/test_assignment_api_token_access.py src/tests/routers/test_assignments_retry.py -q`
- `UV_PROJECT_ENVIRONMENT=/tmp/learnhouse-upstream-api-uv-env uv run python -m py_compile src/services/courses/activities/assignments.py src/tests/services/test_assignments_service.py`
- `uvx ruff check src/services/courses/activities/assignments.py src/tests/services/test_assignments_service.py`
