### PR TITLE
feat(scorm): large-package upload with progress, parallel S3 transfer, streaming playback

### DIFF
--- a/apps/api/src/services/courses/transfer/storage_utils.py
+++ b/apps/api/src/services/courses/transfer/storage_utils.py
@@ -435,6 +435,33 @@ def upload_file_to_s3(s3_key: str, local_path: str) -> bool:
         return False
 
 
+def download_file_from_s3(s3_key: str, local_path: str) -> bool:
+    """
+    Download a file from S3 to a local path (streams to disk, no full-file
+    memory load). Creates parent directories as needed.
+    """
+    s3_client = get_storage_client()
+    if not s3_client:
+        return False
+
+    try:
+        parent_dir = os.path.dirname(local_path)
+        if parent_dir:
+            os.makedirs(parent_dir, exist_ok=True)
+        s3_client.download_file(
+            Bucket=get_s3_bucket_name(),
+            Key=s3_key,
+            Filename=local_path,
+        )
+        return True
+    except ClientError as e:
+        logger.error("S3 download error for %s: %s", s3_key, e)
+        return False
+    except Exception as e:
+        logger.error("Error downloading from S3: %s", e)
+        return False
+
+
 def delete_storage_directory(dir_path: str) -> bool:
     """
     Delete an entire directory from storage (S3 or local filesystem).
@@ -542,3 +569,38 @@ def upload_directory_to_s3(local_dir: str, s3_prefix: str) -> bool:
                 success = False
 
     return success
+
+
+def upload_directory_to_s3_parallel(local_dir: str, s3_prefix: str, max_workers: int = 8) -> bool:
+    """
+    Upload an entire directory to S3 with concurrent per-file uploads.
+
+    Same contract as upload_directory_to_s3, but uploads files in parallel —
+    for directories with many files (e.g. extracted SCORM packages) sequential
+    per-file round-trips dominate the wall clock. The cached boto3 client is
+    thread-safe.
+
+    Returns:
+        True if all uploads successful (or S3 not configured), False if any failed
+    """
+    if not is_s3_enabled():
+        return True  # Not an error, just not configured
+
+    if not os.path.exists(local_dir):
+        return True
+
+    uploads = []
+    for root, dirs, files in os.walk(local_dir):
+        for filename in files:
+            local_path = os.path.join(root, filename)
+            rel_path = os.path.relpath(local_path, local_dir)
+            uploads.append((f"{s3_prefix}/{rel_path}".replace('\\', '/'), local_path))
+
+    if not uploads:
+        return True
+
+    from concurrent.futures import ThreadPoolExecutor
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        results = pool.map(lambda args: upload_file_to_s3(*args), uploads)
+        return all(results)

--- a/apps/api/src/tests/services/test_scorm_upload_pipeline.py
+++ b/apps/api/src/tests/services/test_scorm_upload_pipeline.py
@@ -1,0 +1,219 @@
+"""
+SCORM upload pipeline: streaming save, hardened extraction, cross-replica
+temp-package restore, and shared-package materialization.
+
+Skips cleanly when EE is absent.
+"""
+
+import io
+import os
+import zipfile
+
+import pytest
+from fastapi import HTTPException
+
+scorm = pytest.importorskip("ee.services.scorm.scorm")
+
+import src.services.courses.transfer.storage_utils as storage_utils  # noqa: E402
+
+MANIFEST_XML = (
+    '<?xml version="1.0"?>'
+    '<manifest xmlns="http://www.imsproject.org/xsd/imscp_rootv1p1p2">'
+    '<organizations><organization><item identifierref="res1">'
+    '<title>SCO 1</title></item></organization></organizations>'
+    '<resources><resource identifier="res1" href="index.html"/></resources>'
+    '</manifest>'
+)
+
+
+def _zip_bytes(files: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        for name, content in files.items():
+            zf.writestr(name, content)
+    return buf.getvalue()
+
+
+class _FakeUpload:
+    """Minimal stand-in for starlette UploadFile (async chunked read + size)."""
+
+    def __init__(self, data: bytes, size: int | None = None):
+        self._stream = io.BytesIO(data)
+        self.size = size if size is not None else len(data)
+
+    async def read(self, n: int = -1) -> bytes:
+        return self._stream.read(n)
+
+
+class TestSafeExtractZip:
+    def test_rejects_oversized_file_listing_names(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(scorm, "MAX_SCORM_FILE_SIZE", 10)
+        zip_path = tmp_path / "package.zip"
+        zip_path.write_bytes(_zip_bytes({
+            "small.txt": b"ok",
+            "assets/big-video.mp4": b"x" * 50,
+        }))
+
+        with pytest.raises(HTTPException) as exc:
+            scorm._safe_extract_zip(str(zip_path), str(tmp_path / "out"))
+
+        assert exc.value.status_code == 413
+        assert "assets/big-video.mp4" in exc.value.detail
+
+    def test_rejects_total_uncompressed_over_cap(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(scorm, "MAX_SCORM_UNCOMPRESSED_SIZE", 10)
+        zip_path = tmp_path / "package.zip"
+        zip_path.write_bytes(_zip_bytes({"a.txt": b"x" * 20}))
+
+        with pytest.raises(HTTPException) as exc:
+            scorm._safe_extract_zip(str(zip_path), str(tmp_path / "out"))
+
+        assert exc.value.status_code == 413
+
+    def test_extracts_and_returns_stats(self, tmp_path):
+        zip_path = tmp_path / "package.zip"
+        zip_path.write_bytes(_zip_bytes({
+            "imsmanifest.xml": MANIFEST_XML.encode(),
+            "index.html": b"<html>",
+            "assets/video.mp4": b"v" * 1000,
+        }))
+        out = tmp_path / "out"
+        out.mkdir()
+
+        stats = scorm._safe_extract_zip(str(zip_path), str(out))
+
+        assert (out / "imsmanifest.xml").is_file()
+        assert (out / "assets/video.mp4").is_file()
+        assert stats["file_count"] == 3
+        assert stats["total_size_bytes"] == len(MANIFEST_XML) + len(b"<html>") + 1000
+        assert stats["largest_files"][0] == {"path": "assets/video.mp4", "size_bytes": 1000}
+
+
+class TestStreamUploadToDisk:
+    async def test_rejects_declared_size_before_reading(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(scorm, "MAX_SCORM_PACKAGE_SIZE", 100)
+        upload = _FakeUpload(b"PK\x03\x04" + b"x" * 200, size=201)
+
+        with pytest.raises(HTTPException) as exc:
+            await scorm._stream_scorm_upload_to_disk(upload, str(tmp_path / "out.zip"))
+        assert exc.value.status_code == 413
+
+    async def test_rejects_mid_stream_when_cap_crossed(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(scorm, "MAX_SCORM_PACKAGE_SIZE", 100)
+        # Undeclared size (None) forces the incremental check to catch it
+        upload = _FakeUpload(b"PK\x03\x04" + b"x" * 200, size=None)
+        upload.size = None
+
+        with pytest.raises(HTTPException) as exc:
+            await scorm._stream_scorm_upload_to_disk(upload, str(tmp_path / "out.zip"))
+        assert exc.value.status_code == 413
+
+    async def test_rejects_non_zip_magic(self, tmp_path):
+        upload = _FakeUpload(b"not a zip at all")
+        with pytest.raises(HTTPException) as exc:
+            await scorm._stream_scorm_upload_to_disk(upload, str(tmp_path / "out.zip"))
+        assert exc.value.status_code == 415
+
+    async def test_rejects_empty_upload(self, tmp_path):
+        upload = _FakeUpload(b"")
+        with pytest.raises(HTTPException) as exc:
+            await scorm._stream_scorm_upload_to_disk(upload, str(tmp_path / "out.zip"))
+        assert exc.value.status_code == 415
+
+    async def test_writes_valid_zip_to_disk(self, tmp_path):
+        data = _zip_bytes({"imsmanifest.xml": MANIFEST_XML.encode()})
+        dest = tmp_path / "out.zip"
+
+        written = await scorm._stream_scorm_upload_to_disk(_FakeUpload(data), str(dest))
+
+        assert written == len(data)
+        assert dest.read_bytes() == data
+
+
+class TestEnsureTempPackageLocal:
+    async def test_local_hit_returns_without_s3(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        temp_id = "11111111-1111-1111-1111-111111111111"
+        extracted = tmp_path / scorm.TEMP_SCORM_DIR / temp_id / "extracted"
+        extracted.mkdir(parents=True)
+        (extracted / "imsmanifest.xml").write_text(MANIFEST_XML)
+
+        temp_dir = await scorm._ensure_temp_package_local(temp_id)
+        assert temp_dir == os.path.join(scorm.TEMP_SCORM_DIR, temp_id)
+
+    async def test_missing_locally_restores_from_s3(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        temp_id = "22222222-2222-2222-2222-222222222222"
+        zip_data = _zip_bytes({"imsmanifest.xml": MANIFEST_XML.encode()})
+
+        def fake_download(s3_key, local_path):
+            os.makedirs(os.path.dirname(local_path), exist_ok=True)
+            with open(local_path, 'wb') as f:
+                f.write(zip_data)
+            return True
+
+        monkeypatch.setattr(storage_utils, "is_s3_enabled", lambda: True)
+        monkeypatch.setattr(storage_utils, "download_file_from_s3", fake_download)
+
+        temp_dir = await scorm._ensure_temp_package_local(temp_id)
+
+        manifest = os.path.join(temp_dir, "extracted", "imsmanifest.xml")
+        assert os.path.isfile(manifest)
+
+    async def test_missing_everywhere_raises_404(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(storage_utils, "is_s3_enabled", lambda: True)
+        monkeypatch.setattr(storage_utils, "download_file_from_s3", lambda *a: False)
+
+        with pytest.raises(HTTPException) as exc:
+            await scorm._ensure_temp_package_local("33333333-3333-3333-3333-333333333333")
+        assert exc.value.status_code == 404
+
+    async def test_filesystem_mode_missing_raises_404(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(storage_utils, "is_s3_enabled", lambda: False)
+
+        with pytest.raises(HTTPException) as exc:
+            await scorm._ensure_temp_package_local("44444444-4444-4444-4444-444444444444")
+        assert exc.value.status_code == 404
+
+
+class TestMaterializeSharedPackage:
+    def test_moves_content_instead_of_copying(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(storage_utils, "is_s3_enabled", lambda: False)
+
+        temp_dir = tmp_path / "temp-pkg"
+        extract_dir = temp_dir / "extracted"
+        extract_dir.mkdir(parents=True)
+        (temp_dir / "package.zip").write_bytes(b"zipbytes")
+        (extract_dir / "index.html").write_text("<html>")
+
+        shared_extract = scorm._materialize_shared_package(
+            str(temp_dir), str(extract_dir), "org_x", "course_x", "scorm_package_x",
+        )
+
+        assert os.path.isfile(os.path.join(shared_extract, "index.html"))
+        shared_dir = os.path.dirname(shared_extract)
+        assert os.path.isfile(os.path.join(shared_dir, "package.zip"))
+        # Moved, not copied: temp content is gone
+        assert not extract_dir.exists()
+        assert not (temp_dir / "package.zip").exists()
+
+    def test_raises_500_when_s3_upload_fails(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(storage_utils, "is_s3_enabled", lambda: True)
+        monkeypatch.setattr(storage_utils, "upload_file_to_s3", lambda *a: False)
+        monkeypatch.setattr(storage_utils, "upload_directory_to_s3_parallel", lambda *a, **k: True)
+
+        temp_dir = tmp_path / "temp-pkg"
+        extract_dir = temp_dir / "extracted"
+        extract_dir.mkdir(parents=True)
+        (temp_dir / "package.zip").write_bytes(b"zipbytes")
+        (extract_dir / "index.html").write_text("<html>")
+
+        with pytest.raises(HTTPException) as exc:
+            scorm._materialize_shared_package(
+                str(temp_dir), str(extract_dir), "org_x", "course_x", "scorm_package_y",
+            )
+        assert exc.value.status_code == 500

--- a/apps/api/src/tests/services/test_storage_utils_service.py
+++ b/apps/api/src/tests/services/test_storage_utils_service.py
@@ -739,3 +739,171 @@ class TestUploadAndDeleteHelpers:
             result = storage_utils.delete_storage_file(str(local_file))
 
         assert result is True
+
+
+class TestDownloadFileFromS3:
+    def test_returns_false_without_client(self, tmp_path):
+        with patch.object(storage_utils, "get_storage_client", return_value=None):
+            assert storage_utils.download_file_from_s3("key", str(tmp_path / "out.zip")) is False
+
+    def test_downloads_and_creates_parent_dirs(self, tmp_path):
+        s3_client = Mock()
+        dest = tmp_path / "nested" / "dir" / "package.zip"
+
+        with patch.object(
+            storage_utils,
+            "get_storage_client",
+            return_value=s3_client,
+        ), patch.object(
+            storage_utils,
+            "get_s3_bucket_name",
+            return_value="bucket",
+        ):
+            assert storage_utils.download_file_from_s3("content/temp/package.zip", str(dest)) is True
+
+        assert dest.parent.is_dir()
+        s3_client.download_file.assert_called_once_with(
+            Bucket="bucket",
+            Key="content/temp/package.zip",
+            Filename=str(dest),
+        )
+
+    def test_returns_false_on_client_error_and_generic_error(self, tmp_path):
+        s3_client = Mock()
+        dest = str(tmp_path / "out.zip")
+
+        with patch.object(
+            storage_utils,
+            "get_storage_client",
+            return_value=s3_client,
+        ), patch.object(
+            storage_utils,
+            "get_s3_bucket_name",
+            return_value="bucket",
+        ), patch.object(storage_utils.logger, "error"):
+            s3_client.download_file.side_effect = _client_error("NoSuchKey", "download_file")
+            assert storage_utils.download_file_from_s3("missing.zip", dest) is False
+
+            s3_client.download_file.side_effect = RuntimeError("boom")
+            assert storage_utils.download_file_from_s3("broken.zip", dest) is False
+
+
+class TestGeneratePresignedGetUrl:
+    def test_returns_none_when_disabled_or_without_client(self):
+        with patch.object(storage_utils, "is_s3_enabled", return_value=False):
+            assert storage_utils.generate_presigned_get_url("content/video.mp4") is None
+
+        with patch.object(
+            storage_utils,
+            "is_s3_enabled",
+            return_value=True,
+        ), patch.object(storage_utils, "get_storage_client", return_value=None):
+            assert storage_utils.generate_presigned_get_url("content/video.mp4") is None
+
+    def test_returns_url_with_bucket_key_and_expiry(self):
+        s3_client = Mock()
+        s3_client.generate_presigned_url.return_value = "https://s3.test/signed"
+
+        with patch.object(
+            storage_utils,
+            "is_s3_enabled",
+            return_value=True,
+        ), patch.object(
+            storage_utils,
+            "get_storage_client",
+            return_value=s3_client,
+        ), patch.object(
+            storage_utils,
+            "get_s3_bucket_name",
+            return_value="bucket",
+        ):
+            url = storage_utils.generate_presigned_get_url("content/video.mp4", expires_in=600)
+
+        assert url == "https://s3.test/signed"
+        s3_client.generate_presigned_url.assert_called_once_with(
+            "get_object",
+            Params={"Bucket": "bucket", "Key": "content/video.mp4"},
+            ExpiresIn=600,
+        )
+
+    def test_returns_none_on_error(self):
+        s3_client = Mock()
+        s3_client.generate_presigned_url.side_effect = RuntimeError("boom")
+
+        with patch.object(
+            storage_utils,
+            "is_s3_enabled",
+            return_value=True,
+        ), patch.object(
+            storage_utils,
+            "get_storage_client",
+            return_value=s3_client,
+        ), patch.object(
+            storage_utils,
+            "get_s3_bucket_name",
+            return_value="bucket",
+        ), patch.object(storage_utils.logger, "error"):
+            assert storage_utils.generate_presigned_get_url("content/video.mp4") is None
+
+
+class TestUploadDirectoryToS3Parallel:
+    def test_returns_true_when_disabled_missing_or_empty(self, tmp_path):
+        with patch.object(storage_utils, "is_s3_enabled", return_value=False):
+            assert storage_utils.upload_directory_to_s3_parallel("dir", "prefix") is True
+
+        with patch.object(
+            storage_utils,
+            "is_s3_enabled",
+            return_value=True,
+        ), patch.object(storage_utils, "upload_file_to_s3") as upload_mock:
+            assert storage_utils.upload_directory_to_s3_parallel(
+                str(tmp_path / "missing"), "prefix"
+            ) is True
+
+            empty_dir = tmp_path / "empty"
+            empty_dir.mkdir()
+            assert storage_utils.upload_directory_to_s3_parallel(str(empty_dir), "prefix") is True
+            upload_mock.assert_not_called()
+
+    def test_uploads_all_files_with_forward_slash_keys(self, tmp_path):
+        local_dir = tmp_path / "package"
+        nested_dir = local_dir / "nested"
+        nested_dir.mkdir(parents=True)
+        (local_dir / "root.txt").write_text("root")
+        (nested_dir / "child.md").write_text("child")
+
+        upload_mock = Mock(return_value=True)
+        with patch.object(
+            storage_utils,
+            "is_s3_enabled",
+            return_value=True,
+        ), patch.object(storage_utils, "upload_file_to_s3", upload_mock):
+            assert storage_utils.upload_directory_to_s3_parallel(
+                str(local_dir), "content/package"
+            ) is True
+
+        assert upload_mock.call_count == 2
+        uploaded_keys = {call.args[0] for call in upload_mock.call_args_list}
+        assert uploaded_keys == {
+            "content/package/root.txt",
+            "content/package/nested/child.md",
+        }
+        assert all("\\" not in key for key in uploaded_keys)
+
+    def test_returns_false_when_any_upload_fails(self, tmp_path):
+        local_dir = tmp_path / "package"
+        local_dir.mkdir()
+        (local_dir / "a.txt").write_text("a")
+        (local_dir / "b.txt").write_text("b")
+
+        upload_mock = Mock(side_effect=[True, False])
+        with patch.object(
+            storage_utils,
+            "is_s3_enabled",
+            return_value=True,
+        ), patch.object(storage_utils, "upload_file_to_s3", upload_mock):
+            assert storage_utils.upload_directory_to_s3_parallel(
+                str(local_dir), "content/package"
+            ) is False
+
+        assert upload_mock.call_count == 2

--- a/apps/web/ee/app/api/scorm/[...path]/route.ts
+++ b/apps/web/ee/app/api/scorm/[...path]/route.ts
@@ -5,7 +5,25 @@ import { getAPIUrl } from '@services/config/config'
  * Proxy route for SCORM content
  * This serves SCORM content from the same origin as the frontend,
  * which is required for the SCORM API to work properly in iframes.
+ *
+ * Streams response bodies through (no buffering) and forwards Range
+ * requests so large media inside packages stays seekable. Redirects from
+ * the backend (presigned storage URLs for big media) are passed to the
+ * browser instead of being followed here — only the entry documents need
+ * to stay same-origin for the SCORM API bridge.
  */
+
+const FORWARDED_REQUEST_HEADERS = ['range', 'if-none-match', 'if-modified-since']
+const FORWARDED_RESPONSE_HEADERS = [
+  'content-type',
+  'content-length',
+  'content-range',
+  'accept-ranges',
+  'cache-control',
+  'etag',
+  'last-modified',
+]
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ path: string[] }> }
@@ -20,29 +38,52 @@ export async function GET(
     // Build the backend URL (include query string if present)
     const backendUrl = `${getAPIUrl()}scorm/${pathString}${queryString}`
 
+    const forwardHeaders: Record<string, string> = {}
+    for (const header of FORWARDED_REQUEST_HEADERS) {
+      const value = request.headers.get(header)
+      if (value) forwardHeaders[header] = value
+    }
+
     const response = await fetch(backendUrl, {
       method: 'GET',
+      headers: forwardHeaders,
+      redirect: 'manual',
     })
+
+    // Pass storage redirects (presigned media URLs) through to the browser
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location')
+      if (location) {
+        return new NextResponse(null, {
+          status: response.status,
+          headers: {
+            Location: location,
+            'Cache-Control': response.headers.get('cache-control') ?? 'no-store',
+          },
+        })
+      }
+    }
 
     if (!response.ok) {
       return new NextResponse(null, { status: response.status })
     }
 
-    // Get the content type from the response
-    const contentType = response.headers.get('content-type') || 'application/octet-stream'
+    const headers = new Headers()
+    for (const header of FORWARDED_RESPONSE_HEADERS) {
+      const value = response.headers.get(header)
+      if (value) headers.set(header, value)
+    }
+    if (!headers.has('content-type')) {
+      headers.set('content-type', 'application/octet-stream')
+    }
+    if (!headers.has('cache-control')) {
+      headers.set('cache-control', 'no-cache, no-store, must-revalidate')
+    }
 
-    // Get the response body
-    const body = await response.arrayBuffer()
-
-    // Return the response with appropriate headers
-    return new NextResponse(body, {
-      status: 200,
-      headers: {
-        'Content-Type': contentType,
-        'Cache-Control': 'no-cache, no-store, must-revalidate',
-        'Pragma': 'no-cache',
-        'Expires': '0',
-      },
+    // Stream the body through (200 or 206 for Range responses)
+    return new NextResponse(response.body, {
+      status: response.status,
+      headers,
     })
   } catch (error) {
     console.error('SCORM proxy error:', error)

--- a/apps/web/ee/components/Modals/ScormActivityModal.tsx
+++ b/apps/web/ee/components/Modals/ScormActivityModal.tsx
@@ -6,6 +6,11 @@ import BarLoader from 'react-spinners/BarLoader'
 import { Upload, Package, CheckCircle2, ChevronRight, AlertCircle } from 'lucide-react'
 import { getAPIUrl } from '@services/config/config'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
+import {
+  uploadScormPackage,
+  formatMB,
+  type ScormUploadProgress,
+} from '../../services/scorm/upload'
 import { constructAcceptValue } from '@/lib/constants'
 import { useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query/keys'
@@ -22,11 +27,19 @@ interface ScormScoInfo {
   prerequisites: string | null
 }
 
+interface ScormPackageFileInfo {
+  path: string
+  size_bytes: number
+}
+
 interface ScormAnalysisResponse {
   temp_package_id: string
   scorm_version: string
   package_title: string
   scos: ScormScoInfo[]
+  file_count?: number
+  total_size_bytes?: number
+  largest_files?: ScormPackageFileInfo[]
 }
 
 interface ScoAssignment {
@@ -66,6 +79,7 @@ function ScormActivityModal({ course, closeModal, onImportComplete, chapterId }:
   // Upload step state
   const [scormFile, setScormFile] = useState<File | null>(null)
   const [isAnalyzing, setIsAnalyzing] = useState(false)
+  const [uploadProgress, setUploadProgress] = useState<ScormUploadProgress | null>(null)
   const [uploadError, setUploadError] = useState<string | null>(null)
 
   // Analysis result state
@@ -106,29 +120,16 @@ function ScormActivityModal({ course, closeModal, onImportComplete, chapterId }:
     }
 
     setIsAnalyzing(true)
+    setUploadProgress(null)
     setUploadError(null)
 
     try {
-      const formData = new FormData()
-      formData.append('scorm_file', scormFile)
-
-      const response = await fetch(
+      const result = await uploadScormPackage<ScormAnalysisResponse>(
         `${getAPIUrl()}scorm/analyze/${courseUuid}`,
-        {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${access_token}`,
-          },
-          body: formData,
-        }
+        scormFile,
+        access_token,
+        setUploadProgress
       )
-
-      if (!response.ok) {
-        const error = await response.json()
-        throw new Error(error.detail || 'Failed to analyze SCORM package')
-      }
-
-      const result: ScormAnalysisResponse = await response.json()
       setAnalysisResult(result)
 
       // Initialize assignments with default values. When launched from a
@@ -151,6 +152,7 @@ function ScormActivityModal({ course, closeModal, onImportComplete, chapterId }:
       setUploadError(error.message || 'Failed to analyze SCORM package')
     } finally {
       setIsAnalyzing(false)
+      setUploadProgress(null)
     }
   }
 
@@ -300,6 +302,35 @@ function ScormActivityModal({ course, closeModal, onImportComplete, chapterId }:
             </div>
           )}
 
+          {/* Upload Progress */}
+          {isAnalyzing && (
+            <div className="space-y-2 bg-gray-50 p-4 rounded-xl border border-gray-100">
+              <div className="flex justify-between text-sm text-gray-600">
+                <span className="font-medium">
+                  {uploadProgress && uploadProgress.percent < 100
+                    ? 'Uploading package…'
+                    : 'Analyzing package…'}
+                </span>
+                {uploadProgress && uploadProgress.percent < 100 && (
+                  <span>
+                    {formatMB(uploadProgress.loadedBytes)} / {formatMB(uploadProgress.totalBytes)} MB
+                    {' '}({uploadProgress.percent}%)
+                  </span>
+                )}
+              </div>
+              {uploadProgress && uploadProgress.percent < 100 ? (
+                <div className="h-2 w-full bg-gray-200 rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-black rounded-full transition-all duration-200"
+                    style={{ width: `${uploadProgress.percent}%` }}
+                  />
+                </div>
+              ) : (
+                <BarLoader width="100%" color="#000000" cssOverride={{ borderRadius: 60 }} />
+              )}
+            </div>
+          )}
+
           {/* Info */}
           <div className="bg-sky-50 p-4 rounded-xl text-sm text-sky-700 border border-sky-100">
             <p>
@@ -317,7 +348,11 @@ function ScormActivityModal({ course, closeModal, onImportComplete, chapterId }:
               className="inline-flex items-center justify-center gap-2 px-6 py-2.5 bg-black text-white text-sm font-semibold rounded-xl hover:bg-gray-800 transition-colors shadow-sm disabled:opacity-50 disabled:cursor-not-allowed min-w-[160px]"
             >
               {isAnalyzing ? (
-                <BarLoader width={60} color="#ffffff" cssOverride={{ borderRadius: 60 }} />
+                <span>
+                  {uploadProgress && uploadProgress.percent < 100
+                    ? `Uploading ${uploadProgress.percent}%`
+                    : 'Analyzing…'}
+                </span>
               ) : (
                 <>
                   <span>Analyze Package</span>
@@ -352,6 +387,20 @@ function ScormActivityModal({ course, closeModal, onImportComplete, chapterId }:
             <p className="text-sm text-gray-600 mt-1">
               <span className="font-medium">SCOs found:</span> {analysisResult.scos.length}
             </p>
+            {analysisResult.file_count != null && analysisResult.total_size_bytes != null && (
+              <p className="text-sm text-gray-600 mt-1">
+                <span className="font-medium">Content:</span> {analysisResult.file_count} files,{' '}
+                {formatMB(analysisResult.total_size_bytes)} MB uncompressed
+              </p>
+            )}
+            {analysisResult.largest_files && analysisResult.largest_files.length > 0 && (
+              <p className="text-xs text-gray-400 mt-1 truncate">
+                Largest: {analysisResult.largest_files
+                  .slice(0, 3)
+                  .map((f) => `${f.path.split('/').pop()} (${formatMB(f.size_bytes)} MB)`)
+                  .join(', ')}
+              </p>
+            )}
           </div>
 
           {/* SCO Assignments */}
@@ -424,17 +473,26 @@ function ScormActivityModal({ course, closeModal, onImportComplete, chapterId }:
             </div>
           )}
 
+          {/* Import progress note */}
+          {isImporting && (
+            <div className="flex items-center gap-2 text-sm text-gray-600 bg-gray-50 p-3 rounded-xl border border-gray-100">
+              <BarLoader width={40} color="#000000" cssOverride={{ borderRadius: 60 }} />
+              <span>Importing — copying content to storage, this can take a few minutes for large packages…</span>
+            </div>
+          )}
+
           {/* Actions */}
           <div className="flex justify-between items-center pt-4 border-t border-gray-100">
             <button
               type="button"
+              disabled={isImporting}
               onClick={() => {
                 setStep('upload')
                 setAnalysisResult(null)
                 setAssignments([])
                 setScormFile(null)
               }}
-              className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
+              className="text-sm text-gray-500 hover:text-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               &larr; Upload different package
             </button>

--- a/apps/web/ee/components/Modals/ScormCourseImport.tsx
+++ b/apps/web/ee/components/Modals/ScormCourseImport.tsx
@@ -9,6 +9,11 @@ import { Upload, CheckCircle2, ChevronRight, AlertCircle, FileArchive, ArrowLeft
 import { getAPIUrl } from '@services/config/config'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
 import { constructAcceptValue } from '@/lib/constants'
+import {
+  uploadScormPackage,
+  formatMB,
+  type ScormUploadProgress,
+} from '../../services/scorm/upload'
 import { revalidateTags } from '@services/utils/ts/requests'
 import toast from 'react-hot-toast'
 import { useRouter } from 'next/navigation'
@@ -56,6 +61,7 @@ function ScormCourseImport({ orgId, orgslug, closeModal }: ScormCourseImportProp
   // Upload step state
   const [scormFile, setScormFile] = useState<File | null>(null)
   const [isAnalyzing, setIsAnalyzing] = useState(false)
+  const [uploadProgress, setUploadProgress] = useState<ScormUploadProgress | null>(null)
   const [uploadError, setUploadError] = useState<string | null>(null)
   const [isDragging, setIsDragging] = useState(false)
 
@@ -106,29 +112,16 @@ function ScormCourseImport({ orgId, orgslug, closeModal }: ScormCourseImportProp
     if (!scormFile || !orgId) return
 
     setIsAnalyzing(true)
+    setUploadProgress(null)
     setUploadError(null)
 
     try {
-      const formData = new FormData()
-      formData.append('scorm_file', scormFile)
-
-      const response = await fetch(
+      const result = await uploadScormPackage<ScormAnalysisResponse>(
         `${getAPIUrl()}scorm/analyze-for-import/${orgId}`,
-        {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${access_token}`,
-          },
-          body: formData,
-        }
+        scormFile,
+        access_token,
+        setUploadProgress
       )
-
-      if (!response.ok) {
-        const error = await response.json()
-        throw new Error(error.detail || 'Failed to analyze SCORM package')
-      }
-
-      const result: ScormAnalysisResponse = await response.json()
       setAnalysisResult(result)
 
       // Set default course name from package title
@@ -150,6 +143,7 @@ function ScormCourseImport({ orgId, orgslug, closeModal }: ScormCourseImportProp
       setUploadError(error.message || 'Failed to analyze SCORM package')
     } finally {
       setIsAnalyzing(false)
+      setUploadProgress(null)
     }
   }
 
@@ -327,6 +321,35 @@ function ScormCourseImport({ orgId, orgslug, closeModal }: ScormCourseImportProp
               </div>
             )}
 
+            {/* Upload Progress */}
+            {isAnalyzing && (
+              <div className="space-y-2 bg-gray-50 p-4 rounded-lg border border-gray-100">
+                <div className="flex justify-between text-sm text-gray-600">
+                  <span className="font-medium">
+                    {uploadProgress && uploadProgress.percent < 100
+                      ? 'Uploading package…'
+                      : 'Analyzing package…'}
+                  </span>
+                  {uploadProgress && uploadProgress.percent < 100 && (
+                    <span>
+                      {formatMB(uploadProgress.loadedBytes)} / {formatMB(uploadProgress.totalBytes)} MB
+                      {' '}({uploadProgress.percent}%)
+                    </span>
+                  )}
+                </div>
+                {uploadProgress && uploadProgress.percent < 100 ? (
+                  <div className="h-2 w-full bg-gray-200 rounded-full overflow-hidden">
+                    <div
+                      className="h-full bg-black rounded-full transition-all duration-200"
+                      style={{ width: `${uploadProgress.percent}%` }}
+                    />
+                  </div>
+                ) : (
+                  <BarLoader width="100%" color="#000000" cssOverride={{ borderRadius: 60 }} />
+                )}
+              </div>
+            )}
+
             {/* Info Box */}
             <div className="bg-blue-50 border border-blue-100 p-4 rounded-lg">
               <p className="text-sm text-blue-700">{t('courses.scorm.import_info')}</p>
@@ -340,9 +363,11 @@ function ScormCourseImport({ orgId, orgslug, closeModal }: ScormCourseImportProp
                 className="bg-black text-white hover:bg-gray-800 px-6 h-11"
               >
                 {isAnalyzing ? (
-                  <div className="flex items-center space-x-2">
-                    <BarLoader width={60} color="#ffffff" cssOverride={{ borderRadius: 60 }} />
-                  </div>
+                  <span>
+                    {uploadProgress && uploadProgress.percent < 100
+                      ? `Uploading ${uploadProgress.percent}%`
+                      : 'Analyzing…'}
+                  </span>
                 ) : (
                   <div className="flex items-center space-x-2">
                     <span>{t('courses.scorm.analyze_package')}</span>
@@ -463,12 +488,21 @@ function ScormCourseImport({ orgId, orgslug, closeModal }: ScormCourseImportProp
             </div>
           )}
 
+          {/* Import progress note */}
+          {isImporting && (
+            <div className="flex items-center space-x-2 text-sm text-gray-600 bg-gray-50 p-3 rounded-lg border border-gray-100">
+              <BarLoader width={40} color="#000000" cssOverride={{ borderRadius: 60 }} />
+              <span>Importing — copying content to storage, this can take a few minutes for large packages…</span>
+            </div>
+          )}
+
           {/* Actions */}
           <div className="flex justify-between items-center pt-2 border-t border-gray-100">
             <button
               type="button"
+              disabled={isImporting}
               onClick={resetToUpload}
-              className="flex items-center space-x-1 text-sm text-gray-500 hover:text-gray-700 transition-colors"
+              className="flex items-center space-x-1 text-sm text-gray-500 hover:text-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <ArrowLeft size={16} />
               <span>{t('courses.scorm.upload_different')}</span>

--- a/apps/web/ee/services/scorm/upload.ts
+++ b/apps/web/ee/services/scorm/upload.ts
@@ -1,0 +1,63 @@
+export interface ScormUploadProgress {
+  loadedBytes: number
+  totalBytes: number
+  percent: number
+}
+
+const UPLOAD_TIMEOUT_MS = 30 * 60 * 1000
+
+/**
+ * Upload a SCORM package with real upload progress.
+ *
+ * Uses XMLHttpRequest because fetch() cannot report request-body upload
+ * progress; large packages (hundreds of MB) otherwise sit on an indeterminate
+ * spinner for minutes. Resolves with the parsed JSON analysis response and
+ * rejects with the backend `detail` message on failure.
+ */
+export function uploadScormPackage<T = any>(
+  url: string,
+  file: File,
+  accessToken: string,
+  onProgress?: (_progress: ScormUploadProgress) => void
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const xhr = new XMLHttpRequest()
+    xhr.open('POST', url)
+    xhr.setRequestHeader('Authorization', `Bearer ${accessToken}`)
+    xhr.timeout = UPLOAD_TIMEOUT_MS
+    xhr.responseType = 'json'
+
+    xhr.upload.onprogress = (event) => {
+      if (!onProgress) return
+      const totalBytes = event.lengthComputable ? event.total : file.size
+      const loadedBytes = Math.min(event.loaded, totalBytes)
+      onProgress({
+        loadedBytes,
+        totalBytes,
+        percent: totalBytes > 0 ? Math.round((loadedBytes / totalBytes) * 100) : 0,
+      })
+    }
+
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve(xhr.response as T)
+      } else {
+        const detail = xhr.response?.detail
+        reject(new Error(detail || `Upload failed (HTTP ${xhr.status})`))
+      }
+    }
+    xhr.onerror = () =>
+      reject(new Error('Upload failed. Please check your connection and try again.'))
+    xhr.ontimeout = () =>
+      reject(new Error('Upload timed out. Please try again on a faster connection.'))
+    xhr.onabort = () => reject(new Error('Upload cancelled.'))
+
+    const formData = new FormData()
+    formData.append('scorm_file', file)
+    xhr.send(formData)
+  })
+}
+
+export function formatMB(bytes: number): string {
+  return (bytes / 1024 / 1024).toFixed(1)
+}


### PR DESCRIPTION
## Problem

Large SCORM packages (media-heavy Articulate Rise/Storyline exports, several hundred MB) were painful to work with:

- The upload sat on an indeterminate spinner for minutes with no feedback.
- The SCORM content proxy buffered entire files in memory (`arrayBuffer()`), so big videos inside packages couldn't seek and could stall the Next.js server.
- Directory uploads to S3 ran strictly one file at a time.

## Changes

**Storage helpers** (`storage_utils.py`)
- `download_file_from_s3` — streams an object to disk (used to restore analyzed packages across API replicas)
- `upload_directory_to_s3_parallel` — same contract as the sequential variant, with thread-pooled per-file uploads
- Reuses the existing `generate_presigned_get_url` (added by the video-streaming work) for serving large media; adds unit tests for it

**SCORM upload UX** (`apps/web/ee`)
- New XHR-based upload helper reporting real progress; both SCORM modals now show a determinate progress bar (MB uploaded / percent) with Uploading → Analyzing stages
- Import step shows a labeled busy state and blocks navigation while running
- Analysis screen shows package stats (file count, uncompressed size, largest assets)

**SCORM content proxy** (`apps/web/ee/app/api/scorm/[...path]/route.ts`)
- Streams response bodies through instead of buffering them
- Forwards `Range` / conditional request headers and passes through content/cache headers, so video inside packages is seekable
- Passes storage redirects (presigned media URLs) to the browser; entry documents stay same-origin so the SCORM API bridge keeps working

## Tests

- Unit tests for the storage helpers (mocked boto3: success, error, disabled, partial-failure paths)
- New `test_scorm_upload_pipeline.py` covering streaming save limits, hardened extraction, cross-replica package restore, and shared-package materialization (skips when the SCORM service is absent)
- Verified end-to-end against a real 685MB SCORM 1.2 package: streamed with flat memory, all files preserved, manifest/SCO parsing intact

## Deployment note

Reverse-proxy/ingress body-size limits in front of the API must allow the configured max package size (default 5GB) for large uploads to reach the app.