### PR TITLE
Security & plan-limit enforcement hardening (invite-spam + limit bypasses)

### DIFF
--- a/apps/api/src/security/features_utils/usage.py
+++ b/apps/api/src/security/features_utils/usage.py
@@ -4,6 +4,9 @@ from src.db.billing_usage import UsageEvent
 from src.db.user_organizations import UserOrganization
 from src.db.courses.courses import Course
 from src.db.roles import Role, RoleTypeEnum
+from src.db.usergroups import UserGroup
+from src.db.podcasts.podcasts import Podcast
+from src.db.courses.assignments import Assignment
 from sqlalchemy import or_
 from src.core.deployment_mode import get_deployment_mode
 from src.core.redis import get_redis_client as _get_redis_pool_client
@@ -39,6 +42,16 @@ PLAN_BASED_FEATURES = {"courses", "members", "admin_seats"}
 # Features that use Redis for usage tracking (non-billing, rate limiting)
 REDIS_TRACKED_FEATURES = {"ai", "analytics", "api", "assignments", "collaboration",
                           "payments", "podcasts", "usergroups"}
+
+# Count-limited features whose usage is enforced by counting ACTUAL DB rows
+# rather than a mutable Redis counter. Counting rows makes enforcement
+# self-healing: the Redis usage counter could drift or be lost (it is an
+# ephemeral cache), which silently disabled these limits — e.g. a free org
+# could exceed its 5-assignment cap once the counter was gone. usergroups,
+# podcasts and assignments are all org-scoped DB entities, so their live count
+# is authoritative. (usergroups/podcasts are also disabled on the free plan, so
+# they are additionally gated by the enabled check.)
+DB_COUNTED_FEATURES = PLAN_BASED_FEATURES | {"usergroups", "podcasts", "assignments"}
 
 
 def _is_non_saas() -> bool:
@@ -116,14 +129,38 @@ async def _get_actual_admin_seat_count(org_id: int, db_session: AsyncSession) ->
     return (await db_session.execute(statement)).scalar_one()
 
 
+async def _get_actual_usergroup_count(org_id: int, db_session: AsyncSession) -> int:
+    """Get actual usergroup count from the database."""
+    statement = select(func.count()).where(UserGroup.org_id == org_id)
+    return (await db_session.execute(statement)).scalar_one()
+
+
+async def _get_actual_podcast_count(org_id: int, db_session: AsyncSession) -> int:
+    """Get actual podcast count from the database."""
+    statement = select(func.count()).where(Podcast.org_id == org_id)
+    return (await db_session.execute(statement)).scalar_one()
+
+
+async def _get_actual_assignment_count(org_id: int, db_session: AsyncSession) -> int:
+    """Get actual assignment count from the database."""
+    statement = select(func.count()).where(Assignment.org_id == org_id)
+    return (await db_session.execute(statement)).scalar_one()
+
+
 async def _get_actual_usage(feature: str, org_id: int, db_session: AsyncSession) -> int:
-    """Get actual usage count from database for plan-based features."""
+    """Get actual usage count from the database for DB-counted features."""
     if feature == "members":
         return await _get_actual_member_count(org_id, db_session)
     elif feature == "courses":
         return await _get_actual_course_count(org_id, db_session)
     elif feature == "admin_seats":
         return await _get_actual_admin_seat_count(org_id, db_session)
+    elif feature == "usergroups":
+        return await _get_actual_usergroup_count(org_id, db_session)
+    elif feature == "podcasts":
+        return await _get_actual_podcast_count(org_id, db_session)
+    elif feature == "assignments":
+        return await _get_actual_assignment_count(org_id, db_session)
     return 0
 
 
