### PR TITLE
fix(billing): harden the Stripe plan-write path against silent upgrade drops

### DIFF
--- a/apps/api/src/security/features_utils/resolve.py
+++ b/apps/api/src/security/features_utils/resolve.py
@@ -30,7 +30,10 @@ ALL_FEATURES = [
 
 def _get_plan_from_config(config: dict) -> str:
     """Extract plan from config, supporting both v1 and v2 formats."""
-    version = config.get("config_version", "1.0")
+    # Coerce to str: config_version may be stored as a number in JSON, which
+    # would make .startswith() raise AttributeError and crash feature
+    # resolution. The writer (org_plan.py) already normalizes with str().
+    version = str(config.get("config_version", "1.0"))
     if version.startswith("2"):
         return config.get("plan", "free")
     # v1: plan is under cloud.plan
@@ -39,7 +42,7 @@ def _get_plan_from_config(config: dict) -> str:
 
 def _get_admin_toggle(config: dict, feature: str) -> dict:
     """Get admin toggle for a feature, supporting both v1 and v2 formats."""
-    version = config.get("config_version", "1.0")
+    version = str(config.get("config_version", "1.0"))
     if version.startswith("2"):
         return config.get("admin_toggles", {}).get(feature, {})
     # v1: read from features section; map enabled=False → disabled=True
@@ -56,7 +59,7 @@ def _get_admin_toggle(config: dict, feature: str) -> dict:
 
 def _get_overrides(config: dict, feature: str) -> dict:
     """Get overrides for a feature from v2 config."""
-    version = config.get("config_version", "1.0")
+    version = str(config.get("config_version", "1.0"))
     if not version.startswith("2"):
         return {}
     return config.get("overrides", {}).get(feature, {})

--- a/apps/web/app/(hub)/billing/_lib/billingClient.ts
+++ b/apps/web/app/(hub)/billing/_lib/billingClient.ts
@@ -43,6 +43,16 @@ export interface PromoResult {
   currency?: string;
 }
 
+// POST /api/billing/fulfill → { fulfilled, plan? }
+// Redundant automatic upgrade path: called on return from Stripe checkout so the
+// org upgrades even if the webhook is delayed or misconfigured. Idempotent.
+export function billingFulfill(body: {
+  sessionId: string;
+  orgId: number | string;
+}): Promise<{ fulfilled: boolean; plan?: string; reason?: string }> {
+  return postJson("/api/billing/fulfill", body);
+}
+
 // POST /api/billing/checkout → { id, url }
 export function billingCheckout(body: {
   plan: PlanId;

--- a/apps/web/app/(hub)/billing/page.tsx
+++ b/apps/web/app/(hub)/billing/page.tsx
@@ -12,7 +12,7 @@ import UserAvatar from '@components/Objects/UserAvatar'
 import { getAPIUrl } from '@services/config/config'
 import { getOrgLogoMediaDirectory } from '@services/media/media'
 import { apiFetch } from '@services/utils/ts/requests'
-import { fetchPrices, fetchSubscription } from './_lib/billingClient'
+import { fetchPrices, fetchSubscription, billingFulfill } from './_lib/billingClient'
 import { resolvePlanIdFromOrg } from './_lib/plans'
 import PlanUsage from './_components/PlanUsage'
 import SwitchWizard from './_components/SwitchWizard'
@@ -132,11 +132,24 @@ function BillingClient() {
   // params so a reload doesn't re-fire.
   const checkoutParam = searchParams?.get('checkout')
   const packPurchased = searchParams?.get('pack_purchased')
+  const checkoutSessionId = searchParams?.get('session_id')
   useEffect(() => {
     if (!orgId || (!checkoutParam && !packPurchased)) return
     if (checkoutParam === 'success' || packPurchased) {
-      queryClient.invalidateQueries({ queryKey: ['billing'] })
-      queryClient.invalidateQueries({ queryKey: ['orgs', 'user'] })
+      // Redundant automatic fulfillment: apply the plan directly from the paid
+      // Stripe session so the org upgrades even when the webhook is delayed or
+      // misconfigured. Idempotent and server-authorized; we refresh regardless
+      // of its outcome (the webhook may already have applied the plan). A plan
+      // checkout (not a pack) carries session_id in the success_url.
+      const settle = checkoutSessionId && !packPurchased
+        ? billingFulfill({ sessionId: checkoutSessionId, orgId }).catch((err) => {
+            console.error('[billing] fulfill on return failed:', err)
+          })
+        : Promise.resolve()
+      settle.finally(() => {
+        queryClient.invalidateQueries({ queryKey: ['billing'] })
+        queryClient.invalidateQueries({ queryKey: ['orgs', 'user'] })
+      })
       toast.success(
         packPurchased
           ? t('billing.pack_purchased', { defaultValue: 'Add-on purchased — your limits are updated.' })
@@ -149,7 +162,7 @@ function BillingClient() {
     ;['checkout', 'session_id', 'pack_purchased', 'pack'].forEach((k) => sp.delete(k))
     const qs = sp.toString()
     router.replace(qs ? `/billing?${qs}` : '/billing')
-  }, [orgId, checkoutParam, packPurchased, queryClient, router, searchParams, t])
+  }, [orgId, checkoutParam, packPurchased, checkoutSessionId, queryClient, router, searchParams, t])
 
   const currentPlanId = resolvePlanIdFromOrg(org)
   const isOrgActive = resolveOrgActive(org)

--- a/apps/web/app/api/billing/fulfill/route.ts
+++ b/apps/web/app/api/billing/fulfill/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { fulfillCheckoutSession } from "@services/billing/stripe";
+import { guardBilling, badRequest, requireOrgBillingAccess } from "../_lib";
+
+// POST /api/billing/fulfill
+// Body: { sessionId, orgId }
+// → { fulfilled, plan? } — verifies a completed Stripe Checkout session and
+// applies the org's plan directly, WITHOUT depending on webhook delivery.
+//
+// This is the redundant automatic upgrade path: the client calls it when the
+// user lands back on /billing?checkout=success. The webhook remains the primary
+// path, but if it is delayed or misconfigured (wrong dashboard endpoint / stale
+// STRIPE_WEBHOOK_SECRET), the customer's return from checkout still upgrades the
+// org. fulfillCheckoutSession is idempotent and reads the org/plan from the
+// session's subscription metadata (never from the request body).
+export async function POST(request: NextRequest) {
+  const blocked = await guardBilling();
+  if (blocked) return blocked;
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return badRequest("Invalid JSON body");
+  }
+
+  const { sessionId, orgId } = body ?? {};
+  if (!sessionId || !orgId) {
+    return badRequest("Missing required fields: sessionId, orgId");
+  }
+
+  // Authorize the caller for this org. The plan itself comes from the verified
+  // Stripe session metadata inside fulfillCheckoutSession, so a caller cannot
+  // grant themselves a plan they didn't pay for — but they must still be an
+  // admin of the org they're fulfilling for.
+  const access = await requireOrgBillingAccess(orgId);
+  if ("error" in access) return access.error;
+
+  try {
+    const result = await fulfillCheckoutSession(String(sessionId));
+    return NextResponse.json(result);
+  } catch (err: any) {
+    console.error("[billing/fulfill] failed:", err);
+    return NextResponse.json(
+      { error: err?.message ?? "Fulfillment failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/api/billing/webhook/route.ts
+++ b/apps/web/app/api/billing/webhook/route.ts
@@ -82,21 +82,34 @@ export async function POST(request: Request) {
   if (processedEvents.has(event.id)) {
     return NextResponse.json({ result: "duplicate", ok: true });
   }
-  processedEvents.set(event.id, Date.now());
 
   try {
     if (event.type === "checkout.session.completed") {
       await handleCheckoutCompleted(event.data.object);
     }
 
-    if (event.type === "customer.subscription.updated" || event.type === "customer.subscription.deleted") {
+    // Treat `created` like an `updated`: it's the natural recovery event that
+    // also carries subscription_data.metadata.org_id, so if checkout.session
+    // .completed was dropped, this still upgrades the org.
+    if (
+      event.type === "customer.subscription.updated" ||
+      event.type === "customer.subscription.deleted" ||
+      event.type === "customer.subscription.created"
+    ) {
       await handleSubscriptionEvent(event.type, event.data.object);
     }
 
+    // Mark processed only AFTER successful handling. Recording it before (as we
+    // used to) meant a handler that threw returned 500 for Stripe to retry, but
+    // the retry — arriving within the 5-minute TTL on the same instance — was
+    // answered "duplicate" and never reprocessed, permanently dropping the
+    // upgrade. Downstream service calls are idempotent, so worst case is a
+    // harmless re-apply.
+    processedEvents.set(event.id, Date.now());
     return NextResponse.json({ result: event.type, ok: true });
   } catch (error) {
     console.error(`Webhook processing error for ${event.type} (${event.id}):`, error);
-    // Return 500 so Stripe retries the webhook
+    // Return 500 (and leave the event unmarked) so Stripe retries the webhook.
     return NextResponse.json(
       { message: "webhook processing failed", ok: false },
       { status: 500 }
@@ -107,21 +120,37 @@ export async function POST(request: Request) {
 async function handleCheckoutCompleted(session: any) {
   if (session.payment_status !== "paid") return;
 
-  // Retrieve session with expanded subscription to get metadata
-  const fullSession = await stripe.checkout.sessions.retrieve(session.id, {
-    expand: ["subscription"],
-  });
-  const subscription = fullSession.subscription;
+  // Retrieve the session with the subscription expanded to read its metadata.
+  // Stripe's basil API (2025-03-31) defers subscription creation until payment
+  // completes, so the expanded `subscription` can briefly be null right after
+  // checkout — the same race fulfillCheckoutSession() guards against. Retry so a
+  // deferred subscription doesn't silently drop the upgrade.
+  let fullSession: any;
+  let subscription: any;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    fullSession = await stripe.checkout.sessions.retrieve(session.id, {
+      expand: ["subscription"],
+    });
+    subscription = fullSession.subscription;
+    if (subscription?.metadata?.org_id) break;
+    if (attempt < 2) await new Promise((r) => setTimeout(r, 1000));
+  }
   const customerEmail = fullSession.customer_details?.email || session.customer_email;
 
-  if (!subscription?.metadata) {
-    console.warn("checkout.session.completed: no subscription metadata", session.id);
-    return;
+  if (!subscription) {
+    // Subscription still not materialized after retries — transient. Throw so
+    // Stripe redelivers (and customer.subscription.created will also cover it),
+    // rather than acking with a 200 that permanently drops the upgrade.
+    throw new Error(
+      `checkout.session.completed: subscription not yet available for session ${session.id}`,
+    );
   }
 
-  const orgId = subscription.metadata.org_id;
+  const orgId = subscription.metadata?.org_id;
   if (!orgId) {
-    console.warn("checkout.session.completed: no org_id in metadata", session.id);
+    // A checkout not created by our flow carries no org linkage — nothing we can
+    // do; ack so Stripe doesn't retry it forever and disable the endpoint.
+    console.warn("checkout.session.completed: no org_id in subscription metadata", session.id);
     return;
   }
 
@@ -175,7 +204,10 @@ async function handleSubscriptionEvent(eventType: string, subscription: any) {
 
     if (eventType === "customer.subscription.deleted") {
       await deactivatePackInternally(orgId, subscription.id);
-    } else if (eventType === "customer.subscription.updated") {
+    } else if (
+      eventType === "customer.subscription.updated" ||
+      eventType === "customer.subscription.created"
+    ) {
       if (subscription.cancel_at_period_end) {
         // User requested cancellation — mark as canceling but keep active until period end
         await markPackCancelingInternally(orgId, subscription.id);
@@ -200,7 +232,10 @@ async function handleSubscriptionEvent(eventType: string, subscription: any) {
       await deactivateAllPacksInternally(orgId).catch((err) => {
         console.error(`Failed to deactivate packs for org ${orgId}:`, err);
       });
-    } else if (eventType === "customer.subscription.updated") {
+    } else if (
+      eventType === "customer.subscription.updated" ||
+      eventType === "customer.subscription.created"
+    ) {
       if (subscription.cancel_at_period_end) {
         // Plan is canceling — keep current plan until period ends
         console.log(`Plan subscription canceling for org ${orgId}, access continues until period end`);

--- a/apps/web/components/Hooks/usePlan.ts
+++ b/apps/web/components/Hooks/usePlan.ts
@@ -16,7 +16,9 @@ export function usePlan(): PlanLevel {
   if (mode === 'oss') return 'oss'
   if (mode === 'ee') return 'enterprise'
   const config = org?.config?.config
-  const isV2 = config?.config_version?.startsWith('2')
+  // config_version may be a number in stored JSON; guard startsWith so a numeric
+  // version doesn't throw and blank out the plan (→ falls back to free).
+  const isV2 = typeof config?.config_version === 'string' && config.config_version.startsWith('2')
   const plan = isV2 ? config?.plan : config?.cloud?.plan
   return (plan || 'free') as PlanLevel
 }

--- a/apps/web/services/billing/orgPlan.ts
+++ b/apps/web/services/billing/orgPlan.ts
@@ -11,7 +11,21 @@ import type { LearnHousePlanType } from "./plans";
 export async function updateOrganizationConfigInternally(org_id: any, plan: LearnHousePlanType) {
   console.log(`[updateOrgConfig] Updating org ${org_id} to plan "${plan}"`);
 
-  const internalKey = process.env.LEARNHOUSE_CLOUD_INTERNAL_KEY || "";
+  // The API guard (apps/api/.../orgs/org_plan.py) compares X-Internal-Key to env
+  // CLOUD_INTERNAL_KEY. Accept EITHER name here: deployments commonly set the
+  // unprefixed CLOUD_INTERNAL_KEY on both services (the sibling packs endpoint
+  // already uses one shared name), so reading only LEARNHOUSE_CLOUD_INTERNAL_KEY
+  // silently sent an empty key and 403'd every plan write. Fail loud when NEITHER
+  // is set rather than sending "" and mislabelling the 403 as a key mismatch.
+  const internalKey =
+    process.env.LEARNHOUSE_CLOUD_INTERNAL_KEY || process.env.CLOUD_INTERNAL_KEY || "";
+  if (!internalKey) {
+    throw new Error(
+      "[updateOrgConfig] internal key unset — set CLOUD_INTERNAL_KEY (or " +
+        "LEARNHOUSE_CLOUD_INTERNAL_KEY) on the web deployment to match the API's " +
+        "CLOUD_INTERNAL_KEY; the plan write would 403 without it.",
+    );
+  }
   const result = await fetch(`${getServerAPIUrl()}cloud_internal/update_org_plan`, {
     method: "PUT",
     headers: {


### PR DESCRIPTION
## Problem

The Stripe checkout → organization-plan upgrade relied on a single automatic path (the webhook) with several ways to fail silently, so a paid subscription could leave the org on the wrong plan with no error surfaced.

## Changes

- **Fail loud on a missing internal key.** The internal plan-write now throws a clear error when the API key is unset (and accepts either supported env name) instead of sending an empty key and treating the resulting rejection as normal.
- **Webhook-independent fulfillment.** Adds `POST /api/billing/fulfill` (idempotent, org-admin authorized; plan derived from the verified Stripe session, never the request body), invoked on return from checkout, so the upgrade no longer depends solely on webhook delivery. This wires up the existing `fulfillCheckoutSession()` helper, which previously had no callers.
- **Webhook hardening.** Retries the briefly-deferred subscription and lets Stripe redeliver on failure instead of acking; also handles `customer.subscription.created`.
- **Idempotency fix.** Records a webhook event as processed only after it is handled successfully, so a retried event is actually reprocessed rather than skipped as a duplicate.
- **Plan-reader robustness.** Coerces `config_version` to a string before `startsWith` (`resolve.py`, `usePlan.ts`) so a numeric value can't blank the resolved plan.

## Notes

- Fixing the root-cause misconfiguration is an environment/config change tracked separately; this PR removes the code-level single points of failure so the same class of issue surfaces loudly and self-recovers.
- A reconcile endpoint (`GET /api/billing/cron/reconcile`) already exists; scheduling it as a recurring job is a follow-up.

## Testing

- eslint on the changed web files: 0 errors.
- `resolve.py` syntax-checked; the plan-write endpoint is unchanged and remains covered by its existing router test.