### PR TITLE
fix(auth): stop unexpected sign-outs from transient refresh failures

### DIFF
--- a/apps/api/src/security/auth.py
+++ b/apps/api/src/security/auth.py
@@ -157,7 +157,37 @@ def create_access_token(data: dict, expires_delta: timedelta | None = None):
     return encoded_jwt
 
 
-JWT_REFRESH_TOKEN_EXPIRES = timedelta(days=30)
+# Users must be able to come back after a two-week break (a holiday, a school
+# vacation, a sprint spent elsewhere) and still be signed in.
+MIN_REFRESH_TOKEN_DAYS = 14
+DEFAULT_REFRESH_TOKEN_DAYS = 30
+
+
+def _refresh_token_lifetime() -> timedelta:
+    """Resolve how long a user may stay away before they must sign in again.
+
+    This is the *inactivity* window: every successful refresh mints a brand-new
+    refresh token with a full lifetime, so an active user is never signed out.
+    Only a user who does not open the app at all for this long loses their
+    session.
+
+    Overridable with ``LEARNHOUSE_AUTH_REFRESH_TOKEN_DAYS`` for operators who
+    want a longer or shorter window, but never below
+    ``MIN_REFRESH_TOKEN_DAYS`` — a shorter window is nearly always a
+    misconfiguration that shows up as users complaining they get logged out.
+    """
+    import os
+    raw = os.environ.get("LEARNHOUSE_AUTH_REFRESH_TOKEN_DAYS")
+    if raw:
+        try:
+            days = int(raw)
+            return timedelta(days=max(days, MIN_REFRESH_TOKEN_DAYS))
+        except (TypeError, ValueError):
+            pass
+    return timedelta(days=DEFAULT_REFRESH_TOKEN_DAYS)
+
+
+JWT_REFRESH_TOKEN_EXPIRES = _refresh_token_lifetime()
 JWT_REFRESH_COOKIE_NAME = "LH_refresh"
 
 
@@ -310,7 +340,20 @@ def _mark_refresh_jti_used(user_id: int, jti: str) -> bool:
 # revokes EVERY session for the user — the classic "I keep getting logged
 # out" bug. Within this window we instead re-serve the exact rotated pair the
 # first call issued. Only a replay AFTER the window is treated as theft.
