### PR TITLE
feat: add language trnaslations for paste from clipboard button text

### DIFF
--- a/apps/web/locales/ar.json
+++ b/apps/web/locales/ar.json
@@ -464,6 +464,7 @@
     "image": "صورة",
     "upload_image": "رفع صورة",
     "choose_from_gallery": "اختر من المعرض",
+    "paste_from_clipboard": "لصق من الحافظة",
     "enter_to_add": "اضغط Enter للإضافة...",
     "select_visibility": "اختر الظهور",
     "and_x_more": "و {{count}} أكثر",

--- a/apps/web/locales/bn.json
+++ b/apps/web/locales/bn.json
@@ -476,6 +476,7 @@
     "image": "ছবি",
     "upload_image": "ছবি আপলোড করুন",
     "choose_from_gallery": "গ্যালারি থেকে বেছে নিন",
+    "paste_from_clipboard": "ক্লিপবোর্ড থেকে পেস্ট করুন",
     "enter_to_add": "যোগ করতে এন্টার চাপুন...",
     "select_visibility": "দৃশ্যমানতা নির্বাচন করুন",
     "and_x_more": "এবং আরও {{count}}টি",

--- a/apps/web/locales/de.json
+++ b/apps/web/locales/de.json
@@ -454,6 +454,7 @@
     "image": "Bild",
     "upload_image": "Bild hochladen",
     "choose_from_gallery": "Aus Galerie wählen",
+    "paste_from_clipboard": "Aus der Zwischenablage einfügen",
     "enter_to_add": "Enter zum Hinzufügen...",
     "select_visibility": "Sichtbarkeit wählen",
     "and_x_more": "& {{count}} weitere",

--- a/apps/web/locales/es.json
+++ b/apps/web/locales/es.json
@@ -454,6 +454,7 @@
     "image": "Imagen",
     "upload_image": "Subir imagen",
     "choose_from_gallery": "Elegir de la galería",
+    "paste_from_clipboard": "Pegar desde el portapapeles",
     "enter_to_add": "Enter para añadir...",
     "select_visibility": "Seleccionar visibilidad",
     "and_x_more": "y {{count}} más",

--- a/apps/web/locales/fa.json
+++ b/apps/web/locales/fa.json
@@ -459,6 +459,7 @@
     "image": "تصویر",
     "upload_image": "آپلود تصویر",
     "choose_from_gallery": "انتخاب از گالری",
+    "paste_from_clipboard": "از کلیپ‌بورد قرار دهید",
     "enter_to_add": "برای افزودن Enter را فشار دهید...",
     "select_visibility": "انتخاب قابلیت مشاهده",
     "and_x_more": "و {{count}} مورد دیگر",

--- a/apps/web/locales/fr.json
+++ b/apps/web/locales/fr.json
@@ -454,6 +454,7 @@
     "image": "Image",
     "upload_image": "Téléverser",
     "choose_from_gallery": "Galerie",
+    "paste_from_clipboard": "Coller depuis le presse-papiers",
     "enter_to_add": "Appuyez sur Entrée...",
     "select_visibility": "Choisir la visibilité",
     "and_x_more": "& {{count}} de plus",

--- a/apps/web/locales/hi.json
+++ b/apps/web/locales/hi.json
@@ -476,6 +476,7 @@
     "image": "छवि",
     "upload_image": "छवि अपलोड करें",
     "choose_from_gallery": "गैलरी से चुनें",
+    "paste_from_clipboard": "क्लिपबोर्ड से पेस्ट करें",
     "enter_to_add": "जोड़ने के लिए Enter दबाएं...",
     "select_visibility": "दृश्यता चुनें",
     "and_x_more": "और {{count}} और",

--- a/apps/web/locales/id.json
+++ b/apps/web/locales/id.json
@@ -476,6 +476,7 @@
     "image": "Gambar",
     "upload_image": "Unggah Gambar",
     "choose_from_gallery": "Pilih dari Galeri",
+    "paste_from_clipboard": "Tempel dari clipboard",
     "enter_to_add": "Tekan Enter untuk menambah...",
     "select_visibility": "Pilih visibilitas",
     "and_x_more": "dan {{count}} lainnya",

--- a/apps/web/locales/it.json
+++ b/apps/web/locales/it.json
@@ -454,6 +454,7 @@
     "image": "Immagine",
     "upload_image": "Carica immagine",
     "choose_from_gallery": "Scegli dalla galleria",
+    "paste_from_clipboard": "Incolla dal clipboard",
     "enter_to_add": "Invio per aggiungere...",
     "select_visibility": "Seleziona visibilità",
     "and_x_more": "e altri {{count}}",

--- a/apps/web/locales/ja.json
+++ b/apps/web/locales/ja.json
@@ -464,6 +464,7 @@
     "image": "画像",
     "upload_image": "画像をアップロード",
     "choose_from_gallery": "ギャラリーから選択",
+    "paste_from_clipboard": "クリップボードからペースト",
     "enter_to_add": "Enterキーで追加...",
     "select_visibility": "公開設定を選択",
     "and_x_more": "他 {{count}} 件",

--- a/apps/web/locales/ko.json
+++ b/apps/web/locales/ko.json
@@ -464,6 +464,7 @@
     "image": "이미지",
     "upload_image": "이미지 업로드",
     "choose_from_gallery": "갤러리에서 선택",
