### PR TITLE
refactor(web): share catalog pagination controls

### DIFF
--- a/apps/web/app/orgs/[orgslug]/(withmenu)/boards/boards.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/boards/boards.tsx
@@ -6,12 +6,13 @@ import TypeOfContentTitle from '@components/Objects/StyledElements/Titles/TypeOf
 import { useOrg } from '@components/Contexts/OrgContext'
 import { getBoardThumbnailMediaDirectory } from '@services/media/media'
 import Link from 'next/link'
-import { Search, X, Users, ChevronLeft, ChevronRight } from 'lucide-react'
+import { Search, X, Users } from 'lucide-react'
 import { ChalkboardSimple } from '@phosphor-icons/react'
 import { useTranslation } from 'react-i18next'
 import FeatureGate from '@components/Dashboard/Shared/FeatureGate/FeatureGate'
 import { searchMatchesAny } from '@/lib/search/normalize'
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
+import CatalogPagination, { useCatalogPagination } from '@components/Objects/Catalog/CatalogPagination'
 
 interface BoardsPublicClientProps {
   orgslug: string
@@ -41,50 +42,18 @@ export default function BoardsPublicClient({
     )
   }, [allBoards, searchQuery])
 
-  // Pagination state
-  const [currentPage, setCurrentPage] = useState(1)
-  const itemsPerPage = 12
+  const {
+    currentPage,
+    totalPages,
+    paginatedItems: paginatedBoards,
+    pageNumbers,
+    goToPage,
+    resetPage,
+  } = useCatalogPagination(filteredBoards)
 
   React.useEffect(() => {
-    setCurrentPage(1)
-  }, [searchQuery])
-
-  const totalPages = Math.ceil(filteredBoards.length / itemsPerPage)
-  const paginatedBoards = useMemo(() => {
-    const startIndex = (currentPage - 1) * itemsPerPage
-    return filteredBoards.slice(startIndex, startIndex + itemsPerPage)
-  }, [filteredBoards, currentPage, itemsPerPage])
-
-  const goToPage = (page: number) => {
-    if (page >= 1 && page <= totalPages) {
-      setCurrentPage(page)
-    }
-  }
-
-  const getVisiblePageNumbers = () => {
-    const pages: (number | string)[] = []
-    const maxVisible = 5
-    if (totalPages <= maxVisible) {
-      for (let i = 1; i <= totalPages; i++) pages.push(i)
-    } else {
-      if (currentPage <= 3) {
-        for (let i = 1; i <= 4; i++) pages.push(i)
-        pages.push('...')
-        pages.push(totalPages)
-      } else if (currentPage >= totalPages - 2) {
-        pages.push(1)
-        pages.push('...')
-        for (let i = totalPages - 3; i <= totalPages; i++) pages.push(i)
-      } else {
-        pages.push(1)
-        pages.push('...')
-        for (let i = currentPage - 1; i <= currentPage + 1; i++) pages.push(i)
-        pages.push('...')
-        pages.push(totalPages)
-      }
-    }
-    return pages
-  }
+    resetPage()
+  }, [searchQuery, resetPage])
 
   return (
     <FeatureGate feature="boards" orgslug={orgslug} context="public">
@@ -159,49 +128,15 @@ export default function BoardsPublicClient({
             )}
           </div>
 
-          {/* Pagination Controls */}
-          {totalPages > 1 && (
-            <div className="mt-8 flex items-center justify-center gap-2">
-              <button
-                onClick={() => goToPage(currentPage - 1)}
-                disabled={currentPage === 1}
-                className="flex items-center gap-1 px-3 py-2 text-sm font-medium text-gray-600 bg-white nice-shadow rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                <ChevronLeft className="w-4 h-4" />
-                <span className="hidden sm:inline">{t('pagination.previous')}</span>
-              </button>
-
-              <div className="flex items-center gap-1">
-                {getVisiblePageNumbers().map((page, index) => (
-                  <React.Fragment key={index}>
-                    {page === '...' ? (
-                      <span className="px-2 py-1 text-gray-400">...</span>
-                    ) : (
-                      <button
-                        onClick={() => goToPage(page as number)}
-                        className={`px-3 py-2 text-sm font-medium rounded-lg transition-colors ${
-                          currentPage === page
-                            ? 'bg-black text-white'
-                            : 'bg-white text-gray-600 nice-shadow hover:bg-gray-50'
-                        }`}
-                      >
-                        {page}
-                      </button>
-                    )}
-                  </React.Fragment>
-                ))}
-              </div>
-
-              <button
-                onClick={() => goToPage(currentPage + 1)}
-                disabled={currentPage === totalPages}
-                className="flex items-center gap-1 px-3 py-2 text-sm font-medium text-gray-600 bg-white nice-shadow rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                <span className="hidden sm:inline">{t('pagination.next')}</span>
-                <ChevronRight className="w-4 h-4" />
-              </button>
-            </div>
-          )}
+          <CatalogPagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            pageNumbers={pageNumbers}
+            onPageChange={goToPage}
+            previousLabel={t('pagination.previous')}
+            nextLabel={t('pagination.next')}
+            className="mt-8"
+          />
 
           {totalPages > 1 && (
             <div className="mt-2 text-center text-sm text-gray-500">

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/courses/courses.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/courses/courses.tsx
@@ -10,7 +10,7 @@ import CourseThumbnail from '@components/Objects/Thumbnails/CourseThumbnail'
 import NewCourseButton from '@components/Objects/StyledElements/Buttons/NewCourseButton'
 import useAdminStatus from '@components/Hooks/useAdminStatus'
 import { useTranslation } from 'react-i18next'
-import { BookCopy, ChevronLeft, ChevronRight, Search, X, Users, Info } from 'lucide-react'
+import { BookCopy, Search, X, Users, Info } from 'lucide-react'
 import FeatureGate from '@components/Dashboard/Shared/FeatureGate/FeatureGate'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
@@ -18,6 +18,7 @@ import { searchMatchesAny } from '@/lib/search/normalize'
 import { getUserGroups, getUserGroupResources } from '@services/usergroups/usergroups'
 import { useCourses } from '@/hooks/queries/useCourses'
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
+import CatalogPagination, { useCatalogPagination } from '@components/Objects/Catalog/CatalogPagination'
 
 interface CourseProps {
   orgslug: string
@@ -124,54 +125,19 @@ function Courses(props: CourseProps) {
     return () => clearTimeout(timer)
   }, [searchQuery, filteredCourses.length, allCourses.length, track])
 
-  // Pagination state
-  const [currentPage, setCurrentPage] = useState(1)
-  const itemsPerPage = 12
+  const {
+    currentPage,
+    totalPages,
+    paginatedItems: paginatedCourses,
+    pageNumbers,
+    goToPage,
+    resetPage,
+  } = useCatalogPagination(filteredCourses)
 
   // Reset to page 1 when search or filter changes
   React.useEffect(() => {
-    setCurrentPage(1)
-  }, [searchQuery, selectedUsergroupId])
-
-  // Calculate pagination
-  const totalPages = Math.ceil(filteredCourses.length / itemsPerPage)
-  const paginatedCourses = useMemo(() => {
-    const startIndex = (currentPage - 1) * itemsPerPage
-    return filteredCourses.slice(startIndex, startIndex + itemsPerPage)
-  }, [filteredCourses, currentPage, itemsPerPage])
-
-  // Pagination handlers
-  const goToPage = (page: number) => {
-    if (page >= 1 && page <= totalPages) {
-      setCurrentPage(page)
-    }
-  }
-
-  const getVisiblePageNumbers = () => {
-    const pages: (number | string)[] = []
-    const maxVisible = 5
-
-    if (totalPages <= maxVisible) {
-      for (let i = 1; i <= totalPages; i++) pages.push(i)
-    } else {
-      if (currentPage <= 3) {
-        for (let i = 1; i <= 4; i++) pages.push(i)
-        pages.push('...')
-        pages.push(totalPages)
-      } else if (currentPage >= totalPages - 2) {
-        pages.push(1)
-        pages.push('...')
-        for (let i = totalPages - 3; i <= totalPages; i++) pages.push(i)
-      } else {
-        pages.push(1)
-        pages.push('...')
-        for (let i = currentPage - 1; i <= currentPage + 1; i++) pages.push(i)
-        pages.push('...')
-        pages.push(totalPages)
-      }
-    }
-    return pages
-  }
+    resetPage()
+  }, [searchQuery, selectedUsergroupId, resetPage])
 
   async function closeNewCourseModal() {
     setNewCourseModal(false)
@@ -359,49 +325,15 @@ function Courses(props: CourseProps) {
             )}
           </div>
 
-          {/* Pagination Controls */}
-          {totalPages > 1 && (
-            <div className="mt-8 flex items-center justify-center gap-2">
-              <button
-                onClick={() => goToPage(currentPage - 1)}
-                disabled={currentPage === 1}
-                className="flex items-center gap-1 px-3 py-2 text-sm font-medium text-gray-600 bg-white nice-shadow rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                <ChevronLeft className="w-4 h-4" />
-                <span className="hidden sm:inline">{t('pagination.previous')}</span>
-              </button>
-
-              <div className="flex items-center gap-1">
-                {getVisiblePageNumbers().map((page, index) => (
-                  <React.Fragment key={index}>
-                    {page === '...' ? (
-                      <span className="px-2 py-1 text-gray-400">...</span>
-                    ) : (
-                      <button
-                        onClick={() => goToPage(page as number)}
-                        className={`px-3 py-2 text-sm font-medium rounded-lg transition-colors ${
-                          currentPage === page
-                            ? 'bg-black text-white'
-                            : 'bg-white text-gray-600 nice-shadow hover:bg-gray-50'
-                        }`}
-                      >
-                        {page}
-                      </button>
-                    )}
-                  </React.Fragment>
-                ))}
-              </div>
-
-              <button
-                onClick={() => goToPage(currentPage + 1)}
-                disabled={currentPage === totalPages}
-                className="flex items-center gap-1 px-3 py-2 text-sm font-medium text-gray-600 bg-white nice-shadow rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                <span className="hidden sm:inline">{t('pagination.next')}</span>
-                <ChevronRight className="w-4 h-4" />
-              </button>
-            </div>
-          )}
+          <CatalogPagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            pageNumbers={pageNumbers}
+            onPageChange={goToPage}
+            previousLabel={t('pagination.previous')}
+            nextLabel={t('pagination.next')}
+            className="mt-8"
+          />
 
           {/* Pagination info */}
           {totalPages > 1 && (

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/playgrounds/playgrounds.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/playgrounds/playgrounds.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useRouter } from 'next/navigation'
-import { Search, X, ChevronLeft, ChevronRight } from 'lucide-react'
+import { Search, X } from 'lucide-react'
 import { Cube } from '@phosphor-icons/react'
 import toast from 'react-hot-toast'
 import { useQueryClient } from '@tanstack/react-query'
@@ -17,6 +17,7 @@ import { useLHSession } from '@components/Contexts/LHSessionContext'
 import FeatureGate from '@components/Dashboard/Shared/FeatureGate/FeatureGate'
 import useAdminStatus from '@components/Hooks/useAdminStatus'
 import { searchMatchesAny } from '@/lib/search/normalize'
+import CatalogPagination, { useCatalogPagination } from '@components/Objects/Catalog/CatalogPagination'
 
 interface PlaygroundsClientProps {
   orgslug: string
@@ -39,11 +40,9 @@ export default function PlaygroundsClient({
   const [playgrounds, setPlaygrounds] = useState<Playground[]>(initialPlaygrounds)
   const [searchQuery, setSearchQuery] = useState('')
   const [isCreating, setIsCreating] = useState(false)
-  const [currentPage, setCurrentPage] = useState(1)
   const [showNameModal, setShowNameModal] = useState(false)
   const [newName, setNewName] = useState('')
   const { t } = useTranslation()
-  const itemsPerPage = 12
 
   const filtered = useMemo(() => {
     if (!searchQuery.trim()) return playgrounds
@@ -52,41 +51,18 @@ export default function PlaygroundsClient({
     )
   }, [playgrounds, searchQuery])
 
+  const {
+    currentPage,
+    totalPages,
+    paginatedItems: paginated,
+    pageNumbers,
+    goToPage,
+    resetPage,
+  } = useCatalogPagination(filtered)
+
   React.useEffect(() => {
-    setCurrentPage(1)
-  }, [searchQuery])
-
-  const totalPages = Math.ceil(filtered.length / itemsPerPage)
-  const paginated = useMemo(() => {
-    const start = (currentPage - 1) * itemsPerPage
-    return filtered.slice(start, start + itemsPerPage)
-  }, [filtered, currentPage, itemsPerPage])
-
-  const goToPage = (page: number) => {
-    if (page >= 1 && page <= totalPages) setCurrentPage(page)
-  }
-
-  const getVisiblePageNumbers = () => {
-    const pages: (number | string)[] = []
-    if (totalPages <= 5) {
-      for (let i = 1; i <= totalPages; i++) pages.push(i)
-    } else if (currentPage <= 3) {
-      for (let i = 1; i <= 4; i++) pages.push(i)
-      pages.push('...')
-      pages.push(totalPages)
-    } else if (currentPage >= totalPages - 2) {
-      pages.push(1)
-      pages.push('...')
-      for (let i = totalPages - 3; i <= totalPages; i++) pages.push(i)
-    } else {
-      pages.push(1)
-      pages.push('...')
-      for (let i = currentPage - 1; i <= currentPage + 1; i++) pages.push(i)
-      pages.push('...')
-      pages.push(totalPages)
-    }
-    return pages
-  }
+    resetPage()
+  }, [searchQuery, resetPage])
 
   const openCreateModal = () => {
     setNewName('')
@@ -212,49 +188,15 @@ export default function PlaygroundsClient({
               )}
             </div>
 
-            {/* Pagination */}
-            {totalPages > 1 && (
-              <div className="mt-8 flex items-center justify-center gap-2">
-                <button
-                  onClick={() => goToPage(currentPage - 1)}
-                  disabled={currentPage === 1}
-                  className="flex items-center gap-1 px-3 py-2 text-sm font-medium text-gray-600 bg-white nice-shadow rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                >
-                  <ChevronLeft className="w-4 h-4" />
-                  <span className="hidden sm:inline">Previous</span>
-                </button>
-
-                <div className="flex items-center gap-1">
-                  {getVisiblePageNumbers().map((page, index) => (
-                    <React.Fragment key={index}>
-                      {page === '...' ? (
-                        <span className="px-2 py-1 text-gray-400">...</span>
-                      ) : (
-                        <button
-                          onClick={() => goToPage(page as number)}
-                          className={`px-3 py-2 text-sm font-medium rounded-lg transition-colors ${
-                            currentPage === page
-                              ? 'bg-black text-white'
-                              : 'bg-white text-gray-600 nice-shadow hover:bg-gray-50'
-                          }`}
-                        >
-                          {page}
-                        </button>
-                      )}
-                    </React.Fragment>
-                  ))}
-                </div>
-
-                <button
-                  onClick={() => goToPage(currentPage + 1)}
-                  disabled={currentPage === totalPages}
-                  className="flex items-center gap-1 px-3 py-2 text-sm font-medium text-gray-600 bg-white nice-shadow rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                >
-                  <span className="hidden sm:inline">Next</span>
-                  <ChevronRight className="w-4 h-4" />
-                </button>
-              </div>
-            )}
+            <CatalogPagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              pageNumbers={pageNumbers}
+              onPageChange={goToPage}
+              previousLabel="Previous"
+              nextLabel="Next"
+              className="mt-8"
+            />
 
             {totalPages > 1 && (
               <div className="mt-2 text-center text-sm text-gray-500">

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/podcasts/podcasts.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/podcasts/podcasts.tsx
@@ -11,11 +11,12 @@ import CreatePodcastModal from '@components/Objects/Modals/Podcast/Create/Create
 import NewPodcastButton from '@components/Objects/StyledElements/Buttons/NewPodcastButton'
 import useAdminStatus from '@components/Hooks/useAdminStatus'
 import { PodcastWithEpisodeCount } from '@services/podcasts/podcasts'
-import { Headphones, ChevronLeft, ChevronRight, Search, X } from 'lucide-react'
+import { Headphones, Search, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import FeatureGate from '@components/Dashboard/Shared/FeatureGate/FeatureGate'
 import { searchMatchesAny } from '@/lib/search/normalize'
 import { useTrackView, AnalyticsEvent } from '@services/analytics'
+import CatalogPagination, { useCatalogPagination } from '@components/Objects/Catalog/CatalogPagination'
 
 interface PodcastsClientProps {
   orgslug: string
@@ -53,54 +54,19 @@ export default function PodcastsClient({
     )
   }, [allPodcasts, searchQuery])
 
-  // Pagination state
-  const [currentPage, setCurrentPage] = useState(1)
-  const itemsPerPage = 12
+  const {
+    currentPage,
+    totalPages,
+    paginatedItems: paginatedPodcasts,
+    pageNumbers,
+    goToPage,
+    resetPage,
+  } = useCatalogPagination(filteredPodcasts)
 
   // Reset to page 1 when search changes
   React.useEffect(() => {
-    setCurrentPage(1)
-  }, [searchQuery])
-
-  // Calculate pagination
-  const totalPages = Math.ceil(filteredPodcasts.length / itemsPerPage)
-  const paginatedPodcasts = useMemo(() => {
-    const startIndex = (currentPage - 1) * itemsPerPage
-    return filteredPodcasts.slice(startIndex, startIndex + itemsPerPage)
-  }, [filteredPodcasts, currentPage, itemsPerPage])
-
-  // Pagination handlers
-  const goToPage = (page: number) => {
-    if (page >= 1 && page <= totalPages) {
-      setCurrentPage(page)
-    }
-  }
-
-  const getVisiblePageNumbers = () => {
-    const pages: (number | string)[] = []
-    const maxVisible = 5
-
-    if (totalPages <= maxVisible) {
-      for (let i = 1; i <= totalPages; i++) pages.push(i)
-    } else {
-      if (currentPage <= 3) {
-        for (let i = 1; i <= 4; i++) pages.push(i)
-        pages.push('...')
-        pages.push(totalPages)
-      } else if (currentPage >= totalPages - 2) {
-        pages.push(1)
-        pages.push('...')
-        for (let i = totalPages - 3; i <= totalPages; i++) pages.push(i)
-      } else {
-        pages.push(1)
-        pages.push('...')
-        for (let i = currentPage - 1; i <= currentPage + 1; i++) pages.push(i)
-        pages.push('...')
-        pages.push(totalPages)
-      }
-    }
-    return pages
-  }
+    resetPage()
+  }, [searchQuery, resetPage])
 
   async function closeNewPodcastModal() {
     setNewPodcastModal(false)
@@ -221,49 +187,15 @@ export default function PodcastsClient({
             )}
           </div>
 
-          {/* Pagination Controls */}
-          {totalPages > 1 && (
-            <div className="mt-8 flex items-center justify-center gap-2">
-              <button
-                onClick={() => goToPage(currentPage - 1)}
-                disabled={currentPage === 1}
-                className="flex items-center gap-1 px-3 py-2 text-sm font-medium text-gray-600 bg-white nice-shadow rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                <ChevronLeft className="w-4 h-4" />
-                <span className="hidden sm:inline">{t('pagination.previous')}</span>
-              </button>
-
-              <div className="flex items-center gap-1">
-                {getVisiblePageNumbers().map((page, index) => (
-                  <React.Fragment key={index}>
-                    {page === '...' ? (
-                      <span className="px-2 py-1 text-gray-400">...</span>
-                    ) : (
-                      <button
-                        onClick={() => goToPage(page as number)}
-                        className={`px-3 py-2 text-sm font-medium rounded-lg transition-colors ${
-                          currentPage === page
-                            ? 'bg-black text-white'
-                            : 'bg-white text-gray-600 nice-shadow hover:bg-gray-50'
-                        }`}
-                      >
-                        {page}
-                      </button>
-                    )}
-                  </React.Fragment>
-                ))}
-              </div>
-
-              <button
-                onClick={() => goToPage(currentPage + 1)}
-                disabled={currentPage === totalPages}
-                className="flex items-center gap-1 px-3 py-2 text-sm font-medium text-gray-600 bg-white nice-shadow rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                <span className="hidden sm:inline">{t('pagination.next')}</span>
-                <ChevronRight className="w-4 h-4" />
-              </button>
-            </div>
-          )}
+          <CatalogPagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            pageNumbers={pageNumbers}
+            onPageChange={goToPage}
+            previousLabel={t('pagination.previous')}
+            nextLabel={t('pagination.next')}
+            className="mt-8"
+          />
 
           {/* Pagination info */}
           {totalPages > 1 && (

--- a/apps/web/app/orgs/[orgslug]/dash/boards/client.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/boards/client.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useState, useMemo } from 'react'
-import { Search, X, Users, Globe, Lock, ChevronLeft, ChevronRight, MoreVertical, Settings2, Eye, Trash2, CheckSquare, Square, Copy } from 'lucide-react'
+import { Search, X, Users, Globe, Lock, MoreVertical, Settings2, Eye, Trash2, CheckSquare, Square, Copy } from 'lucide-react'
 import { ChalkboardSimple } from '@phosphor-icons/react'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
@@ -26,6 +26,7 @@ import {
 import Modal from '@components/Objects/StyledElements/Modal/Modal'
 import { searchMatchesAny } from '@/lib/search/normalize'
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
+import CatalogPagination, { useCatalogPagination } from '@components/Objects/Catalog/CatalogPagination'
 
 interface BoardListClientProps {
   org_id: number
@@ -104,9 +105,7 @@ export default function BoardListClient({ org_id, orgslug }: BoardListClientProp
 
   const [createModalOpen, setCreateModalOpen] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
-  const [currentPage, setCurrentPage] = useState(1)
   const [selectedBoards, setSelectedBoards] = useState<Set<string>>(new Set())
-  const itemsPerPage = 12
 
   const { data: boards, isLoading } = useQuery({
     queryKey: queryKeys.boards.list(orgslug),
@@ -124,15 +123,18 @@ export default function BoardListClient({ org_id, orgslug }: BoardListClientProp
     )
   }, [allBoards, searchQuery])
 
-  React.useEffect(() => {
-    setCurrentPage(1)
-  }, [searchQuery])
+  const {
+    currentPage,
+    totalPages,
+    paginatedItems: paginatedBoards,
+    pageNumbers,
+    goToPage: goToCatalogPage,
+    resetPage,
+  } = useCatalogPagination(filteredBoards)
 
-  const totalPages = Math.ceil(filteredBoards.length / itemsPerPage)
-  const paginatedBoards = useMemo(() => {
-    const startIndex = (currentPage - 1) * itemsPerPage
-    return filteredBoards.slice(startIndex, startIndex + itemsPerPage)
-  }, [filteredBoards, currentPage, itemsPerPage])
+  React.useEffect(() => {
+    resetPage()
+  }, [searchQuery, resetPage])
 
   const handleCreated = () => {
     setCreateModalOpen(false)
@@ -211,34 +213,9 @@ export default function BoardListClient({ org_id, orgslug }: BoardListClientProp
 
   const goToPage = (page: number) => {
     if (page >= 1 && page <= totalPages) {
-      setCurrentPage(page)
+      goToCatalogPage(page)
       setSelectedBoards(new Set())
     }
-  }
-
-  const getVisiblePageNumbers = () => {
-    const pages: (number | string)[] = []
-    const maxVisible = 5
-    if (totalPages <= maxVisible) {
-      for (let i = 1; i <= totalPages; i++) pages.push(i)
-    } else {
-      if (currentPage <= 3) {
-        for (let i = 1; i <= 4; i++) pages.push(i)
-        pages.push('...')
-        pages.push(totalPages)
-      } else if (currentPage >= totalPages - 2) {
-        pages.push(1)
-        pages.push('...')
-        for (let i = totalPages - 3; i <= totalPages; i++) pages.push(i)
-      } else {
-        pages.push(1)
-        pages.push('...')
-        for (let i = currentPage - 1; i <= currentPage + 1; i++) pages.push(i)
-        pages.push('...')
-        pages.push(totalPages)
-      }
-    }
-    return pages
   }
 
   return (
@@ -413,49 +390,15 @@ export default function BoardListClient({ org_id, orgslug }: BoardListClientProp
           </div>
         )}
 
-        {/* Pagination Controls */}
-        {totalPages > 1 && (
-          <div className="mt-8 mb-6 flex items-center justify-center gap-2">
-            <button
-              onClick={() => goToPage(currentPage - 1)}
-              disabled={currentPage === 1}
-              className="flex items-center gap-1 px-3 py-2 text-sm font-medium text-gray-600 bg-white nice-shadow rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            >
-              <ChevronLeft className="w-4 h-4" />
-              <span className="hidden sm:inline">{t('boards.pagination.previous')}</span>
-            </button>
-
-            <div className="flex items-center gap-1">
-              {getVisiblePageNumbers().map((page, index) => (
-                <React.Fragment key={index}>
-                  {page === '...' ? (
-                    <span className="px-2 py-1 text-gray-400">...</span>
-                  ) : (
-                    <button
-                      onClick={() => goToPage(page as number)}
-                      className={`px-3 py-2 text-sm font-medium rounded-lg transition-colors ${
-                        currentPage === page
-                          ? 'bg-black text-white'
-                          : 'bg-white text-gray-600 nice-shadow hover:bg-gray-50'
-                      }`}
-                    >
-                      {page}
-                    </button>
-                  )}
-                </React.Fragment>
-              ))}
-            </div>
-
-            <button
-              onClick={() => goToPage(currentPage + 1)}
-              disabled={currentPage === totalPages}
-              className="flex items-center gap-1 px-3 py-2 text-sm font-medium text-gray-600 bg-white nice-shadow rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            >
-              <span className="hidden sm:inline">{t('boards.pagination.next')}</span>
-              <ChevronRight className="w-4 h-4" />
-            </button>
-          </div>
-        )}
+        <CatalogPagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          pageNumbers={pageNumbers}
+          onPageChange={goToPage}
+          previousLabel={t('boards.pagination.previous')}
+          nextLabel={t('boards.pagination.next')}
+          className="mt-8 mb-6"
+        />
 
         {totalPages > 1 && (
           <div className="mb-6 text-center text-sm text-gray-500">

--- a/apps/web/app/orgs/[orgslug]/dash/courses/client.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/courses/client.tsx
@@ -3,7 +3,7 @@ import { Breadcrumbs } from '@components/Objects/Breadcrumbs/Breadcrumbs'
 import CreateCourseModal from '@components/Objects/Modals/Course/Create/CreateCourse'
 import CourseCreationTypeSelector from '@components/Objects/Modals/Course/Create/CourseCreationTypeSelector'
 import AICourseCreationModal from '@components/Objects/Modals/Course/Create/AICourse/AICourseCreationModal'
-import { BookCopy, Search, X, Trash2, ChevronLeft, ChevronRight, Users, Info } from 'lucide-react'
+import { BookCopy, Search, X, Trash2, Users, Info } from 'lucide-react'
 import ScormCourseImport from '../../../../../ee/components/Modals/ScormCourseImport'
 import { ImportTypeSelector, LearnHouseCourseImport } from '@components/Objects/Modals/Course/Import'
 import CourseThumbnail, { removeCoursePrefix } from '@components/Objects/Thumbnails/CourseThumbnail'
@@ -32,6 +32,7 @@ import FeatureGate from '@components/Dashboard/Shared/FeatureGate/FeatureGate'
 import { usePlan } from '@components/Hooks/usePlan'
 import { searchMatchesAny } from '@/lib/search/normalize'
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
+import CatalogPagination, { useCatalogPagination } from '@components/Objects/Catalog/CatalogPagination'
 
 type CourseProps = {
   orgslug: string
@@ -162,21 +163,19 @@ function CoursesHome(params: CourseProps) {
     return courses
   }, [allCourses, searchQuery, usergroupResourceUuids])
 
-  // Pagination state
-  const [currentPage, setCurrentPage] = useState(1)
-  const itemsPerPage = 12
+  const {
+    currentPage,
+    totalPages,
+    paginatedItems: paginatedCourses,
+    pageNumbers,
+    goToPage: goToCatalogPage,
+    resetPage,
+  } = useCatalogPagination(filteredCourses)
 
   // Reset to page 1 when search or filter changes
   React.useEffect(() => {
-    setCurrentPage(1)
-  }, [searchQuery, selectedUsergroupId])
-
-  // Calculate pagination (client-side)
-  const totalPages = Math.ceil(filteredCourses.length / itemsPerPage)
-  const paginatedCourses = useMemo(() => {
-    const startIndex = (currentPage - 1) * itemsPerPage
-    return filteredCourses.slice(startIndex, startIndex + itemsPerPage)
-  }, [filteredCourses, currentPage, itemsPerPage])
+    resetPage()
+  }, [searchQuery, selectedUsergroupId, resetPage])
 
   // Selection state
   const [selectedCourses, setSelectedCourses] = useState<Set<string>>(new Set())
@@ -400,35 +399,9 @@ function CoursesHome(params: CourseProps) {
   // Pagination handlers
   const goToPage = (page: number) => {
     if (page >= 1 && page <= totalPages) {
-      setCurrentPage(page)
+      goToCatalogPage(page)
       setSelectedCourses(new Set())
     }
-  }
-
-  const getVisiblePageNumbers = () => {
-    const pages: (number | string)[] = []
-    const maxVisible = 5
-
-    if (totalPages <= maxVisible) {
-      for (let i = 1; i <= totalPages; i++) pages.push(i)
-    } else {
-      if (currentPage <= 3) {
-        for (let i = 1; i <= 4; i++) pages.push(i)
-        pages.push('...')
-        pages.push(totalPages)
-      } else if (currentPage >= totalPages - 2) {
-        pages.push(1)
-        pages.push('...')
-        for (let i = totalPages - 3; i <= totalPages; i++) pages.push(i)
-      } else {
-        pages.push(1)
-        pages.push('...')
-        for (let i = currentPage - 1; i <= currentPage + 1; i++) pages.push(i)
-        pages.push('...')
-        pages.push(totalPages)
-      }
-    }
-    return pages
   }
 
   if (isCoursesLoading) {
@@ -727,49 +700,15 @@ function CoursesHome(params: CourseProps) {
         )}
       </div>
 
-      {/* Pagination Controls */}
-      {totalPages > 1 && (
-        <div className="mt-8 mb-6 flex items-center justify-center gap-2">
-          <button
-            onClick={() => goToPage(currentPage - 1)}
-            disabled={currentPage === 1}
-            className="flex items-center gap-1 px-3 py-2 text-sm font-medium text-gray-600 bg-white nice-shadow rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          >
-            <ChevronLeft className="w-4 h-4" />
-            <span className="hidden sm:inline">{t('pagination.previous')}</span>
-          </button>
-
-          <div className="flex items-center gap-1">
-            {getVisiblePageNumbers().map((page, index) => (
-              <React.Fragment key={index}>
-                {page === '...' ? (
-                  <span className="px-2 py-1 text-gray-400">...</span>
-                ) : (
-                  <button
-                    onClick={() => goToPage(page as number)}
-                    className={`px-3 py-2 text-sm font-medium rounded-lg transition-colors ${
-                      currentPage === page
-                        ? 'bg-black text-white'
-                        : 'bg-white text-gray-600 nice-shadow hover:bg-gray-50'
-                    }`}
-                  >
-                    {page}
-                  </button>
-                )}
-              </React.Fragment>
-            ))}
-          </div>
-
-          <button
-            onClick={() => goToPage(currentPage + 1)}
-            disabled={currentPage === totalPages}
-            className="flex items-center gap-1 px-3 py-2 text-sm font-medium text-gray-600 bg-white nice-shadow rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          >
-            <span className="hidden sm:inline">{t('pagination.next')}</span>
-            <ChevronRight className="w-4 h-4" />
-          </button>
-        </div>
-      )}
+      <CatalogPagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        pageNumbers={pageNumbers}
+        onPageChange={goToPage}
+        previousLabel={t('pagination.previous')}
+        nextLabel={t('pagination.next')}
+        className="mt-8 mb-6"
+      />
 
       {/* Pagination info */}
       {totalPages > 1 && (

--- a/apps/web/app/orgs/[orgslug]/dash/playgrounds/client.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/playgrounds/client.tsx
@@ -8,8 +8,6 @@ import {
   Globe,
   Lock,
   Users,
-  ChevronLeft,
-  ChevronRight,
   Pencil,
   Trash2,
   Copy,
@@ -35,6 +33,7 @@ import AuthenticatedClientElement from '@components/Security/AuthenticatedClient
 import FeatureGate from '@components/Dashboard/Shared/FeatureGate/FeatureGate'
 import { searchMatchesAny } from '@/lib/search/normalize'
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
+import CatalogPagination, { useCatalogPagination } from '@components/Objects/Catalog/CatalogPagination'
 
 interface PlaygroundsListClientProps {
   org_id: number
@@ -51,13 +50,11 @@ export default function PlaygroundsListClient({ org_id, orgslug }: PlaygroundsLi
   const { track } = useLHAnalytics('dashboard')
 
   const [searchQuery, setSearchQuery] = useState('')
-  const [currentPage, setCurrentPage] = useState(1)
   const [isCreating, setIsCreating] = useState(false)
   const [showNameModal, setShowNameModal] = useState(false)
   const [newName, setNewName] = useState('')
   const [selectedUuids, setSelectedUuids] = useState<Set<string>>(new Set())
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
-  const itemsPerPage = 12
 
   const { data: playgrounds, isLoading } = useQuery({
     queryKey: queryKeys.playgrounds.list(orgslug),
@@ -75,39 +72,16 @@ export default function PlaygroundsListClient({ org_id, orgslug }: PlaygroundsLi
     )
   }, [allPlaygrounds, searchQuery])
 
-  React.useEffect(() => { setCurrentPage(1) }, [searchQuery])
+  const {
+    currentPage,
+    totalPages,
+    paginatedItems: paginated,
+    pageNumbers,
+    goToPage,
+    resetPage,
+  } = useCatalogPagination(filtered)
 
-  const totalPages = Math.ceil(filtered.length / itemsPerPage)
-  const paginated = useMemo(() => {
-    const start = (currentPage - 1) * itemsPerPage
-    return filtered.slice(start, start + itemsPerPage)
-  }, [filtered, currentPage, itemsPerPage])
-
-  const goToPage = (page: number) => {
-    if (page >= 1 && page <= totalPages) setCurrentPage(page)
-  }
-
-  const getVisiblePages = () => {
-    const pages: (number | string)[] = []
-    if (totalPages <= 5) {
-      for (let i = 1; i <= totalPages; i++) pages.push(i)
-    } else if (currentPage <= 3) {
-      for (let i = 1; i <= 4; i++) pages.push(i)
-      pages.push('...')
-      pages.push(totalPages)
-    } else if (currentPage >= totalPages - 2) {
-      pages.push(1)
-      pages.push('...')
-      for (let i = totalPages - 3; i <= totalPages; i++) pages.push(i)
-    } else {
-      pages.push(1)
-      pages.push('...')
-      for (let i = currentPage - 1; i <= currentPage + 1; i++) pages.push(i)
-      pages.push('...')
-      pages.push(totalPages)
-    }
-    return pages
-  }
+  React.useEffect(() => { resetPage() }, [searchQuery, resetPage])
 
   const toggleSelect = (uuid: string) => {
     setSelectedUuids((prev) => {
@@ -332,51 +306,20 @@ export default function PlaygroundsListClient({ org_id, orgslug }: PlaygroundsLi
             </div>
           )}
 
-          {/* Pagination */}
+          <CatalogPagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            pageNumbers={pageNumbers}
+            onPageChange={goToPage}
+            previousLabel="Previous"
+            nextLabel="Next"
+            className="mt-8 mb-6"
+          />
+
           {totalPages > 1 && (
-            <>
-              <div className="mt-8 mb-6 flex items-center justify-center gap-2">
-                <button
-                  onClick={() => goToPage(currentPage - 1)}
-                  disabled={currentPage === 1}
-                  className="flex items-center gap-1 px-3 py-2 text-sm font-medium text-gray-600 bg-white nice-shadow rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                >
-                  <ChevronLeft className="w-4 h-4" />
-                  <span className="hidden sm:inline">Previous</span>
-                </button>
-                <div className="flex items-center gap-1">
-                  {getVisiblePages().map((page, index) => (
-                    <React.Fragment key={index}>
-                      {page === '...' ? (
-                        <span className="px-2 py-1 text-gray-400">...</span>
-                      ) : (
-                        <button
-                          onClick={() => goToPage(page as number)}
-                          className={`px-3 py-2 text-sm font-medium rounded-lg transition-colors ${
-                            currentPage === page
-                              ? 'bg-black text-white'
-                              : 'bg-white text-gray-600 nice-shadow hover:bg-gray-50'
-                          }`}
-                        >
-                          {page}
-                        </button>
-                      )}
-                    </React.Fragment>
-                  ))}
-                </div>
-                <button
-                  onClick={() => goToPage(currentPage + 1)}
-                  disabled={currentPage === totalPages}
-                  className="flex items-center gap-1 px-3 py-2 text-sm font-medium text-gray-600 bg-white nice-shadow rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                >
-                  <span className="hidden sm:inline">Next</span>
-                  <ChevronRight className="w-4 h-4" />
-                </button>
-              </div>
-              <div className="mb-6 text-center text-sm text-gray-500">
-                Page {currentPage} of {totalPages}
-              </div>
-            </>
+            <div className="mb-6 text-center text-sm text-gray-500">
+              Page {currentPage} of {totalPages}
+            </div>
           )}
         </div>
 

--- a/apps/web/components/Objects/Catalog/CatalogPagination.tsx
+++ b/apps/web/components/Objects/Catalog/CatalogPagination.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import React, { useCallback, useMemo, useState } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import {
+  CATALOG_PAGE_SIZE,
+  CatalogPageNumber,
+  getCatalogPageNumbers,
+} from './catalogPagination'
+
+const paginationWrapperClassName = 'flex items-center justify-center gap-2'
+const paginationNavButtonClassName =
+  'flex items-center gap-1 px-3 py-2 text-sm font-medium text-gray-600 bg-white nice-shadow rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors'
+const paginationPagesClassName = 'flex items-center gap-1'
+const paginationEllipsisClassName = 'px-2 py-1 text-gray-400'
+const paginationPageButtonBaseClassName =
+  'px-3 py-2 text-sm font-medium rounded-lg transition-colors'
+const paginationActivePageButtonClassName = 'bg-black text-white'
+const paginationInactivePageButtonClassName =
+  'bg-white text-gray-600 nice-shadow hover:bg-gray-50'
+
+type CatalogPaginationProps = {
+  currentPage: number
+  totalPages: number
+  pageNumbers: CatalogPageNumber[]
+  onPageChange: (_page: number) => void
+  previousLabel: string
+  nextLabel: string
+  className?: string
+}
+
+export function useCatalogPagination<T>(
+  items: T[],
+  pageSize = CATALOG_PAGE_SIZE
+) {
+  const [currentPage, setCurrentPage] = useState(1)
+  const totalPages = Math.ceil(items.length / pageSize)
+  const visibleCurrentPage = totalPages > 0 ? Math.min(currentPage, totalPages) : 1
+
+  const paginatedItems = useMemo(() => {
+    const startIndex = (visibleCurrentPage - 1) * pageSize
+    return items.slice(startIndex, startIndex + pageSize)
+  }, [items, visibleCurrentPage, pageSize])
+
+  const pageNumbers = useMemo(
+    () => getCatalogPageNumbers(visibleCurrentPage, totalPages),
+    [visibleCurrentPage, totalPages]
+  )
+
+  const goToPage = useCallback((page: number) => {
+    if (page >= 1 && page <= totalPages) {
+      setCurrentPage(page)
+    }
+  }, [totalPages])
+
+  const resetPage = useCallback(() => {
+    setCurrentPage(1)
+  }, [])
+
+  return {
+    currentPage: visibleCurrentPage,
+    totalPages,
+    paginatedItems,
+    pageNumbers,
+    goToPage,
+    resetPage,
+  }
+}
+
+export default function CatalogPagination({
+  currentPage,
+  totalPages,
+  pageNumbers,
+  onPageChange,
+  previousLabel,
+  nextLabel,
+  className,
+}: CatalogPaginationProps) {
+  if (totalPages <= 1) {
+    return null
+  }
+
+  const wrapperClassName = [className, paginationWrapperClassName]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <div className={wrapperClassName}>
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 1}
+        className={paginationNavButtonClassName}
+      >
+        <ChevronLeft className="w-4 h-4" />
+        <span className="hidden sm:inline">{previousLabel}</span>
+      </button>
+
+      <div className={paginationPagesClassName}>
+        {pageNumbers.map((page, index) => (
+          <React.Fragment key={`${page}-${index}`}>
+            {page === '...' ? (
+              <span className={paginationEllipsisClassName}>...</span>
+            ) : (
+              <button
+                onClick={() => onPageChange(page)}
+                className={`${paginationPageButtonBaseClassName} ${
+                  currentPage === page
+                    ? paginationActivePageButtonClassName
+                    : paginationInactivePageButtonClassName
+                }`}
+              >
+                {page}
+              </button>
+            )}
+          </React.Fragment>
+        ))}
+      </div>
+
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage === totalPages}
+        className={paginationNavButtonClassName}
+      >
+        <span className="hidden sm:inline">{nextLabel}</span>
+        <ChevronRight className="w-4 h-4" />
+      </button>
+    </div>
+  )
+}

--- a/apps/web/components/Objects/Catalog/catalogPagination.ts
+++ b/apps/web/components/Objects/Catalog/catalogPagination.ts
@@ -1,0 +1,42 @@
+export const CATALOG_PAGE_SIZE = 12
+
+export type CatalogPageNumber = number | '...'
+
+export function getCatalogPageNumbers(
+  currentPage: number,
+  totalPages: number
+): CatalogPageNumber[] {
+  const pages: CatalogPageNumber[] = []
+  const maxVisiblePages = 5
+
+  if (totalPages <= 0) {
+    return pages
+  }
+
+  if (totalPages <= maxVisiblePages) {
+    for (let page = 1; page <= totalPages; page++) pages.push(page)
+    return pages
+  }
+
+  if (currentPage <= 3) {
+    for (let page = 1; page <= 4; page++) pages.push(page)
+    pages.push('...', totalPages)
+    return pages
+  }
+
+  if (currentPage >= totalPages - 2) {
+    pages.push(1, '...')
+    for (let page = totalPages - 3; page <= totalPages; page++) {
+      pages.push(page)
+    }
+    return pages
+  }
+
+  pages.push(1, '...')
+  for (let page = currentPage - 1; page <= currentPage + 1; page++) {
+    pages.push(page)
+  }
+  pages.push('...', totalPages)
+
+  return pages
+}

--- a/apps/web/tests/catalog-pagination.test.mjs
+++ b/apps/web/tests/catalog-pagination.test.mjs
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getCatalogPageNumbers,
+} from "../components/Objects/Catalog/catalogPagination.ts";
+
+describe("getCatalogPageNumbers", () => {
+  test("returns no pages when there are no results", () => {
+    expect(getCatalogPageNumbers(1, 0)).toEqual([]);
+  });
+
+  test("returns every page when the list fits in the visible window", () => {
+    expect(getCatalogPageNumbers(1, 1)).toEqual([1]);
+    expect(getCatalogPageNumbers(3, 5)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  test("keeps the first pages visible near the beginning", () => {
+    expect(getCatalogPageNumbers(1, 10)).toEqual([1, 2, 3, 4, "...", 10]);
+    expect(getCatalogPageNumbers(3, 10)).toEqual([1, 2, 3, 4, "...", 10]);
+  });
+
+  test("keeps the current page centered in the middle", () => {
+    expect(getCatalogPageNumbers(5, 10)).toEqual([1, "...", 4, 5, 6, "...", 10]);
+  });
+
+  test("keeps the last pages visible near the end", () => {
+    expect(getCatalogPageNumbers(8, 10)).toEqual([1, "...", 7, 8, 9, 10]);
+    expect(getCatalogPageNumbers(10, 10)).toEqual([1, "...", 7, 8, 9, 10]);
+  });
+});


### PR DESCRIPTION
## What this does

Refactors the duplicated catalog pagination implementation into a shared catalog helper and control.

Today each catalog page owns the same 12-item page size, visible-page-number algorithm, page slicing, previous/next buttons, ellipsis rendering, and active-page styling. This PR moves the shared behavior into:

- `components/Objects/Catalog/catalogPagination.ts`
- `components/Objects/Catalog/CatalogPagination.tsx`

Then it wires the shared hook/control into the public and dashboard catalog lists for courses, boards, podcasts, and playgrounds.

The refactor keeps the existing behavior and presentation intact:

- keeps the 12-item page size;
- keeps the same visible page windows at the beginning, middle, and end;
- keeps the existing labels and pagination info text per page;
- keeps public search/filter resets to page 1;
- keeps dashboard course and board page changes clearing selected items.

Closes #928.

## Why this matters

Pagination is a shared catalog interaction. Centralizing the helper and control makes future fixes easier to test and prevents the same behavior or styling change from drifting across seven separate list implementations.

## Testing

- `bun test tests`
- `bun run build`
- `bun run lint:strict -- 'app/orgs/[orgslug]/(withmenu)/boards/boards.tsx' 'app/orgs/[orgslug]/(withmenu)/courses/courses.tsx' 'app/orgs/[orgslug]/(withmenu)/playgrounds/playgrounds.tsx' 'app/orgs/[orgslug]/(withmenu)/podcasts/podcasts.tsx' 'app/orgs/[orgslug]/dash/boards/client.tsx' 'app/orgs/[orgslug]/dash/courses/client.tsx' 'app/orgs/[orgslug]/dash/playgrounds/client.tsx' 'components/Objects/Catalog/CatalogPagination.tsx' 'components/Objects/Catalog/catalogPagination.ts'` (0 errors; existing hook warnings remain in touched pages)
- Visual check with local Next dev server and a temporary fixture proxy: verified `/courses` and `/playgrounds` render page 1, click `Next`, and render page 2 with 25-item fixtures on desktop; also verified `/courses` pagination on a mobile viewport.
