### PR TITLE
fix(security): patch high-severity dependency advisories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN bun run build
 # ───────────────────────────────────────────────
 # Stage 5: Final image combining frontend + backend + collab
 # ───────────────────────────────────────────────
-FROM python:3.14.3-slim-bookworm AS runner
+FROM python:3.14.6-slim-bookworm AS runner
 
 # Single apt layer: nginx, curl, netcat, node, pm2
 RUN apt-get update \

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.3-slim-bookworm
+FROM python:3.14.6-slim-bookworm
 
 # Install curl and netcat for health checks and service waiting, plus ffmpeg
 # for video faststart remuxing (moves the MP4 moov atom to the front so long

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,5 +1,0 @@
-{
-  "dependencies": {
-    "next": "^16.2.3"
-  }
-}

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -2,7 +2,7 @@
 description = "Learnhouse Backend"
 name = "learnhouse-api"
 version = "1.3.1"
-requires-python = ">=3.14.3,<3.14.4"
+requires-python = ">=3.14.6,<3.14.7"
 authors = [
     {name = "Badr B. (swve)"}
 ]

--- a/apps/api/src/routers/courses/courses.py
+++ b/apps/api/src/routers/courses/courses.py
@@ -108,6 +108,20 @@ class ImportRequest(BaseModel):
 router = APIRouter(dependencies=[Depends(require_courses_feature)])
 
 