+    "paste_from_clipboard": "클립보드에서 붙여넣기",
     "enter_to_add": "Enter 키로 추가...",
     "select_visibility": "공개 설정 선택",
     "and_x_more": "외 {{count}}건",

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -454,6 +454,7 @@
     "image": "Afbeelding",
     "upload_image": "Afbeelding uploaden",
     "choose_from_gallery": "Kies uit galerij",
+    "paste_from_clipboard": "Plakken vanuit klembord",
     "enter_to_add": "Druk op Enter om toe te voegen...",
     "select_visibility": "Selecteer zichtbaarheid",
     "and_x_more": "en {{count}} meer",

--- a/apps/web/locales/pl.json
+++ b/apps/web/locales/pl.json
@@ -476,6 +476,7 @@
     "image": "Obraz",
     "upload_image": "Prześlij obraz",
     "choose_from_gallery": "Wybierz z galerii",
+    "paste_from_clipboard": "Wklej schowka",
     "enter_to_add": "Naciśnij Enter, aby dodać...",
     "select_visibility": "Wybierz widoczność",
     "and_x_more": "i {{count}} więcej",

--- a/apps/web/locales/pt.json
+++ b/apps/web/locales/pt.json
@@ -454,6 +454,7 @@
     "image": "Imagem",
     "upload_image": "Enviar Imagem",
     "choose_from_gallery": "Escolher da Galeria",
+    "paste_from_clipboard": "Colar da área de transferência",
     "enter_to_add": "Pressione Enter para adicionar...",
     "select_visibility": "Selecionar visibilidade",
     "and_x_more": "e mais {{count}}",

--- a/apps/web/locales/ru.json
+++ b/apps/web/locales/ru.json
@@ -476,6 +476,7 @@
     "image": "Изображение",
     "upload_image": "Загрузить изображение",
     "choose_from_gallery": "Выбрать из галереи",
+    "paste_from_clipboard": "Вставить из буфера обмена",
     "enter_to_add": "Нажмите Enter, чтобы добавить...",
     "select_visibility": "Выберите видимость",
     "and_x_more": "и еще {{count}}",

--- a/apps/web/locales/sk.json
+++ b/apps/web/locales/sk.json
@@ -458,6 +458,7 @@
     "image": "Obrázok",
     "upload_image": "Nahrať obrázok",
     "choose_from_gallery": "Vybrať z galérie",
+    "paste_from_clipboard": "Vložiť zo schránky",
     "enter_to_add": "Enter, aby ste mohli pridať...",
     "select_visibility": "Vybrať viditeľnosť",
     "and_x_more": "a {{count}} ďalších",

--- a/apps/web/locales/th.json
+++ b/apps/web/locales/th.json
@@ -476,6 +476,7 @@
     "image": "รูปภาพ",
     "upload_image": "อัปโหลดรูปภาพ",
     "choose_from_gallery": "เลือกจากคลังภาพ",
+    "paste_from_clipboard": "วางจากคลิปบอร์ด",
     "enter_to_add": "กด Enter เพื่อเพิ่ม...",
     "select_visibility": "เลือกการมองเห็น",
     "and_x_more": "และอีก {{count}} อย่าง",

--- a/apps/web/locales/tr.json
+++ b/apps/web/locales/tr.json
@@ -476,6 +476,7 @@
     "image": "Resim",
     "upload_image": "Resim Yükle",
     "choose_from_gallery": "Galeriden Seç",
+    "paste_from_clipboard": "Panodan Yapıştır",
     "enter_to_add": "Eklemek için Enter tuşuna basın...",
     "select_visibility": "Görünürlüğü seçin",
     "and_x_more": "ve {{count}} tane daha",

--- a/apps/web/locales/uk.json
+++ b/apps/web/locales/uk.json
@@ -458,6 +458,7 @@
     "image": "Зображення",
     "upload_image": "Завантажити зображення",
     "choose_from_gallery": "Виберіть із галереї",
+    "paste_from_clipboard": "Вставити з буфера обміну",
     "enter_to_add": "Введіть, щоб додати...",
     "select_visibility": "Виберіть видимість",
     "and_x_more": "& {{count}} більше",

--- a/apps/web/locales/vi.json
+++ b/apps/web/locales/vi.json
@@ -476,6 +476,7 @@
     "image": "Hình ảnh",
     "upload_image": "Tải ảnh lên",
     "choose_from_gallery": "Chọn từ thư viện",
+    "paste_from_clipboard": "Dán từ khay nhớ tạm",
     "enter_to_add": "Nhấn Enter để thêm...",
     "select_visibility": "Chọn chế độ hiển thị",
     "and_x_more": "và {{count}} khác",

--- a/apps/web/locales/zh.json
+++ b/apps/web/locales/zh.json
@@ -464,6 +464,7 @@
     "image": "图像",
     "upload_image": "上传图像",
     "choose_from_gallery": "从图库中选择",
+    "paste_from_clipboard": "从剪贴板粘贴",
     "enter_to_add": "按 Enter 键添加...",
     "select_visibility": "选择可见性",
     "and_x_more": "以及另外 {{count}} 个",


### PR DESCRIPTION
### Summary

Adds support for the "Paste from Clipboard" button text by introducing language translations. This ensures the button label is displayed according to the user's selected language, improving the application's multilingual experience.

### Changes

- Added translation keys for the Paste from Clipboard button text.
- Included translations for all supported languages.

### Testing

- Verified the button text changes correctly when switching application languages.