-REFRESH_GRACE_WINDOW_SECONDS = 30
+#
+# 30 seconds turned out to be far too tight in production. Legitimate replays
+# routinely arrive minutes apart, not milliseconds:
+#   - A server-rendered page consumes the refresh token, and the browser only
+#     re-presents it on the next client-side refresh.
+#   - A laptop is suspended mid-refresh and resumes later on the old cookie.
+#   - A background tab wakes up and refreshes with a cookie another tab has
+#     already rotated.
+#   - A slow/flaky mobile connection retries after a long timeout.
+# Every one of those was being classified as token theft, which revokes ALL of
+# the user's sessions on ALL devices. Five minutes keeps genuine replay
+# detection meaningful (a stolen token reused hours or days later is still
+# caught) while making the common benign cases non-fatal.
+REFRESH_GRACE_WINDOW_SECONDS = 5 * 60
 
 
 def _store_refresh_grace(

--- a/apps/api/src/services/security/rate_limiting.py
+++ b/apps/api/src/services/security/rate_limiting.py
@@ -194,8 +194,20 @@ def check_verification_resend_rate_limit(email: str) -> Tuple[bool, int]:
 
 def check_refresh_rate_limit(request: Request) -> Tuple[bool, int]:
     """
-    Check token refresh rate limit: 60 attempts per minute per IP.
-    This prevents brute-force attacks on the refresh endpoint.
+    Check token refresh rate limit: 600 attempts per minute per IP.
+
+    This limit exists for DoS protection only, NOT for credential guessing:
+    /auth/refresh requires an already-valid, server-signed refresh JWT, so
+    there is nothing here an attacker can brute-force.
+
+    The limit is keyed per IP, and schools/companies — LearnHouse's core
+    audience — put hundreds of users behind a single NAT address. The previous
+    60/minute ceiling was reached by a few dozen people signing in at the same
+    time (start of a class, Monday morning), and every request over the line
+    got a 429 that the frontend then treated as "your session is dead" —
+    logging out an entire site at once. Keep this generous; the real
+    protections are the JWT signature, the revocation blocklist, and the
+    one-time-use rotation.
 
     Returns:
         Tuple of (is_allowed, retry_after_seconds)
@@ -205,7 +217,7 @@ def check_refresh_rate_limit(request: Request) -> Tuple[bool, int]:
 
     is_allowed, count, retry_after = check_rate_limit(
         key=key,
-        max_attempts=60,
+        max_attempts=600,
         window_seconds=60  # 1 minute
     )
 

--- a/apps/api/src/tests/security/test_auth.py
+++ b/apps/api/src/tests/security/test_auth.py
@@ -402,3 +402,61 @@ class TestAuth:
                 await get_current_user(request=mock_request, db_session=mock_db_session)
 
         assert exc_info.value.status_code == 401
+
+class TestSessionLifetime:
+    """Guards on how long a user may stay away before being signed out.
+
+    These exist because the inactivity window regressed in production and
+    users were being signed out while their session still had weeks of life.
+    """
+
+    def test_refresh_lifetime_defaults_to_thirty_days(self):
+        from src.security.auth import _refresh_token_lifetime, DEFAULT_REFRESH_TOKEN_DAYS
+
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+            os.environ.pop("LEARNHOUSE_AUTH_REFRESH_TOKEN_DAYS", None)
+            assert _refresh_token_lifetime() == timedelta(days=DEFAULT_REFRESH_TOKEN_DAYS)
+
+    def test_refresh_lifetime_honours_env_override(self):
+        from src.security.auth import _refresh_token_lifetime
+
+        with patch.dict("os.environ", {"LEARNHOUSE_AUTH_REFRESH_TOKEN_DAYS": "45"}):
+            assert _refresh_token_lifetime() == timedelta(days=45)
+
+    def test_refresh_lifetime_never_drops_below_two_weeks(self):
+        """A user must survive a two-week absence. Anything shorter is clamped:
+        a too-small value is nearly always a misconfiguration, and it shows up
+        as users complaining they keep getting logged out."""
+        from src.security.auth import _refresh_token_lifetime, MIN_REFRESH_TOKEN_DAYS
+
+        assert MIN_REFRESH_TOKEN_DAYS == 14
+        for bad in ("1", "7", "13", "0", "-5"):
+            with patch.dict("os.environ", {"LEARNHOUSE_AUTH_REFRESH_TOKEN_DAYS": bad}):
+                assert _refresh_token_lifetime() == timedelta(days=MIN_REFRESH_TOKEN_DAYS)
+
+    def test_refresh_lifetime_ignores_garbage_env(self):
+        from src.security.auth import _refresh_token_lifetime, DEFAULT_REFRESH_TOKEN_DAYS
+
+        with patch.dict("os.environ", {"LEARNHOUSE_AUTH_REFRESH_TOKEN_DAYS": "not-a-number"}):
+            assert _refresh_token_lifetime() == timedelta(days=DEFAULT_REFRESH_TOKEN_DAYS)
+
+    def test_issued_refresh_token_outlives_two_weeks(self):
+        """End-to-end: a freshly minted refresh token is still valid well past
+        the two-week mark."""
+        token = create_refresh_token({"sub": "test@example.com"})
+        decoded = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        exp = datetime.fromtimestamp(decoded["exp"], tz=timezone.utc)
+
+        assert exp - datetime.now(timezone.utc) > timedelta(days=14)
+
+    def test_replay_grace_window_tolerates_slow_clients(self):
+        """The grace window absorbs benign duplicate refreshes (a suspended
+        laptop, a background tab, a retried request on a bad connection).
+
+        At 30 seconds those were being misread as token theft, which revokes
+        every session the user has on every device. Keep it comfortably above
+        a page-load timescale."""
+        from src.security.auth import REFRESH_GRACE_WINDOW_SECONDS
+
+        assert REFRESH_GRACE_WINDOW_SECONDS >= 120

--- a/apps/api/src/tests/services/test_rate_limiting_service.py
+++ b/apps/api/src/tests/services/test_rate_limiting_service.py
@@ -267,7 +267,11 @@ def test_increment_rate_limit_existing_and_missing_keys():
     [
         (check_login_rate_limit, "login:203.0.113.9", 30, 5 * 60),
         (check_signup_rate_limit, "signup:203.0.113.9", 10, 60 * 60),
-        (check_refresh_rate_limit, "refresh:203.0.113.9", 60, 60),
+        # Deliberately generous: /auth/refresh is cookie-authenticated, so there
+        # is nothing to brute-force, and this limit is keyed per IP. Schools and
+        # companies put hundreds of users behind one NAT address, and a limit
+        # low enough to catch them signs out an entire site at once.
+        (check_refresh_rate_limit, "refresh:203.0.113.9", 600, 60),
         (check_api_token_rate_limit, "api_token:203.0.113.9", 10, 60 * 60),
     ],
 )

--- a/apps/web/app/api/auth/[...path]/route.ts
+++ b/apps/web/app/api/auth/[...path]/route.ts
@@ -68,6 +68,16 @@ const REFRESH_FAST_PATH_HEADROOM_MS = 2 * 60 * 1000
 const CLEAR_HTTPONLY = [ACCESS_TOKEN_COOKIE, REFRESH_TOKEN_COOKIE, 'LH_custom_domain']
 const CLEAR_MARKERS = ['LH_session', 'LH_org']
 
+// A refresh failure only justifies destroying the session when the backend
+// rejected the CREDENTIAL itself. 401/403 are terminal — the refresh cookie is
+// expired, revoked, or was flagged as replayed, and re-sending it will never
+// work. Everything else (429 rate limit, 5xx during a deploy, gateway
+// timeouts) is a server-side hiccup that says nothing about the token's
+// validity, and the user's session must survive it.
+function isTerminalAuthFailure(status: number): boolean {
+  return status === 401 || status === 403
+}
+
 function appendClearAuthCookies(response: NextResponse, request: NextRequest) {
   const securePart = request.nextUrl.protocol === 'https:' ? '; Secure' : ''
   const host = request.headers.get('host') || ''
@@ -273,12 +283,19 @@ async function proxyRequest(
     }
   }
 
-  // A failed refresh means the refresh cookie is dead (revoked, expired, or a
-  // replay outside the grace window). Clear all auth cookies so the browser
-  // stops sending a stale 30-day refresh token + LH_session marker, which
-  // would otherwise loop the client through repeated failed refreshes instead
-  // of cleanly falling back to the login screen.
-  if (pathSegments === 'refresh' && !backendResponse.ok) {
+  // Only destroy the session when the backend says the refresh CREDENTIAL is
+  // dead — 401 (expired/revoked/replayed) or 403. Those are terminal: the
+  // cookie will never work again, so we clear it and let the client fall back
+  // to the login screen instead of looping on failed refreshes.
+  //
+  // Every other failure is transient and MUST NOT log the user out. A 429 from
+  // the per-IP refresh rate limit, a 502 while the API rolls out, a 500, a
+  // gateway timeout — none of those mean the user's 30-day refresh token is
+  // invalid. Clearing cookies on those was silently ending sessions that had
+  // weeks of life left, and because the httpOnly refresh cookie was deleted
+  // the user could not recover except by signing in again. Whole classrooms
+  // behind one NAT IP were being signed out together this way.
+  if (pathSegments === 'refresh' && isTerminalAuthFailure(backendResponse.status)) {
     appendClearAuthCookies(response, request)
   }
 

--- a/apps/web/app/board/[boarduuid]/client.tsx
+++ b/apps/web/app/board/[boarduuid]/client.tsx
@@ -7,27 +7,41 @@ import { getBoard } from '@services/boards/boards'
 import { getOrganizationContextInfo } from '@services/organizations/orgs'
 import BoardCanvas from '@components/Dashboard/Boards/BoardCanvas'
 import { useTrackView, AnalyticsEvent } from '@services/analytics'
+import { useLHSession } from '@components/Contexts/LHSessionContext'
 
 interface BoardCanvasClientProps {
   boardUuid: string
-  accessToken: string
+  /**
+   * Server-read access token. Absent whenever the access-token cookie has
+   * lapsed (every visit more than 8 hours after the last one) — the server
+   * deliberately does not refresh, because refreshing there would consume the
+   * browser's one-time-use refresh token. We fall back to the client session,
+   * which holds a freshly refreshed token once AuthContext has hydrated.
+   */
+  accessToken?: string
   orgslug: string
   username: string
 }
 
 export default function BoardCanvasClient({ boardUuid, accessToken, orgslug, username }: BoardCanvasClientProps) {
+  const session = useLHSession() as any
+  const token: string | undefined = accessToken || session?.data?.tokens?.access_token
+  const displayName =
+    username || session?.data?.user?.username || session?.data?.user?.email || 'Anonymous'
+
   const { data: board, isLoading, error } = useQuery({
     queryKey: queryKeys.boards.detail(boardUuid),
-    queryFn: () => getBoard(boardUuid, accessToken),
-    enabled: !!accessToken,
+    // Guarded by `enabled` — queryFn never runs without a token.
+    queryFn: () => getBoard(boardUuid, token as string),
+    enabled: !!token,
     staleTime: 60_000,
   })
 
   // Fetch org info to get org_uuid for media URLs in board blocks
   const { data: orgData } = useQuery({
     queryKey: queryKeys.org.detail(orgslug),
-    queryFn: () => getOrganizationContextInfo(orgslug, null, accessToken),
-    enabled: !!orgslug,
+    queryFn: () => getOrganizationContextInfo(orgslug, null, token),
+    enabled: !!orgslug && !!token,
     staleTime: 60_000,
   })
 
@@ -38,7 +52,10 @@ export default function BoardCanvasClient({ boardUuid, accessToken, orgslug, use
     'learner',
   )
 
-  if (isLoading) {
+  // No token yet means AuthContext is still trading the refresh cookie for an
+  // access token. The board query is disabled until then, so keep showing the
+  // spinner rather than falling through to "not found".
+  if (!token || isLoading) {
     return (
       <div className="flex h-screen items-center justify-center bg-[#f8f8f8]">
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-gray-300 border-t-black" />
@@ -57,9 +74,9 @@ export default function BoardCanvasClient({ boardUuid, accessToken, orgslug, use
   return (
     <BoardCanvas
       board={board}
-      accessToken={accessToken}
+      accessToken={token}
       orgslug={orgslug}
-      username={username}
+      username={displayName}
       orgUuid={orgData?.org_uuid || ''}
     />
   )

--- a/apps/web/app/board/[boarduuid]/page.tsx
+++ b/apps/web/app/board/[boarduuid]/page.tsx
@@ -31,7 +31,13 @@ async function BoardEditorPage(props: any) {
   // Require authentication to access board canvas. Bare /login only — the proxy
   // rewrites it to /auth/login with tenant context; an /orgs/{slug}/login path
   // isn't a real route (the /orgs prefix is an internal rewrite target) → 404.
-  if (!access_token) {
+  //
+  // Redirect ONLY when there is no session at all. A session the server could
+  // not resolve (`unresolved`: refresh cookie present, access token expired)
+  // belongs to a signed-in user — bouncing them to /login here was signing
+  // people out just for coming back after their 8-hour access token lapsed.
+  // The client picks up the real token from the session context instead.
+  if (!session) {
     redirect(`/login?redirect=/board/${params.boarduuid}`)
   }
 
@@ -45,7 +51,7 @@ async function BoardEditorPage(props: any) {
       boardUuid={boardUuid}
       accessToken={access_token}
       orgslug={orgslug}
-      username={session?.user?.username || session?.user?.email || 'Anonymous'}
+      username={session?.user?.username || session?.user?.email || ''}
     />
   )
 }

--- a/apps/web/components/Contexts/AuthContext.tsx
+++ b/apps/web/components/Contexts/AuthContext.tsx
@@ -31,6 +31,17 @@ export interface Session {
 
 export type SessionStatus = 'loading' | 'authenticated' | 'unauthenticated'
 
+// Result of trying to trade the refresh cookie for an access token.
+//
+// `unauthenticated` and `transient` are kept apart on purpose: only the former
+// may end a session. Treating a rate limit, a 5xx, or an offline browser as
+// "signed out" destroys an httpOnly refresh cookie that still had weeks left,
+// and the user has no way back except signing in again.
+export type RefreshOutcome =
+  | { status: 'ok'; access_token: string; expiry?: number }
+  | { status: 'unauthenticated' }
+  | { status: 'transient' }
+
 export interface UseSessionReturn {
   data: Session | null
   status: SessionStatus
@@ -192,7 +203,7 @@ export function SessionProvider({
 
   // Use ref for refresh promise to avoid issues with stale closures
   // but still deduplicate within the same tab
-  const refreshPromiseRef = useRef<Promise<{ access_token: string; expiry?: number } | null> | null>(null)
+  const refreshPromiseRef = useRef<Promise<RefreshOutcome> | null>(null)
   const isRefreshingRef = useRef(false)
   const authFailureHandledRef = useRef(false)
   // Monotonic auth epoch: bumped on every logout/clear. An in-flight refresh that
@@ -256,35 +267,37 @@ export function SessionProvider({
     }
   }, [])
 
-  // Fetch user session from backend
+  // Fetch user session from backend.
+  //
+  // Returns `null` ONLY when the backend says this token is not a valid
+  // identity (401/403). Any other failure throws, so callers can tell "you are
+  // signed out" apart from "the request did not get through" and avoid tearing
+  // down a healthy session over a server blip.
   const fetchUserSession = useCallback(async (token: string, expiry?: number): Promise<Session | null> => {
-    try {
-      const response = await fetch(`${getAPIUrl()}users/session`, {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-        credentials: 'include',
-      })
+    const response = await fetch(`${getAPIUrl()}users/session`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      credentials: 'include',
+    })
 
-      if (!response.ok) {
-        console.error(`Session fetch failed with status: ${response.status}`)
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
         return null
       }
+      throw new Error(`Session fetch failed with status: ${response.status}`)
+    }
 
-      const data = await response.json()
-      return {
-        user: data.user,
-        roles: data.roles,
-        tokens: {
-          access_token: token,
-          refresh_token: undefined, // Stored in httpOnly cookie
-          expiry: expiry,
-        },
-      }
-    } catch (error) {
-      console.error('Error fetching user session:', error)
-      return null
+    const data = await response.json()
+    return {
+      user: data.user,
+      roles: data.roles,
+      tokens: {
+        access_token: token,
+        refresh_token: undefined, // Stored in httpOnly cookie
+        expiry: expiry,
+      },
     }
   }, [])
 
@@ -296,8 +309,15 @@ export function SessionProvider({
     return document.cookie.split('; ').some((c) => c.startsWith('LH_session='))
   }, [])
 
-  // Refresh access token using refresh token cookie
-  const refreshAccessToken = useCallback(async (): Promise<{ access_token: string; expiry?: number } | null> => {
+  // Refresh access token using refresh token cookie.
+  //
+  // The outcome is deliberately three-way. Collapsing "the server is having a
+  // bad minute" into "you are logged out" is what made sessions evaporate: a
+  // single 429 from the shared-IP refresh rate limit, or one 502 during an API
+  // rollout, used to tear down a session that still had weeks of validity.
+  // Only `unauthenticated` — the backend explicitly rejecting the refresh
+  // credential — may end a session.
+  const refreshAccessToken = useCallback(async (): Promise<RefreshOutcome> => {
     // Deduplicate refresh requests within this tab
     if (isRefreshingRef.current && refreshPromiseRef.current) {
       return refreshPromiseRef.current
@@ -313,11 +333,16 @@ export function SessionProvider({
         })
 
         if (!response.ok) {
-          if (response.status === 401) {
-            // Refresh token expired or invalid
-            return null
+          // 401/403 are the only statuses that mean the refresh cookie itself
+          // is dead. The proxy clears cookies on exactly these, so the two
+          // layers agree on what ends a session.
+          if (response.status === 401 || response.status === 403) {
+            return { status: 'unauthenticated' } as const
           }
-          throw new Error(`Refresh failed with status: ${response.status}`)
+          console.warn(
+            `[auth] refresh failed with ${response.status} — keeping session, will retry`,
+          )
+          return { status: 'transient' } as const
         }
 
         const data = await response.json()
@@ -325,16 +350,19 @@ export function SessionProvider({
         // Validate response structure
         if (!data.access_token) {
           console.error('Invalid refresh response: missing access_token')
-          return null
+          return { status: 'transient' } as const
         }
 
         return {
+          status: 'ok',
           access_token: data.access_token,
           expiry: typeof data.expiry === 'number' ? data.expiry : undefined,
-        }
+        } as const
       } catch (error) {
-        console.error('Token refresh failed:', error)
-        return null
+        // Network error, offline, DNS blip, aborted request. Says nothing
+        // about whether the user is still signed in.
+        console.warn('[auth] refresh request could not be sent:', error)
+        return { status: 'transient' } as const
       } finally {
         isRefreshingRef.current = false
         refreshPromiseRef.current = null
@@ -358,7 +386,20 @@ export function SessionProvider({
     setAccessToken(token)
     setTokenExpiry(expiry || null)
 
-    const sessionData = await fetchUserSession(token, expiry)
+    let sessionData: Session | null
+    try {
+      sessionData = await fetchUserSession(token, expiry)
+    } catch (error) {
+      // Transient — the profile lookup did not complete. We hold a freshly
+      // issued access token, so the user IS signed in, but without user data
+      // there is nothing to render as authenticated. Leave the cookies alone
+      // and settle on 'unauthenticated', which is the state the refetch
+      // interval polls from (it keys off the surviving session marker), so the
+      // tab recovers on its own instead of hanging on 'loading' forever.
+      console.warn('[auth] session lookup failed, keeping session:', error)
+      setStatus('unauthenticated')
+      return false
+    }
     // A logout/clear that fired during the await bumped the epoch — abort the
     // write so we don't resurrect a session that was just invalidated.
     if (authEpochRef.current !== epoch) return false
@@ -380,14 +421,16 @@ export function SessionProvider({
   const refreshSessionInternal = useCallback(async () => {
     try {
       const refreshResult = await refreshAccessToken()
-      if (refreshResult) {
+      if (refreshResult.status === 'ok') {
         await applySessionFromToken(refreshResult.access_token, refreshResult.expiry)
-      } else {
+      } else if (refreshResult.status === 'unauthenticated') {
         clearAuthState()
       }
+      // 'transient': leave the current session in place. The refetch interval
+      // will try again shortly.
     } catch (error) {
+      // Never end a session because of an unexpected client-side error.
       console.error('Session refresh error:', error)
-      clearAuthState()
     }
   }, [applySessionFromToken, clearAuthState, refreshAccessToken])
 
@@ -420,15 +463,19 @@ export function SessionProvider({
 
       if (!currentToken || isTokenExpiringSoon(currentExpiry)) {
         const refreshResult = await refreshAccessToken()
-        if (refreshResult) {
+        if (refreshResult.status === 'ok') {
           currentToken = refreshResult.access_token
           currentExpiry = refreshResult.expiry || null
           setAccessToken(currentToken)
           setTokenExpiry(currentExpiry)
-        } else {
-          // No valid token, user is unauthenticated
+        } else if (refreshResult.status === 'unauthenticated') {
+          // The backend rejected the refresh credential — genuinely signed out.
           clearAuthState()
           return null
+        } else {
+          // Transient failure. Keep whatever session we already have rather
+          // than signing the user out over a hiccup; the next tick retries.
+          return currentToken
         }
       }
 
@@ -450,9 +497,11 @@ export function SessionProvider({
         return null
       }
     } catch (error) {
-      console.error('Session refresh error:', error)
-      clearAuthState()
-      return null
+      // Reaching here means a request could not be completed (offline, 5xx,
+      // aborted). That is not a signal about the user's identity, so the
+      // session stays as-is and the refetch interval retries.
+      console.warn('[auth] session refresh could not complete, keeping session:', error)
+      return accessTokenRef.current
     }
   }, [accessToken, tokenExpiry, fetchUserSession, isTokenExpiringSoon, refreshAccessToken, clearAuthState])
 
@@ -474,11 +523,16 @@ export function SessionProvider({
 
       if (!isMounted) return
 
-      if (refreshResult) {
-        if (!isMounted) return
+      if (refreshResult.status === 'ok') {
         await applySessionFromToken(refreshResult.access_token, refreshResult.expiry)
-      } else {
+      } else if (refreshResult.status === 'unauthenticated') {
         clearAuthState()
+      } else {
+        // Transient failure on a cold start. The refresh cookie is very likely
+        // still good, so don't wipe it — drop back to 'unauthenticated' status
+        // WITHOUT clearing cookies, and let the refetch interval recover the
+        // session once the backend is reachable again.
+        setStatus('unauthenticated')
       }
     }
 
@@ -489,9 +543,18 @@ export function SessionProvider({
     }
   }, [applySessionFromToken, clearAuthState, hasSessionMarker, refreshAccessToken])
 
-  // Set up refetch interval
+  // Set up refetch interval.
+  //
+  // Also runs while unauthenticated IF the session marker cookie is still
+  // present. That combination means "we hold a refresh cookie but couldn't
+  // turn it into a session yet" — i.e. a transient failure — and polling is
+  // what lets the tab heal itself once the backend is reachable again, instead
+  // of stranding the user on a logged-out UI until they reload.
   useEffect(() => {
-    if (refetchInterval && status === 'authenticated') {
+    const shouldPoll =
+      status === 'authenticated' || (status === 'unauthenticated' && hasSessionMarker())
+
+    if (refetchInterval && shouldPoll) {
       intervalRef.current = setInterval(() => {
         refreshSession()
       }, refetchInterval)
@@ -502,7 +565,7 @@ export function SessionProvider({
         clearInterval(intervalRef.current)
       }
     }
-  }, [refetchInterval, status, refreshSession])
+  }, [refetchInterval, status, refreshSession, hasSessionMarker])
 
   // Sign in function
   const handleSignIn = useCallback(

--- a/apps/web/lib/auth/server.ts
+++ b/apps/web/lib/auth/server.ts
@@ -15,19 +15,36 @@ export interface Session {
     refresh_token?: string | undefined
     expiry?: number | undefined
   } | undefined
+  /**
+   * True when a refresh cookie exists but the server could not turn it into an
+   * access token without consuming it. The user is signed in; the server just
+   * can't see who they are. Pages must NOT redirect to /login on this — render
+   * and let the client hydrate the real session.
+   */
+  unresolved?: boolean
 }
 
 /**
  * Get server-side session by reading tokens from cookies.
  *
- * Since cookies are now set by Next.js API routes (same origin),
- * they are reliably readable by the Next.js server.
+ * IMPORTANT — this must never call `/api/v1/auth/refresh`.
+ *
+ * Refresh tokens are one-time-use: the backend marks the presented `jti` as
+ * consumed and returns a rotated replacement. A Server Component cannot set
+ * cookies, so any refresh performed here consumes the browser's token and then
+ * throws the replacement away. The browser keeps sending the dead token, and
+ * once the backend's grace window lapses that looks exactly like a stolen
+ * token being replayed — which revokes EVERY session the user has, on every
+ * device. That is the "I was randomly logged out" report.
+ *
+ * So: use the access token if we have one, otherwise report the session as
+ * unresolved and let the client restore it through `/api/auth/refresh`, which
+ * is a Route Handler and *can* persist the rotation.
  */
 export async function getServerSession(): Promise<Session | null> {
   try {
     const cookieStore = await cookies()
 
-    // Try to get access token directly
     const accessToken = cookieStore.get(ACCESS_TOKEN_COOKIE)
 
     if (accessToken?.value) {
@@ -50,69 +67,18 @@ export async function getServerSession(): Promise<Session | null> {
           },
         }
       }
-
-      // Access token expired or invalid, try refresh
-      console.log('[SERVER_SESSION] Access token invalid, trying refresh')
     }
 
-    // Try to refresh using refresh token
+    // No usable access token. If a refresh cookie is present the user is still
+    // signed in — we just can't prove it from here without burning the token.
+    // Report an unresolved session so pages can avoid bouncing a logged-in
+    // user to /login; the client resolves it on hydration.
     const refreshToken = cookieStore.get(REFRESH_TOKEN_COOKIE)
-
-    if (!refreshToken?.value) {
-      return null
+    if (refreshToken?.value) {
+      return { user: undefined, roles: [], tokens: undefined, unresolved: true }
     }
 
-    // Exchange refresh token for new access token via backend
-    const refreshResponse = await fetch(`${BACKEND_URL}/api/v1/auth/refresh`, {
-      method: 'GET',
-      headers: {
-        Cookie: `${REFRESH_TOKEN_COOKIE}=${refreshToken.value}`,
-      },
-      cache: 'no-store',
-    })
-
-    if (!refreshResponse.ok) {
-      console.log('[SERVER_SESSION] Refresh failed:', refreshResponse.status)
-      return null
-    }
-
-    const refreshData = await refreshResponse.json()
-
-    if (!refreshData.access_token) {
-      return null
-    }
-
-    // Fetch user session with the new access token
-    const sessionResponse = await fetch(`${BACKEND_URL}/api/v1/users/session`, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${refreshData.access_token}`,
-      },
-      cache: 'no-store',
-    })
-
-    if (!sessionResponse.ok) {
-      // Return minimal session with just the token
-      return {
-        user: undefined,
-        roles: [],
-        tokens: {
-          access_token: refreshData.access_token,
-          expiry: refreshData.expiry,
-        },
-      }
-    }
-
-    const sessionData = await sessionResponse.json()
-
-    return {
-      user: sessionData.user,
-      roles: sessionData.roles,
-      tokens: {
-        access_token: refreshData.access_token,
-        expiry: refreshData.expiry,
-      },
-    }
+    return null
   } catch (error) {
     console.error('[SERVER_SESSION] Error:', error)
     return null
@@ -122,37 +88,16 @@ export async function getServerSession(): Promise<Session | null> {
 /**
  * Get access token from cookies for server-side API calls.
  * This is a lightweight alternative when you only need the token.
+ *
+ * Returns null rather than refreshing — see the note on `getServerSession`
+ * about why a Server Component must not consume a one-time-use refresh token.
+ * Callers should treat null as "render without personalised data" and let the
+ * client fill it in.
  */
 export async function getServerAccessToken(): Promise<string | null> {
   try {
     const cookieStore = await cookies()
-
-    // Try access token first
-    const accessToken = cookieStore.get(ACCESS_TOKEN_COOKIE)
-    if (accessToken?.value) {
-      return accessToken.value
-    }
-
-    // Try to refresh
-    const refreshToken = cookieStore.get(REFRESH_TOKEN_COOKIE)
-    if (!refreshToken?.value) {
-      return null
-    }
-
-    const response = await fetch(`${BACKEND_URL}/api/v1/auth/refresh`, {
-      method: 'GET',
-      headers: {
-        Cookie: `${REFRESH_TOKEN_COOKIE}=${refreshToken.value}`,
-      },
-      cache: 'no-store',
-    })
-
-    if (!response.ok) {
-      return null
-    }
-
-    const data = await response.json()
-    return data.access_token || null
+    return cookieStore.get(ACCESS_TOKEN_COOKIE)?.value || null
   } catch (error) {
     console.error('[SERVER_SESSION] Error getting access token:', error)
     return null


### PR DESCRIPTION
Users were getting signed out unexpectedly. The session lifetime was never the problem — several code paths ended sessions on conditions unrelated to whether the user is still authenticated.

- Auth proxy cleared every auth cookie on any non-ok refresh, including 429 and 5xx. A brief hiccup destroyed a refresh cookie with weeks of validity. Only 401/403 end a session now, and the client makes the same distinction.
- Refresh rate limit was 60/min per IP. The endpoint is cookie-authenticated, and many users legitimately share one address. Raised to 600/min.
- `getServerSession()` called the rotating refresh endpoint from Server Components, which cannot set cookies — consuming the one-time-use token and discarding the replacement. The browser then re-presented a consumed token, which is treated as theft and revokes every session on every device. Server-side resolution no longer refreshes.
- Benign-replay grace window raised from 30s to 5min. Reuse hours or days later is still caught.

Inactivity window is now explicit and configurable via `LEARNHOUSE_AUTH_REFRESH_TOKEN_DAYS` (default 30), clamped to a 14-day floor.

## Testing
- Full API suite passes (4016), 6 new tests for the lifetime floor and grace window.
- TypeScript clean and 0 eslint errors on changed files.

## Follow-up
There is currently no telemetry on refresh outcomes, which made this much harder to diagnose than it should have been. Worth adding an outcome tag on the refresh endpoint separately.