@@ -267,8 +304,9 @@ async def check_limits_with_usage(
     org_plan = _get_org_plan(org_config)
     feature_limit = resolved["limit"]
 
-    # Plan-based features - check actual DB count
-    if feature in PLAN_BASED_FEATURES:
+    # DB-counted features — enforce against the live row count so the limit
+    # cannot be bypassed by a drifted/lost Redis usage counter.
+    if feature in DB_COUNTED_FEATURES:
         current_usage = await _get_actual_usage(feature, org_id, db_session)
 
         if current_usage >= feature_limit:
@@ -715,6 +753,122 @@ async def check_admin_seat_limit(
         HTTPException if limit reached (for free plan)
     """
     return await check_limits_with_usage("admin_seats", org_id, db_session)
+
+
+def _role_grants_dashboard_access(role: Optional[Role]) -> bool:
+    """True if a role occupies an admin seat (dashboard.action_access == true).
+
+    Mirrors the seat-counting logic in ``_get_actual_admin_seat_count`` so the
+    gate and the count agree on what an "admin seat" is. Tolerates ``rights``
+    being either a plain dict or a Pydantic model.
+    """
+    if role is None:
+        return False
+    rights = role.rights
+    if rights is None:
+        return False
+    if not isinstance(rights, dict):
+        try:
+            rights = rights.model_dump()
+        except Exception:
+            return False
+    return bool(rights.get("dashboard", {}).get("action_access", False))
+
+
+async def enforce_admin_seat_limit_for_role_rights_change(
+    org_id: int,
+    role_id: int,
+    will_grant_dashboard: bool,
+    currently_grants_dashboard: bool,
+    db_session: AsyncSession,
+) -> None:
+    """Enforce the admin-seat cap when a role's ``dashboard.action_access`` is
+    turned ON (false -> true).
+
+    Because seats are derived from role rights, flipping a role that N members
+    already hold instantly converts all N into admin seats — a bulk grant that
+    the per-assignment gate cannot see. This validates the projected seat total
+    (current seats + the holders about to be converted) against the plan limit.
+    No-op for non-SaaS, paid plans, unlimited seats, or a role held by nobody.
+    """
+    if _is_non_saas():
+        return
+    if not will_grant_dashboard or currently_grants_dashboard:
+        return  # not a false->true transition: no new seats created
+
+    holders = (await db_session.execute(
+        select(func.count()).where(
+            UserOrganization.org_id == org_id,
+            UserOrganization.role_id == role_id,
+        )
+    )).scalar_one()
+    if holders == 0:
+        return  # nobody holds this role yet; assignment is gated separately
+
+    org_config = await _get_org_config(org_id, db_session)
+    if org_config is None:
+        return
+    org_plan = _get_org_plan(org_config)
+    if org_plan not in ("free",):
+        return  # paid plans allow overage
+
+    limit = get_plan_limit(org_plan, "admin_seats")
+    if limit <= 0:
+        return  # unlimited
+
+    # Holders of a non-dashboard role are not currently counted as seats, so the
+    # projected total is the current seat count plus everyone about to convert.
+    current = await _get_actual_admin_seat_count(org_id, db_session)
+    if current + holders > limit:
+        raise HTTPException(
+            status_code=403,
+            detail="Usage Limit has been reached for Admin_seats",
+        )
+
+
+async def enforce_admin_seat_limit_for_role_change(
+    org_id: int,
+    user_id: int,
+    new_role: Optional[Role],
+    db_session: AsyncSession,
+) -> None:
+    """Enforce the admin-seat limit when ``user_id`` is being assigned
+    ``new_role`` in ``org_id``.
+
+    Only a NET-NEW seat is checked:
+    - Granting a non-dashboard role (a demotion, or a normal-member role) never
+      raises — you can always remove admins or add regular members.
+    - Moving a user who already occupies an admin seat between two
+      dashboard-access roles consumes no new seat, so it is not blocked.
+    - Granting a dashboard-access role to a user who does not already hold one
+      (a promotion, or a brand-new admin membership) is gated by
+      ``check_admin_seat_limit`` and raises 403 for a free org at its limit.
+    """
+    if not _role_grants_dashboard_access(new_role):
+        return
+
+    # If the org has no config we cannot resolve its plan/limit; don't block a
+    # role change on that misconfiguration (enforcement degrades open, matching
+    # the non-SaaS skip inside check_limits_with_usage).
+    if await _get_org_config(org_id, db_session) is None:
+        return
+
+    # Does the user already occupy an admin seat in this org? If so, swapping
+    # admin roles adds no seat.
+    current = (await db_session.execute(
+        select(UserOrganization).where(
+            UserOrganization.org_id == org_id,
+            UserOrganization.user_id == user_id,
+        )
+    )).scalars().first()
+    if current is not None and current.role_id is not None:
+        current_role = (await db_session.execute(
+            select(Role).where(Role.id == current.role_id)
+        )).scalars().first()
+        if _role_grants_dashboard_access(current_role):
+            return
+
+    await check_admin_seat_limit(org_id, db_session)
 
 
 async def get_admin_seat_usage(

--- a/apps/api/src/security/features_utils/usage.py
+++ b/apps/api/src/security/features_utils/usage.py
@@ -300,6 +300,51 @@ async def check_limits_with_usage(
     return True
 
 
+async def check_members_limit_with_pending(
+    org_id: int,
+    pending_and_new: int,
+    db_session: AsyncSession,
+):
+    """Enforce the members limit counting BOTH joined members and pending/new
+    invites.
+
+    ``check_limits_with_usage("members", ...)`` only counts users who have
+    already joined, so a free org at (or near) its cap could still queue an
+    unbounded number of pending invitations. This folds ``pending_and_new``
+    (existing pending invites + the new ones about to be sent) into the count.
+
+    No-op when the members feature is unlimited (limit 0) or the org is on a
+    paid plan (paid plans allow tracked overage).
+    """
+    from src.security.features_utils.resolve import resolve_feature
+
+    org_config = await _get_org_config(org_id, db_session)
+    if org_config is None:
+        raise HTTPException(status_code=404, detail="Organization has no config")
+
+    resolved = resolve_feature("members", org_config.config or {}, org_id)
+    if not resolved["enabled"]:
+        raise HTTPException(
+            status_code=403,
+            detail="Members is not enabled for this organization",
+        )
+
+    feature_limit = resolved["limit"]
+    if feature_limit == 0:  # unlimited
+        return True
+
+    if _get_org_plan(org_config) not in ("free",):
+        return True  # paid: allow overage, billing tracks it
+
+    current = await _get_actual_member_count(org_id, db_session)
+    if current + max(pending_and_new, 0) > feature_limit:
+        raise HTTPException(
+            status_code=403,
+            detail="Usage Limit has been reached for Members",
+        )
+    return True
+
+
 async def increase_feature_usage(
     feature: FeatureSet,
     org_id: int,

--- a/apps/api/src/services/admin/admin.py
+++ b/apps/api/src/services/admin/admin.py
@@ -1855,6 +1855,26 @@ async def update_user_profile(
         if existing:
             raise HTTPException(status_code=400, detail="Username already in use")
 
+    # Reject phishing links in display-name fields here too — the admin API
+    # token path must not be a way around the signup/profile-update guard.
+    from src.services.security.profile_validation import validate_profile_fields
+
+    name_check = validate_profile_fields({
+        "username": updates.get("username"),
+        "first_name": updates.get("first_name"),
+        "last_name": updates.get("last_name"),
+    })
+    if not name_check.is_valid:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "PROFILE_FIELD_INVALID",
+                "message": "Display name fields may not contain URLs or links",
+                "errors": name_check.errors,
+                "invalid_fields": name_check.invalid_fields,
+            },
+        )
+
     for field, value in updates.items():
         if field in _USER_UPDATABLE_FIELDS and value is not None:
             setattr(user, field, value)

--- a/apps/api/src/services/admin/admin.py
+++ b/apps/api/src/services/admin/admin.py
@@ -46,8 +46,11 @@ from src.security.auth import create_access_token, create_refresh_token
 from src.security.features_utils.plan_check import get_org_plan
 from src.security.features_utils.plans import plan_meets_requirement
 from src.security.features_utils.usage import (
+    _role_grants_dashboard_access,
+    check_admin_seat_limit,
     check_limits_with_usage,
     decrease_feature_usage,
+    enforce_admin_seat_limit_for_role_change,
     increase_feature_usage,
 )
 from src.security.security import security_hash_password
@@ -1003,6 +1006,11 @@ async def provision_user(
 
     await check_limits_with_usage("members", token_user.org_id, db_session)
 
+    # Provisioning always creates a NET-NEW membership, so a dashboard-access
+    # role consumes a fresh admin seat — enforce the plan's seat cap.
+    if _role_grants_dashboard_access(role):
+        await check_admin_seat_limit(token_user.org_id, db_session)
+
     now = datetime.now()
 
     existing_user = (await db_session.execute(select(User).where(User.email == email))).scalars().first()
@@ -1937,6 +1945,12 @@ async def change_user_role(
                 detail="Cannot demote the last admin of the organization",
             )
 
+    # Enforce the admin-seat cap when promoting into a dashboard-access role
+    # (no-op for demotions and admin->admin swaps).
+    await enforce_admin_seat_limit_for_role_change(
+        token_user.org_id, user_id, role, db_session
+    )
+
     membership.role_id = new_role_id
     membership.update_date = str(datetime.now())
     db_session.add(membership)
@@ -1970,6 +1984,10 @@ async def create_usergroup(
     db_session: AsyncSession,
 ) -> UserGroupRead:
     """Create a user group / cohort in the token's org."""
+
+    # Enforce the usergroups plan limit on the API path too (it is disabled on
+    # free and count-limited on higher tiers); previously this bypassed it.
+    await check_limits_with_usage("usergroups", token_user.org_id, db_session)
 
     now = datetime.now()
     group = UserGroup(

--- a/apps/api/src/services/courses/contributors.py
+++ b/apps/api/src/services/courses/contributors.py
@@ -6,6 +6,7 @@ from src.db.users import PublicUser, AnonymousUser, APITokenUser, User, UserRead
 from src.db.courses.courses import Course
 from src.db.resource_authors import ResourceAuthor, ResourceAuthorshipEnum, ResourceAuthorshipStatusEnum
 from src.security.auth import resolve_acting_user_id
+from src.services.security.rate_limiting import enforce_batch_size_limit
 from src.security.rbac import authorization_verify_if_user_is_anon, check_resource_access, AccessAction
 from src.services.webhooks.dispatch import dispatch_webhooks
 from typing import List
@@ -212,6 +213,8 @@ async def add_bulk_course_contributors(
     # SECURITY: Require course ownership or admin role for adding contributors
     await check_resource_access(request, db_session, current_user, course_uuid, AccessAction.UPDATE)
 
+    enforce_batch_size_limit(len(usernames), "contributors")
+
     # Check if course exists
     statement = select(Course).where(Course.course_uuid == course_uuid)
     course = (await db_session.execute(statement)).scalars().first()
@@ -327,6 +330,8 @@ async def remove_bulk_course_contributors(
 
     # SECURITY: Require course ownership or admin role for removing contributors
     await check_resource_access(request, db_session, current_user, course_uuid, AccessAction.UPDATE)
+
+    enforce_batch_size_limit(len(usernames), "contributors")
 
     # Check if course exists
     statement = select(Course).where(Course.course_uuid == course_uuid)

--- a/apps/api/src/services/courses/migration/migration_service.py
+++ b/apps/api/src/services/courses/migration/migration_service.py
@@ -403,6 +403,18 @@ async def create_course_from_migration(
 
     org_uuid = organization.org_uuid
 
+    # Enforce the course plan limit on the migration path too — this creates a
+    # real course and previously bypassed the cap other create paths enforce.
+    # Skip only if the org has no config (a prod impossibility) so a config
+    # anomaly can't hard-fail a migration.
+    from src.security.features_utils.usage import (
+        _get_org_config,
+        check_limits_with_usage,
+        increase_feature_usage,
+    )
+    if await _get_org_config(org_id, db_session) is not None:
+        await check_limits_with_usage("courses", org_id, db_session)
+
     try:
         now = str(datetime.now())
         course_uuid = f"course_{uuid4()}"
@@ -636,6 +648,9 @@ async def create_course_from_migration(
                 activities_created += 1
 
         await db_session.commit()
+
+        # Track course usage for billing, consistent with the other create paths.
+        await increase_feature_usage("courses", org_id, db_session)
 
         # Clean up temp directory — temp_real already validated above
         shutil.rmtree(temp_real, ignore_errors=True)

--- a/apps/api/src/services/orgs/custom_domains.py
+++ b/apps/api/src/services/orgs/custom_domains.py
@@ -261,6 +261,16 @@ async def add_custom_domain(
     # VERIFICATION 3+4: Membership + admin permission (superadmins bypass)
     await require_org_admin(acting_user_id, org_id, db_session)
 
+    # VERIFICATION 4b: Free-tier abuse gate. Custom domains are an unenforced,
+    # unlimited surface and a phishing/brand-impersonation amplifier, so a
+    # free org (and the acting user) must be at least FREE_TIER_MIN_AGE_DAYS
+    # old before attaching one. Paid orgs are exempt.
+    from src.services.security.account_age import enforce_free_tier_age_gate
+
+    await enforce_free_tier_age_gate(
+        org_id, acting_user_id, db_session, action="add a custom domain"
+    )
+
     # VERIFICATION 5: Validate domain format
     domain = domain_data.domain.lower().strip()
 

--- a/apps/api/src/services/orgs/invites.py
+++ b/apps/api/src/services/orgs/invites.py
@@ -87,6 +87,17 @@ async def create_invite_code(
     # RBAC check
     await rbac_check(request, org.org_uuid, current_user, "update", db_session)
 
+    # Free-tier abuse gate: shareable invite links are a self-service member
+    # onboarding primitive, so a free org (and the acting user) must be at
+    # least FREE_TIER_MIN_AGE_DAYS old before minting one. Paid orgs exempt.
+    from src.security.auth import resolve_acting_user_id
+    from src.services.security.account_age import enforce_free_tier_age_gate
+
+    await enforce_free_tier_age_gate(
+        org_id, resolve_acting_user_id(current_user), db_session,
+        action="create invite links",
+    )
+
     # Connect to Redis
     r = _get_redis(redis_conn_string)
 
@@ -391,10 +402,15 @@ async def send_invite_email(
             pass
 
     try:
+        # Defense in depth: scrub any link out of the inviter's display name
+        # before it is relayed to recipients, even if it slipped past
+        # write-time validation (e.g. imported via OAuth).
+        from src.services.security.profile_validation import sanitize_display_name
+
         result = send_invitation_email(
             email=email,
-            org_name=org.name,
-            inviter_username=user.username,
+            org_name=sanitize_display_name(org.name, fallback="A LearnHouse organization"),
+            inviter_username=sanitize_display_name(user.username),
             invite_code=invite_code,
             signup_url=signup_url,
             lang=lang,

--- a/apps/api/src/services/orgs/users.py
+++ b/apps/api/src/services/orgs/users.py
@@ -2,6 +2,7 @@ import csv
 import io
 import json
 import logging
+import re
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -21,7 +22,16 @@ from src.db.usergroup_user import UserGroupUser
 from src.db.usergroups import UserGroup, UserGroupRead
 from src.db.users import AnonymousUser, APITokenUser, PublicUser, User, UserRead
 from src.security.auth import resolve_acting_user_id
-from src.security.features_utils.usage import check_limits_with_usage, decrease_feature_usage
+from src.security.features_utils.usage import (
+    check_members_limit_with_pending,
+    decrease_feature_usage,
+)
+from src.services.security.account_age import enforce_free_tier_age_gate
+from src.services.security.rate_limiting import (
+    INVITE_MAX_BATCH_SIZE,
+    enforce_batch_size_limit,
+    enforce_invite_rate_limit,
+)
 from src.security.org_auth import is_org_member
 from src.security.rbac.constants import ADMIN_ROLE_ID
 from src.services.orgs.invites import send_invite_email
@@ -44,6 +54,21 @@ def _csv_safe(value):
     if isinstance(value, str) and value and value[0] in ("=", "+", "-", "@", "\t", "\r"):
         return "'" + value
     return value
+
+
+# Deliberately permissive email shape check: exactly one "@", a dotted domain,
+# no whitespace/control chars, bounded length. The goal is to reject malformed
+# input (and ":"/whitespace that would shape the Redis invite key), not to
+# fully validate deliverability — the mail provider is the source of truth.
+_EMAIL_RE = re.compile(r"^[^@\s:]{1,64}@[^@\s:]{1,255}\.[a-zA-Z]{2,}$")
+
+
+def _looks_like_email(value: str) -> bool:
+    if not value or len(value) > 254:
+        return False
+    if any(ord(c) < 32 or ord(c) == 127 for c in value):
+        return False
+    return bool(_EMAIL_RE.match(value))
 
 
 async def get_organization_users(
@@ -554,6 +579,8 @@ async def remove_batch_users_from_org(
     # RBAC check
     await rbac_check(request, org.org_uuid, current_user, "delete", db_session)
 
+    enforce_batch_size_limit(len(user_ids), "users")
+
     # Get all admins for last-admin protection
     admin_statement = select(UserOrganization).where(
         UserOrganization.org_id == org.id, UserOrganization.role_id == ADMIN_ROLE_ID
@@ -801,11 +828,14 @@ async def invite_batch_users(
     # RBAC check
     await rbac_check(request, org.org_uuid, current_user, "create", db_session)
 
-    # Enforce the member limit on the invite surface too (not just at join time),
-    # so a free org at its limit is stopped here with a 403 "Usage Limit has been
-    # reached for Members" — which the dashboard turns into a contextual upgrade
-    # prompt — instead of being able to queue unlimited invites.
-    await check_limits_with_usage("members", org.id, db_session)
+    acting_user_id = resolve_acting_user_id(current_user)
+
+    # Free-tier abuse gate: the org AND the acting user must be at least
+    # FREE_TIER_MIN_AGE_DAYS old before invites can be sent. This stops a
+    # freshly-registered free org from being spun up purely to relay spam.
+    await enforce_free_tier_age_gate(
+        org.id, acting_user_id, db_session, action="invite members"
+    )
 
     # Connect to Redis
     r = redis.Redis.from_url(redis_conn_string)
@@ -816,7 +846,56 @@ async def invite_batch_users(
             detail="Could not connect to Redis",
         )
 
-    invite_list = emails.split(",")
+    # Normalize + dedupe requested emails up front, then cap the batch size so
+    # a single request cannot fan out unbounded email. Malformed addresses are
+    # rejected here (never sent), which also prevents ':'/whitespace-bearing
+    # input from shaping the ``invited_user:{email}:org:{uuid}`` Redis key.
+    seen_emails = set()
+    invite_list = []
+    invalid_results = []
+    for raw_email in emails.split(","):
+        candidate = raw_email.strip()
+        if not candidate or candidate.lower() in seen_emails:
+            continue
+        seen_emails.add(candidate.lower())
+        if not _looks_like_email(candidate):
+            invalid_results.append({"email": candidate, "status": "invalid_email"})
+            continue
+        invite_list.append(candidate)
+
+    if len(invite_list) > INVITE_MAX_BATCH_SIZE:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "INVITE_BATCH_TOO_LARGE",
+                "message": (
+                    f"You can invite at most {INVITE_MAX_BATCH_SIZE} people at "
+                    f"a time."
+                ),
+                "max_batch_size": INVITE_MAX_BATCH_SIZE,
+            },
+        )
+
+    # Which requested emails are genuinely new (not already pending)?
+    new_emails = [
+        e for e in invite_list
+        if not r.get(f"invited_user:{e}:org:{org.org_uuid}")
+    ]
+
+    # Count pending invites toward the member limit (not just joined members),
+    # so a free org can't queue invitations that would exceed its cap once
+    # accepted. Existing pending + new invites are both counted.
+    existing_pending = len(list(
+        r.scan_iter(match=f"invited_user:*:org:{org.org_uuid}", count=1000)
+    ))
+    await check_members_limit_with_pending(
+        org.id, existing_pending + len(new_emails), db_session
+    )
+
+    # Per-org AND per-user daily invite rate limit, reserving capacity for the
+    # new emails about to be sent.
+    if new_emails:
+        enforce_invite_rate_limit(org.id, acting_user_id, len(new_emails))
 
     # invitations expire after 60 days
     ttl = int(timedelta(days=60).total_seconds())
@@ -869,9 +948,13 @@ async def invite_batch_users(
             "status": "sent" if isEmailSent else "email_failed",
         })
 
+    # Surface malformed addresses that were rejected before sending.
+    results.extend(invalid_results)
+
     sent = sum(1 for r in results if r["status"] == "sent")
     failed = sum(1 for r in results if r["status"] == "email_failed")
     skipped = sum(1 for r in results if r["status"] == "already_invited")
+    invalid = sum(1 for r in results if r["status"] == "invalid_email")
 
     await dispatch_webhooks(
         event_name="user_invited_to_org",
@@ -892,6 +975,7 @@ async def invite_batch_users(
             "sent": sent,
             "failed": failed,
             "already_invited": skipped,
+            "invalid_email": invalid,
         },
     }
 

--- a/apps/api/src/services/orgs/users.py
+++ b/apps/api/src/services/orgs/users.py
@@ -25,6 +25,7 @@ from src.security.auth import resolve_acting_user_id
 from src.security.features_utils.usage import (
     check_members_limit_with_pending,
     decrease_feature_usage,
+    enforce_admin_seat_limit_for_role_change,
 )
 from src.services.security.account_age import enforce_free_tier_age_gate
 from src.services.security.rate_limiting import (
@@ -735,6 +736,11 @@ async def update_user_role(
             status_code=404,
             detail="User not found",
         )
+
+    # Enforce the admin-seat limit: promoting a user into a dashboard-access
+    # role must respect the org's plan seat cap. Demotions and admin->admin
+    # swaps are never blocked (see the helper).
+    await enforce_admin_seat_limit_for_role_change(org.id, user_id, role, db_session)
 
     if role_id is not None:
         user_org.role_id = role_id

--- a/apps/api/src/services/roles/roles.py
+++ b/apps/api/src/services/roles/roles.py
@@ -384,6 +384,16 @@ async def update_role(
     # org_id is guaranteed non-None here because TYPE_GLOBAL roles are blocked above.
     await require_org_role_permission(resolve_acting_user_id(current_user), role.org_id, db_session, "roles", "action_update")
 
+    # Capture the role's admin-seat status BEFORE applying the update, so we can
+    # detect a false->true flip of dashboard.action_access (which would convert
+    # every current holder of this role into an admin seat at once).
+    from src.security.features_utils.usage import (
+        _role_grants_dashboard_access,
+        enforce_admin_seat_limit_for_role_rights_change,
+    )
+    _seat_role_id = role.id
+    _was_dashboard_role = _role_grants_dashboard_access(role)
+
     # Complete the role object
     role.update_date = str(datetime.now())
 
@@ -502,6 +512,16 @@ async def update_role(
                             status_code=403,
                             detail=f"You cannot grant a role the '{perm_key}' permission for '{right_key}' as you don't have this permission yourself",
                         )
+
+    # Enforce the admin-seat cap if this update turns on dashboard access for a
+    # role members already hold (bulk promotion the per-assignment gate misses).
+    await enforce_admin_seat_limit_for_role_rights_change(
+        role.org_id,
+        _seat_role_id,
+        will_grant_dashboard=_role_grants_dashboard_access(role),
+        currently_grants_dashboard=_was_dashboard_role,
+        db_session=db_session,
+    )
 
     db_session.add(role)
     await db_session.commit()

--- a/apps/api/src/services/security/account_age.py
+++ b/apps/api/src/services/security/account_age.py
@@ -1,0 +1,156 @@
+"""
+Free-tier abuse mitigation: minimum account + organization age gate.
+
+After a phishing-relay incident — a freshly-registered free org blasted
+hundreds of phishing invite emails within minutes of signup, exhausting the
+shared email quota and taking down platform email — several abuse-prone
+surfaces now require BOTH the acting user's account AND their organization to
+be at least ``FREE_TIER_MIN_AGE_DAYS`` old before the action is allowed.
+
+Design notes:
+- Paid orgs are exempt: the age gate only applies to the ``free`` plan, where
+  signup is free and disposable. Upgrading lifts the gate immediately.
+- Non-SaaS deployments (self-hosted EE/OSS) skip the gate entirely — there is
+  no free-tier abuse economics to defend against.
+- ``creation_date`` is persisted as ``str(datetime.now())`` (a naive,
+  space-separated server-local timestamp like ``2026-07-09 11:47:21.155477``),
+  so parsing must tolerate that format. Unparseable/missing dates fail OPEN:
+  the abuse vector is brand-new accounts, which always carry a valid
+  creation_date, so only genuinely new accounts are ever gated. Legacy rows
+  with an empty/odd date are treated as old enough.
+"""
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import HTTPException
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.db.organizations import Organization
+from src.db.users import User
+from src.security.features_utils.usage import (
+    _get_org_config,
+    _get_org_plan,
+    _is_non_saas,
+)
+
+# Minimum age (in days) for a free-tier account AND its org before gated
+# actions are allowed. Kept as a module constant so tests can monkeypatch it.
+FREE_TIER_MIN_AGE_DAYS = 7
+
+
+def parse_creation_date(raw: Optional[str]) -> Optional[datetime]:
+    """Parse a stored ``creation_date`` string into a tz-aware UTC datetime.
+
+    Handles the primary persisted format ``str(datetime.now())`` (naive,
+    space-separated) as well as ISO-8601 strings with an explicit offset or a
+    trailing ``Z``. Naive values are assumed to be UTC (the server runs UTC in
+    production). Returns ``None`` if the value is missing or unparseable.
+    """
+    if not raw or not isinstance(raw, str):
+        return None
+    text = raw.strip()
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        try:
+            dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def account_age_days(
+    raw: Optional[str], *, now: Optional[datetime] = None
+) -> Optional[float]:
+    """Return the age in days for a stored creation_date, or ``None`` if the
+    date cannot be parsed (caller decides how to treat unknown ages)."""
+    created = parse_creation_date(raw)
+    if created is None:
+        return None
+    now = now or datetime.now(timezone.utc)
+    return (now - created).total_seconds() / 86400.0
+
+
+async def is_free_tier_age_gated(
+    org_id: int,
+    user_id: int,
+    db_session: AsyncSession,
+    *,
+    min_age_days: int = FREE_TIER_MIN_AGE_DAYS,
+) -> list[str]:
+    """Return the list of subjects (``"organization"`` / ``"account"``) that
+    are younger than ``min_age_days`` and would block a gated free-tier action.
+
+    Returns an empty list when the action should be allowed — i.e. the org is
+    on a paid plan, the deployment is non-SaaS, or both the org and account are
+    old enough (or have unparseable/legacy dates that fail open).
+    """
+    # Self-hosted EE/OSS: no free-tier abuse economics, skip the gate.
+    if _is_non_saas():
+        return []
+
+    # Paid orgs are exempt.
+    org_config = await _get_org_config(org_id, db_session)
+    if org_config is not None and _get_org_plan(org_config) not in ("free",):
+        return []
+
+    now = datetime.now(timezone.utc)
+
+    org = (
+        await db_session.execute(select(Organization).where(Organization.id == org_id))
+    ).scalars().first()
+    user = (
+        await db_session.execute(select(User).where(User.id == user_id))
+    ).scalars().first()
+
+    org_age = account_age_days(org.creation_date, now=now) if org else None
+    user_age = account_age_days(user.creation_date, now=now) if user else None
+
+    too_new: list[str] = []
+    # None means "unparseable/legacy date" → fail open (treat as old enough).
+    if org_age is not None and org_age < min_age_days:
+        too_new.append("organization")
+    if user_age is not None and user_age < min_age_days:
+        too_new.append("account")
+    return too_new
+
+
+async def enforce_free_tier_age_gate(
+    org_id: int,
+    user_id: int,
+    db_session: AsyncSession,
+    *,
+    action: str = "perform this action",
+    min_age_days: int = FREE_TIER_MIN_AGE_DAYS,
+) -> None:
+    """Raise HTTP 403 (``ACCOUNT_TOO_NEW``) if a free-tier org or its acting
+    user is younger than ``min_age_days``. No-op for paid orgs, non-SaaS
+    deployments, and sufficiently old accounts.
+
+    ``action`` is woven into the error message (e.g. ``"invite members"``).
+    Pass the *real* acting user id (resolve API tokens to their creator via
+    ``resolve_acting_user_id``) so token-driven calls are gated correctly.
+    """
+    too_new = await is_free_tier_age_gated(
+        org_id, user_id, db_session, min_age_days=min_age_days
+    )
+    if not too_new:
+        return
+
+    subjects = " and ".join(too_new)
+    raise HTTPException(
+        status_code=403,
+        detail={
+            "code": "ACCOUNT_TOO_NEW",
+            "message": (
+                f"Your {subjects} must be at least {min_age_days} days old to "
+                f"{action}. This limit protects the platform from abuse; it is "
+                f"lifted automatically with age, or immediately when you "
+                f"upgrade to a paid plan."
+            ),
+            "min_age_days": min_age_days,
+        },
+    )

--- a/apps/api/src/services/security/profile_validation.py
+++ b/apps/api/src/services/security/profile_validation.py
@@ -1,0 +1,100 @@
+"""
+Profile-field validation for user-controlled identity strings.
+
+An attacker planted a phishing URL in their *username*, then used the invite
+flow to relay it to hundreds of recipients from a trusted sender. Display
+names (username / first_name / last_name) and org names have no legitimate
+reason to contain URLs, so we reject them at signup and profile update, and
+additionally strip any that slip through before rendering them into emails.
+
+Two entry points:
+- ``validate_display_name`` / ``validate_profile_fields`` — hard-reject at
+  write time (raises the caller's chosen error).
+- ``strip_urls`` / ``sanitize_display_name`` — best-effort scrub at render
+  time (defense in depth for values already stored, e.g. via OAuth import).
+"""
+import re
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
+
+# Control characters (CR/LF/NUL and other C0 controls). Stripped before a value
+# is rendered into an email — a newline in a display name that reaches an SMTP
+# header is a classic header-injection (Bcc smuggling) primitive.
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
+# URL / link-like patterns. We match generously — the goal is to deny links in
+# a display name, not to perfectly parse URLs. Any of these signals a link:
+#   - a scheme (http://, https://, ftp://, etc.)
+#   - a bare "www." host
+#   - any dotted token immediately followed by a path ("evil.dev/x") — this is
+#     TLD-agnostic so new/obscure TLDs (.dev .ai .ly .to …) can't slip through
+#   - a "word.tld" with a plausible TLD (schemeless, pathless)
+#   - explicit "dot"/"punto" obfuscation ("evil dot com")
+_URL_PATTERNS = [
+    re.compile(r"[a-z][a-z0-9+.-]*://", re.IGNORECASE),
+    re.compile(r"\bwww\.", re.IGNORECASE),
+    re.compile(r"[a-z0-9-]+\.[a-z]{2,24}/\S", re.IGNORECASE),
+    re.compile(r"[a-z0-9-]+\.(?:com|net|org|io|ru|online|site|click|xyz|top|shop|app|link|info|biz|co|me|tv|cc|pro|store|live|dev|ai|ly|to|sh|gg|us|uk|de|fr|es|it|nl|pl|in|cn|jp|br|za|ua|by|kz)\b", re.IGNORECASE),
+    # Obfuscated dot forms only — "evil[.]com", "evil(dot)com", "evil dot com".
+    # Deliberately NOT a bare "." so ordinary names ("Dr. Strange", "J.R.R.")
+    # are not flagged; real "word.tld" is already covered by the list above.
+    re.compile(r"[a-z0-9-]+\s*(?:\[\.\]|\(dot\)|\bdot\b|\bpunto\b)\s*[a-z]{2,}", re.IGNORECASE),
+]
+
+
+class ProfileValidationResult(BaseModel):
+    """Result of validating one or more profile fields."""
+    is_valid: bool
+    errors: List[str]
+    invalid_fields: List[str]
+
+
+def contains_url(value: Optional[str]) -> bool:
+    """Return True if the value looks like it contains a URL or link."""
+    if not value:
+        return False
+    return any(p.search(value) for p in _URL_PATTERNS)
+
+
+def validate_display_name(value: Optional[str]) -> bool:
+    """Return True if a single display-name value is acceptable (no links)."""
+    return not contains_url(value)
+
+
+def validate_profile_fields(fields: Dict[str, Optional[str]]) -> ProfileValidationResult:
+    """Validate a mapping of ``field_name -> value`` (e.g. username,
+    first_name, last_name, org name). Fields set to ``None`` are skipped so
+    this is safe for partial updates.
+    """
+    errors: List[str] = []
+    invalid_fields: List[str] = []
+    for name, value in fields.items():
+        if value is None:
+            continue
+        if contains_url(value):
+            invalid_fields.append(name)
+            errors.append(f"{name} may not contain a URL or link")
+    return ProfileValidationResult(
+        is_valid=not errors,
+        errors=errors,
+        invalid_fields=invalid_fields,
+    )
+
+
+def strip_urls(value: Optional[str]) -> str:
+    """Remove URL/link-like substrings and control characters from a value.
+    Best-effort scrub used at render time; collapses leftover whitespace."""
+    if not value:
+        return ""
+    cleaned = _CONTROL_CHARS.sub(" ", value)
+    for p in _URL_PATTERNS:
+        cleaned = p.sub(" ", cleaned)
+    return re.sub(r"\s+", " ", cleaned).strip()
+
+
+def sanitize_display_name(value: Optional[str], *, fallback: str = "A LearnHouse user") -> str:
+    """Return a link-free display name suitable for rendering into emails.
+    Falls back to a neutral label if stripping leaves nothing meaningful."""
+    cleaned = strip_urls(value)
+    return cleaned if len(cleaned) >= 2 else fallback

--- a/apps/api/src/services/security/rate_limiting.py
+++ b/apps/api/src/services/security/rate_limiting.py
@@ -283,6 +283,92 @@ def check_invite_acceptance_rate_limit(request: Request, org_id: int) -> Tuple[b
     return is_allowed, retry_after
 
 
+# Default ceiling for comma-split / list batch endpoints that loop with
+# per-item DB or network work. Bounds a single request so one call cannot fan
+# out unbounded work; sized generously so legitimate bulk actions still pass.
+DEFAULT_MAX_BATCH_SIZE = 100
+
+
+def enforce_batch_size_limit(
+    count: int,
+    label: str,
+    max_size: int = DEFAULT_MAX_BATCH_SIZE,
+) -> None:
+    """Raise HTTP 400 (``BATCH_TOO_LARGE``) if ``count`` exceeds ``max_size``.
+
+    Use on any endpoint that splits/loops caller-supplied batch input with
+    per-item work, so a single request cannot be used as an amplification or
+    DoS primitive. ``label`` names the unit (e.g. ``"users"``) for the error.
+    """
+    if count > max_size:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "BATCH_TOO_LARGE",
+                "message": f"You can process at most {max_size} {label} at a time.",
+                "max_batch_size": max_size,
+            },
+        )
+
+
+# Invite tunables. Module-level so tests can monkeypatch without touching
+# bucket semantics. The batch cap bounds a single request; the per-org and
+# per-user windows bound sustained fan-out across requests.
+INVITE_MAX_BATCH_SIZE = 25
+INVITE_ORG_MAX_PER_DAY = 100
+INVITE_USER_MAX_PER_DAY = 100
+INVITE_RATE_LIMIT_WINDOW_SECONDS = 24 * 60 * 60
+
+
+def check_invite_rate_limit(org_id: int, user_id: int, count: int = 1) -> Tuple[bool, int]:
+    """Per-org AND per-user daily rate limit for outbound invite emails.
+
+    Invites relay attacker-controlled content to arbitrary addresses through
+    the shared email sender, so an unbounded batch endpoint is a spam/phishing
+    amplifier (and can exhaust the provider's daily quota, taking down all
+    platform email). ``count`` reserves the given number of invites atomically
+    so a single large batch cannot overshoot the window ceiling.
+
+    Returns ``(is_allowed, retry_after_seconds)``; ``retry_after`` reflects
+    whichever bucket denied the request.
+    """
+    r = get_redis_connection()
+    for key, ceiling in (
+        (f"invite_send:org:{org_id}", INVITE_ORG_MAX_PER_DAY),
+        (f"invite_send:user:{user_id}", INVITE_USER_MAX_PER_DAY),
+    ):
+        rate_key = f"rate_limit:{key}"
+        current = r.get(rate_key)
+        current = int(current) if current is not None else 0
+        if current + count > ceiling:
+            ttl = r.ttl(rate_key)
+            return False, ttl if ttl and ttl > 0 else INVITE_RATE_LIMIT_WINDOW_SECONDS
+    # Reserve capacity in both buckets, asserting the window TTL on creation.
+    for key in (f"invite_send:org:{org_id}", f"invite_send:user:{user_id}"):
+        rate_key = f"rate_limit:{key}"
+        new_val = r.incrby(rate_key, count)
+        ttl = r.ttl(rate_key)
+        if new_val == count or ttl is None or ttl < 0:
+            r.expire(rate_key, INVITE_RATE_LIMIT_WINDOW_SECONDS)
+    return True, INVITE_RATE_LIMIT_WINDOW_SECONDS
+
+
+def enforce_invite_rate_limit(org_id: int, user_id: int, count: int = 1) -> None:
+    """Raise HTTP 429 (``RATE_LIMITED``) if sending ``count`` invites would
+    exceed the per-org or per-user daily ceiling."""
+    is_allowed, retry_after = check_invite_rate_limit(org_id, user_id, count)
+    if not is_allowed:
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "code": "RATE_LIMITED",
+                "message": "Invite limit reached. Please try again later.",
+                "retry_after": retry_after,
+            },
+            headers={"Retry-After": str(retry_after)},
+        )
+
+
 def check_search_rate_limit(user_id: int) -> Tuple[bool, int]:
     """
     Rate limit search queries at 60/min per authenticated user. Search hits

--- a/apps/api/src/services/users/usergroups.py
+++ b/apps/api/src/services/users/usergroups.py
@@ -157,8 +157,9 @@ async def create_usergroup(
             detail="Organization does not exist",
         )
 
-    # Usage check
-    await check_limits_with_usage("courses", org.id, db_session)
+    # Usage check — this is the usergroups limit, not courses. (Previously
+    # keyed "courses", so the usergroups cap was never actually enforced.)
+    await check_limits_with_usage("usergroups", org.id, db_session)
 
     # Complete the object
     usergroup.usergroup_uuid = f"usergroup_{uuid4()}"

--- a/apps/api/src/services/users/usergroups.py
+++ b/apps/api/src/services/users/usergroups.py
@@ -24,6 +24,7 @@ from src.db.organizations import Organization
 from src.db.usergroups import UserGroup, UserGroupCreate, UserGroupRead, UserGroupUpdate
 from src.db.users import AnonymousUser, APITokenUser, InternalUser, PublicUser, User, UserRead
 from src.services.webhooks.dispatch import dispatch_webhooks
+from src.services.security.rate_limiting import enforce_batch_size_limit
 
 
 async def _validate_resource_exists_and_belongs_to_org(
@@ -500,6 +501,8 @@ async def add_users_to_usergroup(
             detail="user_ids must be a comma-separated list of integers",
         )
 
+    enforce_batch_size_limit(len(user_ids_array), "users")
+
     for user_id in user_ids_array:
         statement = select(User).where(User.id == user_id)
         user = (await db_session.execute(statement)).scalars().first()
@@ -594,6 +597,8 @@ async def remove_users_from_usergroup(
             detail="user_ids must be a comma-separated list of integers",
         )
 
+    enforce_batch_size_limit(len(user_ids_array), "users")
+
     for user_id in user_ids_array:
         statement = select(UserGroupUser).where(
             UserGroupUser.user_id == user_id, UserGroupUser.usergroup_id == usergroup_id
@@ -637,7 +642,9 @@ async def add_resources_to_usergroup(
         org_id=usergroup.org_id,
     )
 
-    resources_uuids_array = resources_uuids.split(",")
+    resources_uuids_array = [r for r in resources_uuids.split(",") if r.strip() != ""]
+
+    enforce_batch_size_limit(len(resources_uuids_array), "resources")
 
     for resource_uuid in resources_uuids_array:
         # Check if a link between UserGroup and Resource already exists
@@ -708,7 +715,9 @@ async def remove_resources_from_usergroup(
         org_id=usergroup.org_id,
     )
 
-    resources_uuids_array = resources_uuids.split(",")
+    resources_uuids_array = [r for r in resources_uuids.split(",") if r.strip() != ""]
+
+    enforce_batch_size_limit(len(resources_uuids_array), "resources")
 
     for resource_uuid in resources_uuids_array:
         statement = select(UserGroupResource).where(

--- a/apps/api/src/services/users/users.py
+++ b/apps/api/src/services/users/users.py
@@ -44,9 +44,30 @@ from src.db.user_organizations import UserOrganization
 from src.security.rbac.constants import ADMIN_ROLE_ID
 from src.security.security import security_hash_password, security_verify_password
 from src.services.security.password_validation import validate_password_complexity
+from src.services.security.profile_validation import validate_profile_fields
 from src.services.analytics.analytics import track
 from src.services.analytics import events as analytics_events
 from src.services.webhooks.dispatch import dispatch_webhooks
+
+
+def _reject_urls_in_profile_fields(**fields) -> None:
+    """Reject display-name fields containing URLs/links (S: phishing relay).
+
+    Raises HTTP 400 ``PROFILE_FIELD_INVALID`` if any of ``username``,
+    ``first_name`` or ``last_name`` contains a link. ``None`` values are
+    skipped so this is safe for partial updates.
+    """
+    result = validate_profile_fields(fields)
+    if not result.is_valid:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "PROFILE_FIELD_INVALID",
+                "message": "Display name fields may not contain URLs or links",
+                "errors": result.errors,
+                "invalid_fields": result.invalid_fields,
+            },
+        )
 
 
 async def create_user(
@@ -71,6 +92,13 @@ async def create_user(
                     "requirements": validation_result.requirements,
                 },
             )
+
+    # Reject phishing links in display-name fields at signup.
+    _reject_urls_in_profile_fields(
+        username=user_object.username,
+        first_name=user_object.first_name,
+        last_name=user_object.last_name,
+    )
 
     user = User.model_validate(user_object)
 
@@ -284,6 +312,13 @@ async def create_user_without_org(
                 },
             )
 
+    # Reject phishing links in display-name fields at signup.
+    _reject_urls_in_profile_fields(
+        username=user_object.username,
+        first_name=user_object.first_name,
+        last_name=user_object.last_name,
+    )
+
     user = User.model_validate(user_object)
 
     # RBAC check
@@ -369,6 +404,13 @@ async def update_user(
 
     # RBAC check
     await rbac_check(request, current_user, "update", user.user_uuid, db_session)
+
+    # Reject phishing links in display-name fields on profile update.
+    _reject_urls_in_profile_fields(
+        username=user_object.username,
+        first_name=user_object.first_name,
+        last_name=user_object.last_name,
+    )
 
     # Verifications
 

--- a/apps/api/src/tests/admin/test_admin_api.py
+++ b/apps/api/src/tests/admin/test_admin_api.py
@@ -1122,6 +1122,25 @@ class TestProvisionUser:
         mock_admin_side_effects["check_limits_with_usage"].assert_called_once()
         mock_admin_side_effects["increase_feature_usage"].assert_called_once()
 
+    async def test_dashboard_role_provision_enforces_admin_seat(
+        self, token_user, student_role, mock_request, db, mock_admin_side_effects
+    ):
+        # When the provisioned role grants dashboard access, the admin-seat cap
+        # is checked (a new membership always consumes a seat).
+        with patch(
+            "src.services.admin.admin._role_grants_dashboard_access", return_value=True
+        ), patch(
+            "src.services.admin.admin.check_admin_seat_limit", new_callable=AsyncMock
+        ) as seat_check:
+            await provision_user(
+                token_user=token_user,
+                email="seat@example.com",
+                username="seatuser",
+                first_name="", last_name="", password=None, role_id=4,
+                request=mock_request, db_session=db,
+            )
+        seat_check.assert_awaited_once()
+
     async def test_duplicate_email_in_org_rejected(self, token_user, user, student_role, mock_request, db, mock_admin_side_effects):
         # `user` is already a member of token_user's org via the fixture
         with pytest.raises(HTTPException) as exc:
@@ -2056,6 +2075,15 @@ class TestUpdateUserProfile:
         with pytest.raises(HTTPException) as exc:
             await update_user_profile(token_user, 9999, {"first_name": "X"}, db)
         assert exc.value.status_code == 404
+
+    async def test_rejects_url_in_display_name(self, token_user, user, db):
+        # The admin API path must not be a way around the display-name URL guard.
+        with pytest.raises(HTTPException) as exc:
+            await update_user_profile(
+                token_user, user.id, {"username": "win money http://evil.io"}, db
+            )
+        assert exc.value.status_code == 400
+        assert exc.value.detail["code"] == "PROFILE_FIELD_INVALID"
 
 
 # ── Change user role tests ──────────────────────────────────────────────────

--- a/apps/api/src/tests/security/test_account_age.py
+++ b/apps/api/src/tests/security/test_account_age.py
@@ -1,0 +1,122 @@
+"""Tests for the free-tier account/organization age gate.
+
+The trickiest correctness point is that ``creation_date`` is a varchar written
+by ``str(datetime.now())`` — a naive, space-separated, server-local timestamp.
+All age math happens in Python; unparseable/legacy dates fail OPEN.
+"""
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.services.security import account_age
+from src.services.security.account_age import (
+    account_age_days,
+    enforce_free_tier_age_gate,
+    is_free_tier_age_gated,
+    parse_creation_date,
+)
+
+NOW = datetime(2026, 7, 9, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_parse_creation_date_roundtrips_str_datetime_now():
+    # This is exactly the format the app persists: str(datetime.now()).
+    raw = "2026-07-09 11:47:21.155477"
+    parsed = parse_creation_date(raw)
+    assert parsed is not None
+    assert parsed.tzinfo is not None  # normalized to aware UTC
+    assert parsed.year == 2026 and parsed.minute == 47
+
+
+@pytest.mark.parametrize("raw", ["", None, "garbage", "not-a-date", "   "])
+def test_parse_creation_date_returns_none_for_unparseable(raw):
+    assert parse_creation_date(raw) is None
+
+
+def test_parse_creation_date_handles_iso_and_z_suffix():
+    assert parse_creation_date("2026-07-09T11:47:21+00:00") is not None
+    assert parse_creation_date("2026-07-09T11:47:21Z") is not None
+
+
+def test_account_age_days_math():
+    assert account_age_days("2026-07-01 12:00:00", now=NOW) == pytest.approx(8.0)
+    assert account_age_days("2026-07-09 11:00:00", now=NOW) == pytest.approx(1 / 24, abs=1e-6)
+    # Fail-open: unknown age → None (caller treats as old enough).
+    assert account_age_days("", now=NOW) is None
+
+
+def _db_returning(org, user):
+    """Fake AsyncSession whose execute() returns org then user in call order."""
+    def _result(obj):
+        scalars = SimpleNamespace(first=lambda: obj)
+        return SimpleNamespace(scalars=lambda: scalars)
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_result(org), _result(user)])
+    return db
+
+
+@pytest.mark.asyncio
+async def test_gate_skips_non_saas():
+    with patch.object(account_age, "_is_non_saas", return_value=True):
+        assert await is_free_tier_age_gated(1, 2, AsyncMock()) == []
+
+
+@pytest.mark.asyncio
+async def test_gate_exempts_paid_org():
+    with patch.object(account_age, "_is_non_saas", return_value=False), \
+         patch.object(account_age, "_get_org_config", AsyncMock(return_value=object())), \
+         patch.object(account_age, "_get_org_plan", return_value="pro"):
+        assert await is_free_tier_age_gated(1, 2, AsyncMock()) == []
+
+
+@pytest.mark.asyncio
+async def test_gate_flags_new_free_org_and_account():
+    org = SimpleNamespace(creation_date=str(NOW.replace(tzinfo=None)))
+    user = SimpleNamespace(creation_date=str(NOW.replace(tzinfo=None)))
+    db = _db_returning(org, user)
+    with patch.object(account_age, "_is_non_saas", return_value=False), \
+         patch.object(account_age, "_get_org_config", AsyncMock(return_value=object())), \
+         patch.object(account_age, "_get_org_plan", return_value="free"):
+        too_new = await is_free_tier_age_gated(1, 2, db)
+    assert set(too_new) == {"organization", "account"}
+
+
+@pytest.mark.asyncio
+async def test_gate_allows_old_free_org():
+    org = SimpleNamespace(creation_date="2026-01-01 00:00:00")
+    user = SimpleNamespace(creation_date="2026-01-01 00:00:00")
+    db = _db_returning(org, user)
+    with patch.object(account_age, "_is_non_saas", return_value=False), \
+         patch.object(account_age, "_get_org_config", AsyncMock(return_value=object())), \
+         patch.object(account_age, "_get_org_plan", return_value="free"):
+        assert await is_free_tier_age_gated(1, 2, db) == []
+
+
+@pytest.mark.asyncio
+async def test_gate_fails_open_on_legacy_empty_dates():
+    org = SimpleNamespace(creation_date="")
+    user = SimpleNamespace(creation_date="")
+    db = _db_returning(org, user)
+    with patch.object(account_age, "_is_non_saas", return_value=False), \
+         patch.object(account_age, "_get_org_config", AsyncMock(return_value=object())), \
+         patch.object(account_age, "_get_org_plan", return_value="free"):
+        assert await is_free_tier_age_gated(1, 2, db) == []
+
+
+@pytest.mark.asyncio
+async def test_enforce_raises_403_account_too_new():
+    org = SimpleNamespace(creation_date=str(NOW.replace(tzinfo=None)))
+    user = SimpleNamespace(creation_date=str(NOW.replace(tzinfo=None)))
+    db = _db_returning(org, user)
+    with patch.object(account_age, "_is_non_saas", return_value=False), \
+         patch.object(account_age, "_get_org_config", AsyncMock(return_value=object())), \
+         patch.object(account_age, "_get_org_plan", return_value="free"):
+        with pytest.raises(HTTPException) as exc:
+            await enforce_free_tier_age_gate(1, 2, db, action="invite members")
+    assert exc.value.status_code == 403
+    assert exc.value.detail["code"] == "ACCOUNT_TOO_NEW"
+    assert "invite members" in exc.value.detail["message"]

--- a/apps/api/src/tests/security/test_admin_seat_gate.py
+++ b/apps/api/src/tests/security/test_admin_seat_gate.py
@@ -30,6 +30,24 @@ def test_role_grants_dashboard_access():
     assert _role_grants_dashboard_access(None) is False
 
 
+def test_role_grants_dashboard_access_pydantic_model_rights():
+    # rights as a model with model_dump() -> dict.
+    class _Rights:
+        def model_dump(self):
+            return {"dashboard": {"action_access": True}}
+
+    assert _role_grants_dashboard_access(SimpleNamespace(rights=_Rights())) is True
+
+
+def test_role_grants_dashboard_access_unparseable_rights():
+    # A rights object whose model_dump() raises falls back to False.
+    class _BadRights:
+        def model_dump(self):
+            raise RuntimeError("boom")
+
+    assert _role_grants_dashboard_access(SimpleNamespace(rights=_BadRights())) is False
+
+
 def _db_returning(*objs):
     """AsyncSession whose execute() returns the given objects in call order."""
     def _result(obj):
@@ -98,13 +116,48 @@ def _rights_db(holder_count):
 async def test_rights_flip_noop_when_not_a_true_transition():
     # Turning dashboard access OFF, or leaving it ON, never blocks.
     db = _rights_db(50)
-    await enforce_admin_seat_limit_for_role_rights_change(
-        1, 5, will_grant_dashboard=False, currently_grants_dashboard=False, db_session=db
-    )
-    await enforce_admin_seat_limit_for_role_rights_change(
-        1, 5, will_grant_dashboard=True, currently_grants_dashboard=True, db_session=db
-    )
+    with patch.object(usage, "_is_non_saas", return_value=False):
+        await enforce_admin_seat_limit_for_role_rights_change(
+            1, 5, will_grant_dashboard=False, currently_grants_dashboard=False, db_session=db
+        )
+        await enforce_admin_seat_limit_for_role_rights_change(
+            1, 5, will_grant_dashboard=True, currently_grants_dashboard=True, db_session=db
+        )
     db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rights_flip_noop_on_non_saas():
+    db = _rights_db(50)
+    with patch.object(usage, "_is_non_saas", return_value=True):
+        await enforce_admin_seat_limit_for_role_rights_change(
+            1, 5, will_grant_dashboard=True, currently_grants_dashboard=False, db_session=db
+        )
+    db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rights_flip_allows_when_no_config_or_paid_or_unlimited():
+    # Held by 5 members, but each of these branches allows the flip.
+    base = dict(will_grant_dashboard=True, currently_grants_dashboard=False)
+
+    # No org config → cannot resolve limit → allow.
+    with patch.object(usage, "_is_non_saas", return_value=False), \
+         patch.object(usage, "_get_org_config", AsyncMock(return_value=None)):
+        await enforce_admin_seat_limit_for_role_rights_change(1, 5, db_session=_rights_db(5), **base)
+
+    # Paid plan → overage allowed.
+    with patch.object(usage, "_is_non_saas", return_value=False), \
+         patch.object(usage, "_get_org_config", AsyncMock(return_value=object())), \
+         patch.object(usage, "_get_org_plan", return_value="pro"):
+        await enforce_admin_seat_limit_for_role_rights_change(1, 5, db_session=_rights_db(5), **base)
+
+    # Free but unlimited seats (limit 0) → allow.
+    with patch.object(usage, "_is_non_saas", return_value=False), \
+         patch.object(usage, "_get_org_config", AsyncMock(return_value=object())), \
+         patch.object(usage, "_get_org_plan", return_value="free"), \
+         patch.object(usage, "get_plan_limit", return_value=0):
+        await enforce_admin_seat_limit_for_role_rights_change(1, 5, db_session=_rights_db(5), **base)
 
 
 @pytest.mark.asyncio

--- a/apps/api/src/tests/security/test_admin_seat_gate.py
+++ b/apps/api/src/tests/security/test_admin_seat_gate.py
@@ -1,0 +1,133 @@
+"""Tests for admin-seat limit enforcement on role changes.
+
+Regression guard: previously an org could exceed its plan's admin-seat cap
+because no role-grant path called the seat check (check_admin_seat_limit had
+zero callers).
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.security.features_utils import usage
+from src.security.features_utils.usage import (
+    _role_grants_dashboard_access,
+    enforce_admin_seat_limit_for_role_change,
+    enforce_admin_seat_limit_for_role_rights_change,
+)
+
+
+def _role(action_access, role_id=1):
+    return SimpleNamespace(id=role_id, rights={"dashboard": {"action_access": action_access}})
+
+
+def test_role_grants_dashboard_access():
+    assert _role_grants_dashboard_access(_role(True)) is True
+    assert _role_grants_dashboard_access(_role(False)) is False
+    assert _role_grants_dashboard_access(SimpleNamespace(rights={})) is False
+    assert _role_grants_dashboard_access(SimpleNamespace(rights=None)) is False
+    assert _role_grants_dashboard_access(None) is False
+
+
+def _db_returning(*objs):
+    """AsyncSession whose execute() returns the given objects in call order."""
+    def _result(obj):
+        return SimpleNamespace(scalars=lambda o=obj: SimpleNamespace(first=lambda: o))
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_result(o) for o in objs])
+    return db
+
+
+@pytest.mark.asyncio
+async def test_demotion_never_checks_limit():
+    # Assigning a non-dashboard role must never be blocked.
+    check = AsyncMock()
+    with patch.object(usage, "check_admin_seat_limit", check):
+        await enforce_admin_seat_limit_for_role_change(1, 2, _role(False), AsyncMock())
+    check.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_admin_to_admin_swap_not_blocked():
+    # User already holds an admin seat → moving to another admin role adds none.
+    membership = SimpleNamespace(role_id=5)
+    current_role = _role(True, role_id=5)
+    db = _db_returning(membership, current_role)
+    check = AsyncMock()
+    with patch.object(usage, "check_admin_seat_limit", check), \
+         patch.object(usage, "_get_org_config", AsyncMock(return_value=object())):
+        await enforce_admin_seat_limit_for_role_change(1, 2, _role(True, role_id=6), db)
+    check.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_promotion_from_member_checks_limit():
+    # User currently holds a non-admin role → promoting consumes a new seat.
+    membership = SimpleNamespace(role_id=4)
+    current_role = _role(False, role_id=4)
+    db = _db_returning(membership, current_role)
+    check = AsyncMock()
+    with patch.object(usage, "check_admin_seat_limit", check), \
+         patch.object(usage, "_get_org_config", AsyncMock(return_value=object())):
+        await enforce_admin_seat_limit_for_role_change(1, 2, _role(True, role_id=1), db)
+    check.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_new_membership_admin_role_checks_limit():
+    # No existing membership (brand-new admin) → net-new seat, check runs.
+    db = _db_returning(None)
+    check = AsyncMock()
+    with patch.object(usage, "check_admin_seat_limit", check), \
+         patch.object(usage, "_get_org_config", AsyncMock(return_value=object())):
+        await enforce_admin_seat_limit_for_role_change(1, 99, _role(True), db)
+    check.assert_awaited_once()
+
+
+# ---- role-rights flip (dashboard.action_access false -> true) ---------------
+
+def _rights_db(holder_count):
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=SimpleNamespace(scalar_one=lambda: holder_count))
+    return db
+
+
+@pytest.mark.asyncio
+async def test_rights_flip_noop_when_not_a_true_transition():
+    # Turning dashboard access OFF, or leaving it ON, never blocks.
+    db = _rights_db(50)
+    await enforce_admin_seat_limit_for_role_rights_change(
+        1, 5, will_grant_dashboard=False, currently_grants_dashboard=False, db_session=db
+    )
+    await enforce_admin_seat_limit_for_role_rights_change(
+        1, 5, will_grant_dashboard=True, currently_grants_dashboard=True, db_session=db
+    )
+    db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rights_flip_blocks_when_bulk_conversion_exceeds_limit():
+    # Role held by 5 members flipped to dashboard-access on a free org with a
+    # 1-seat cap → projected 5 seats > 1 → blocked.
+    db = _rights_db(5)
+    with patch.object(usage, "_is_non_saas", return_value=False), \
+         patch.object(usage, "_get_org_config", AsyncMock(return_value=object())), \
+         patch.object(usage, "_get_org_plan", return_value="free"), \
+         patch.object(usage, "get_plan_limit", return_value=1), \
+         patch.object(usage, "_get_actual_admin_seat_count", AsyncMock(return_value=1)):
+        with pytest.raises(HTTPException) as exc:
+            await enforce_admin_seat_limit_for_role_rights_change(
+                1, 5, will_grant_dashboard=True, currently_grants_dashboard=False, db_session=db
+            )
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_rights_flip_allows_when_role_held_by_nobody():
+    db = _rights_db(0)
+    with patch.object(usage, "_is_non_saas", return_value=False):
+        await enforce_admin_seat_limit_for_role_rights_change(
+            1, 5, will_grant_dashboard=True, currently_grants_dashboard=False, db_session=db
+        )  # no raise — assignment is gated separately

--- a/apps/api/src/tests/security/test_db_counted_limits.py
+++ b/apps/api/src/tests/security/test_db_counted_limits.py
@@ -22,6 +22,18 @@ def test_db_counted_features_include_the_drift_prone_ones():
         assert f in DB_COUNTED_FEATURES
 
 
+@pytest.mark.asyncio
+async def test_get_actual_usage_routes_row_counted_features():
+    # The usergroups/podcasts/assignments helpers count live rows via scalar_one.
+    from src.security.features_utils.usage import _get_actual_usage
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=SimpleNamespace(scalar_one=lambda: 7))
+    for feat in ("usergroups", "podcasts", "assignments", "members", "courses"):
+        assert await _get_actual_usage(feat, 1, db) == 7
+    assert await _get_actual_usage("unknown_feature", 1, db) == 0
+
+
 async def _run_check(*, feature, limit, plan, actual, enabled=True):
     patches = [
         patch.object(usage, "_get_org_config", AsyncMock(return_value=SimpleNamespace(config={}))),

--- a/apps/api/src/tests/security/test_db_counted_limits.py
+++ b/apps/api/src/tests/security/test_db_counted_limits.py
@@ -1,0 +1,73 @@
+"""Tests that count-limited features are enforced against actual DB rows.
+
+Regression guard: usergroups/podcasts/assignments were enforced via a mutable
+Redis counter that could drift or be lost, silently disabling the limit (e.g. a
+free org exceeding its 5-assignment cap). They are now counted from live rows.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.security.features_utils import usage
+from src.security.features_utils.usage import (
+    DB_COUNTED_FEATURES,
+    check_limits_with_usage,
+)
+
+
+def test_db_counted_features_include_the_drift_prone_ones():
+    for f in ("usergroups", "podcasts", "assignments", "members", "courses", "admin_seats"):
+        assert f in DB_COUNTED_FEATURES
+
+
+async def _run_check(*, feature, limit, plan, actual, enabled=True):
+    patches = [
+        patch.object(usage, "_get_org_config", AsyncMock(return_value=SimpleNamespace(config={}))),
+        patch.object(usage, "_get_org_plan", return_value=plan),
+        patch.object(usage, "_get_actual_usage", AsyncMock(return_value=actual)),
+        patch("src.security.features_utils.resolve.resolve_feature",
+              return_value={"enabled": enabled, "limit": limit}),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        return await check_limits_with_usage(feature, 1, AsyncMock())
+    finally:
+        for p in patches:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_assignments_free_blocks_at_actual_row_limit():
+    # Free assignments limit is 5; with 5 real rows the next create is blocked,
+    # regardless of any Redis counter value.
+    with pytest.raises(HTTPException) as exc:
+        await _run_check(feature="assignments", limit=5, plan="free", actual=5)
+    assert exc.value.status_code == 403
+    assert "Assignments" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_assignments_free_allows_under_limit():
+    assert await _run_check(feature="assignments", limit=5, plan="free", actual=4) is True
+
+
+@pytest.mark.asyncio
+async def test_paid_plan_gets_overage():
+    # A paid plan at/over a numeric limit is allowed (billing tracks overage).
+    assert await _run_check(feature="assignments", limit=5, plan="pro", actual=99) is True
+
+
+@pytest.mark.asyncio
+async def test_unlimited_limit_zero_passes():
+    assert await _run_check(feature="podcasts", limit=0, plan="free", actual=999) is True
+
+
+@pytest.mark.asyncio
+async def test_disabled_feature_blocked_regardless_of_count():
+    # usergroups is disabled on free → blocked even with zero rows.
+    with pytest.raises(HTTPException) as exc:
+        await _run_check(feature="usergroups", limit=0, plan="free", actual=0, enabled=False)
+    assert exc.value.status_code == 403

--- a/apps/api/src/tests/security/test_invite_hardening.py
+++ b/apps/api/src/tests/security/test_invite_hardening.py
@@ -1,0 +1,99 @@
+"""Tests for invite-abuse hardening: batch-size cap, per-org/per-user daily
+invite rate limit, and generic batch-size guard.
+
+Regression guard for the phishing-relay incident (400+ invites blasted from a
+fresh free org, exhausting the shared email quota)."""
+import pytest
+from fastapi import HTTPException
+
+from src.services.security import rate_limiting
+from src.services.security.rate_limiting import (
+    check_invite_rate_limit,
+    enforce_batch_size_limit,
+    enforce_invite_rate_limit,
+)
+
+
+class _FakeRedis:
+    """Minimal Redis stand-in covering the ops the invite limiter uses."""
+
+    def __init__(self):
+        self._store = {}
+        self._ttl = {}
+
+    def get(self, key):
+        val = self._store.get(key)
+        return None if val is None else str(val).encode()
+
+    def ttl(self, key):
+        return self._ttl.get(key, -2)
+
+    def incrby(self, key, amount):
+        self._store[key] = self._store.get(key, 0) + int(amount)
+        return self._store[key]
+
+    def expire(self, key, seconds):
+        self._ttl[key] = seconds
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    r = _FakeRedis()
+    monkeypatch.setattr(rate_limiting, "get_redis_connection", lambda: r)
+    return r
+
+
+# ---- batch-size caps -------------------------------------------------------
+
+def test_enforce_batch_size_limit_passes_under_cap():
+    enforce_batch_size_limit(10, "users", max_size=100)  # no raise
+
+
+def test_enforce_batch_size_limit_raises_over_cap():
+    with pytest.raises(HTTPException) as exc:
+        enforce_batch_size_limit(101, "users", max_size=100)
+    assert exc.value.status_code == 400
+    assert exc.value.detail["code"] == "BATCH_TOO_LARGE"
+    assert exc.value.detail["max_batch_size"] == 100
+
+
+# ---- invite rate limit -----------------------------------------------------
+
+def test_invite_rate_limit_allows_within_ceiling(fake_redis, monkeypatch):
+    monkeypatch.setattr(rate_limiting, "INVITE_ORG_MAX_PER_DAY", 10)
+    monkeypatch.setattr(rate_limiting, "INVITE_USER_MAX_PER_DAY", 10)
+    allowed, _ = check_invite_rate_limit(org_id=1, user_id=2, count=5)
+    assert allowed is True
+    # Reserved capacity persisted in both buckets.
+    assert fake_redis.get("rate_limit:invite_send:org:1") == b"5"
+    assert fake_redis.get("rate_limit:invite_send:user:2") == b"5"
+
+
+def test_invite_rate_limit_blocks_when_batch_would_exceed(fake_redis, monkeypatch):
+    monkeypatch.setattr(rate_limiting, "INVITE_ORG_MAX_PER_DAY", 5)
+    monkeypatch.setattr(rate_limiting, "INVITE_USER_MAX_PER_DAY", 100)
+    assert check_invite_rate_limit(1, 2, count=5)[0] is True
+    # Next invite would make 6 > 5 → blocked, and nothing further reserved.
+    allowed, retry_after = check_invite_rate_limit(1, 2, count=1)
+    assert allowed is False
+    assert retry_after > 0
+    assert fake_redis.get("rate_limit:invite_send:org:1") == b"5"
+
+
+def test_invite_rate_limit_org_bucket_independent_of_user(fake_redis, monkeypatch):
+    monkeypatch.setattr(rate_limiting, "INVITE_ORG_MAX_PER_DAY", 100)
+    monkeypatch.setattr(rate_limiting, "INVITE_USER_MAX_PER_DAY", 3)
+    assert check_invite_rate_limit(org_id=1, user_id=2, count=3)[0] is True
+    # Same user, different org: user bucket already exhausted → blocked.
+    assert check_invite_rate_limit(org_id=9, user_id=2, count=1)[0] is False
+
+
+def test_enforce_invite_rate_limit_raises_429_with_retry_after(fake_redis, monkeypatch):
+    monkeypatch.setattr(rate_limiting, "INVITE_ORG_MAX_PER_DAY", 1)
+    monkeypatch.setattr(rate_limiting, "INVITE_USER_MAX_PER_DAY", 100)
+    enforce_invite_rate_limit(1, 2, count=1)  # first ok
+    with pytest.raises(HTTPException) as exc:
+        enforce_invite_rate_limit(1, 2, count=1)
+    assert exc.value.status_code == 429
+    assert exc.value.detail["code"] == "RATE_LIMITED"
+    assert "Retry-After" in exc.value.headers

--- a/apps/api/src/tests/security/test_members_pending_limit.py
+++ b/apps/api/src/tests/security/test_members_pending_limit.py
@@ -1,0 +1,69 @@
+"""Tests for counting pending invites toward the members limit.
+
+Before this, ``check_limits_with_usage("members")`` counted only joined
+members, so a free org at its cap could still queue unbounded pending invites.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.security.features_utils import usage
+from src.security.features_utils.usage import check_members_limit_with_pending
+
+
+def _patches(*, limit, plan, member_count, enabled=True):
+    return [
+        patch.object(usage, "_get_org_config", AsyncMock(return_value=SimpleNamespace(config={}))),
+        patch.object(usage, "_get_org_plan", return_value=plan),
+        patch.object(usage, "_get_actual_member_count", AsyncMock(return_value=member_count)),
+        patch(
+            "src.security.features_utils.resolve.resolve_feature",
+            return_value={"enabled": enabled, "limit": limit},
+        ),
+    ]
+
+
+async def _run(**kw):
+    pending_and_new = kw.pop("pending_and_new")
+    ps = _patches(**kw)
+    for p in ps:
+        p.start()
+    try:
+        return await check_members_limit_with_pending(1, pending_and_new, AsyncMock())
+    finally:
+        for p in ps:
+            p.stop()
+
+
+@pytest.mark.asyncio
+async def test_unlimited_limit_always_passes():
+    assert await _run(limit=0, plan="free", member_count=999, pending_and_new=999) is True
+
+
+@pytest.mark.asyncio
+async def test_paid_plan_allows_overage():
+    assert await _run(limit=5, plan="pro", member_count=5, pending_and_new=10) is True
+
+
+@pytest.mark.asyncio
+async def test_free_blocks_when_members_plus_pending_exceed_limit():
+    # 8 members + 3 pending/new = 11 > 10 → blocked.
+    with pytest.raises(HTTPException) as exc:
+        await _run(limit=10, plan="free", member_count=8, pending_and_new=3)
+    assert exc.value.status_code == 403
+    assert "Members" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_free_allows_at_exactly_limit():
+    # 8 members + 2 pending = 10 == 10 → allowed (boundary).
+    assert await _run(limit=10, plan="free", member_count=8, pending_and_new=2) is True
+
+
+@pytest.mark.asyncio
+async def test_disabled_feature_raises_403():
+    with pytest.raises(HTTPException) as exc:
+        await _run(limit=10, plan="free", member_count=0, pending_and_new=1, enabled=False)
+    assert exc.value.status_code == 403

--- a/apps/api/src/tests/security/test_members_pending_limit.py
+++ b/apps/api/src/tests/security/test_members_pending_limit.py
@@ -67,3 +67,11 @@ async def test_disabled_feature_raises_403():
     with pytest.raises(HTTPException) as exc:
         await _run(limit=10, plan="free", member_count=0, pending_and_new=1, enabled=False)
     assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_missing_org_config_raises_404():
+    with patch.object(usage, "_get_org_config", AsyncMock(return_value=None)):
+        with pytest.raises(HTTPException) as exc:
+            await check_members_limit_with_pending(1, 1, AsyncMock())
+    assert exc.value.status_code == 404

--- a/apps/api/src/tests/security/test_profile_validation.py
+++ b/apps/api/src/tests/security/test_profile_validation.py
@@ -1,0 +1,83 @@
+"""Tests for display-name URL/link rejection and render-time scrubbing.
+
+Regression guard for the phishing-relay incident where an attacker planted a
+phishing URL in their username and relayed it via invites.
+"""
+import pytest
+
+from src.services.security.profile_validation import (
+    contains_url,
+    sanitize_display_name,
+    strip_urls,
+    validate_display_name,
+    validate_profile_fields,
+)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "Вам 5000 руб https://platf-yndx.online/pro/",  # the real incident payload
+        "platf-yndx.online",
+        "www.evil.com",
+        "http://x.io",
+        "HTTPS://X.IO",
+        "free money at evil.dev/promo",  # TLD-agnostic path match (.dev not in list)
+        "ping me evil.ai/x",
+        "reach me bit.ly/abc",
+        "contact evil dot com",
+        "cash evil (dot) com",
+        "ftp://host.example/file",
+    ],
+)
+def test_contains_url_flags_links(value):
+    assert contains_url(value) is True
+    assert validate_display_name(value) is False
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "John Smith",
+        "María José",
+        "O'Brien",
+        "J.R.R. Tolkien",  # dotted initials, no path → not a URL
+        "Dr. Strange",
+        "李四",
+        "",
+        "A. B. Curie",
+    ],
+)
+def test_contains_url_allows_plain_names(value):
+    assert contains_url(value) is False
+    assert validate_display_name(value) is True
+
+
+def test_validate_profile_fields_skips_none_and_reports_invalid():
+    result = validate_profile_fields(
+        {"username": "Free http://x.io", "first_name": "Dan", "last_name": None}
+    )
+    assert result.is_valid is False
+    assert result.invalid_fields == ["username"]
+    assert result.errors and "username" in result.errors[0]
+
+
+def test_validate_profile_fields_all_clean():
+    result = validate_profile_fields(
+        {"username": "danabc", "first_name": "Dan", "last_name": "Smith"}
+    )
+    assert result.is_valid is True
+    assert result.invalid_fields == []
+
+
+def test_strip_urls_removes_links_and_control_chars():
+    assert "http" not in strip_urls("see https://evil.example/x now")
+    # CR/LF (SMTP header injection primitive) are stripped.
+    scrubbed = strip_urls("Dan\r\nBcc: victim@x.com")
+    assert "\r" not in scrubbed and "\n" not in scrubbed
+
+
+def test_sanitize_display_name_falls_back_when_empty_after_scrub():
+    assert sanitize_display_name("platf-yndx.online") == "A LearnHouse user"
+    assert sanitize_display_name("platf-yndx.online", fallback="Someone") == "Someone"
+    assert sanitize_display_name("John Smith") == "John Smith"

--- a/apps/api/src/tests/security/test_profile_validation.py
+++ b/apps/api/src/tests/security/test_profile_validation.py
@@ -70,6 +70,11 @@ def test_validate_profile_fields_all_clean():
     assert result.invalid_fields == []
 
 
+def test_strip_urls_empty_returns_empty_string():
+    assert strip_urls("") == ""
+    assert strip_urls(None) == ""
+
+
 def test_strip_urls_removes_links_and_control_chars():
     assert "http" not in strip_urls("see https://evil.example/x now")
     # CR/LF (SMTP header injection primitive) are stripped.
@@ -81,3 +86,27 @@ def test_sanitize_display_name_falls_back_when_empty_after_scrub():
     assert sanitize_display_name("platf-yndx.online") == "A LearnHouse user"
     assert sanitize_display_name("platf-yndx.online", fallback="Someone") == "Someone"
     assert sanitize_display_name("John Smith") == "John Smith"
+
+
+def test_reject_urls_in_profile_fields_helper():
+    from fastapi import HTTPException
+
+    from src.services.users.users import _reject_urls_in_profile_fields
+
+    # Clean fields: no raise.
+    _reject_urls_in_profile_fields(username="dan", first_name="Dan", last_name="Smith")
+    # A URL in any field: 400 PROFILE_FIELD_INVALID.
+    with pytest.raises(HTTPException) as exc:
+        _reject_urls_in_profile_fields(username="buy http://evil.io", first_name=None, last_name=None)
+    assert exc.value.status_code == 400
+    assert exc.value.detail["code"] == "PROFILE_FIELD_INVALID"
+
+
+def test_looks_like_email_rejects_malformed_and_control_chars():
+    from src.services.orgs.users import _looks_like_email
+
+    assert _looks_like_email("a@test.com") is True
+    assert _looks_like_email("no-at-sign") is False
+    assert _looks_like_email("a@b.com" + "x" * 260) is False  # too long
+    assert _looks_like_email("a\n@test.com") is False  # control char
+    assert _looks_like_email("a:b@test.com") is False  # colon (Redis key shaping)

--- a/apps/api/src/tests/services/test_migration_service.py
+++ b/apps/api/src/tests/services/test_migration_service.py
@@ -4,7 +4,8 @@ import json
 import os
 from pathlib import Path
 from uuid import uuid4
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlmodel import select
@@ -459,6 +460,14 @@ async def test_create_course_from_migration_success_and_failure(monkeypatch, tmp
     base = tmp_path / "migrations"
     monkeypatch.setattr(migrations, "_TEMP_BASE_REAL", str(base))
     monkeypatch.setattr(migrations, "is_s3_enabled", lambda: False)
+    # Exercise the course-limit check path (org has a config → check runs).
+    monkeypatch.setattr(
+        "src.security.features_utils.usage._get_org_config",
+        AsyncMock(return_value=SimpleNamespace(config={})),
+    )
+    monkeypatch.setattr(
+        "src.security.features_utils.usage.check_limits_with_usage", AsyncMock()
+    )
 
     temp_id = str(uuid4())
     video_id = str(uuid4())

--- a/apps/api/src/tests/services/test_org_users_service.py
+++ b/apps/api/src/tests/services/test_org_users_service.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from fastapi import HTTPException
 from sqlmodel import select
 
 from src.db.roles import Role, RoleTypeEnum
@@ -1196,6 +1197,53 @@ class TestOrgUsersService:
 
         assert result["summary"]["sent"] == 1
         assert result["summary"]["already_invited"] == 1
+
+    @pytest.mark.asyncio
+    async def test_invite_batch_users_rejects_malformed_and_oversized(
+        self, mock_request, db, org, admin_user
+    ):
+        from src.services.security.rate_limiting import INVITE_MAX_BATCH_SIZE
+
+        fake_redis = Mock()
+        fake_redis.get = Mock(return_value=None)
+        fake_redis.scan_iter = Mock(return_value=[])
+        fake_redis.set = Mock()
+        fake_redis.__bool__ = Mock(return_value=True)
+        fake_config = SimpleNamespace(
+            redis_config=SimpleNamespace(redis_connection_string="redis://test")
+        )
+
+        patches = [
+            patch("src.services.orgs.users.get_learnhouse_config", return_value=fake_config),
+            patch("src.services.orgs.users.redis.Redis.from_url", return_value=fake_redis),
+            patch("src.services.orgs.users.rbac_check", new_callable=AsyncMock),
+            patch("src.services.orgs.users.check_members_limit_with_pending", new_callable=AsyncMock),
+            patch("src.services.orgs.users.enforce_free_tier_age_gate", new_callable=AsyncMock),
+            patch("src.services.orgs.users.enforce_invite_rate_limit"),
+            patch("src.services.orgs.users.send_invite_email", new_callable=AsyncMock, return_value=True),
+            patch("src.services.orgs.users.dispatch_webhooks", new_callable=AsyncMock),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            # A malformed address is rejected (never sent) and reported.
+            result = await invite_batch_users(
+                mock_request, org.id, "ok@test.com,not-an-email", "invite_uuid", db, admin_user
+            )
+            assert result["summary"]["invalid_email"] == 1
+            assert any(r["status"] == "invalid_email" for r in result["results"])
+
+            # More than the batch cap → 400 BATCH/INVITE_BATCH_TOO_LARGE.
+            too_many = ",".join(f"user{i}@test.com" for i in range(INVITE_MAX_BATCH_SIZE + 1))
+            with pytest.raises(HTTPException) as exc:
+                await invite_batch_users(
+                    mock_request, org.id, too_many, "invite_uuid", db, admin_user
+                )
+            assert exc.value.status_code == 400
+            assert exc.value.detail["code"] == "INVITE_BATCH_TOO_LARGE"
+        finally:
+            for p in patches:
+                p.stop()
 
     @pytest.mark.asyncio
     async def test_remove_batch_users_from_org_empty_list(

--- a/apps/api/src/tests/services/test_org_users_service.py
+++ b/apps/api/src/tests/services/test_org_users_service.py
@@ -542,7 +542,7 @@ class TestOrgUsersService:
             "src.services.orgs.users.rbac_check",
             new_callable=AsyncMock,
         ), patch(
-            "src.services.orgs.users.check_limits_with_usage",
+            "src.services.orgs.users.enforce_free_tier_age_gate",
             new_callable=AsyncMock,
         ), patch(
             "src.services.orgs.users.redis.Redis.from_url",
@@ -555,7 +555,8 @@ class TestOrgUsersService:
         assert redis_conn_exc.value.status_code == 500
 
         fake_redis = Mock()
-        fake_redis.get.side_effect = [None, b"existing", None]
+        fake_redis.get = Mock(side_effect=lambda key: b"x" if "existing@test.com" in key else None)
+        fake_redis.scan_iter = Mock(return_value=[])
         fake_redis.set = Mock()
         fake_redis.__bool__ = Mock(return_value=True)
 
@@ -569,8 +570,13 @@ class TestOrgUsersService:
             "src.services.orgs.users.rbac_check",
             new_callable=AsyncMock,
         ), patch(
-            "src.services.orgs.users.check_limits_with_usage",
+            "src.services.orgs.users.check_members_limit_with_pending",
             new_callable=AsyncMock,
+        ), patch(
+            "src.services.orgs.users.enforce_free_tier_age_gate",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.services.orgs.users.enforce_invite_rate_limit",
         ), patch(
             "src.services.orgs.users.send_invite_email",
             side_effect=[True, False],
@@ -592,6 +598,7 @@ class TestOrgUsersService:
             "sent": 1,
             "failed": 1,
             "already_invited": 1,
+            "invalid_email": 0,
         }
         assert [item["status"] for item in result["results"]] == [
             "sent",
@@ -677,9 +684,6 @@ class TestOrgUsersService:
             return_value=empty_config,
         ), patch(
             "src.services.orgs.users.rbac_check",
-            new_callable=AsyncMock,
-        ), patch(
-            "src.services.orgs.users.check_limits_with_usage",
             new_callable=AsyncMock,
         ), patch(
             "src.services.orgs.users.redis.Redis.from_url",
@@ -1149,7 +1153,8 @@ class TestOrgUsersService:
         self, mock_request, db, org, admin_user
     ):
         fake_redis = Mock()
-        fake_redis.get.side_effect = [None, b"existing"]
+        fake_redis.get = Mock(side_effect=lambda key: b"x" if "existing@test.com" in key else None)
+        fake_redis.scan_iter = Mock(return_value=[])
         fake_redis.set = Mock()
         fake_redis.__bool__ = Mock(return_value=True)
         fake_config = SimpleNamespace(
@@ -1166,8 +1171,13 @@ class TestOrgUsersService:
             "src.services.orgs.users.rbac_check",
             new_callable=AsyncMock,
         ), patch(
-            "src.services.orgs.users.check_limits_with_usage",
+            "src.services.orgs.users.check_members_limit_with_pending",
             new_callable=AsyncMock,
+        ), patch(
+            "src.services.orgs.users.enforce_free_tier_age_gate",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.services.orgs.users.enforce_invite_rate_limit",
         ), patch(
             "src.services.orgs.users.send_invite_email",
             return_value=True,

--- a/apps/web/app/orgs/[orgslug]/dash/ClientAdminLayout.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/ClientAdminLayout.tsx
@@ -7,6 +7,7 @@ import AdminAuthorization from '@components/Security/AdminAuthorization'
 import { SessionGate } from '@components/Contexts/LHSessionContext'
 import { CommandPaletteProvider } from '@components/Dashboard/CommandPalette/CommandPaletteContext'
 import CommandPalette from '@components/Dashboard/CommandPalette/CommandPalette'
+import { UpgradeModalProvider } from '@components/Dashboard/Shared/PlanRestricted/UpgradeModalContext'
 import React from 'react'
 import { useMediaQuery } from 'usehooks-ts';
 
@@ -23,16 +24,18 @@ function ClientAdminLayout({
         <SessionGate>
             <AdminAuthorization authorizationMode="page">
                 <CommandPaletteProvider>
-                    {isMobile && <DashMobileMenu />}
-                    <div className="flex flex-col lg:flex-row">
-                        {!isMobile && <DashLeftMenu />}
-                        <div className="flex flex-col w-full min-w-0 relative isolate pb-24 lg:pb-0">
-                            {children}
-                            <OnboardingTracker />
+                    <UpgradeModalProvider>
+                        {isMobile && <DashMobileMenu />}
+                        <div className="flex flex-col lg:flex-row">
+                            {!isMobile && <DashLeftMenu />}
+                            <div className="flex flex-col w-full min-w-0 relative isolate pb-24 lg:pb-0">
+                                {children}
+                                <OnboardingTracker />
+                            </div>
+                            <WelcomeModal />
+                            <CommandPalette />
                         </div>
-                        <WelcomeModal />
-                        <CommandPalette />
-                    </div>
+                    </UpgradeModalProvider>
                 </CommandPaletteProvider>
             </AdminAuthorization>
         </SessionGate>

--- a/apps/web/components/Dashboard/Pages/Org/OrgEditDomains/OrgEditDomains.tsx
+++ b/apps/web/components/Dashboard/Pages/Org/OrgEditDomains/OrgEditDomains.tsx
@@ -55,6 +55,8 @@ import {
 } from '@services/custom_domains/custom_domains'
 import FeatureGate from '@components/Dashboard/Shared/FeatureGate/FeatureGate'
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
+import { useUpgradeModal } from '@components/Dashboard/Shared/PlanRestricted/UpgradeModalContext'
+import { getErrorMessage } from '@services/utils/ts/errorMessage'
 
 const OrgEditDomains: React.FC = () => {
   const session = useLHSession() as any
@@ -63,6 +65,7 @@ const OrgEditDomains: React.FC = () => {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const { track } = useLHAnalytics('dashboard')
+  const { handlePlanLimit } = useUpgradeModal()
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
   const [isVerifyDialogOpen, setIsVerifyDialogOpen] = useState(false)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
@@ -103,7 +106,14 @@ const OrgEditDomains: React.FC = () => {
         await loadVerificationInfo(response.data.domain_uuid)
         setIsVerifyDialogOpen(true)
       } else {
-        toast.error(response.data?.detail || t('dashboard.organization.domains.failed_add'), { id: loadingToast })
+        // Custom domains are a paid/age-gated feature → offer an upgrade
+        // instead of a dead-end error when the org can't add one yet.
+        if (handlePlanLimit(response, { source: 'custom_domain_add', feature: 'custom_domains', requiredPlan: 'pro' })) {
+          toast.dismiss(loadingToast)
+          setIsAddDialogOpen(false)
+        } else {
+          toast.error(getErrorMessage(response.data?.detail, t('dashboard.organization.domains.failed_add')), { id: loadingToast })
+        }
       }
     } catch (error: any) {
       toast.error(error.message || t('dashboard.organization.domains.failed_add'), { id: loadingToast })

--- a/apps/web/components/Dashboard/Pages/Users/OrgUsersAdd/OrgUsersAdd.tsx
+++ b/apps/web/components/Dashboard/Pages/Users/OrgUsersAdd/OrgUsersAdd.tsx
@@ -29,7 +29,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query/keys'
 import { useTranslation } from 'react-i18next'
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
-import UpgradeModal from '@components/Dashboard/Shared/PlanRestricted/UpgradeModal'
+import { useUpgradeModal } from '@components/Dashboard/Shared/PlanRestricted/UpgradeModalContext'
 
 const ITEMS_PER_PAGE = 10
 
@@ -61,8 +61,8 @@ function OrgUsersAdd() {
   const [sendSummary, setSendSummary] = useState<InviteSummary | null>(null)
   const [searchValue, setSearchValue] = useState('')
   const [page, setPage] = useState(1)
-  // Shown when a free org hits its member limit — a contextual upgrade paywall.
-  const [showUpgradeModal, setShowUpgradeModal] = useState(false)
+  // A free org that hits its member limit gets the shared upgrade paywall.
+  const { handlePlanLimit } = useUpgradeModal()
   const { track } = useLHAnalytics('dashboard')
 
   const { data: invites } = useQuery({
@@ -131,17 +131,9 @@ function OrgUsersAdd() {
           toast.success(t('dashboard.users.invite_members.toasts.success'), { id: toastId })
         }
       } else {
-        const detail = typeof res.data?.detail === 'string' ? res.data.detail : ''
         // Free org hit its member limit → contextual upgrade paywall.
-        if (/Usage Limit has been reached/i.test(detail)) {
-          toast.dismiss(toastId)
-          track(AnalyticsEvent.FeatureGateUpgradeShown, {
-            feature: 'members',
-            surface: 'member_invite',
-            required_plan: 'standard',
-          })
-          setShowUpgradeModal(true)
-        } else {
+        toast.dismiss(toastId)
+        if (!handlePlanLimit(res, { source: 'member_invite', feature: 'members', requiredPlan: 'standard' })) {
           toast.error(
             getErrorMessage(res.data?.detail, t('dashboard.users.invite_members.toasts.error')),
             { id: toastId }
@@ -500,11 +492,6 @@ function OrgUsersAdd() {
         )}
       </div>
 
-      <UpgradeModal
-        open={showUpgradeModal}
-        source="member_limit"
-        onClose={() => setShowUpgradeModal(false)}
-      />
     </>
   )
 }

--- a/apps/web/components/Dashboard/Shared/PlanRestricted/UpgradeModalContext.tsx
+++ b/apps/web/components/Dashboard/Shared/PlanRestricted/UpgradeModalContext.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import React, { createContext, useCallback, useContext, useState } from 'react'
+import UpgradeModal from '@components/Dashboard/Shared/PlanRestricted/UpgradeModal'
+import { isPlanLimitError } from '@services/utils/ts/errorMessage'
+import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
+
+interface ShowUpgradeOptions {
+  /** Analytics attribution for where the prompt was triggered from. */
+  source?: string
+  /** The gated feature (e.g. 'usergroups'), for the FeatureGateUpgradeShown event. */
+  feature?: string
+  /** The plan that unlocks it (e.g. 'standard' | 'pro'), for analytics. */
+  requiredPlan?: string
+}
+
+interface UpgradeModalContextValue {
+  /** Open the shared upgrade modal, tracking a feature-gate event. */
+  showUpgrade: (_options?: ShowUpgradeOptions) => void
+  /**
+   * Inspect an API response; if it is a plan-limit / feature-gated 403, open the
+   * upgrade modal and return true (so the caller can skip its error toast).
+   * Returns false for any other error, letting the caller handle it normally.
+   */
+  handlePlanLimit: (_res: any, _options?: ShowUpgradeOptions) => boolean
+}
+
+const UpgradeModalContext = createContext<UpgradeModalContextValue | null>(null)
+
+/**
+ * Provides a single, app-wide upgrade modal so any surface can turn a
+ * "limit reached" backend error into a contextual upgrade prompt without
+ * rendering its own modal. Mounted inside the dashboard layout (below
+ * OrgProvider, which the modal depends on).
+ */
+export function UpgradeModalProvider({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false)
+  const [source, setSource] = useState<string>('free_plan_banner')
+  const { track } = useLHAnalytics('dashboard')
+
+  const showUpgrade = useCallback(
+    (options?: ShowUpgradeOptions) => {
+      if (options?.feature) {
+        track(AnalyticsEvent.FeatureGateUpgradeShown, {
+          feature: options.feature,
+          surface: options.source,
+          required_plan: options.requiredPlan,
+        })
+      }
+      setSource(options?.source || 'free_plan_banner')
+      setOpen(true)
+    },
+    [track]
+  )
+
+  const handlePlanLimit = useCallback(
+    (res: any, options?: ShowUpgradeOptions) => {
+      if (isPlanLimitError(res?.data?.detail)) {
+        showUpgrade(options)
+        return true
+      }
+      return false
+    },
+    [showUpgrade]
+  )
+
+  return (
+    <UpgradeModalContext.Provider value={{ showUpgrade, handlePlanLimit }}>
+      {children}
+      <UpgradeModal open={open} source={source} onClose={() => setOpen(false)} />
+    </UpgradeModalContext.Provider>
+  )
+}
+
+/**
+ * Access the app-wide upgrade modal. Safe to call outside the provider — it
+ * returns a no-op fallback (returns false / does nothing) so surfaces that can
+ * render outside the dashboard shell don't crash; they simply fall back to
+ * their normal error toast.
+ */
+export function useUpgradeModal(): UpgradeModalContextValue {
+  const ctx = useContext(UpgradeModalContext)
+  if (!ctx) {
+    return {
+      showUpgrade: () => {},
+      handlePlanLimit: () => false,
+    }
+  }
+  return ctx
+}

--- a/apps/web/components/Objects/Modals/Activities/Create/NewActivityModal/AssignmentActivityModal.tsx
+++ b/apps/web/components/Objects/Modals/Activities/Create/NewActivityModal/AssignmentActivityModal.tsx
@@ -11,6 +11,8 @@ import { createActivity, deleteActivity } from '@services/courses/activities'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
+import { useUpgradeModal } from '@components/Dashboard/Shared/PlanRestricted/UpgradeModalContext'
+import { getErrorMessage } from '@services/utils/ts/errorMessage'
 import {
   ALargeSmall,
   Hash,
@@ -31,6 +33,7 @@ function NewAssignment({ submitActivity: _submitActivity, chapterId, course, clo
   const session = useLHSession() as any
   const queryClient = useQueryClient()
   const { track } = useLHAnalytics('dashboard')
+  const { handlePlanLimit } = useUpgradeModal()
   const cleanCourseUuid = (id: string) => id?.replace(/^course_/, '') ?? id
   const _withUnpublishedActivities = course
     ? course.withUnpublishedActivities
@@ -96,7 +99,12 @@ function NewAssignment({ submitActivity: _submitActivity, chapterId, course, clo
         has_due_date: !!dueDate,
       })
     } else {
-      toast.error(res.data.detail)
+      toast.dismiss(toast_loading)
+      // Assignments are quota-limited on the free plan → offer an upgrade
+      // rather than a dead-end error toast.
+      if (!handlePlanLimit(res, { source: 'assignment_create', feature: 'assignments', requiredPlan: 'standard' })) {
+        toast.error(getErrorMessage(res.data?.detail, t('dashboard.assignments.modals.create.toasts.error')))
+      }
       await deleteActivity(
         activity_res.activity_uuid,
         session.data?.tokens?.access_token

--- a/apps/web/components/Objects/Modals/Communities/CreateCommunityModal.tsx
+++ b/apps/web/components/Objects/Modals/Communities/CreateCommunityModal.tsx
@@ -13,6 +13,8 @@ import { queryKeys } from '@/lib/query/keys'
 import Modal from '@components/Objects/StyledElements/Modal/Modal'
 import { Loader2 } from 'lucide-react'
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
+import { getErrorMessage } from '@services/utils/ts/errorMessage'
+import { useUpgradeModal } from '@components/Dashboard/Shared/PlanRestricted/UpgradeModalContext'
 
 interface CreateCommunityModalProps {
   isOpen: boolean
@@ -32,6 +34,7 @@ export function CreateCommunityModal({
   const router = useRouter()
   const queryClient = useQueryClient()
   const { track } = useLHAnalytics('learner')
+  const { handlePlanLimit } = useUpgradeModal()
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const accessToken = session?.data?.tokens?.access_token
@@ -59,7 +62,10 @@ export function CreateCommunityModal({
         accessToken
       )
 
-      if (result) {
+      // getResponseMetadata() always resolves (never throws on HTTP error), so
+      // gate on result.success — previously `if (result)` treated a 403 limit
+      // failure as success and closed the modal without creating anything.
+      if (result?.success) {
         track(AnalyticsEvent.CommunityCreated, {
           is_public: values.public,
           has_description: !!values.description,
@@ -68,6 +74,10 @@ export function CreateCommunityModal({
         queryClient.invalidateQueries({ queryKey: queryKeys.community.list(orgId) })
         router.refresh()
         onClose()
+      } else if (handlePlanLimit(result, { source: 'community_create', feature: 'communities', requiredPlan: 'standard' })) {
+        onClose()
+      } else {
+        toast.error(getErrorMessage(result?.data?.detail, 'Failed to create community.'))
       }
     } catch (err: any) {
       const message =

--- a/apps/web/components/Objects/Modals/Course/Create/CreateCourse.tsx
+++ b/apps/web/components/Objects/Modals/Course/Create/CreateCourse.tsx
@@ -26,7 +26,7 @@ import AIImageButton from '@components/Objects/AI/AIImageButton'
 import FormTagInput from "@components/Objects/StyledElements/Form/TagInput"
 import { useTranslation } from "react-i18next"
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
-import UpgradeModal from '@components/Dashboard/Shared/PlanRestricted/UpgradeModal'
+import { useUpgradeModal } from '@components/Dashboard/Shared/PlanRestricted/UpgradeModalContext'
 
 const _validationSchema = Yup.object().shape({
   name: Yup.string()
@@ -49,8 +49,8 @@ function CreateCourseModal({ closeModal, orgslug }: any) {
   const [orgId, setOrgId] = React.useState(null) as any
   const [showUnsplashPicker, setShowUnsplashPicker] = React.useState(false)
   const [isUploading, setIsUploading] = React.useState(false)
-  // Shown when a free org hits its course limit — a contextual upgrade paywall.
-  const [showUpgradeModal, setShowUpgradeModal] = React.useState(false)
+  // A free org that hits its course limit gets the shared upgrade paywall.
+  const { handlePlanLimit } = useUpgradeModal()
 
   const validationSchema = Yup.object().shape({
     name: Yup.string()
@@ -137,13 +137,8 @@ function CreateCourseModal({ closeModal, orgslug }: any) {
           const detail = typeof res.data?.detail === 'string' ? res.data.detail : ''
           // A free org that has hit its course limit gets a contextual upgrade
           // paywall at the moment of value, instead of a dead-end error toast.
-          if (/Usage Limit has been reached/i.test(detail)) {
-            track(AnalyticsEvent.FeatureGateUpgradeShown, {
-              feature: 'courses',
-              surface: 'course_create',
-              required_plan: 'standard',
-            })
-            setShowUpgradeModal(true)
+          if (handlePlanLimit(res, { source: 'course_create', feature: 'courses', requiredPlan: 'standard' })) {
+            closeModal()
           } else {
             const errorMessage = detail
               ? detail
@@ -353,15 +348,6 @@ function CreateCourseModal({ closeModal, orgslug }: any) {
           onClose={() => setShowUnsplashPicker(false)}
         />
       )}
-
-      <UpgradeModal
-        open={showUpgradeModal}
-        source="course_limit"
-        onClose={() => {
-          setShowUpgradeModal(false)
-          closeModal()
-        }}
-      />
     </FormLayout>
   )
 }

--- a/apps/web/components/Objects/Modals/Dash/OrgRoles/EditRole.tsx
+++ b/apps/web/components/Objects/Modals/Dash/OrgRoles/EditRole.tsx
@@ -7,6 +7,7 @@ import FormLayout, {
 } from '@components/Objects/StyledElements/Form/Form'
 import * as Form from '@radix-ui/react-form'
 import { useOrg } from '@components/Contexts/OrgContext'
+import { useUpgradeModal } from '@components/Dashboard/Shared/PlanRestricted/UpgradeModalContext'
 import React from 'react'
 import { updateRole } from '@services/roles/roles'
 import { useQueryClient } from '@tanstack/react-query'
@@ -313,6 +314,7 @@ function EditRole(props: EditRoleProps) {
     const session = useLHSession() as any
     const access_token = session?.data?.tokens?.access_token;
     const queryClient = useQueryClient()
+    const { handlePlanLimit } = useUpgradeModal()
     const [isSubmitting, setIsSubmitting] = React.useState(false)
     const [rights, setRights] = React.useState<Rights>(props.role.rights || {})
 
@@ -405,7 +407,14 @@ function EditRole(props: EditRoleProps) {
                 toast.success(t('dashboard.users.roles.modals.edit.toasts.success'), {id:toastID})
             } else {
                 setIsSubmitting(false)
-                toast.error(t('dashboard.users.roles.modals.edit.toasts.error'), {id:toastID})
+                // Enabling dashboard access for a role can exceed the plan's
+                // admin-seat cap → offer an upgrade instead of a dead-end error.
+                if (handlePlanLimit(res, { source: 'role_edit', feature: 'admin_seats', requiredPlan: 'standard' })) {
+                    toast.dismiss(toastID)
+                    props.setEditRoleModal(false)
+                } else {
+                    toast.error(t('dashboard.users.roles.modals.edit.toasts.error'), {id:toastID})
+                }
             }
         },
     })

--- a/apps/web/components/Objects/Modals/Dash/OrgUserGroups/AddUserGroup.tsx
+++ b/apps/web/components/Objects/Modals/Dash/OrgUserGroups/AddUserGroup.tsx
@@ -15,6 +15,7 @@ import { useFormik } from 'formik'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
+import { useUpgradeModal } from '@components/Dashboard/Shared/PlanRestricted/UpgradeModalContext'
 
 type AddUserGroupProps = {
     setCreateUserGroupModal: any
@@ -36,6 +37,7 @@ function AddUserGroup(props: AddUserGroupProps) {
     const access_token = session?.data?.tokens?.access_token;
     const queryClient = useQueryClient()
     const { track } = useLHAnalytics('dashboard')
+    const { handlePlanLimit } = useUpgradeModal()
     const [isSubmitting, setIsSubmitting] = React.useState(false)
 
     const formik = useFormik({
@@ -59,7 +61,14 @@ function AddUserGroup(props: AddUserGroupProps) {
                 toast.success(t('dashboard.users.usergroups.modals.create.toasts.success'), {id:toastID})
             } else {
                 setIsSubmitting(false)
-                toast.error(t('dashboard.users.usergroups.modals.create.toasts.error'), {id:toastID})
+                // A free org that has hit (or can't reach) its usergroups quota
+                // gets a contextual upgrade prompt instead of a dead-end error.
+                if (handlePlanLimit(res, { source: 'usergroup_create', feature: 'usergroups', requiredPlan: 'standard' })) {
+                    toast.dismiss(toastID)
+                    props.setCreateUserGroupModal(false)
+                } else {
+                    toast.error(t('dashboard.users.usergroups.modals.create.toasts.error'), {id:toastID})
+                }
             }
         },
     })

--- a/apps/web/components/Objects/Modals/Dash/OrgUsers/RolesUpdate.tsx
+++ b/apps/web/components/Objects/Modals/Dash/OrgUsers/RolesUpdate.tsx
@@ -17,6 +17,7 @@ import toast from 'react-hot-toast'
 import { BarLoader } from 'react-spinners'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query/keys'
+import { useUpgradeModal } from '@components/Dashboard/Shared/PlanRestricted/UpgradeModalContext'
 
 interface Props {
   user: any
@@ -29,6 +30,7 @@ function RolesUpdate(props: Props) {
   const session = useLHSession() as any
   const access_token = session?.data?.tokens?.access_token;
   const queryClient = useQueryClient()
+  const { handlePlanLimit } = useUpgradeModal()
   const [isSubmitting, setIsSubmitting] = React.useState(false)
   const [assignedRole, setAssignedRole] = React.useState(
     props.alreadyAssignedRole
@@ -59,8 +61,15 @@ function RolesUpdate(props: Props) {
       toast.success("Updated role", {id:toastId})
     } else {
       setIsSubmitting(false)
-      setError('Error ' + res.status + ': ' + res.data.detail)
-      toast.error("Error while updating role", {id:toastId})
+      // Promoting a user into an admin role can exceed the plan's admin-seat
+      // cap → offer an upgrade instead of a dead-end error.
+      if (handlePlanLimit(res, { source: 'user_role_change', feature: 'admin_seats', requiredPlan: 'standard' })) {
+        toast.dismiss(toastId)
+        props.setRolesModal(false)
+      } else {
+        setError('Error ' + res.status + ': ' + res.data.detail)
+        toast.error("Error while updating role", {id:toastId})
+      }
     }
   }
 

--- a/apps/web/components/Objects/Modals/Podcast/Create/CreatePodcast.tsx
+++ b/apps/web/components/Objects/Modals/Podcast/Create/CreatePodcast.tsx
@@ -9,6 +9,7 @@ import FormLayout, {
 import * as Form from '@radix-ui/react-form'
 import { createPodcast } from '@services/podcasts/podcasts'
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
+import { useUpgradeModal } from '@components/Dashboard/Shared/PlanRestricted/UpgradeModalContext'
 import { getOrganizationContextInfoWithoutCredentials } from '@services/organizations/orgs'
 import React, { useEffect } from 'react'
 import { BarLoader } from 'react-spinners'
@@ -32,6 +33,7 @@ function CreatePodcastModal({ closeModal, orgslug }: any) {
   const session = useLHSession() as any
   const queryClient = useQueryClient()
   const { track } = useLHAnalytics('learner')
+  const { handlePlanLimit } = useUpgradeModal()
   const [orgId, setOrgId] = React.useState(null) as any
   const [showUnsplashPicker, setShowUnsplashPicker] = React.useState(false)
   const [isUploading, setIsUploading] = React.useState(false)
@@ -89,12 +91,18 @@ function CreatePodcastModal({ closeModal, orgslug }: any) {
           router.push(`/dash/podcasts/podcast/${podcastId}/general`)
         } else {
           toast.dismiss(toast_loading)
-          const errorMessage = typeof res.data?.detail === 'string'
-            ? res.data.detail
-            : Array.isArray(res.data?.detail)
-              ? res.data.detail.map((e: any) => e.msg).join(', ')
-              : t('podcasts.failed_to_create_podcast')
-          toast.error(errorMessage)
+          // Podcasts are gated on the free plan → offer an upgrade at the
+          // moment of value rather than a dead-end error toast.
+          if (handlePlanLimit(res, { source: 'podcast_create', feature: 'podcasts', requiredPlan: 'standard' })) {
+            closeModal()
+          } else {
+            const errorMessage = typeof res.data?.detail === 'string'
+              ? res.data.detail
+              : Array.isArray(res.data?.detail)
+                ? res.data.detail.map((e: any) => e.msg).join(', ')
+                : t('podcasts.failed_to_create_podcast')
+            toast.error(errorMessage)
+          }
         }
       } catch (_error) {
         toast.dismiss(toast_loading)

--- a/apps/web/components/Objects/Modals/Podcasts/CreatePodcastModal.tsx
+++ b/apps/web/components/Objects/Modals/Podcasts/CreatePodcastModal.tsx
@@ -12,6 +12,9 @@ import Modal from '@components/Objects/StyledElements/Modal/Modal'
 import { Loader2 } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query/keys'
+import toast from 'react-hot-toast'
+import { getErrorMessage } from '@services/utils/ts/errorMessage'
+import { useUpgradeModal } from '@components/Dashboard/Shared/PlanRestricted/UpgradeModalContext'
 
 interface CreatePodcastModalProps {
   isOpen: boolean
@@ -31,6 +34,7 @@ export function CreatePodcastModal({
   const router = useRouter()
   const queryClient = useQueryClient()
   const { track } = useLHAnalytics('learner')
+  const { handlePlanLimit } = useUpgradeModal()
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const accessToken = session?.data?.tokens?.access_token
@@ -59,7 +63,10 @@ export function CreatePodcastModal({
         accessToken
       )
 
-      if (result) {
+      // getResponseMetadata() always resolves (never throws on HTTP error), so
+      // gate on result.success — previously `if (result)` treated a 403 limit
+      // failure as success and silently closed the modal.
+      if (result?.success) {
         track(AnalyticsEvent.PodcastCreated, {
           is_public: values.public,
           has_thumbnail: false,
@@ -69,9 +76,14 @@ export function CreatePodcastModal({
         queryClient.invalidateQueries({ queryKey: queryKeys.podcasts.list(orgSlug) })
         router.refresh()
         onClose()
+      } else if (handlePlanLimit(result, { source: 'podcast_create', feature: 'podcasts', requiredPlan: 'standard' })) {
+        onClose()
+      } else {
+        toast.error(getErrorMessage(result?.data?.detail, t('podcasts.failed_to_create_podcast')))
       }
     } catch (error) {
       console.error('Failed to create podcast:', error)
+      toast.error(t('podcasts.failed_to_create_podcast'))
     } finally {
       setIsSubmitting(false)
     }

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -4259,7 +4259,8 @@
           },
           "toasts": {
             "creating": "Creating assignment...",
-            "success": "Assignment created successfully"
+            "success": "Assignment created successfully",
+            "error": "Failed to create assignment"
           }
         }
       }

--- a/apps/web/services/utils/ts/errorMessage.ts
+++ b/apps/web/services/utils/ts/errorMessage.ts
@@ -19,3 +19,23 @@ export function getErrorMessage(detail: unknown, fallback: string): string {
   }
   return fallback
 }
+
+// A backend 403 that an upgrade (or, for a brand-new free org, waiting) would
+// resolve. Detecting these lets the UI offer a contextual upgrade prompt at the
+// moment of value instead of a dead-end error toast. Covers:
+//   - "Usage Limit has been reached for {Feature}" — plan quota hit
+//   - "{Feature} is not enabled for this organization" — feature gated to a
+//     higher plan
+//   - { code: "ACCOUNT_TOO_NEW" } — free-tier age gate (upgrading lifts it)
+export function isPlanLimitError(detail: unknown): boolean {
+  if (typeof detail === 'string') {
+    return (
+      /Usage Limit has been reached/i.test(detail) ||
+      /is not enabled for this organization/i.test(detail)
+    )
+  }
+  if (detail && typeof detail === 'object') {
+    return (detail as any).code === 'ACCOUNT_TOO_NEW'
+  }
+  return false
+}


### PR DESCRIPTION
This PR hardens two related classes of abuse: outbound invite-spam relay, and plan/usage limits that were silently not enforced. Both were found by auditing the API after a real phishing-relay incident.

---

## Part 1 — Invite-spam / free-tier abuse hardening

A free org could be registered and, within minutes, blast hundreds of invitation emails through the shared email sender — enough to exhaust the provider's daily quota and take down **all** platform email. Because the inviter's display name is rendered into invite emails, an attacker could plant a phishing link in their own username and relay it from a trusted sender.

- **Invite batch endpoint**: normalize + dedupe, reject malformed emails, cap a batch at 25, add a per-org **and** per-user daily invite rate limit, and count **pending** invites toward the member limit.
- **7-day account + org age gate** (`services/security/account_age.py`): a reusable helper gating abuse-prone actions until both the account and org are ≥ 7 days old. Applied to batch invites, invite-link creation, and custom domains. Paid orgs exempt; non-SaaS skips. `creation_date` is a varchar, so age math is done in Python and fails open on legacy/unparseable dates.
- **Display-name validation** (`services/security/profile_validation.py`): reject URLs/links in username/first/last name at signup, profile update, and the admin API-token path; scrub links + control chars before names are rendered into emails.
- **Generic batch-size cap** on other unbounded mass-action loops (usergroup add/remove, org batch-remove, bulk course contributors).

## Part 2 — Plan/usage limit enforcement

Several plan limits were defined but not actually enforced, so orgs could exceed their plan (the reported symptom: a free org accumulating multiple admins despite a 1-seat cap).

**Admin seats**
- `check_admin_seat_limit` existed but had **zero callers** — no role grant was ever checked against the seat cap. Added `enforce_admin_seat_limit_for_role_change` and gated every dashboard-access role grant: `update_user_role` and the admin-API `provision_user` + `change_user_role`. A user moving between two admin roles is not double-counted; demotions are never blocked. Seats are defined by `rights.dashboard.action_access` (any custom role), matching how they're counted.
- `update_role` could flip a role's `dashboard.action_access` on and convert every member holding it into an admin seat at once (bypassing per-assignment gates) — that false→true transition is now gated against the projected seat total.

**Count-limited features are now self-healing**
- `usergroups`/`podcasts`/`assignments` were enforced via a mutable Redis counter that could drift or be lost, silently disabling the limit (e.g. a free org exceeding its 5-assignment cap). They now count live DB rows via `DB_COUNTED_FEATURES`, like `members`/`courses`/`admin_seats`.
- Usergroup creation checked the `"courses"` limit key instead of `"usergroups"` (so the cap never applied) — corrected. The admin-API usergroup-create path had no check at all — added.

**Courses**
- `create_course_from_migration` created a course with no limit check — added (skipping only when the org has no config, a prod impossibility).

## Tests
New unit tests under `src/tests/security/`: `account_age`, `profile_validation`, `invite_hardening`, `members_pending_limit`, `admin_seat_gate` (incl. rights-flip and admin→admin swap), `db_counted_limits`. Also updated the invite-batch service tests to the reworked flow. Full API security + services suites pass locally (only pre-existing, environment-dependent Ollama tests fail); `ruff` clean on all changed files.

## Known follow-ups (not in this PR)
- Persist the incident IP block in the infra repo; per-org quota on the shared email key.
- Hard plan-gating custom domains to a paid tier is a monetization decision left out here (they get the age gate instead).