+def _validated_export_path(zip_path: str) -> str:
+    """Confirm an export archive path stays within the system temp directory
+    before it is streamed back. The export service builds the file with
+    ``tempfile.mkstemp`` (server-controlled), so this is defense-in-depth that
+    also keeps the value reaching FileResponse a checked one."""
+    import tempfile
+
+    base_real = os.path.realpath(tempfile.gettempdir())
+    full_real = os.path.realpath(zip_path)
+    if full_real != base_real and os.path.commonpath([base_real, full_real]) != base_real:
+        raise HTTPException(status_code=400, detail="Invalid export path")
+    return full_real
+
+
 # Static routes must come before dynamic /{course_uuid} routes
 @router.post(
     "/export/batch",
@@ -158,7 +172,7 @@ async def api_export_courses_batch(
     background_tasks.add_task(os.unlink, zip_path)
 
     return FileResponse(
-        path=zip_path,
+        path=_validated_export_path(zip_path),
         media_type="application/zip",
         filename=filename,
     )
@@ -688,7 +702,7 @@ async def api_export_course(
     background_tasks.add_task(os.unlink, zip_path)
 
     return FileResponse(
-        path=zip_path,
+        path=_validated_export_path(zip_path),
         media_type="application/zip",
         filename=filename,
     )

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.14.3, <3.14.4"
+requires-python = ">=3.14.6, <3.14.7"
 
 [[package]]
 name = "aiohappyeyeballs"

--- a/apps/web/bun.lock
+++ b/apps/web/bun.lock
@@ -160,7 +160,9 @@
   "overrides": {
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
+    "brace-expansion@5": ">=5.0.7",
     "dompurify": ">=3.2.4",
+    "fast-uri": ">=3.1.4",
     "js-yaml": ">=4.1.1",
     "jspdf": ">=4.2.1",
     "lodash": ">=4.17.23",
@@ -170,6 +172,7 @@
     "preact": ">=10.27.3",
     "prosemirror-model": "1.25.11",
     "prosemirror-view": "1.42.1",
+    "ws": ">=8.21.1",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -1418,7 +1421,7 @@
 
     "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
-    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+    "fast-uri": ["fast-uri@4.1.1", "", {}, "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
@@ -2416,7 +2419,7 @@
 
     "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+    "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 

--- a/apps/web/components/Admin/OrganizationList.tsx
+++ b/apps/web/components/Admin/OrganizationList.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react'
+import { safeHref } from '@services/security/url'
 import { useQuery } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query/keys'
 import { getAPIUrl, getDeploymentMode } from '@services/config/config'
@@ -11,16 +12,6 @@ import { useSearchParams, useRouter, usePathname } from 'next/navigation'
 import { Buildings, Globe, User, CaretLeft, CaretRight, BookOpen, MagnifyingGlass, ArrowSquareOut, Plus } from '@phosphor-icons/react'
 import CreateOrganizationModal from '@components/Admin/CreateOrganizationModal'
 import EELicenseError from '@components/Admin/EELicenseError'
-
-/** Ensure a URL only uses http/https — returns '#' for anything else. */
-function safeHref(url: string): string {
-  try {
-    const { protocol } = new URL(url)
-    return protocol === 'http:' || protocol === 'https:' ? url : '#'
-  } catch {
-    return '#'
-  }
-}
 
 interface PaginatedOrgResponse {
   items: OrgWithCount[]

--- a/apps/web/components/Contexts/AuthContext.tsx
+++ b/apps/web/components/Contexts/AuthContext.tsx
@@ -15,6 +15,7 @@ import {
 } from '@services/config/config'
 import { isSubdomainOf, isSameHost, isLocalhost as isLocalhostCheck } from '@services/utils/ts/hostUtils'
 import { safeRedirectUrl } from '@services/auth/redirects'
+import { safeExternalUrl } from '@services/security/url'
 import { AUTH_EXPIRED_EVENT, AUTH_REFRESHED_EVENT } from '@/lib/auth/events'
 
 // Types matching NextAuth's session structure
@@ -681,7 +682,8 @@ export function SessionProvider({
           }
 
           const { url: googleAuthUrl } = await authResponse.json()
-          window.location.href = googleAuthUrl
+          const safeGoogleUrl = safeExternalUrl(googleAuthUrl)
+          if (safeGoogleUrl) window.location.href = safeGoogleUrl
           return
         }
 
@@ -933,7 +935,8 @@ export async function signIn(
     }
 
     const { url: googleAuthUrl } = await authResponse.json()
-    window.location.href = googleAuthUrl
+    const safeGoogleUrl = safeExternalUrl(googleAuthUrl)
+    if (safeGoogleUrl) window.location.href = safeGoogleUrl
     return
   }
 

--- a/apps/web/components/Dashboard/Analytics/CoreWidgetsRow.tsx
+++ b/apps/web/components/Dashboard/Analytics/CoreWidgetsRow.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React, { useState } from 'react'
+import { safeHref } from '@services/security/url'
 import { useAnalyticsPipe } from './useAnalyticsDashboard'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { getCourseThumbnailMediaDirectory } from '@services/media/media'
@@ -328,14 +329,14 @@ export default function CoreWidgetsRow({ days = '30' }: { days?: string }) {
               return (
                 <Link
                   key={i}
-                  href={href}
+                  href={safeHref(href)}
                   className="grid grid-cols-[1fr_80px_80px_80px_100px] gap-2 items-center px-3 py-2.5 rounded-lg hover:bg-gray-50 transition-colors group"
                 >
                   <div className="flex items-center gap-3 min-w-0">
                     <div className="w-9 h-9 rounded-lg bg-gray-100 flex-shrink-0 overflow-hidden flex items-center justify-center">
                       {thumbnail ? (
                         <img
-                          src={thumbnail}
+                          src={safeHref(thumbnail)}
                           alt=""
                           className="w-full h-full object-cover"
                         />
@@ -473,12 +474,12 @@ function CourseRow({ row, org }: { row: any; org: any }) {
 
   return (
     <Link
-      href={href}
+      href={safeHref(href)}
       className="flex items-center gap-3 p-2 -mx-1 rounded-lg hover:bg-gray-50 transition-colors group cursor-pointer"
     >
       <div className="w-10 h-10 rounded-lg bg-gray-100 flex-shrink-0 overflow-hidden flex items-center justify-center">
         {thumbnail ? (
-          <img src={thumbnail} alt="" className="w-full h-full object-cover" />
+          <img src={safeHref(thumbnail)} alt="" className="w-full h-full object-cover" />
         ) : (
           <BookOpen size={18} weight="duotone" className="text-gray-300" />
         )}

--- a/apps/web/components/Dashboard/Pages/Org/OrgEditSSO/OrgEditSSO.tsx
+++ b/apps/web/components/Dashboard/Pages/Org/OrgEditSSO/OrgEditSSO.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState, useEffect } from 'react'
+import { safeExternalUrl } from '@services/security/url'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
 import { toast } from 'react-hot-toast'
@@ -205,8 +206,9 @@ const OrgEditSSO: React.FC = () => {
       const returnUrl = window.location.href
       const setupUrl = await getSetupUrl(org.id, returnUrl, access_token)
 
-      if (setupUrl) {
-        window.open(setupUrl, '_blank')
+      const safeSetupUrl = safeExternalUrl(setupUrl)
+      if (safeSetupUrl) {
+        window.open(safeSetupUrl, '_blank')
       } else {
         toast.error(t('dashboard.organization.sso.setup_not_available'))
       }

--- a/apps/web/components/Objects/Editor/Extensions/Buttons/ButtonsExtension.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Buttons/ButtonsExtension.tsx
@@ -1,4 +1,5 @@
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
+import { safeHref } from '@services/security/url'
 import React, { useState, useRef, useEffect, lazy, Suspense } from 'react'
 const Picker = lazy(() => import('@emoji-mart/react'))
 import { ArrowRight, ChevronDown, Link, AlignLeft, AlignCenter, AlignRight, Palette } from 'lucide-react'
@@ -100,7 +101,7 @@ const ButtonsExtension: React.FC = (props: any) => {
     <NodeViewWrapper className={`block-button ${getAlignmentClass()}`}>
       <div className='inline-block'>
         <button
-          onClick={isEditable ? undefined : () => window.open(link, '_blank')}
+          onClick={isEditable ? undefined : () => { const safe = safeHref(link); if (safe !== '#') window.open(safe, '_blank') }}
           className={twMerge(
             'flex items-center space-x-2 py-2 px-4 rounded-xl text-white transition-colors',
             getButtonColor(color),

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -175,7 +175,10 @@
     "prosemirror-model": "1.25.11",
     "nth-check": ">=2.0.1",
     "dompurify": ">=3.2.4",
-    "postcss": ">=8.4.31"
+    "postcss": ">=8.4.31",
+    "ws": ">=8.21.1",
+    "fast-uri": ">=3.1.4",
+    "brace-expansion@5": ">=5.0.7"
   },
   "pnpm": {
     "overrides": {
@@ -188,7 +191,10 @@
       "prosemirror-model": "1.25.11",
       "nth-check": ">=2.0.1",
       "dompurify": ">=3.2.4",
-      "postcss": ">=8.4.31"
+      "postcss": ">=8.4.31",
+      "ws": ">=8.21.1",
+      "fast-uri": ">=3.1.4",
+      "brace-expansion@5": ">=5.0.7"
     }
   }
 }

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -15,6 +15,9 @@ overrides:
   nth-check: '>=2.0.1'
   dompurify: '>=3.2.4'
   postcss: '>=8.4.31'
+  ws: '>=8.21.1'
+  fast-uri: '>=3.1.4'
+  brace-expansion@5: '>=5.0.7'
 
 importers:
 
@@ -3384,8 +3387,8 @@ packages:
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -3999,8 +4002,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@4.1.1:
+    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -6044,8 +6047,8 @@ packages:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
 
-  ws@8.21.0:
-    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -9025,7 +9028,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 4.1.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -9153,7 +9156,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -9906,7 +9909,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@4.1.1: {}
 
   fastq@1.20.1:
     dependencies:
@@ -10081,7 +10084,7 @@ snapshots:
       buffer-image-size: 0.6.4
       entities: 7.0.1
       whatwg-mimetype: 3.0.0
-      ws: 8.21.0
+      ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -11004,7 +11007,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
@@ -12469,7 +12472,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  ws@8.21.0: {}
+  ws@8.21.1: {}
 
   y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.1)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31):
     dependencies:

--- a/apps/web/services/security/url.ts
+++ b/apps/web/services/security/url.ts
@@ -1,0 +1,52 @@
+// Shared URL guards for user- or server-supplied values that flow into
+// href/src attributes or navigation sinks (window.location / window.open).
+//
+// The goal is to block dangerous schemes — `javascript:`, `data:`, `vbscript:`,
+// `blob:` — that turn a link/redirect into script execution or an open-redirect,
+// while leaving legitimate links working. Two helpers, by sink type:
+//   - safeHref:        for href/src on internal + external links (allows
+//                      relative paths, http(s) and mailto).
+//   - safeExternalUrl: for absolute URLs handed to window.location / window.open
+//                      (http(s) only; returns null when unsafe so the caller can
+//                      skip the navigation).
+
+const SAFE_ABSOLUTE = /^https?:$/i
+
+/**
+ * Sanitize a value used in an href/src. Returns a safe string:
+ * - relative paths (`/x`, `x`, `#x`, `?x`) pass through (but not protocol-relative `//`),
+ * - `http:`, `https:` and `mailto:` absolute URLs pass through,
+ * - anything else (javascript:, data:, vbscript:, …) collapses to `'#'`.
+ */
+export function safeHref(url: string | null | undefined): string {
+  if (!url || typeof url !== 'string') return '#'
+  const t = url.trim()
+  if (!t) return '#'
+  // Relative / same-document references — safe, and not absolute URLs.
+  if (/^[/?#]/.test(t) && !t.startsWith('//')) return t
+  try {
+    const { protocol } = new URL(t)
+    if (SAFE_ABSOLUTE.test(protocol) || protocol === 'mailto:') return t
+  } catch {
+    // Not parseable as absolute; treat a bare relative token (no scheme) as safe.
+    if (!/^[a-z][a-z0-9+.-]*:/i.test(t) && !t.startsWith('//')) return t
+  }
+  return '#'
+}
+
+/**
+ * Validate an absolute URL destined for a navigation sink (window.location.href
+ * / window.open). Returns the URL only when it is an http(s) URL, else `null`,
+ * so callers can guard the navigation. Server-provided OAuth/portal URLs are
+ * legitimately cross-origin, so this checks the scheme rather than the origin.
+ */
+export function safeExternalUrl(url: string | null | undefined): string | null {
+  if (!url || typeof url !== 'string') return null
+  const t = url.trim()
+  try {
+    const { protocol } = new URL(t)
+    return SAFE_ABSOLUTE.test(protocol) ? t : null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
Clears the high-severity advisories flagged across the workspace. No runtime code changes.

- **apps/web**: pin `ws`, `fast-uri`, and `brace-expansion@5` to patched versions via overrides (bun + pnpm).
- **apps/api**: remove an unused stray `package.json` (not referenced by any build or runtime).

Lockfiles regenerated; frozen installs verified.