### PR TITLE
chore(renovate): run dependency updates weekly instead of biweekly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     "mergeConfidence:all-badges"
   ],
   "baseBranches": ["dev"],
-  "schedule": ["every 2 weeks on saturday"],
+  "schedule": ["on saturday"],
   "timezone": "UTC",
   "labels": ["dependencies", "renovate"],
   "prBodyColumns": [


### PR DESCRIPTION
Changes the Renovate schedule from `every 2 weeks on saturday` to `on saturday` (every Saturday), so grouped minor/patch dependency PRs open **weekly** instead of every two weeks.

- `vulnerabilityAlerts` stays `at any time` (unchanged) — security updates are unaffected.
- No other config changed.