### PR TITLE
fix(api): allow API tokens on /usergroups with org-boundary guards

### DIFF
--- a/apps/api/src/router.py
+++ b/apps/api/src/router.py
@@ -71,8 +71,16 @@ v1_router.include_router(
     usergroups.router,
     prefix="/usergroups",
     tags=["usergroups"],
+    # Admit API tokens (headless enrollment/usergroup management) while still
+    # rejecting anonymous callers — same pattern as /assignments. `usergroups`
+    # is already an allowed API-token resource type in the RBAC layer
+    # (rbac.py authorization_verify_api_token_permissions), and every handler
+    # authorizes through usergroups.rbac_check, which has an APITokenUser branch
+    # enforcing the token's usergroups rights + org boundary. The two handlers
+    # that authorize against a placeholder uuid (create, get-by-resource) get an
+    # explicit token org-boundary check in the service layer.
     dependencies=[
-        Depends(require_authenticated_user),
+        Depends(require_authenticated_user_or_api_token),
         Depends(require_plan_for_usergroups("standard", "User Groups")),
     ],
 )

--- a/apps/api/src/services/users/usergroups.py
+++ b/apps/api/src/services/users/usergroups.py
@@ -111,13 +111,27 @@ async def _validate_resource_exists_and_belongs_to_org(
 async def create_usergroup(
     request: Request,
     db_session: AsyncSession,
-    current_user: PublicUser | AnonymousUser,
+    current_user: PublicUser | AnonymousUser | APITokenUser,
     usergroup_create: UserGroupCreate,
 ) -> UserGroupRead:
 
     from src.security.auth import resolve_acting_user_id
 
     usergroup = UserGroup.model_validate(usergroup_create)
+
+    # SECURITY: enforce the API-token org boundary. The target org here comes
+    # from the request body (usergroup_create.org_id), which neither the global
+    # path/query org-boundary net (auth._verify_api_token_org_boundary) nor the
+    # RBAC element-org lookup can see — the RBAC check below authorizes against
+    # the placeholder "usergroup_X", whose org resolves to None so the boundary
+    # check is skipped. Without this, a token whose creator also belongs to
+    # another org could create a usergroup in that other org. A token is bound
+    # to exactly one org, so refuse any mismatch.
+    if isinstance(current_user, APITokenUser) and usergroup_create.org_id != current_user.org_id:
+        raise HTTPException(
+            status_code=403,
+            detail="API token cannot create resources outside its organization",
+        )
 
     await require_org_membership(
         resolve_acting_user_id(current_user), usergroup_create.org_id, db_session
@@ -273,7 +287,7 @@ async def read_usergroups_by_org_id(
 async def get_usergroups_by_resource(
     request: Request,
     db_session: AsyncSession,
-    current_user: PublicUser | AnonymousUser,
+    current_user: PublicUser | AnonymousUser | APITokenUser,
     resource_uuid: str,
 ) -> list[UserGroupRead]:
 
@@ -299,6 +313,19 @@ async def get_usergroups_by_resource(
     from src.security.auth import resolve_acting_user_id
 
     target_org_id = usergroup_resources[0].org_id
+
+    # SECURITY: enforce the API-token org boundary. The org is derived from the
+    # resource here, not from an org_id path/query param, so the global boundary
+    # net cannot see it, and the RBAC check above ran against the placeholder
+    # "usergroup_X" (org None → boundary skipped). Refuse cross-org reads so a
+    # token cannot enumerate another org's usergroups via a resource its creator
+    # happens to be able to reach.
+    if isinstance(current_user, APITokenUser) and target_org_id != current_user.org_id:
+        raise HTTPException(
+            status_code=403,
+            detail="API token cannot access resources outside its organization",
+        )
+
     await require_org_membership(
         resolve_acting_user_id(current_user), target_org_id, db_session
     )

--- a/apps/api/src/tests/routers/test_usergroups_router.py
+++ b/apps/api/src/tests/routers/test_usergroups_router.py
@@ -3,14 +3,19 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from httpx import ASGITransport, AsyncClient
 
 from src.core.events.database import get_db_session
-from src.db.usergroups import UserGroupRead
-from src.db.users import UserRead
+from src.db.usergroup_resources import UserGroupResource
+from src.db.usergroups import UserGroup, UserGroupCreate, UserGroupRead
+from src.db.users import APITokenUser, UserRead
 from src.routers.usergroups import router as usergroups_router
 from src.security.auth import get_current_user
+from src.services.users.usergroups import (
+    create_usergroup,
+    get_usergroups_by_resource,
+)
 
 
 @pytest.fixture
@@ -126,3 +131,74 @@ class TestUsergroupsRouter:
         assert response.status_code == 422
         assert "integer user IDs" in response.json()["detail"]
         service_mock.assert_not_awaited()
+
+
+class TestUsergroupsApiTokenOrgBoundary:
+    """API tokens may manage usergroups, but never across their org boundary.
+
+    The router admits API tokens (require_authenticated_user_or_api_token) and
+    most handlers authorize against a real usergroup uuid, so the RBAC layer
+    resolves the element's org and enforces the boundary. These tests lock down
+    the two handlers that authorize against the ``usergroup_X`` placeholder —
+    create (org from the request body) and get-by-resource (org from the
+    resource) — where the placeholder's org resolves to None and the RBAC
+    boundary check is skipped, so the service layer must guard the boundary.
+    """
+
+    def _token(self, org_id: int, **rights) -> APITokenUser:
+        return APITokenUser(
+            id=1,
+            user_uuid="apitoken_test",
+            username="api_token",
+            org_id=org_id,
+            rights=rights or None,
+            token_name="Test Token",
+            created_by_user_id=1,
+        )
+
+    async def test_create_usergroup_cross_org_rejected(self, db, org, other_org, mock_request):
+        # Token scoped to `org` tries to create a group in `other_org` via the
+        # request body — invisible to the global path/query org-boundary net.
+        # Must 403 before any DB write.
+        token = self._token(org.id, usergroups={"action_create": True})
+        with pytest.raises(HTTPException) as exc:
+            await create_usergroup(
+                mock_request,
+                db,
+                token,
+                UserGroupCreate(name="Cohort", description="", org_id=other_org.id),
+            )
+        assert exc.value.status_code == 403
+        assert "outside its organization" in exc.value.detail
+
+    async def test_get_usergroups_by_resource_cross_org_rejected(self, db, org, other_org, mock_request):
+        # A usergroup + resource link living entirely in other_org.
+        ug = UserGroup(
+            org_id=other_org.id,
+            name="Other",
+            description="",
+            usergroup_uuid="usergroup_other",
+            creation_date="2024-01-01",
+            update_date="2024-01-01",
+        )
+        db.add(ug)
+        await db.commit()
+        await db.refresh(ug)
+        db.add(
+            UserGroupResource(
+                usergroup_id=ug.id,
+                resource_uuid="course_other",
+                org_id=other_org.id,
+                creation_date="2024-01-01",
+                update_date="2024-01-01",
+            )
+        )
+        await db.commit()
+
+        # Token scoped to `org` with read rights clears the placeholder RBAC
+        # check, then the service must refuse because the resource is in other_org.
+        token = self._token(org.id, usergroups={"action_read": True})
+        with pytest.raises(HTTPException) as exc:
+            await get_usergroups_by_resource(mock_request, db, token, "course_other")
+        assert exc.value.status_code == 403
+        assert "outside its organization" in exc.value.detail

--- a/apps/api/src/tests/security/test_api_token_access.py
+++ b/apps/api/src/tests/security/test_api_token_access.py
@@ -321,8 +321,19 @@ class TestAllowedEndpoints:
         assert isinstance(mock_api_token_user, APITokenUser)
 
     def test_usergroups_router_allows_api_tokens(self, mock_api_token_user):
-        """Test that /usergroups router allows API tokens"""
+        """The /usergroups router admits API tokens (headless enrollment).
+
+        It mounts ``require_authenticated_user_or_api_token`` instead of
+        ``require_authenticated_user``: tokens reach the handlers, where every
+        operation authorizes through ``usergroups.rbac_check`` (the
+        ``usergroups`` rights bucket + org boundary). The two handlers that
+        authorize against the ``usergroup_X`` placeholder — create and
+        get-by-resource — additionally enforce an explicit token org-boundary
+        check in the service layer, since the placeholder's org resolves to
+        None and would otherwise skip the boundary comparison.
+        """
         assert isinstance(mock_api_token_user, APITokenUser)
+        assert mock_api_token_user.org_id is not None
 
     def test_payments_router_allows_api_tokens(self, mock_api_token_user):
         """Test that /payments router allows API tokens (EE)"""

--- a/apps/api/src/tests/security/test_require_authenticated_non_api_token.py
+++ b/apps/api/src/tests/security/test_require_authenticated_non_api_token.py
@@ -4,7 +4,7 @@ Regression tests for F-2: get_non_api_token_user silently admitted AnonymousUser
 The historical helper only rejected APITokenUser. Every router that used it
 as the router-level dependency (e.g. /ai/*, /blocks/*, /trail/*, /analytics,
 /code, /webhooks, /api-tokens, /roles, /ai_credits, /custom_domains,
-/migration, /assignments, /usergroups, /utils, /boards/playground,
+/migration, /utils, /boards/playground,
 /playgrounds, /playgrounds_generator, /packs, /audit_logs) treated
 unauthenticated callers as "authenticated-but-anonymous" and relied on each
 handler to remember to reject them.

--- a/apps/api/src/tests/test_root_router.py
+++ b/apps/api/src/tests/test_root_router.py
@@ -157,6 +157,11 @@ def _install_stub_modules(monkeypatch: pytest.MonkeyPatch) -> None:
         "src.routers.orgs.packs",
         internal_router=_named_router("src.routers.orgs.packs.internal_router"),
     )
+    install_router_module(
+        "src.routers.orgs.org_plan",
+        "src.routers.orgs.org_plan",
+        internal_router=_named_router("src.routers.orgs.org_plan.internal_router"),
+    )
     sys.modules["src.routers.orgs"].ai_credits = sys.modules[
         "src.routers.orgs.ai_credits"
     ]
@@ -164,6 +169,7 @@ def _install_stub_modules(monkeypatch: pytest.MonkeyPatch) -> None:
         "src.routers.orgs.custom_domains"
     ]
     sys.modules["src.routers.orgs"].packs = sys.modules["src.routers.orgs.packs"]
+    sys.modules["src.routers.orgs"].org_plan = sys.modules["src.routers.orgs.org_plan"]
 
     install_router_module("src.routers.courses.chapters", "src.routers.courses.chapters")
     install_router_module(
@@ -338,11 +344,12 @@ class TestRootRouter:
         )
         assert usergroups["prefix"] == "/usergroups"
         assert usergroups["tags"] == ["usergroups"]
-        # F-2: usergroups now requires an authenticated, non-API-token user
-        # in addition to the plan gate. Before the fix, anonymous callers
-        # could bypass auth if the plan check happened to allow them.
+        # usergroups admits API tokens (headless enrollment/usergroup mgmt) via
+        # require_authenticated_user_or_api_token — anonymous is still rejected
+        # (401) and the plan gate still applies. Per-handler rbac_check enforces
+        # the token's usergroups rights + org boundary.
         assert _dependency_names(usergroups) == [
-            "get_authenticated_non_api_token_user",
+            "require_authenticated_user_or_api_token",
             "require_plan_for_usergroups_standard_user_groups",
         ]
 


### PR DESCRIPTION
## Problem

The `/usergroups` router mounts `require_authenticated_user`, which **rejects API tokens** (`APITokenUser` → 403). But `usergroups` is already an allowed API-token resource type in the RBAC layer (`authorization_verify_api_token_permissions`, `rbac.py`), and every usergroups handler authorizes through `usergroups.rbac_check`, which already has an `APITokenUser` branch. So the plumbing to support tokens exists — the router-level dependency is the only thing blocking it.

Two consequences:
- The developer API docs page (`/dash/developers/api`) lists a **Usergroups** category that headless `lh_` token clients cannot actually call — the endpoints require a logged-in session. Misleading for integrators.
- No token path to enroll/unenroll users into courses via usergroups outside the `/admin` router.

## Change

Switch the router to `require_authenticated_user_or_api_token` — the **same pattern `/assignments` already uses**: admit tokens, still reject anonymous (401), keep the Standard-plan gate. Per-handler `rbac_check` continues to enforce the token's `usergroups` rights bucket, and for handlers that authorize against a **real** usergroup UUID the org boundary is enforced via the RBAC element-org lookup (`get_element_organization_id`).

### Security: closing two placeholder-UUID org-boundary gaps

Two handlers authorize against the placeholder `"usergroup_X"`, whose org resolves to `None`, so the RBAC boundary comparison is **skipped**:

| Handler | Where the org comes from | Why the global net misses it |
|---|---|---|
| `create_usergroup` | request **body** (`UserGroupCreate.org_id`) | `_verify_api_token_org_boundary` only reads path/query params |
| `get_usergroups_by_resource` | derived from the **resource** | param is `resource_uuid`, not `org_id` |

Without a guard, a token whose creator *also* belongs to another org could create a usergroup in / read usergroups of that other org (the shared `require_org_membership` check validates the token **creator's** membership, not the token's org). Both now get an explicit `APITokenUser` org-boundary check in the service layer (`token.org_id` must match the target org, else 403). All other usergroups handlers authorize against a real UUID (or a path `org_id`, caught by the global net) and were already covered.

## Tests
- `test_root_router`: assert the new usergroups dependency. Also stubs the missing `src.routers.orgs.org_plan` module in the router-wiring fixture — a **pre-existing gap** that made this test error on collection (`ImportError: cannot import name 'org_plan'`) on clean `dev`.
- New regression tests for both cross-org rejections (create + by-resource) using the real in-memory DB + `other_org` fixture.
- Refreshed docstrings in `test_api_token_access` / `test_require_authenticated_non_api_token`.

`1595 passed, 4 skipped` across `security/`, `routers/`, `admin/` suites (warnings are pre-existing and in unrelated files).

## Not included
Deliberately scoped to the standalone `/usergroups` router. The `/admin` usergroup operations already work with tokens and are unchanged.