### PR TITLE
fix(assignments): learner UX gaps and assignment integrity issues

### DIFF
--- a/apps/api/src/services/courses/activities/assignments.py
+++ b/apps/api/src/services/courses/activities/assignments.py
@@ -77,8 +77,13 @@ _REGEX_TIMEOUT_SECONDS = 0.5
 
 # Thousands-grouped numbers, used to disambiguate comma-as-thousands from
 # comma-as-decimal when parsing NUMBER_ANSWER submissions.
-_THOUSANDS_INT = re.compile(r"^\d{1,3}(,\d{3})+$")          # 1,000 / 1,000,000
-_THOUSANDS_DEC = re.compile(r"^\d{1,3}(,\d{3})+\.\d+$")     # 1,000.50
+# The optional sign matters: anchoring at ^\d meant a negative grouped number
+# ("-1,000") never matched here and fell through to the European-decimal branch,
+# where the comma became a decimal point and -1,000 parsed as -1.0 — marking a
+# correct answer wrong. Negative correct values are authorable and the student
+# input is free text, so this was reachable.
+_THOUSANDS_INT = re.compile(r"^[+-]?\d{1,3}(,\d{3})+$")          # 1,000 / -1,000,000
+_THOUSANDS_DEC = re.compile(r"^[+-]?\d{1,3}(,\d{3})+\.\d+$")     # 1,000.50 / -1,000.50
 
 logger = logging.getLogger(__name__)
 
@@ -232,6 +237,13 @@ def _strip_answer_key(contents, keep_answer_keys: bool = False):
     # keys so the correct answers can't be read before submitting.
     c.pop("correct_answers", None)
     c.pop("correct_value", None)
+    # `explanation` is reveal-gated content too: the authoring placeholder is
+    # "explain why the answer is correct", and both the SHORT_ANSWER and
+    # NUMBER_ANSWER student views render it only inside the reveal panel.
+    # Leaving it in leaked the answer in prose — readable straight from the
+    # tasks GET before submitting, and still visible while retries remain even
+    # though correct_value/correct_answers were withheld.
+    c.pop("explanation", None)
 
     questions = c.get("questions")
     if isinstance(questions, list):
@@ -1624,7 +1636,62 @@ async def delete_assignment_task(
     await db_session.delete(assignment_task)
     await db_session.commit()
 
+    # Already-graded learners keep a frozen `grade` that still includes the
+    # points from the task we just removed, while the denominator is recomputed
+    # live from the surviving tasks. That desync is real corruption: with
+    # 60 + 100 = 160 stored, deleting the 100-point task leaves the read path
+    # clamping to "100/100 · A" for someone who actually scored 60/60. Re-run
+    # the aggregate for every graded submission so both halves of the fraction
+    # come from the same task set. Certificate eligibility reads the same
+    # numbers, so leaving them stale could also mis-award a certificate.
+    await _regrade_graded_submissions(
+        assignment=assignment,
+        course=course,
+        db_session=db_session,
+    )
+
     return {"message": "Assignment Task deleted"}
+
+
+async def _regrade_graded_submissions(
+    assignment: Assignment,
+    course: Course,
+    db_session: AsyncSession,
+) -> None:
+    """Recompute stored grades for every GRADED submission of ``assignment``.
+
+    Call after the task set changes, so the persisted numerator stops
+    disagreeing with the live denominator. Best-effort per learner: one
+    learner's failure must not abort the teacher's edit.
+    """
+    graded = (await db_session.execute(
+        select(AssignmentUserSubmission).where(
+            AssignmentUserSubmission.assignment_id == assignment.id,
+            AssignmentUserSubmission.submission_status
+            == AssignmentUserSubmissionStatus.GRADED,
+        )
+    )).scalars().all()
+
+    for submission in graded:
+        if submission.user_id is None:
+            continue
+        try:
+            await _apply_grade_and_finalize(
+                assignment=assignment,
+                course=course,
+                user_id=submission.user_id,
+                assignment_user_submission=submission,
+                db_session=db_session,
+                overall_feedback=None,
+                auto_graded=True,
+                dispatch_webhook=False,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to recompute grade for user %s on assignment %s after a task change",
+                submission.user_id,
+                assignment.assignment_uuid,
+            )
 
 
 ## > Assignments Tasks Submissions CRUD
@@ -1758,6 +1825,36 @@ async def handle_assignment_task_submission(
                     detail="Assignment deadline has passed",
                 )
 
+            # SECURITY: answers are frozen once the attempt has been handed in.
+            # Without this, a learner could keep PUTting task answers after
+            # SUBMITTED/GRADED. Combined with show_correct_answers (which hands
+            # the key over post-grade), they could replay the correct answers and
+            # any later re-grade — which re-derives every non-manually-graded task
+            # from the CURRENT stored answers — would score the tampered version.
+            # Editing an existing attempt in place is exactly what the retry flow
+            # exists to prevent; retry deletes the task rows first and re-opens
+            # the submission as PENDING.
+            existing_user_submission = (await db_session.execute(
+                select(AssignmentUserSubmission).where(
+                    AssignmentUserSubmission.user_id == current_user.id,
+                    AssignmentUserSubmission.assignment_id == assignment.id,
+                )
+            )).scalars().first()
+            if existing_user_submission is not None and (
+                existing_user_submission.submission_status
+                not in (
+                    AssignmentUserSubmissionStatus.PENDING,
+                    AssignmentUserSubmissionStatus.NOT_SUBMITTED,
+                )
+            ):
+                raise HTTPException(
+                    status_code=403,
+                    detail=(
+                        "This assignment has already been handed in. "
+                        "Use retry to attempt it again."
+                    ),
+                )
+
         # SECURITY: answer submissions cannot carry grades - only check if actual values are being set
         if (assignment_task_submission_object.grade is not None and assignment_task_submission_object.grade != 0) or \
            (assignment_task_submission_object.task_submission_grade_feedback is not None and assignment_task_submission_object.task_submission_grade_feedback != ""):
@@ -1796,6 +1893,27 @@ async def handle_assignment_task_submission(
                 status_code=404,
                 detail="Assignment Task Submission not found",
             )
+    elif is_instructor and (
+        assignment_task_submission_object.grade is not None
+        or assignment_task_submission_object.task_submission_grade_feedback is not None
+    ):
+        # An instructor writing a GRADE without naming a target submission has
+        # nothing to grade. Falling through to the save-progress lookup below
+        # keyed the write on submitter.id — the TEACHER — so grading a task the
+        # learner never submitted created a phantom instructor-owned row (scored
+        # 0 by the create branch) while the UI reported success and the learner's
+        # grade never moved. There is no safe target to guess: fail loudly.
+        #
+        # Narrowed to grade-bearing payloads on purpose: an instructor who is
+        # also taking their own course legitimately saves ANSWERS through this
+        # same path with no uuid, and that must keep working.
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Cannot grade this task: the learner has no submission for it. "
+                "A target submission is required to record a grade."
+            ),
+        )
     else:
         # Save-progress path: without an explicit UUID, update/create the
         # submitter's own submission for this task.
@@ -1836,6 +1954,9 @@ async def handle_assignment_task_submission(
         assignment_task_submission = AssignmentTaskSubmission(
             assignment_task_submission_uuid=assignment_task_submission_uuid or f"assignmenttasksubmission_{uuid4()}",
             task_submission=model_data["task_submission"],
+            # Safe to hardcode: this branch is now reachable only on the learner
+            # save-progress path (instructors without a target uuid are rejected
+            # above), and learner writes never carry a grade.
             grade=0,  # Always start with 0 for new submissions
             task_submission_grade_feedback="",  # Start with empty feedback
             assignment_task_id=int(assignment_task.id),  # type: ignore
@@ -2667,16 +2788,44 @@ async def read_assignment_submissions(
     assignment_tasks = (await db_session.execute(tasks_statement)).scalars().all()
     max_grade = sum(int(t.max_grade_value or 0) for t in assignment_tasks)
 
+    submissions = (await db_session.execute(statement)).scalars().all()
+
+    # Per-task breakdown for the whole page in ONE query, keyed by (user, task).
+    # The analytics "task difficulty" chart reads grade_display.tasks, but this
+    # endpoint never populated it — only the single-submission endpoints did —
+    # so that chart rendered its empty state for every assignment ever shipped.
+    # Batched deliberately: a per-row query here would be N+1 over the page.
+    task_ids = [t.id for t in assignment_tasks if t.id is not None]
+    user_ids = [s.user_id for s in submissions if s.user_id is not None]
+    submissions_by_user_task: dict = {}
+    if task_ids and user_ids:
+        task_sub_rows = (await db_session.execute(
+            select(AssignmentTaskSubmission).where(
+                AssignmentTaskSubmission.assignment_task_id.in_(task_ids),  # type: ignore[attr-defined]
+                AssignmentTaskSubmission.user_id.in_(user_ids),  # type: ignore[attr-defined]
+            )
+        )).scalars().all()
+        for ts in task_sub_rows:
+            submissions_by_user_task.setdefault(ts.user_id, {})[ts.assignment_task_id] = ts
+
     results = []
-    for sub in (await db_session.execute(statement)).scalars().all():
+    for sub in submissions:
         row = AssignmentUserSubmissionRead.model_validate(sub).model_dump()
         if sub.submission_status == AssignmentUserSubmissionStatus.GRADED:
-            row["grade_display"] = compute_assignment_grade(
+            grade_display = compute_assignment_grade(
                 int(sub.grade or 0),
                 max_grade,
                 assignment.grading_type,
                 pass_threshold_percentage=assignment.pass_threshold_percentage,
             )
+            # Reuse the threshold compute_assignment_grade already resolved so
+            # the per-task `passed` flags agree with the overall verdict.
+            grade_display["tasks"] = _build_tasks_breakdown(
+                assignment_tasks,
+                submissions_by_user_task.get(sub.user_id, {}),
+                grade_display["passing_threshold"],
+            )
+            row["grade_display"] = grade_display
         else:
             row["grade_display"] = None
         results.append(row)
@@ -2994,6 +3143,20 @@ async def retry_assignment_submission(
             detail="Only graded submissions can be retried",
         )
 
+    # Retry is destructive and irreversible: it deletes every task submission,
+    # zeroes the grade, reopens the trail step, revokes the certificate and
+    # demotes the enrollment. Past the deadline the student cannot resubmit —
+    # every write path 403s — so allowing it here destroyed graded work with no
+    # way back. Every other learner write is deadline-gated (file upload, task
+    # submission, submit-for-grading); this one was the sole gap.
+    if _is_assignment_past_due(assignment) and not await _is_assignment_instructor(
+        request, current_user, course.course_uuid, db_session
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="Assignment deadline has passed",
+        )
+
     # Enforce the attempt cap. max_retries=0 means unlimited; otherwise the
     # current attempt_number must be strictly less than max_retries so the
     # increment below stays within bounds.
@@ -3085,12 +3248,19 @@ async def _apply_grade_and_finalize(
     db_session: AsyncSession,
     overall_feedback: str | None = None,
     auto_graded: bool = False,
+    dispatch_webhook: bool = True,
 ) -> dict:
     """
     Core grading logic shared by manual and auto-grade flows. Computes the
     final grade from existing per-task submissions, persists it with status
     GRADED, dispatches the webhook, and returns the enriched grade dict
     (including per-task breakdown).
+
+    ``dispatch_webhook=False`` is for bulk recomputation (e.g. after a teacher
+    deletes a task) where the grade is being corrected rather than newly
+    awarded — firing ``assignment_graded`` once per enrolled learner on an
+    admin edit would be a webhook storm, and integrations would read it as a
+    fresh grading event.
 
     IMPORTANT: This helper does NO permission checks. Callers must enforce
     access control before calling it. It exists so that both the teacher's
@@ -3206,25 +3376,26 @@ async def _apply_grade_and_finalize(
     await db_session.commit()
     await db_session.refresh(assignment_user_submission)
 
-    await dispatch_webhooks(
-        event_name="assignment_graded",
-        org_id=course.org_id,
-        data={
-            "user_id": user_id,
-            "assignment_uuid": assignment.assignment_uuid,
-            "course_uuid": course.course_uuid,
-            "grade": computed["grade"],
-            "max_grade": computed["max_grade"],
-            "percentage": computed["percentage"],
-            "display_grade": computed["display_grade"],
-            "letter_grade": computed["letter_grade"],
-            "points_summary": computed["points_summary"],
-            "passed": computed["passed"],
-            "grading_type": computed["grading_type"],
-            "overall_feedback": computed["overall_feedback"],
-            "auto_graded": auto_graded,
-        },
-    )
+    if dispatch_webhook:
+        await dispatch_webhooks(
+            event_name="assignment_graded",
+            org_id=course.org_id,
+            data={
+                "user_id": user_id,
+                "assignment_uuid": assignment.assignment_uuid,
+                "course_uuid": course.course_uuid,
+                "grade": computed["grade"],
+                "max_grade": computed["max_grade"],
+                "percentage": computed["percentage"],
+                "display_grade": computed["display_grade"],
+                "letter_grade": computed["letter_grade"],
+                "points_summary": computed["points_summary"],
+                "passed": computed["passed"],
+                "grading_type": computed["grading_type"],
+                "overall_feedback": computed["overall_feedback"],
+                "auto_graded": auto_graded,
+            },
+        )
 
     return computed
 
@@ -3271,6 +3442,23 @@ async def grade_assignment_submission(
         raise HTTPException(
             status_code=404,
             detail="Assignment User Submission not found",
+        )
+
+    # A PENDING row is a retry in flight: the previous task submissions have
+    # been deleted and the learner has not handed anything in yet. Grading it
+    # sums an empty set, writes 0, flips the row to GRADED and fires the graded
+    # webhook — after which the learner's resubmit 400s (only PENDING /
+    # NOT_SUBMITTED are resubmittable), permanently at the retry cap. The retry
+    # path has the mirror guard ("Only graded submissions can be retried"); this
+    # side was missing it. The submissions list rendering PENDING as "Submitted"
+    # made hitting this easy.
+    if assignment_user_submission.submission_status in (
+        AssignmentUserSubmissionStatus.PENDING,
+        AssignmentUserSubmissionStatus.NOT_SUBMITTED,
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="This learner has not handed in an attempt yet — nothing to grade.",
         )
 
     computed = await _apply_grade_and_finalize(
@@ -3499,12 +3687,20 @@ async def get_assignments_from_course(
             detail="Course not found",
         )
 
-    # Get Assignments
-    statement = select(Assignment).where(Assignment.course_id == course.id)
-    assignments = (await db_session.execute(statement)).scalars().all()
-
     # RBAC check
     await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
+
+    # Get Assignments. Unpublished (draft) assignments are instructor-only:
+    # `Assignment.published` was never consulted anywhere, so this endpoint
+    # enumerated every draft to anyone with course READ, and the tasks endpoint
+    # then handed over next week's exam questions. Answer keys are stripped
+    # separately, so this is unreleased-content exposure rather than key
+    # exposure — but the parent Activity's `published` flag is what hides drafts
+    # in navigation, and these direct endpoints bypassed it.
+    statement = select(Assignment).where(Assignment.course_id == course.id)
+    if not await _is_assignment_instructor(request, current_user, course.course_uuid, db_session):
+        statement = statement.where(Assignment.published == True)  # noqa: E712
+    assignments = (await db_session.execute(statement)).scalars().all()
 
     # return assignments read
     return [AssignmentRead.model_validate(assignment) for assignment in assignments]

--- a/apps/api/src/tests/services/test_assignments_service.py
+++ b/apps/api/src/tests/services/test_assignments_service.py
@@ -16,6 +16,7 @@ Session to AsyncSession in this PR:
 
 from datetime import datetime, timedelta
 from types import SimpleNamespace
+from uuid import uuid4
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -35,6 +36,7 @@ from src.db.courses.assignments import (
     AssignmentTaskSubmissionUpdate,
     AssignmentTaskTypeEnum,
     AssignmentUpdate,
+    AssignmentUserSubmission,
     AssignmentUserSubmissionCreate,
     AssignmentUserSubmissionRead,
     AssignmentUserSubmissionStatus,
@@ -47,6 +49,7 @@ from src.db.trails import Trail
 from src.db.users import APITokenUser
 from src.services.courses.activities.assignments import (
     _block_api_tokens,
+    _check_number_answer,
     _is_assignment_past_due,
     create_assignment,
     create_assignment_submission,
@@ -74,6 +77,7 @@ from src.services.courses.activities.assignments import (
     read_user_assignment_task_submissions,
     read_user_assignment_task_submissions_me,
     read_user_assignment_task_submissions_me_batch,
+    retry_assignment_submission,
     update_assignment,
     update_assignment_submission,
     update_assignment_task,
@@ -1972,3 +1976,153 @@ class TestUpdateAssignmentSubmissionProtectedFields:
             )
         # Unchanged: the submission still belongs to the original assignment.
         assert result.assignment_id == assignment.id
+
+
+class TestAssignmentIntegrityGuards:
+    """Guards added after an audit found several ways to corrupt graded work."""
+
+    async def _set_due(self, db, assignment, due_date):
+        assignment.due_date = due_date
+        db.add(assignment)
+        await db.commit()
+        await db.refresh(assignment)
+
+    async def _user_submission(self, db, assignment, user, status):
+        sub = AssignmentUserSubmission(
+            assignment_id=assignment.id,
+            user_id=user.id,
+            assignmentusersubmission_uuid=f"assignmentusersubmission_{uuid4()}",
+            submission_status=status,
+            grade=0,
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(sub)
+        await db.commit()
+        await db.refresh(sub)
+        return sub
+
+    async def test_learner_cannot_edit_answers_after_submitting(
+        self, mock_request, db, assignment, assignment_task, regular_user
+    ):
+        """Answers freeze at hand-in.
+
+        Otherwise a learner who has been shown the answer key (show_correct_answers
+        reveals it post-grade) could replay the correct answers, and the next
+        re-grade — which re-derives from the CURRENT stored answers — would score
+        the tampered version.
+        """
+        await self._user_submission(
+            db, assignment, regular_user, AssignmentUserSubmissionStatus.GRADED
+        )
+        obj = AssignmentTaskSubmissionUpdate(task_submission={"answer": "tampered"})
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, side_effect=[False, True]):
+            with pytest.raises(HTTPException) as exc:
+                await handle_assignment_task_submission(
+                    mock_request, assignment_task.assignment_task_uuid, obj, regular_user, db
+                )
+        assert exc.value.status_code == 403
+        assert "already been handed in" in exc.value.detail
+
+    async def test_learner_can_still_edit_answers_while_pending(
+        self, mock_request, db, assignment, assignment_task, regular_user
+    ):
+        """A PENDING row is an attempt in progress — saving must keep working."""
+        await self._user_submission(
+            db, assignment, regular_user, AssignmentUserSubmissionStatus.PENDING
+        )
+        obj = AssignmentTaskSubmissionUpdate(task_submission={"answer": "draft"})
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, side_effect=[False, True]):
+            result = await handle_assignment_task_submission(
+                mock_request, assignment_task.assignment_task_uuid, obj, regular_user, db
+            )
+        assert isinstance(result, AssignmentTaskSubmissionRead)
+
+    async def test_instructor_grade_without_target_submission_is_rejected(
+        self, mock_request, db, assignment_task, admin_user
+    ):
+        """Grading a task the learner never submitted used to write the grade to
+        the INSTRUCTOR's own row, force it to 0, and report success."""
+        obj = AssignmentTaskSubmissionUpdate(grade=8)
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, return_value=True):
+            with pytest.raises(HTTPException) as exc:
+                await handle_assignment_task_submission(
+                    mock_request, assignment_task.assignment_task_uuid, obj, admin_user, db
+                )
+        assert exc.value.status_code == 400
+        assert "no submission" in exc.value.detail
+
+    async def test_instructor_answer_without_target_submission_still_allowed(
+        self, mock_request, db, assignment_task, admin_user
+    ):
+        """An instructor taking their own course saves ANSWERS through the same
+        path with no target uuid — the grade guard must not catch that."""
+        obj = AssignmentTaskSubmissionUpdate(task_submission={"answer": "x"})
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, return_value=True):
+            result = await handle_assignment_task_submission(
+                mock_request, assignment_task.assignment_task_uuid, obj, admin_user, db
+            )
+        assert isinstance(result, AssignmentTaskSubmissionRead)
+
+    async def test_retry_past_due_is_rejected(
+        self, mock_request, db, assignment, course, regular_user
+    ):
+        """Retry wipes answers, grade, trail step and certificate. Past the
+        deadline the learner can never resubmit, so this destroyed graded work."""
+        assignment.allow_retries = True
+        await self._set_due(db, assignment, "2000-01-01")
+        await self._user_submission(
+            db, assignment, regular_user, AssignmentUserSubmissionStatus.GRADED
+        )
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, return_value=False):
+            with pytest.raises(HTTPException) as exc:
+                await retry_assignment_submission(
+                    mock_request, assignment.assignment_uuid, regular_user, db
+                )
+        assert exc.value.status_code == 403
+        assert "deadline has passed" in exc.value.detail
+
+    async def test_grading_a_pending_submission_is_rejected(
+        self, mock_request, db, assignment, course, regular_user, admin_user
+    ):
+        """A PENDING row is a retry in flight with its task rows deleted.
+        Grading it summed an empty set, wrote 0, and locked the learner out."""
+        await self._user_submission(
+            db, assignment, regular_user, AssignmentUserSubmissionStatus.PENDING
+        )
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, return_value=True), \
+             patch(_PATCH_DISPATCH, new_callable=AsyncMock), \
+             patch(_PATCH_TRACK, new_callable=AsyncMock):
+            with pytest.raises(HTTPException) as exc:
+                await grade_assignment_submission(
+                    mock_request, regular_user.id, assignment.assignment_uuid, admin_user, db
+                )
+        assert exc.value.status_code == 400
+        assert "not handed in" in exc.value.detail
+
+
+class TestNumberAnswerSignedThousands:
+    """Signed thousands-grouped numbers were parsed as decimals."""
+
+    def test_negative_grouped_integer_matches(self):
+        assert _check_number_answer("-1,000", -1000, 0) is True
+
+    def test_plus_signed_grouped_integer_matches(self):
+        assert _check_number_answer("+1,000", 1000, 0) is True
+
+    def test_negative_multi_group_matches(self):
+        assert _check_number_answer("-1,234,567", -1234567, 0) is True
+
+    def test_negative_grouped_decimal_matches(self):
+        assert _check_number_answer("-1,000.50", -1000.5, 0) is True
+
+    def test_european_decimal_still_parsed_as_decimal(self):
+        """The disambiguation this regex feeds must not regress: a bare
+        "3,14" is still a European decimal, not three-thousand-fourteen."""
+        assert _check_number_answer("3,14", 3.14, 0) is True

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/course/[courseuuid]/activity/[activityid]/activity.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/course/[courseuuid]/activity/[activityid]/activity.tsx
@@ -49,6 +49,11 @@ const Canva = lazy(() => import('@components/Objects/Activities/DynamicCanva/Dyn
 const VideoActivity = lazy(() => import('@components/Objects/Activities/Video/Video'))
 const DocumentPdfActivity = lazy(() => import('@components/Objects/Activities/DocumentPdf/DocumentPdf'))
 const AssignmentStudentActivity = lazy(() => import('@components/Objects/Activities/Assignment/AssignmentStudentActivity'))
+// Deadline rule shared with the learner activity view (and mirroring the
+// server's _is_assignment_past_due) so the submit/retry affordances agree with
+// what the API will actually accept. Static import: it's a pure function, and
+// gating render on the lazy chunk would flash the wrong control.
+import { isAssignmentPastDue } from '@components/Objects/Activities/Assignment/AssignmentStudentActivity'
 const AIActivityAsk = lazy(() => import('@components/Objects/Activities/AI/AIActivityAsk'))
 const AISidePanelContentWrapper = lazy(() => import('@components/Objects/Activities/AI/AIActivityAsk').then(mod => ({ default: mod.AISidePanelContentWrapper })))
 const AISidePanelInline = lazy(() => import('@components/Objects/Activities/AI/AIActivityAsk').then(mod => ({ default: mod.AISidePanelInline })))
@@ -365,11 +370,21 @@ function ActivityClient(props: ActivityClientProps) {
     }
   }, [activity, course, assignment, orgslug]);
 
-  // Navigate to an activity
+  // Past the last activity lies the course-end screen holding the certificate.
+  const isLastActivity = currentIndex >= 0 && !nextActivity;
+
+  // Navigate to an activity. A null target means "there is nothing after this
+  // one" — on the final activity that means the course-end/certificate screen
+  // rather than a dead end.
   const navigateToActivity = (activity: any) => {
-    if (!activity) return;
-    
     const cleanCourseUuid = course.course_uuid?.replace('course_', '');
+    if (!activity) {
+      if (isLastActivity) {
+        router.push(getUriWithOrg(orgslug, '') + `/course/${cleanCourseUuid}/activity/end`);
+      }
+      return;
+    }
+
     router.push(getUriWithOrg(orgslug, '') + `/course/${cleanCourseUuid}/activity/${activity.cleanUuid}`);
   };
 
@@ -730,17 +745,27 @@ function ActivityClient(props: ActivityClientProps) {
                             <button
                               onClick={() => navigateToActivity(nextActivity)}
                               className={`flex items-center space-x-1.5 p-2 rounded-md transition-all duration-200 cursor-pointer ${
-                                nextActivity
+                                nextActivity || isLastActivity
                                   ? 'text-gray-700'
                                   : 'opacity-50 text-gray-400 cursor-not-allowed'
                               }`}
-                              disabled={!nextActivity}
-                              title={nextActivity ? `${t('common.next')}: ${nextActivity.name}` : t('activities.no_next_activity')}
+                              disabled={!nextActivity && !isLastActivity}
+                              title={
+                                nextActivity
+                                  ? `${t('common.next')}: ${nextActivity.name}`
+                                  : isLastActivity
+                                    ? t('course.finish_course', 'Finish course')
+                                    : t('activities.no_next_activity')
+                              }
                             >
                               <div className="flex flex-col items-end">
                                 <span className="text-xs text-gray-500">{t('common.next')}</span>
                                 <span className="text-sm capitalize font-semibold text-right">
-                                  {nextActivity ? nextActivity.name : t('activities.no_next_activity')}
+                                  {nextActivity
+                                    ? nextActivity.name
+                                    : isLastActivity
+                                      ? t('course.finish_course', 'Finish course')
+                                      : t('activities.no_next_activity')}
                                 </span>
                               </div>
                               <ChevronRight size={20} className="text-gray-800 shrink-0" />
@@ -1363,11 +1388,20 @@ function NextActivityButton({ course, currentActivityId, orgslug }: { course: an
 
   const nextActivity = findNextActivity();
 
-  if (!nextActivity) return null;
+  // On the LAST activity, Next advances to the course-end screen (which holds
+  // the certificate) instead of disappearing. Previously the only route there
+  // was the trophy icon on the progress bar, which learners did not find — and
+  // it was unreachable altogether for anyone who had already marked the final
+  // activity complete on an earlier visit.
+  const isLastActivity = !nextActivity;
+  const cleanCourseUuid = course.course_uuid?.replace('course_', '');
 
   const navigateToActivity = () => {
-    const cleanCourseUuid = course.course_uuid?.replace('course_', '');
-    router.push(getUriWithOrg(orgslug, '') + `/course/${cleanCourseUuid}/activity/${nextActivity.cleanUuid}`);
+    router.push(
+      isLastActivity
+        ? getUriWithOrg(orgslug, '') + `/course/${cleanCourseUuid}/activity/end`
+        : getUriWithOrg(orgslug, '') + `/course/${cleanCourseUuid}/activity/${nextActivity.cleanUuid}`
+    );
   };
 
   return (
@@ -1377,7 +1411,9 @@ function NextActivityButton({ course, currentActivityId, orgslug }: { course: an
     >
       <span className="text-[10px] font-bold text-gray-500 mb-1 uppercase">{t('common.next')}</span>
       <div className="flex items-center space-x-1">
-        <span className="text-xs sm:text-sm font-semibold truncate max-w-[120px] sm:max-w-[200px]">{nextActivity.name}</span>
+        <span className="text-xs sm:text-sm font-semibold truncate max-w-[120px] sm:max-w-[200px]">
+          {isLastActivity ? t('course.finish_course', 'Finish course') : nextActivity.name}
+        </span>
         <ChevronRight size={17} className="shrink-0" />
       </div>
     </div>
@@ -1573,6 +1609,23 @@ function AssignmentTools(props: {
   const isRetryAttempt = isAwaitingSubmission && submission?.length > 0 && attemptNumber > 1;
 
   if (isAwaitingSubmission) {
+    // Past the deadline the server 403s every write, including the flush that
+    // "Submit for grading" performs. Offering the button anyway produced a
+    // generic failure toast with no explanation of why.
+    if (isAssignmentPastDue(props.assignment?.due_date)) {
+      return (
+        <div className="bg-rose-800 rounded-md px-4 nice-shadow flex flex-col p-2.5 text-white transition delay-150 duration-300 ease-in-out">
+          <span className="text-[10px] font-bold mb-1 uppercase">{t('common.status')}</span>
+          <div className="flex items-center space-x-2">
+            <BookOpenCheck size={17} />
+            <span className="text-xs font-bold">
+              {t('assignments.past_due', { defaultValue: 'Deadline passed' })}
+            </span>
+          </div>
+        </div>
+      )
+    }
+
     return (
       <ConfirmationModal
         confirmationButtonText={t('assignments.submit_assignment')}
@@ -1632,7 +1685,13 @@ function AssignmentTools(props: {
     const attemptsRemaining = maxRetries
       ? Math.max(0, maxRetries - currentAttempt)
       : null;
-    const canRetry = allowRetries && (maxRetries === 0 || currentAttempt < maxRetries);
+    // Past the deadline the server refuses a retry — and rightly so: retry wipes
+    // the answers, grade and certificate, and every resubmit path is deadline
+    // gated, so a retry here would destroy graded work with no way back. Mirror
+    // that client-side rather than offering a button that 403s.
+    const retryPastDue = isAssignmentPastDue(props.assignment?.due_date);
+    const canRetry =
+      allowRetries && !retryPastDue && (maxRetries === 0 || currentAttempt < maxRetries);
 
     return (
       <>
@@ -1751,7 +1810,15 @@ function AssignmentTools(props: {
                     <div className="space-y-1.5">
                       {tasks.map((tb: any) => {
                         const pct = Math.max(0, Math.min(100, tb.percentage || 0));
-                        const passedTask = tb.submitted && pct >= 60;
+                        // Use the server's per-task verdict. Hardcoding 60 here
+                        // contradicted the real threshold (50 for most grading
+                        // types, or the teacher's own pass_threshold_percentage),
+                        // so a task at 50% rendered as failing in this modal while
+                        // the hero above it said "Passing" and the page behind it
+                        // showed a green "Task passed" card.
+                        const passedTask = tb.submitted && (
+                          typeof tb.passed === 'boolean' ? tb.passed : pct >= 60
+                        );
                         return (
                           <div
                             key={tb.assignment_task_uuid}

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/courses/courses.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/courses/courses.tsx
@@ -10,7 +10,9 @@ import CourseThumbnail from '@components/Objects/Thumbnails/CourseThumbnail'
 import NewCourseButton from '@components/Objects/StyledElements/Buttons/NewCourseButton'
 import useAdminStatus from '@components/Hooks/useAdminStatus'
 import { useTranslation } from 'react-i18next'
-import { BookCopy, Search, X, Users, Info } from 'lucide-react'
+import { BookCopy, Search, X, Users, Info, LogIn } from 'lucide-react'
+import Link from 'next/link'
+import { getUriWithOrg } from '@services/config/config'
 import FeatureGate from '@components/Dashboard/Shared/FeatureGate/FeatureGate'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
@@ -34,6 +36,7 @@ function Courses(props: CourseProps) {
   const org = useOrg() as any
   const session = useLHSession() as any
   const access_token = session?.data?.tokens?.access_token
+  const isAuthenticated = session?.status === 'authenticated'
   const { track } = useLHAnalytics('learner')
   const { data: coursesData, isLoading: coursesLoading } = useCourses(orgslug)
 
@@ -295,19 +298,44 @@ function Courses(props: CourseProps) {
             {allCourses.length === 0 && !searchQuery && (
               <div className="col-span-full flex flex-col justify-center items-center py-12 px-4 border-2 border-dashed border-gray-100 rounded-2xl bg-gray-50/30">
                 <div className="p-4 bg-white rounded-full nice-shadow mb-4">
-                  <BookCopy className="w-8 h-8 text-gray-300" strokeWidth={1.5} />
+                  {isAuthenticated ? (
+                    <BookCopy className="w-8 h-8 text-gray-300" strokeWidth={1.5} />
+                  ) : (
+                    <LogIn className="w-8 h-8 text-gray-300" strokeWidth={1.5} />
+                  )}
                 </div>
                 <h1 className="text-xl font-bold text-gray-600 mb-2">
-                  {t('courses.no_courses')}
+                  {isAuthenticated
+                    ? t('courses.no_courses')
+                    : t('courses.sign_in_to_see_courses', 'Log in to see your courses')}
                 </h1>
                 <p className="text-md text-gray-400 mb-6 text-center max-w-xs">
-                  {isUserAdmin ? (
+                  {!isAuthenticated ? (
+                    t(
+                      'courses.sign_in_to_see_courses_description',
+                      'Courses in this academy may only be visible once you are signed in.',
+                    )
+                  ) : isUserAdmin ? (
                     t('courses.create_courses_placeholder')
                   ) : (
                     t('courses.no_courses_available')
                   )}
                 </p>
-                {isUserAdmin && (
+                {/* An anonymous visitor sees an empty list whenever the org has no
+                    PUBLIC courses — the API filters non-public ones out rather than
+                    erroring, so "no courses" and "not signed in" are indistinguishable
+                    from here. Prompt for sign-in instead of implying the academy is
+                    empty. */}
+                {!isAuthenticated && (
+                  <Link
+                    href={getUriWithOrg(orgslug, '/login')}
+                    className="inline-flex items-center gap-2 justify-center px-4 py-2 bg-gray-900 text-white rounded-lg text-sm font-semibold hover:bg-gray-800 transition-colors"
+                  >
+                    <LogIn size={16} />
+                    {t('auth.sign_in', 'Sign in')}
+                  </Link>
+                )}
+                {isAuthenticated && isUserAdmin && (
                   <div className="mt-4">
                     <AuthenticatedClientElement
                       action="create"

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskCodeObject.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskCodeObject.tsx
@@ -1,6 +1,9 @@
 'use client'
 import { useAssignments } from '@components/Contexts/Assignments/AssignmentContext'
-import { useAssignmentTaskSubmissions } from '@components/Contexts/Assignments/AssignmentSubmissionContext'
+import {
+  useAssignmentSubmission,
+  useAssignmentTaskSubmissions,
+} from '@components/Contexts/Assignments/AssignmentSubmissionContext'
 import {
   useAssignmentsTask,
   useAssignmentsTaskDispatch,
@@ -30,7 +33,7 @@ import {
   ChevronDown,
   ChevronRight,
   ShieldCheck,
-  BookOpen,
+  Lock,
   Settings2,
 } from 'lucide-react'
 import React, { useEffect, useState } from 'react'
@@ -96,7 +99,12 @@ type CodeTaskContents = {
   show_test_details_on_fail?: boolean     // reveal Expected/Got on a failed test (default true)
   show_hidden_test_count?: boolean        // show "N hidden tests" badge (default true)
   require_passing_to_submit?: boolean     // student must pass visible tests to save (default false)
-  show_solution_after_submit?: boolean    // show reference solution once a submission exists (default false)
+  // DEPRECATED / INERT: the API strips `solution_code` from the task contents
+  // for EVERY student, unconditionally and by design, so a learner can never
+  // receive the reference solution and this flag can never have an effect.
+  // The teacher-facing toggle was removed (it silently did nothing), but the
+  // field is kept on the type so existing stored contents round-trip unchanged.
+  show_solution_after_submit?: boolean
 }
 
 type CodeTestResult = {
@@ -176,6 +184,20 @@ function TaskCodeObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskCod
   const assignment = useAssignments() as any
   const taskSubmissionsMap = useAssignmentTaskSubmissions()
   const queryClient = useQueryClient()
+
+  // Student lock, derived exactly like the sibling task types (see
+  // TaskShortAnswerObject) and like AssignmentBoxUI's own `canStudentSave`:
+  // once the learner has SUBMITTED for grading (or been GRADED) auto-save is
+  // switched off, so anything they keep typing is silently discarded on
+  // reload. The editor must therefore become read-only at that point.
+  const assignmentSubmission = useAssignmentSubmission() as any
+  const latestSubmissionStatus =
+    Array.isArray(assignmentSubmission) && assignmentSubmission.length > 0
+      ? assignmentSubmission[0]?.submission_status
+      : null
+  const submissionIsGraded = latestSubmissionStatus === 'GRADED'
+  const canStudentSave =
+    !submissionIsGraded && latestSubmissionStatus !== 'SUBMITTED'
 
   // Editor state
   const [contents, setContents] = useState<CodeTaskContents>(DEFAULT_CONTENTS)
@@ -387,6 +409,10 @@ function TaskCodeObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskCod
   }
 
   // Student-gating helpers: derived from the student-behavior flags.
+  // `visibleTestCases` are the only ones a learner can see, run and reason
+  // about — the API strips the hidden ones' stdin/expectedStdout before the
+  // task ever reaches them.
+  const visibleTestCases = contents.test_cases.filter((tc) => !tc.hidden)
   // `visibleResults` is the subset of run results that are NOT hidden test
   // cases — those are the only ones the student can see and reason about.
   const visibleResults = results.filter((r) => {
@@ -395,17 +421,27 @@ function TaskCodeObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskCod
   })
   const allVisiblePassing =
     visibleResults.length > 0 && visibleResults.every((r) => r.passed)
-  // Only enforce the "must pass" gate when the teacher turned it on.
-  const submissionGatedByPassing = contents.require_passing_to_submit === true
+  // Only enforce the "must pass" gate when the teacher turned it on AND there
+  // is at least one visible test to pass. A task made of hidden tests only
+  // could otherwise never satisfy the gate, locking the learner out forever.
+  const submissionGatedByPassing =
+    contents.require_passing_to_submit === true && visibleTestCases.length > 0
   const submissionBlocked = submissionGatedByPassing && !allVisiblePassing
 
   // --- SUBMIT (student) ---
   async function submitFC(opts?: { silent?: boolean }) {
     if (!assignmentTaskUUID) return true
     // Enforce "must pass all visible tests" gate if the teacher enabled it.
+    // This is a POLICY refusal, not a failure: returning `false` would make
+    // useAutoSave treat it as a transient error and retry every few seconds
+    // forever (permanent amber "Couldn't save — retrying…" chip) and would
+    // also fail the assignment-wide flushAll(), blocking submission of the
+    // WHOLE assignment. `'blocked'` is handled by useAutoSave as terminal —
+    // no retry, no error state. Genuine network/server failures below still
+    // return `false` so they keep being retried.
     if (submissionBlocked) {
       if (!opts?.silent) toast.error(t('dashboard.assignments.editor.task_editor.code.must_pass_toast'))
-      return false
+      return 'blocked' as const
     }
     const values = {
       assignment_task_submission_uuid: userSubmissions?.assignment_task_submission_uuid || null,
@@ -442,14 +478,29 @@ function TaskCodeObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskCod
   // --- RUN CODE ---
   async function runCode() {
     if (isRunning) return
-    if (contents.test_cases.length === 0) {
-      toast.error('No test cases defined')
+    // The API strips `stdin` / `expectedStdout` from every HIDDEN test case
+    // before sending the task contents to a student (deliberate: hidden tests
+    // must stay secret). Sending them back would post
+    // {stdin: undefined, expected_stdout: undefined}, which JSON.stringify
+    // drops entirely — and the server's TestCase model requires both — so the
+    // WHOLE batch 422'd and the learner got zero results, including for the
+    // visible tests. Students therefore only ever run the visible tests; the
+    // hidden ones are executed server-side at grading time.
+    const testCasesToRun =
+      view === 'student' ? visibleTestCases : contents.test_cases
+    if (testCasesToRun.length === 0) {
+      toast.error(
+        view === 'student'
+          ? t('dashboard.assignments.editor.task_editor.code.no_runnable_tests', {
+              defaultValue: 'This task has no tests you can run — your code is checked at grading time.',
+            })
+          : 'No test cases defined'
+      )
       return
     }
     setIsRunning(true)
     setShowResults(true)
     try {
-      // Always run ALL test cases — hidden ones just have details masked in the UI
       const resp = await fetch(`${getAPIUrl()}code/execute-batch`, {
         method: 'POST',
         headers: {
@@ -459,7 +510,7 @@ function TaskCodeObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskCod
         body: JSON.stringify({
           language_id: contents.language_id,
           source_code: code,
-          test_cases: contents.test_cases.map((tc) => ({
+          test_cases: testCasesToRun.map((tc) => ({
             id: tc.id,
             label: tc.label,
             stdin: tc.stdin,
@@ -476,18 +527,23 @@ function TaskCodeObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskCod
       }
 
       const data = await resp.json()
-      const newResults: CodeTestResult[] = data.results.map((r: any) => ({
-        id: r.id,
-        label: r.label,
-        passed: r.passed,
-        actual_stdout: r.actual_stdout,
-        expected_stdout: r.expected_stdout,
-        stderr: r.stderr,
-        compile_output: r.compile_output,
-        status: r.status,
-        time: r.time,
-        memory: r.memory,
-      }))
+      // Match every result back to its test case BY ID — after filtering, array
+      // indices no longer line up with contents.test_cases.
+      const newResults: CodeTestResult[] = (data.results ?? []).map((r: any) => {
+        const tc = testCasesToRun.find((t) => t.id === r.id)
+        return {
+          id: r.id ?? tc?.id,
+          label: r.label ?? tc?.label ?? '',
+          passed: r.passed,
+          actual_stdout: r.actual_stdout,
+          expected_stdout: r.expected_stdout,
+          stderr: r.stderr,
+          compile_output: r.compile_output,
+          status: r.status,
+          time: r.time,
+          memory: r.memory,
+        }
+      })
       setResults(newResults)
     } catch (err) {
       console.error('Code execution error:', err)
@@ -526,6 +582,9 @@ function TaskCodeObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskCod
           Authorization: `Bearer ${access_token}`,
         },
         body: JSON.stringify({
+          // Grading intentionally runs ALL test cases, hidden ones included:
+          // this view is instructor-only and its contents are NOT stripped, so
+          // stdin/expectedStdout are present. Do not filter here.
           language_id: contents.language_id,
           source_code: code,
           test_cases: contents.test_cases.map((tc) => ({
@@ -848,13 +907,14 @@ function TaskCodeObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskCod
                   checked={contents.require_passing_to_submit === true}
                   onChange={(v) => setContents((prev) => ({ ...prev, require_passing_to_submit: v }))}
                 />
-                <CodeOptionToggle
-                  icon={<BookOpen size={13} />}
-                  label={t('dashboard.assignments.editor.task_editor.code.show_solution_label')}
-                  description={t('dashboard.assignments.editor.task_editor.code.show_solution_description')}
-                  checked={contents.show_solution_after_submit === true}
-                  onChange={(v) => setContents((prev) => ({ ...prev, show_solution_after_submit: v }))}
-                />
+                {/* The "Reveal solution after submit" toggle used to live here.
+                    It was removed because it could never do anything: the API
+                    strips `solution_code` from the task contents for EVERY
+                    student, unconditionally and by design. It only appeared to
+                    work when a teacher previewed the task (teachers get the
+                    unstripped contents), so it misled teachers into believing
+                    learners would see the reference solution. Do not re-add it
+                    without also changing the server-side stripping. */}
               </div>
             </div>
 
@@ -891,12 +951,17 @@ function TaskCodeObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskCod
               )}
             </div>
 
-            {/* Code Editor */}
+            {/* Code Editor — locked once the submission is SUBMITTED/GRADED.
+                Auto-save is switched off at that point (AssignmentBoxUI's
+                `canStudentSave`), so any further typing would be silently lost
+                on reload and would not reach the grader. Mirrors the read-only
+                treatment of the other task types. */}
             <div className={`rounded-md overflow-hidden ${cmClassName}`}>
               {cmTheme && (
                 <CodeMirror
                   value={code}
                   onChange={(val) => {
+                    if (!canStudentSave) return
                     interactedRef.current = true
                     setCode(val)
                   }}
@@ -904,10 +969,26 @@ function TaskCodeObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskCod
                   theme={cmTheme}
                   style={cmStyles}
                   height="300px"
+                  readOnly={!canStudentSave}
+                  editable={canStudentSave}
                   basicSetup={{ lineNumbers: true, foldGutter: false }}
                 />
               )}
             </div>
+            {!canStudentSave && (
+              <div className="flex items-center space-x-1.5 text-[10px] text-slate-500 bg-slate-100 rounded-md px-2 py-1 w-fit">
+                <Lock size={11} />
+                <span>
+                  {submissionIsGraded
+                    ? t('dashboard.assignments.editor.task_editor.code.locked_graded_hint', {
+                        defaultValue: 'This submission has been graded — your code is read-only.',
+                      })
+                    : t('dashboard.assignments.editor.task_editor.code.locked_submitted_hint', {
+                        defaultValue: 'You have submitted this assignment — your code is read-only.',
+                      })}
+                </span>
+              </div>
+            )}
             {antiPasteEnabled && (
               <div className="flex items-center space-x-1.5 text-[10px] text-amber-600 bg-amber-50 rounded-md px-2 py-1 w-fit">
                 <span>🔒</span>
@@ -938,48 +1019,25 @@ function TaskCodeObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskCod
               </div>
             )}
 
-            {/* Results */}
+            {/* Results — hidden tests are never run client-side, so they are
+                listed as "not shown" rather than counted as failures. */}
             {showResults && (
               <TestResultsPanel
                 results={results}
                 testCases={contents.test_cases}
                 view="student"
                 showDetailsOnFail={contents.show_test_details_on_fail !== false}
+                maskedTestCases={contents.test_cases.filter(
+                  (tc) => tc.hidden && !results.some((r) => r.id === tc.id)
+                )}
+                showMaskedCount={contents.show_hidden_test_count !== false}
               />
             )}
 
-            {/* Reference solution — revealed after a saved submission when
-                the teacher chose to show it. */}
-            {contents.show_solution_after_submit === true &&
-              contents.solution_code &&
-              userSubmissions && (
-                <div className="flex flex-col space-y-1">
-                  <button
-                    onClick={() => setShowSolution(!showSolution)}
-                    className="flex items-center space-x-1 text-xs font-semibold text-slate-600 hover:text-slate-800 w-fit"
-                  >
-                    {showSolution ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-                    <BookOpen size={13} />
-                    <span>{t('dashboard.assignments.editor.task_editor.code.reference_solution_label')}</span>
-                  </button>
-                  {showSolution && (
-                    <div className={`rounded-md overflow-hidden ${cmClassName}`}>
-                      {cmTheme && (
-                        <CodeMirror
-                          value={contents.solution_code}
-                          extensions={cmExtensions}
-                          theme={cmTheme}
-                          style={cmStyles}
-                          height="220px"
-                          readOnly
-                          editable={false}
-                          basicSetup={{ lineNumbers: true, foldGutter: false }}
-                        />
-                      )}
-                    </div>
-                  )}
-                </div>
-              )}
+            {/* The student-side "reference solution" panel used to live here.
+                It was removed together with its teacher toggle: `solution_code`
+                is stripped server-side for every student, so the panel could
+                never render for a learner. */}
           </>
         )}
 
@@ -1066,14 +1124,22 @@ function TestResultsPanel({
   testCases,
   view,
   showDetailsOnFail = true,
+  maskedTestCases = [],
+  showMaskedCount = true,
 }: {
   results: CodeTestResult[]
   testCases: CodeTestCase[]
   view: 'student' | 'grading'
   showDetailsOnFail?: boolean
+  // Test cases that were NOT run client-side (hidden ones, whose stdin /
+  // expected output the API withholds from students). They are rendered as
+  // masked/unknown rows so a learner doesn't read them as failures.
+  maskedTestCases?: CodeTestCase[]
+  showMaskedCount?: boolean
 }) {
   const passedCount = results.filter((r) => r.passed).length
   const totalCount = results.length
+  const maskedShown = showMaskedCount ? maskedTestCases : []
 
   return (
     <div className="flex flex-col space-y-2 p-3 bg-slate-50 rounded-md border border-slate-200">
@@ -1088,7 +1154,11 @@ function TestResultsPanel({
               : 'bg-red-100 text-red-700'
           }`}
         >
-          {passedCount === totalCount ? 'All Passed' : 'Some Failed'}
+          {passedCount === totalCount
+            ? maskedShown.length > 0
+              ? 'Visible Tests Passed'
+              : 'All Passed'
+            : 'Some Failed'}
         </span>
       </div>
       <div className="flex flex-col space-y-1.5">
@@ -1152,6 +1222,23 @@ function TestResultsPanel({
             </div>
           )
         })}
+        {/* Hidden tests the student can't run: shown as unknown, never as
+            failures. They are executed server-side when the assignment is
+            graded. */}
+        {maskedShown.map((tc) => (
+          <div
+            key={tc.id}
+            className="flex flex-col p-2 rounded-md text-sm bg-slate-100 border border-slate-200"
+          >
+            <div className="flex items-center space-x-2">
+              <EyeOff size={14} className="text-slate-400 flex-none" />
+              <span className="font-medium text-slate-500">{tc.label}</span>
+            </div>
+            <div className="mt-1 pl-6 text-xs text-slate-400 italic">
+              Hidden test — run when your work is graded
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   )

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskFileObject.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskFileObject.tsx
@@ -1,12 +1,12 @@
 import { useAssignments } from '@components/Contexts/Assignments/AssignmentContext';
-import { useAssignmentTaskSubmissions } from '@components/Contexts/Assignments/AssignmentSubmissionContext';
+import { useAssignmentSubmission, useAssignmentTaskSubmissions } from '@components/Contexts/Assignments/AssignmentSubmissionContext';
 import { useAssignmentsTaskDispatch } from '@components/Contexts/Assignments/AssignmentsTaskContext';
 import { useLHSession } from '@components/Contexts/LHSessionContext';
 import { useOrg } from '@components/Contexts/OrgContext';
 import AssignmentBoxUI from '@components/Objects/Activities/Assignment/AssignmentBoxUI'
 import { getAssignmentTask, getAssignmentTaskSubmissionsUser, handleAssignmentTaskSubmission, updateSubFile } from '@services/courses/assignments';
 import { getTaskFileSubmissionDir } from '@services/media/media';
-import { Cloud, Download, File, Info, Loader, UploadCloud } from 'lucide-react'
+import { Cloud, Download, File, Info, Loader, Lock, UploadCloud } from 'lucide-react'
 import Link from 'next/link';
 import React, { useEffect, useState } from 'react'
 import toast from 'react-hot-toast';
@@ -41,6 +41,22 @@ export default function TaskFileObject({ view, user_id, assignmentTaskUUID, onGr
     const taskSubmissionsMap = useAssignmentTaskSubmissions();
     const queryClient = useQueryClient();
 
+    // Student lock — same derivation as AssignmentBoxUI's `canStudentSave` and
+    // the sibling task types (see TaskShortAnswerObject). The upload endpoint
+    // only enforces the deadline: it returns a file_uuid and writes NO
+    // submission row, so the new file is persisted purely by auto-save. Once
+    // the submission is SUBMITTED/GRADED auto-save is off, meaning a fresh
+    // upload would show a green success chip but be lost on reload while the
+    // teacher grades the OLD file. So the upload has to be gated too.
+    const assignmentSubmission = useAssignmentSubmission() as any;
+    const latestSubmissionStatus =
+        Array.isArray(assignmentSubmission) && assignmentSubmission.length > 0
+            ? assignmentSubmission[0]?.submission_status
+            : null;
+    const submissionIsGraded = latestSubmissionStatus === 'GRADED';
+    const canStudentSave =
+        !submissionIsGraded && latestSubmissionStatus !== 'SUBMITTED';
+
     /* TEACHER VIEW CODE */
     /* TEACHER VIEW CODE */
 
@@ -57,6 +73,12 @@ export default function TaskFileObject({ view, user_id, assignmentTaskUUID, onGr
     const interactedRef = React.useRef(false);
 
     const handleFileChange = async (event: any) => {
+        // Defense in depth: the input is not rendered once the submission is
+        // SUBMITTED/GRADED, but a stale/duplicated node must not slip an upload
+        // through that could never be persisted (see canStudentSave above).
+        if (view === 'student' && !canStudentSave) {
+            return;
+        }
         interactedRef.current = true;
         // Check if user is authenticated
         if (!access_token) {
@@ -82,10 +104,16 @@ export default function TaskFileObject({ view, user_id, assignmentTaskUUID, onGr
             setIsLoading(false)
         } else {
             assignmentTaskStateHook({ type: 'reload' })
-            setUserSubmissions({
+            // Only the file uuid comes back from this endpoint — it uploads the
+            // file and does NOT create/return a submission row. Reading
+            // `assignment_task_submission_uuid` off this response yielded
+            // undefined and wiped the existing submission uuid, so the follow-up
+            // auto-save created a duplicate row instead of updating the current
+            // one. Keep whatever uuid we already hold.
+            setUserSubmissions((prev) => ({
+                ...prev,
                 fileUUID: res.data.file_uuid,
-                assignment_task_submission_uuid: res.data.assignment_task_submission_uuid
-            })
+            }))
             queryClient.invalidateQueries({ queryKey: queryKeys.assignments.taskSubmission(assignment.assignment_object.assignment_uuid) });
             setIsLoading(false)
             setError('')
@@ -211,6 +239,16 @@ export default function TaskFileObject({ view, user_id, assignmentTaskUUID, onGr
     }
 
     async function gradeCustomFC(grade: number, feedback?: string) {
+        // Same guard as the sibling task types (TaskShortAnswerObject:259).
+        // Without an existing submission uuid the grade is written against the
+        // INSTRUCTOR's own row, where it is silently forced to 0 while the UI
+        // reports success — so refuse instead of grading a phantom submission.
+        if (!userSubmissions?.assignment_task_submission_uuid) {
+            toast.error(t('assignments.no_task_submission_to_grade', {
+                defaultValue: 'This student has not submitted a file for this task yet.',
+            }));
+            return;
+        }
         await applyManualGrade({
             grade,
             feedback,
@@ -346,6 +384,25 @@ export default function TaskFileObject({ view, user_id, assignmentTaskUUID, onGr
                                         <div className="font-medium animate-pulse antialiased items-center bg-slate-100 text-slate-600 text-xs sm:text-sm rounded-md px-4 sm:px-5 py-2.5 flex">
                                             <Loader size={15} className="mr-2" />
                                             <span>Loading</span>
+                                        </div>
+                                    </div>
+                                ) : !canStudentSave ? (
+                                    // Locked: uploading now would look successful
+                                    // but could never be persisted (auto-save is
+                                    // off once SUBMITTED/GRADED), so the teacher
+                                    // would keep grading the previous file.
+                                    <div className="flex justify-center items-center w-full mt-5">
+                                        <div className="flex justify-center bg-slate-50 border border-slate-200 rounded-md text-slate-500 space-x-2 items-center p-3 transition-all shadow-xs w-full sm:w-auto">
+                                            <Lock size={15} className="text-slate-400" />
+                                            <div className="text-xs sm:text-sm font-medium">
+                                                {submissionIsGraded
+                                                    ? t('dashboard.assignments.editor.task_editor.general.upload_locked_graded', {
+                                                        defaultValue: 'This submission has been graded — your file can no longer be changed.',
+                                                    })
+                                                    : t('dashboard.assignments.editor.task_editor.general.upload_locked_submitted', {
+                                                        defaultValue: 'You have submitted this assignment — your file can no longer be changed.',
+                                                    })}
+                                            </div>
                                         </div>
                                     </div>
                                 ) : (

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskFormObject.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskFormObject.tsx
@@ -5,7 +5,7 @@ import { useLHSession } from '@components/Contexts/LHSessionContext';
 import AssignmentBoxUI from '@components/Objects/Activities/Assignment/AssignmentBoxUI';
 import { getAssignmentTask, getAssignmentTaskSubmissionsUser, handleAssignmentTaskSubmission, updateAssignmentTask } from '@services/courses/assignments';
 import { Check, Info, Minus, Plus, PlusCircle, X, Type } from 'lucide-react';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
 import { v4 as uuidv4 } from 'uuid';
 import { useTranslation } from 'react-i18next';
@@ -87,6 +87,23 @@ function TaskFormObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskFor
             },
         ] : []
     );
+
+    // Did the answer key actually reach the client?
+    //
+    // The API strips `blanks[].correctAnswer` from the task payload whenever the
+    // student isn't allowed to see it yet — notably while retry attempts remain
+    // (see _student_may_see_answer_key; max_retries=0 means unlimited, so it
+    // never reveals). The client can't re-derive that rule (it has no
+    // attempt_number here), so `showCorrectAnswers` can be true while the key is
+    // absent — and the reveal chip would then render an empty
+    // "Expected answer:". Trust the key only when it is genuinely present.
+    const answerKeyPresent = useMemo(
+        () => questions.some((question) =>
+            (question.blanks ?? []).some((blank) => typeof blank.correctAnswer === 'string')
+        ),
+        [questions]
+    );
+    const revealAnswerKey = showCorrectAnswers && answerKeyPresent;
 
     const handleQuestionChange = (index: number, value: string) => {
         const updatedQuestions = [...questions];
@@ -244,6 +261,17 @@ function TaskFormObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskFor
             // during the save round-trip survives and re-triggers auto-save.
             setInitialUserSubmissions({ ...userSubmissions, assignment_task_submission_uuid: savedUUID });
             setUserSubmissions(prev => ({ ...prev, assignment_task_submission_uuid: savedUUID }));
+            // Keep the shared batch task-submissions cache in step with what we
+            // just persisted. It has a 60s staleTime, so without this a remount
+            // re-hydrates the page-load snapshot and overwrites answers the
+            // learner already saved. Patching (rather than invalidating) is what
+            // makes this safe on the ~1s silent auto-save path.
+            if (res.data) {
+                queryClient.setQueryData(
+                    queryKeys.assignments.taskSubmission(assignment.assignment_object.assignment_uuid),
+                    (prev: any) => (prev ? { ...prev, [assignmentTaskUUID]: res.data } : prev)
+                );
+            }
             // Silent auto-saves skip the refetch (draft save; would re-hydrate).
             if (!opts?.silent) {
                 queryClient.invalidateQueries({ queryKey: queryKeys.assignments.taskSubmission(assignment.assignment_object.assignment_uuid) });
@@ -259,6 +287,15 @@ function TaskFormObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskFor
     const gradeCustomFC = async (grade: number, feedback?: string) => {
         if (!user_id) {
             toast.error('User ID is required for grading.');
+            return;
+        }
+        // There must be an existing submission row to grade. Without this guard
+        // (the siblings already have it) the PUT falls through to an upsert on
+        // the CALLER's own row — the instructor's — where the grade is silently
+        // forced to 0 while the UI reports success, and the student's task stays
+        // ungraded.
+        if (!userSubmissions?.assignment_task_submission_uuid) {
+            toast.error(t('dashboard.assignments.submissions.preview.not_submitted'));
             return;
         }
         await applyManualGrade({
@@ -575,7 +612,13 @@ function TaskFormObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskFor
                                                         data-blank-id={blank.blankUUID}
                                                         className="w-full mx-2 px-3 pr-6 text-neutral-600 bg-[#00008b00] border-2 border-gray-200 rounded-md focus:border-blue-400 focus:ring-2 focus:ring-blue-200 text-sm font-bold transition-all"
                                                     />
-                                                    {showCorrectAnswers && (
+                                                    {/* Render nothing at all when this blank's key
+                                                        was withheld — the learner still sees their
+                                                        own answer and their score. An empty
+                                                        "Expected answer:" is worse than nothing.
+                                                        Checked per blank too, so a partially
+                                                        stripped payload can't leak a blank chip. */}
+                                                    {revealAnswerKey && typeof blank.correctAnswer === 'string' && (
                                                         <div className="mx-2 text-xs text-emerald-700 bg-emerald-50 px-2 py-1 rounded-md inline-flex items-center space-x-1 w-fit">
                                                             <Check size={11} />
                                                             <span className="font-semibold">{t('assignments.form.expected_answer')}:</span>

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskNumberAnswerObject.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskNumberAnswerObject.tsx
@@ -18,6 +18,8 @@ import { CheckCircle2, XCircle } from 'lucide-react'
 import React, { useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
+import { useQueryClient } from '@tanstack/react-query'
+import { queryKeys } from '@/lib/query/keys'
 import { applyManualGrade } from './applyManualGrade'
 
 type NumberAnswerContents = {
@@ -57,6 +59,20 @@ function normalizeContents(raw: any): NumberAnswerContents {
   }
 }
 
+// Did the answer key actually reach the client?
+//
+// The API strips `correct_value` from the task payload whenever the student
+// isn't allowed to see it yet — notably while retry attempts remain (see
+// _student_may_see_answer_key; max_retries=0 means unlimited, so it never
+// reveals). The client can't re-derive that rule (it has no attempt_number
+// here), so `showCorrectAnswers` can be true while the key is absent. In that
+// state normalizeContents defaults correct_value to 0 and the reveal panel
+// would confidently claim "Accepted range: 0 ± tolerance" to a learner who
+// answered correctly. Capture presence from the RAW payload, before defaults.
+function hasAnswerKey(raw: any): boolean {
+  return typeof raw?.correct_value === 'number' && Number.isFinite(raw.correct_value)
+}
+
 function TaskNumberAnswerObject({
   view,
   assignmentTaskUUID,
@@ -69,6 +85,7 @@ function TaskNumberAnswerObject({
   const assignmentTaskState = useAssignmentsTask() as any
   const assignmentTaskStateHook = useAssignmentsTaskDispatch() as any
   const assignment = useAssignments() as any
+  const queryClient = useQueryClient()
   // Same reveal gate as the other task types: teacher must opt in, and the
   // submission must already be GRADED before any correct-answer hint appears.
   const assignmentSubmission = useAssignmentSubmission() as any
@@ -80,6 +97,11 @@ function TaskNumberAnswerObject({
     && !!assignment?.assignment_object?.show_correct_answers
 
   const [contents, setContents] = useState<NumberAnswerContents>(DEFAULT_CONTENTS)
+  // Tracks whether the server actually sent the answer key (see hasAnswerKey).
+  const [answerKeyPresent, setAnswerKeyPresent] = useState(false)
+  // The server applies a third reveal condition the client can't reproduce, so
+  // the opt-in gate alone isn't enough — only reveal when the key is really here.
+  const revealAnswerKey = showCorrectAnswers && answerKeyPresent
   const [studentAnswer, setStudentAnswer] = useState<string>('')
   const [initialAnswer, setInitialAnswer] = useState<string>('')
   // Tracks whether the student has typed in the input; once true, we stop
@@ -96,8 +118,10 @@ function TaskNumberAnswerObject({
     if (view === 'teacher' && assignmentTaskState?.assignmentTask?.contents) {
       const c = assignmentTaskState.assignmentTask.contents
       if (c.prompt !== undefined || c.correct_value !== undefined) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect
+        /* eslint-disable react-hooks/set-state-in-effect */
         setContents(normalizeContents(c))
+        setAnswerKeyPresent(hasAnswerKey(c))
+        /* eslint-enable react-hooks/set-state-in-effect */
       }
     }
   }, [view, assignmentTaskState])
@@ -110,12 +134,12 @@ function TaskNumberAnswerObject({
       setAssignmentTaskOutsideProvider(res.data)
       if (res.data.contents) {
         setContents(normalizeContents(res.data.contents))
+        setAnswerKeyPresent(hasAnswerKey(res.data.contents))
       }
     }
   }
 
   async function loadOwnSubmission() {
-    if (interactedRef.current) return
     if (!assignmentTaskUUID) return
     const res = await getAssignmentTaskSubmissionsMe(
       assignmentTaskUUID,
@@ -124,9 +148,18 @@ function TaskNumberAnswerObject({
     )
     if (res.success && res.data) {
       setUserSubmissions(res.data)
-      const saved = res.data.task_submission?.answer ?? ''
-      setStudentAnswer(String(saved))
-      setInitialAnswer(String(saved))
+      const saved = String(res.data.task_submission?.answer ?? '')
+      // The interaction guard has to be checked HERE, after the await — not
+      // before it. If the learner starts typing during the round trip, a
+      // pre-await check still lets the late response overwrite their text AND
+      // reset the dirty baseline, so auto-save never fires and the answer is
+      // silently lost at submit time. Always adopt the submission row + the
+      // saved baseline (a save must target the right row, and the baseline is
+      // what makes the draft look dirty), but keep their in-progress text.
+      setInitialAnswer(saved)
+      if (!interactedRef.current) {
+        setStudentAnswer(saved)
+      }
     }
   }
 
@@ -202,6 +235,16 @@ function TaskNumberAnswerObject({
     if (res.success) {
       setUserSubmissions(res.data)
       setInitialAnswer(studentAnswer)
+      // Keep the shared batch task-submissions cache in step with what we just
+      // persisted. It has a 60s staleTime, so without this a remount re-hydrates
+      // the page-load snapshot and overwrites answers the learner already saved.
+      // Patching (rather than invalidating) avoids a refetch on every ~1s
+      // silent auto-save.
+      const taskUUID = assignmentTaskUUID
+      queryClient.setQueryData(
+        queryKeys.assignments.taskSubmission(assignment.assignment_object.assignment_uuid),
+        (prev: any) => (prev ? { ...prev, [taskUUID]: res.data } : prev)
+      )
       if (!opts?.silent) toast.success(t('dashboard.assignments.editor.toasts.task_saved'))
       return true
     } else {
@@ -383,7 +426,10 @@ function TaskNumberAnswerObject({
                 <span className="text-sm font-medium text-slate-500">{contents.unit}</span>
               )}
             </div>
-            {showCorrectAnswers && (
+            {/* No answer-key panel at all when the key was withheld — the
+                learner still sees their own answer and their score. A
+                fabricated "Accepted range: 0" would be worse than nothing. */}
+            {revealAnswerKey && (
               <div className="flex flex-col space-y-1.5 p-3 rounded-md bg-emerald-50 border border-emerald-200">
                 <div className="flex items-center space-x-1.5 text-xs font-semibold text-emerald-700">
                   <CheckCircle2 size={13} />

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskQuizObject.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskQuizObject.tsx
@@ -5,7 +5,7 @@ import { useLHSession } from '@components/Contexts/LHSessionContext';
 import AssignmentBoxUI from '@components/Objects/Activities/Assignment/AssignmentBoxUI';
 import { getAssignmentTask, getAssignmentTaskSubmissionsUser, handleAssignmentTaskSubmission, updateAssignmentTask } from '@services/courses/assignments';
 import { Check, Info, Minus, Plus, PlusCircle, X } from 'lucide-react';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
 import { v4 as uuidv4 } from 'uuid';
 import { useTranslation } from 'react-i18next';
@@ -148,6 +148,34 @@ function TaskQuizObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskQui
         questions: [],
         submissions: [],
     });
+
+    // Whether the answer key actually reached the client.
+    //
+    // The API strips `assigned_right_answer` from every option whenever the
+    // student is not yet allowed to see it — notably while retries remain
+    // (see _student_may_see_answer_key). The client cannot re-derive that rule
+    // (it has no attempt_number here), so `showCorrectAnswers` can be true
+    // while the key is absent. Rendering the key markers in that state made
+    // `undefined` read as "not the right answer", so EVERY option — including
+    // the one the learner correctly picked — was labelled "Wrong", even on a
+    // 100% submission. Only trust the key when it is genuinely present.
+    const answerKeyPresent = useMemo(
+        () => questions.some((question) =>
+            question.options.some((option) => typeof option.assigned_right_answer === 'boolean')
+        ),
+        [questions]
+    );
+    const revealAnswerKey = showCorrectAnswers && answerKeyPresent;
+
+    // Did the learner pick this option?
+    const isOptionSelected = (questionUUID?: string, optionUUID?: string) =>
+        userSubmissions.submissions.some(
+            (submission) =>
+                submission.questionUUID === questionUUID &&
+                submission.optionUUID === optionUUID &&
+                submission.answer
+        );
+
     const [initialUserSubmissions, setInitialUserSubmissions] = useState<QuizSubmitSchema>({
         questions: [],
         submissions: [],
@@ -317,9 +345,32 @@ function TaskQuizObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskQui
                     ),
                 }));
                 // Silent auto-saves skip the refetch: it isn't needed for a
-                // draft save and would re-hydrate the batch every ~1s.
+                // draft save and would re-hydrate the batch every ~1s. They
+                // must still PATCH the cache though — with staleTime 60_000 the
+                // batch query otherwise keeps serving the page-load snapshot,
+                // so a remount (task retry, tab switch, route change) re-seeded
+                // the baseline from pre-autosave data and overwrote answers
+                // that were already on the server.
                 if (!opts?.silent) {
                     queryClient.invalidateQueries({ queryKey: queryKeys.assignments.taskSubmission(assignment.assignment_object.assignment_uuid) });
+                } else {
+                    queryClient.setQueryData(
+                        queryKeys.assignments.taskSubmission(assignment.assignment_object.assignment_uuid),
+                        (old: any) => {
+                            // Only patch an existing map — never fabricate one, or a
+                            // task with no fetched batch would hydrate from thin air.
+                            if (!old || typeof old !== 'object') return old;
+                            const previous = old[assignmentTaskUUID] ?? {};
+                            return {
+                                ...old,
+                                [assignmentTaskUUID]: {
+                                    ...previous,
+                                    assignment_task_submission_uuid: savedUUID,
+                                    task_submission: updatedUserSubmissions,
+                                },
+                            };
+                        }
+                    );
                 }
                 return true;
             } else {
@@ -353,6 +404,18 @@ function TaskQuizObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskQui
     }
 
     async function gradeCustomFC(grade: number, feedback?: string) {
+        // Without an existing submission row there is nothing to grade: the API
+        // would fall through to a branch keyed on the SUBMITTER (here the
+        // instructor), writing the grade onto the instructor's own row where it
+        // is forced to 0 — while the UI toasted success and the learner's grade
+        // never moved. `userSubmissions` is seeded with a truthy default object
+        // in this component, so the uuid field itself must be checked.
+        if (!userSubmissions?.assignment_task_submission_uuid) {
+            toast.error(t('dashboard.assignments.editor.toasts.no_submission_to_grade', {
+                defaultValue: 'This student has no submission for this task yet, there is nothing to grade.',
+            }));
+            return;
+        }
         await applyManualGrade({
             grade,
             feedback,
@@ -369,6 +432,15 @@ function TaskQuizObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskQui
 
     async function gradeFC() {
         if (assignmentTaskUUID) {
+            // Same trap as the manual path: auto-grading a task the student
+            // never submitted has no row to target, so the write lands on the
+            // instructor's own (0-scored) row while the toast claims success.
+            if (!userSubmissions?.assignment_task_submission_uuid) {
+                toast.error(t('dashboard.assignments.editor.toasts.no_submission_to_grade', {
+                    defaultValue: 'This student has no submission for this task yet, there is nothing to grade.',
+                }));
+                return;
+            }
             const maxPoints = assignmentTaskOutsideProvider?.max_grade_value || 100;
             // Grade PER QUESTION (mirrors the server's _grade_quiz_task): a
             // question counts only when the student's selected option set exactly
@@ -535,71 +607,73 @@ function TaskQuizObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskQui
 
                                                 </>
                                             )}
-                                            {view === 'student' && showCorrectAnswers && (
-                                                <div className={`w-fit flex-none flex text-[10px] px-2 py-0.5 space-x-1 items-center h-fit rounded-lg ${
-                                                    option.assigned_right_answer
-                                                        ? 'bg-emerald-50 text-emerald-700'
-                                                        : 'bg-rose-50 text-rose-600'
-                                                }`}>
-                                                    {option.assigned_right_answer ? <Check size={10} /> : <X size={10} />}
-                                                    <p className='font-bold'>
-                                                        {option.assigned_right_answer
-                                                            ? t('assignments.quiz.correct_answer')
-                                                            : t('assignments.quiz.incorrect_answer')}
-                                                    </p>
-                                                </div>
-                                            )}
+                                            {/* Verdict badge. Only options the learner actually
+                                                chose get a right/wrong verdict; the option that
+                                                WAS correct is highlighted separately so they can
+                                                still learn from the review. Untouched wrong
+                                                options get no badge at all — previously every
+                                                option was labelled, which read as "you got all
+                                                of these wrong". */}
+                                            {view === 'student' && revealAnswerKey && (() => {
+                                                const selected = isOptionSelected(question.questionUUID, option.optionUUID);
+                                                const correct = !!option.assigned_right_answer;
+                                                if (!selected && !correct) return null;
+                                                if (selected && correct) {
+                                                    return (
+                                                        <div className="w-fit flex-none flex text-[10px] px-2 py-0.5 space-x-1 items-center h-fit rounded-lg bg-emerald-50 text-emerald-700">
+                                                            <Check size={10} />
+                                                            <p className='font-bold'>{t('assignments.quiz.correct_answer')}</p>
+                                                        </div>
+                                                    );
+                                                }
+                                                if (selected && !correct) {
+                                                    return (
+                                                        <div className="w-fit flex-none flex text-[10px] px-2 py-0.5 space-x-1 items-center h-fit rounded-lg bg-rose-50 text-rose-600">
+                                                            <X size={10} />
+                                                            <p className='font-bold'>{t('assignments.quiz.incorrect_answer')}</p>
+                                                        </div>
+                                                    );
+                                                }
+                                                // Correct but not chosen — show what the answer was.
+                                                return (
+                                                    <div className="w-fit flex-none flex text-[10px] px-2 py-0.5 space-x-1 items-center h-fit rounded-lg bg-emerald-50/70 text-emerald-700 border border-emerald-200">
+                                                        <Check size={10} />
+                                                        <p className='font-bold'>{t('assignments.quiz.correct_answer')}</p>
+                                                    </div>
+                                                );
+                                            })()}
                                             {view === 'student' && (
                                                 <div
                                                     className={`w-[20px] flex-none flex items-center h-[20px] rounded-lg ${
-                                                        userSubmissions.submissions.find(
-                                                            (submission) =>
-                                                                submission.questionUUID === question.questionUUID &&
-                                                                submission.optionUUID === option.optionUUID &&
-                                                                submission.answer
-                                                        )
+                                                        isOptionSelected(question.questionUUID, option.optionUUID)
                                                             ? "bg-green-200/60 text-green-500 hover:bg-green-300"
                                                             : "bg-slate-200/60 text-slate-500 hover:bg-slate-300"
                                                     } text-sm transition-all ease-linear ${submissionIsGraded ? '' : 'cursor-pointer'}`}
                                                     onClick={() => !submissionIsGraded && chooseOption(qIndex, oIndex)}
                                                 >
-                                                    {userSubmissions.submissions.find(
-                                                        (submission) =>
-                                                            submission.questionUUID === question.questionUUID &&
-                                                            submission.optionUUID === option.optionUUID &&
-                                                            submission.answer
-                                                    ) ? (
+                                                    {isOptionSelected(question.questionUUID, option.optionUUID) ? (
                                                         <Check size={12} className="mx-auto" />
                                                     ) : (
-                                                        <X size={12} className="mx-auto" />
+                                                        // While answering this is an empty checkbox. After grading a
+                                                        // cross here would look like a verdict on an option the
+                                                        // learner never picked, so leave it blank.
+                                                        !submissionIsGraded && <X size={12} className="mx-auto" />
                                                     )}
                                                 </div>
                                             )}
                                             {view === 'grading' && (
-                                                <>
-                                                   
-                                                    <div className={`w-[20px] flex-none flex items-center h-[20px] rounded-lg ${
-                                                        userSubmissions.submissions.find(
-                                                            (submission) =>
-                                                                submission.questionUUID === question.questionUUID &&
-                                                                submission.optionUUID === option.optionUUID &&
-                                                                submission.answer
-                                                        )
-                                                            ? "bg-green-200/60 text-green-500"
-                                                            : "bg-slate-200/60 text-slate-500"
-                                                    } text-sm`}>
-                                                        {userSubmissions.submissions.find(
-                                                            (submission) =>
-                                                                submission.questionUUID === question.questionUUID &&
-                                                                submission.optionUUID === option.optionUUID &&
-                                                                submission.answer
-                                                        ) ? (
-                                                            <Check size={12} className="mx-auto" />
-                                                        ) : (
-                                                            <X size={12} className="mx-auto" />
-                                                        )}
-                                                    </div>
-                                                </>
+                                                // Marks what the LEARNER chose. The answer key is already
+                                                // shown by the "Marked as True/False" badge above, so a
+                                                // cross on every unchosen option only added noise.
+                                                <div className={`w-[20px] flex-none flex items-center h-[20px] rounded-lg ${
+                                                    isOptionSelected(question.questionUUID, option.optionUUID)
+                                                        ? "bg-green-200/60 text-green-500"
+                                                        : "bg-slate-200/60 text-slate-500"
+                                                } text-sm`}>
+                                                    {isOptionSelected(question.questionUUID, option.optionUUID) && (
+                                                        <Check size={12} className="mx-auto" />
+                                                    )}
+                                                </div>
                                             )}
 
                                         </div>

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskShortAnswerObject.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskShortAnswerObject.tsx
@@ -18,6 +18,8 @@ import { CheckCircle2, Plus, X, XCircle } from 'lucide-react'
 import React, { useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
+import { useQueryClient } from '@tanstack/react-query'
+import { queryKeys } from '@/lib/query/keys'
 import { applyManualGrade } from './applyManualGrade'
 
 type MatchMode = 'exact' | 'case_insensitive' | 'contains' | 'regex'
@@ -60,6 +62,20 @@ function normalizeContents(raw: any): ShortAnswerContents {
   }
 }
 
+// Did the answer key actually reach the client?
+//
+// The API strips `correct_answers` from the task payload whenever the student
+// isn't allowed to see it yet — notably while retry attempts remain (see
+// _student_may_see_answer_key; max_retries=0 means unlimited, so it never
+// reveals). The client can't re-derive that rule (it has no attempt_number
+// here), so `showCorrectAnswers` can be true while the key is absent. In that
+// state normalizeContents defaults to [''], which defeats the `length > 0`
+// guard and renders an "Accepted answers" panel holding one blank chip.
+// Capture presence from the RAW payload, before defaults apply.
+function hasAnswerKey(raw: any): boolean {
+  return Array.isArray(raw?.correct_answers) && raw.correct_answers.length > 0
+}
+
 function TaskShortAnswerObject({
   view,
   assignmentTaskUUID,
@@ -72,6 +88,7 @@ function TaskShortAnswerObject({
   const assignmentTaskState = useAssignmentsTask() as any
   const assignmentTaskStateHook = useAssignmentsTaskDispatch() as any
   const assignment = useAssignments() as any
+  const queryClient = useQueryClient()
   // Student-only reveal: after the submission is GRADED and the teacher
   // opted into showing correct answers, inline the accepted answer list
   // next to the student's input.
@@ -84,6 +101,11 @@ function TaskShortAnswerObject({
     && !!assignment?.assignment_object?.show_correct_answers
 
   const [contents, setContents] = useState<ShortAnswerContents>(DEFAULT_CONTENTS)
+  // Tracks whether the server actually sent the answer key (see hasAnswerKey).
+  const [answerKeyPresent, setAnswerKeyPresent] = useState(false)
+  // The server applies a third reveal condition the client can't reproduce, so
+  // the opt-in gate alone isn't enough — only reveal when the key is really here.
+  const revealAnswerKey = showCorrectAnswers && answerKeyPresent
   const [studentAnswer, setStudentAnswer] = useState<string>('')
   const [initialAnswer, setInitialAnswer] = useState<string>('')
   // Hydration race guard: once the learner starts typing, don't let a late
@@ -100,8 +122,10 @@ function TaskShortAnswerObject({
     if (view === 'teacher' && assignmentTaskState?.assignmentTask?.contents) {
       const c = assignmentTaskState.assignmentTask.contents
       if (c.prompt !== undefined || Array.isArray(c.correct_answers)) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect
+        /* eslint-disable react-hooks/set-state-in-effect */
         setContents(normalizeContents(c))
+        setAnswerKeyPresent(hasAnswerKey(c))
+        /* eslint-enable react-hooks/set-state-in-effect */
       }
     }
   }, [view, assignmentTaskState])
@@ -114,12 +138,12 @@ function TaskShortAnswerObject({
       setAssignmentTaskOutsideProvider(res.data)
       if (res.data.contents) {
         setContents(normalizeContents(res.data.contents))
+        setAnswerKeyPresent(hasAnswerKey(res.data.contents))
       }
     }
   }
 
   async function loadOwnSubmission() {
-    if (interactedRef.current) return
     if (!assignmentTaskUUID) return
     const res = await getAssignmentTaskSubmissionsMe(
       assignmentTaskUUID,
@@ -129,8 +153,17 @@ function TaskShortAnswerObject({
     if (res.success && res.data) {
       setUserSubmissions(res.data)
       const saved = res.data.task_submission?.answer ?? ''
-      setStudentAnswer(saved)
+      // The interaction guard has to be checked HERE, after the await — not
+      // before it. If the learner starts typing during the round trip, a
+      // pre-await check still lets the late response overwrite their text AND
+      // reset the dirty baseline, so auto-save never fires and the answer is
+      // silently lost at submit time. Always adopt the submission row + the
+      // saved baseline (a save must target the right row, and the baseline is
+      // what makes the draft look dirty), but keep their in-progress text.
       setInitialAnswer(saved)
+      if (!interactedRef.current) {
+        setStudentAnswer(saved)
+      }
     }
   }
 
@@ -222,6 +255,16 @@ function TaskShortAnswerObject({
     if (res.success) {
       setUserSubmissions(res.data)
       setInitialAnswer(studentAnswer)
+      // Keep the shared batch task-submissions cache in step with what we just
+      // persisted. It has a 60s staleTime, so without this a remount re-hydrates
+      // the page-load snapshot and overwrites answers the learner already saved.
+      // Patching (rather than invalidating) avoids a refetch on every ~1s
+      // silent auto-save.
+      const taskUUID = assignmentTaskUUID
+      queryClient.setQueryData(
+        queryKeys.assignments.taskSubmission(assignment.assignment_object.assignment_uuid),
+        (prev: any) => (prev ? { ...prev, [taskUUID]: res.data } : prev)
+      )
       if (!opts?.silent) toast.success(t('dashboard.assignments.editor.toasts.task_saved'))
       return true
     } else {
@@ -415,7 +458,10 @@ function TaskShortAnswerObject({
               )}
               className="w-full px-3 py-2 text-sm border-2 border-gray-200 rounded-md bg-white focus:border-blue-400 focus:ring-2 focus:ring-blue-200 outline-none"
             />
-            {showCorrectAnswers && contents.correct_answers.length > 0 && (
+            {/* No answer-key panel at all when the key was withheld — the
+                learner still sees their own answer and their score. A panel
+                holding one blank chip would be worse than nothing. */}
+            {revealAnswerKey && (
               <div className="flex flex-col space-y-1.5 p-3 rounded-md bg-emerald-50 border border-emerald-200">
                 <div className="flex items-center space-x-1.5 text-xs font-semibold text-emerald-700">
                   <CheckCircle2 size={13} />

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/applyManualGrade.ts
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/applyManualGrade.ts
@@ -1,5 +1,21 @@
 import toast from 'react-hot-toast'
 import { handleAssignmentTaskSubmission } from '@services/courses/assignments'
+import i18n from '@/lib/i18n'
+
+/**
+ * Why a manual grade didn't go through. Returned (instead of silently doing
+ * nothing) so a caller can surface a real failure rather than assume success.
+ */
+export type ManualGradeFailure =
+    | 'missing-task'
+    | 'invalid-grade'
+    | 'grade-above-max'
+    | 'missing-submission'
+    | 'request-failed'
+
+export type ManualGradeResult =
+    | { success: true }
+    | { success: false; reason: ManualGradeFailure }
 
 interface ApplyManualGradeArgs {
     grade: number
@@ -29,15 +45,25 @@ export async function applyManualGrade({
     assignmentTaskSubmissionUUID,
     taskSubmissionPayload,
     onSuccess,
-}: ApplyManualGradeArgs): Promise<void> {
-    if (!assignmentTaskUUID) return
+}: ApplyManualGradeArgs): Promise<ManualGradeResult> {
+    if (!assignmentTaskUUID) return { success: false, reason: 'missing-task' }
     if (Number.isNaN(grade) || grade < 0) {
         toast.error('Grade must be a positive number.')
-        return
+        return { success: false, reason: 'invalid-grade' }
     }
     if (grade > maxPoints) {
         toast.error(`Grade cannot be more than ${maxPoints} points`)
-        return
+        return { success: false, reason: 'grade-above-max' }
+    }
+    // Defence in depth for every task type: with no target submission row the
+    // API falls back to a branch keyed on the SUBMITTER — the instructor —
+    // creating a phantom instructor-owned row that is forced to 0 while the UI
+    // cheerfully reported "Task graded successfully". Refuse loudly instead.
+    if (!assignmentTaskSubmissionUUID) {
+        toast.error(i18n.t('dashboard.assignments.editor.toasts.no_submission_to_grade', {
+            defaultValue: 'This student has no submission for this task yet, there is nothing to grade.',
+        }))
+        return { success: false, reason: 'missing-submission' }
     }
     const trimmed = feedback?.trim()
     const finalFeedback = trimmed && trimmed.length > 0
@@ -59,7 +85,8 @@ export async function applyManualGrade({
     if (res.success) {
         onSuccess()
         toast.success(`Task graded successfully with ${grade} points`)
-    } else {
-        toast.error('Error grading task, please retry later.')
+        return { success: true }
     }
+    toast.error('Error grading task, please retry later.')
+    return { success: false, reason: 'request-failed' }
 }

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/page.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/page.tsx
@@ -167,20 +167,31 @@ function PublishingState() {
 
     async function updateAssignmentPublishState(assignmentUUID: string) {
         const nextPublished = !assignment?.assignment_object?.published
-        const res = await updateAssignment({ published: nextPublished }, assignmentUUID, access_token)
-        const res2 = await updateActivity({ published: nextPublished }, assignment?.activity_object?.activity_uuid, access_token)
         const toast_loading = toast.loading(t('dashboard.assignments.detail.publishing.toasts.updating'))
-        if (res.success && res2) {
-            queryClient.invalidateQueries({ queryKey: queryKeys.assignments.detail(assignmentUUID) })
-            toast.success(t('dashboard.assignments.detail.publishing.toasts.update_success'))
-            toast.dismiss(toast_loading)
-            track(AnalyticsEvent.AssignmentPublishToggled, {
-                published: nextPublished,
-                task_count: assignment?.assignment_tasks?.length ?? 0,
-            })
-        }
-        else {
+        try {
+            const res = await updateAssignment({ published: nextPublished }, assignmentUUID, access_token)
+            const res2 = await updateActivity({ published: nextPublished }, assignment?.activity_object?.activity_uuid, access_token)
+            // `res2` is a response-metadata envelope — always an object, so the
+            // old `res.success && res2` guard degenerated to `res.success` and
+            // reported success even when the activity leg 404'd/5xx'd, leaving
+            // the badge on "Published" while learners still couldn't see it.
+            if (res.success && res2.success) {
+                queryClient.invalidateQueries({ queryKey: queryKeys.assignments.detail(assignmentUUID) })
+                toast.success(t('dashboard.assignments.detail.publishing.toasts.update_success'))
+                track(AnalyticsEvent.AssignmentPublishToggled, {
+                    published: nextPublished,
+                    task_count: assignment?.assignment_tasks?.length ?? 0,
+                })
+            }
+            else {
+                toast.error(t('dashboard.assignments.detail.publishing.toasts.update_error'))
+            }
+        } catch (_e) {
             toast.error(t('dashboard.assignments.detail.publishing.toasts.update_error'))
+        } finally {
+            // Dismiss in `finally`: it used to live in the success branch only,
+            // so any failure left a spinner toast on screen forever.
+            toast.dismiss(toast_loading)
         }
     }
 

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/subpages/AssignmentAnalyticsSubPage.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/subpages/AssignmentAnalyticsSubPage.tsx
@@ -54,12 +54,39 @@ type Submission = {
         percentage_display?: string;
         tasks?: Array<{
             assignment_task_uuid: string;
+            title?: string;
             grade: number;
+            max_grade?: number;
+            // 0–100. The only field the difficulty chart may use: its axis is
+            // domain={[0, 100]} and the tooltip reads "x / 100", so raw points
+            // (which are out of the task's own max) would be plotted wrong.
+            percentage?: number;
             passed: boolean;
             display_grade: string;
         }>;
     };
 };
+
+// The submissions endpoint pages server-side (`limit` defaults to 50, caps at
+// 500) and returns a bare array. Analytics computed over an unpaginated call
+// silently described only the newest 50 submissions — the average, median,
+// pass rate and distribution were all wrong for any real cohort.
+const SUBMISSIONS_PAGE_SIZE = 500;
+// Hard stop so a server that ignores `offset` can't spin this loop forever.
+const SUBMISSIONS_MAX_PAGES = 20;
+
+async function fetchAllAssignmentSubmissions(assignment_uuid: string, access_token: string): Promise<Submission[]> {
+    const all: Submission[] = [];
+    for (let page = 0; page < SUBMISSIONS_MAX_PAGES; page++) {
+        const url = `${getAPIUrl()}assignments/assignment_${assignment_uuid}/submissions`
+            + `?limit=${SUBMISSIONS_PAGE_SIZE}&offset=${page * SUBMISSIONS_PAGE_SIZE}`;
+        const batch = await apiFetch(url, access_token);
+        if (!Array.isArray(batch)) break;
+        all.push(...batch);
+        if (batch.length < SUBMISSIONS_PAGE_SIZE) break;
+    }
+    return all;
+}
 
 const GRADE_BUCKETS = [
     { key: 'F', label: 'F', min: 0, max: 59, color: '#e11d48' },      // rose-600
@@ -79,7 +106,8 @@ function AssignmentAnalyticsSubPage({ assignment_uuid }: { assignment_uuid: stri
 
     const { data: submissions } = useQuery<Submission[]>({
         queryKey: queryKeys.assignments.analytics(assignment_uuid),
-        queryFn: () => apiFetch(`${getAPIUrl()}assignments/assignment_${assignment_uuid}/submissions`, access_token),
+        // Paged fetch — stats over a newest-50 slice are not stats.
+        queryFn: () => fetchAllAssignmentSubmissions(assignment_uuid, access_token),
         enabled: !!(assignment_uuid && access_token),
         staleTime: 10_000,
         refetchInterval: 30_000,
@@ -181,10 +209,19 @@ function AssignmentAnalyticsSubPage({ assignment_uuid }: { assignment_uuid: stri
         for (const s of graded) {
             const tArr = s.grade_display?.tasks || [];
             for (const ts of tArr) {
+                // Aggregate the 0–100 `percentage`, never the raw `grade`: the
+                // chart's X axis is domain={[0, 100]} and its tooltip renders
+                // "value / 100", so points out of a per-task max would be
+                // plotted against the wrong scale. Fall back to deriving the
+                // percentage from grade/max_grade, and skip the entry entirely
+                // when neither is usable so the card degrades to its empty
+                // state instead of charting zeroes.
+                const pct = taskEntryPct(ts);
+                if (pct === null) continue;
                 const key = ts.assignment_task_uuid;
                 const entry = taskAgg.get(key) || { total: 0, sum: 0, passed: 0 };
                 entry.total += 1;
-                entry.sum += Number(ts.grade) || 0;
+                entry.sum += pct;
                 if (ts.passed) entry.passed += 1;
                 taskAgg.set(key, entry);
             }
@@ -482,7 +519,7 @@ function AssignmentAnalyticsSubPage({ assignment_uuid }: { assignment_uuid: stri
                                     <Tooltip
                                         cursor={{ fill: '#f9fafb' }}
                                         contentStyle={{ fontSize: 12, borderRadius: 8, border: 'none', boxShadow: '0 2px 10px rgba(0,0,0,0.08)' }}
-                                        formatter={(value: any, name: any, props: any) => {
+                                        formatter={(value: any, name: any, _props: any) => {
                                             if (name === 'avg') return [`${value} / 100`, t('dashboard.assignments.analytics.tasks.avg_grade')];
                                             return [value, name];
                                         }}
@@ -669,7 +706,7 @@ function EmptyChart({ message }: { message: string }) {
 function PerformerRow({
     submission,
     rank,
-    tone,
+    tone: _tone,
     access_token,
 }: {
     submission: Submission;
@@ -766,6 +803,23 @@ function submissionPct(s: Submission): number | null {
     // Last resort: treat `grade` as already a percentage when it plausibly is.
     const g = Number(s.grade);
     if (!isNaN(g) && g >= 0 && g <= 100) return g;
+    return null;
+}
+
+// Extract a 0–100 percentage from one per-task breakdown entry. Returns null
+// when the payload carries no usable number — the submissions list endpoint
+// hasn't always exposed a per-task breakdown, and the difficulty card must
+// fall back to its empty state rather than plot a flat row of zeroes.
+function taskEntryPct(ts: any): number | null {
+    const pct = Number(ts?.percentage);
+    if (!isNaN(pct) && ts?.percentage !== null && ts?.percentage !== undefined) {
+        return Math.max(0, Math.min(100, pct));
+    }
+    const grade = Number(ts?.grade);
+    const max = Number(ts?.max_grade);
+    if (!isNaN(grade) && !isNaN(max) && max > 0) {
+        return Math.max(0, Math.min(100, (grade / max) * 100));
+    }
     return null;
 }
 

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/subpages/AssignmentSubmissionsSubPage.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/subpages/AssignmentSubmissionsSubPage.tsx
@@ -4,14 +4,17 @@ import Modal from '@components/Objects/StyledElements/Modal/Modal';
 import { getAPIUrl } from '@services/config/config';
 import { getUserAvatarMediaDirectory } from '@services/media/media';
 import { apiFetch } from '@services/utils/ts/requests';
-import { useQuery } from '@tanstack/react-query';
+import { useQueries, useQuery } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/query/keys';
 import {
+    AlertTriangle,
     ArrowUpDown,
     Calendar,
     CheckCircle2,
     ChevronDown,
+    CircleDashed,
     Clock,
+    Hourglass,
     Inbox,
     RotateCcw,
     Search,
@@ -36,7 +39,44 @@ type SortField =
     | 'late_first'       // LATE submissions at the top
     | 'recently_graded'; // GRADED first, then sorted by submission date
 type SortDirection = 'asc' | 'desc';
-type StatusFilter = 'ALL' | 'LATE' | 'SUBMITTED' | 'GRADED';
+type StatusFilter = 'ALL' | 'LATE' | 'SUBMITTED' | 'GRADED' | 'PENDING' | 'NOT_SUBMITTED';
+
+// The submissions endpoint is paginated server-side (`limit` defaults to 50,
+// caps at 500) and answers with a bare array — no total, no cursor. Requesting
+// it without params silently returned only the newest 50 submitters, which made
+// the stats, the filters and the search lie and left everyone else ungradable.
+// So we page through explicitly until a short page comes back.
+const SUBMISSIONS_PAGE_SIZE = 500;
+// Hard stop so a misbehaving server (e.g. one that ignores `offset`) can never
+// spin this loop forever.
+const SUBMISSIONS_MAX_PAGES = 20;
+const SUBMISSIONS_FETCH_CAP = SUBMISSIONS_PAGE_SIZE * SUBMISSIONS_MAX_PAGES;
+
+// Fetch every page of an assignment's submissions. When the returned array is
+// exactly SUBMISSIONS_FETCH_CAP long we bailed on the page guard rather than on
+// a short page, which is what the UI uses to warn about truncation.
+async function fetchAllAssignmentSubmissions(assignment_uuid: string, access_token: string) {
+    const all: any[] = [];
+    for (let page = 0; page < SUBMISSIONS_MAX_PAGES; page++) {
+        const url = `${getAPIUrl()}assignments/assignment_${assignment_uuid}/submissions`
+            + `?limit=${SUBMISSIONS_PAGE_SIZE}&offset=${page * SUBMISSIONS_PAGE_SIZE}`;
+        const batch = await apiFetch(url, access_token);
+        if (!Array.isArray(batch)) break;
+        all.push(...batch);
+        if (batch.length < SUBMISSIONS_PAGE_SIZE) break;
+    }
+    return all;
+}
+
+// Display name used by the list-level search + name sort. Kept identical to
+// what SubmissionRow renders so a student can never match one and not the other.
+function displayNameOf(user: any): string {
+    if (!user) return '';
+    if (user.first_name || user.last_name) {
+        return `${user.first_name || ''} ${user.last_name || ''}`.trim();
+    }
+    return user.username || '';
+}
 
 function AssignmentSubmissionsSubPage({ assignment_uuid }: { assignment_uuid: string }) {
     const { t } = useTranslation();
@@ -51,7 +91,9 @@ function AssignmentSubmissionsSubPage({ assignment_uuid }: { assignment_uuid: st
 
     const { data: assignmentSubmissions } = useQuery({
         queryKey: queryKeys.assignments.allSubmissions(assignment_uuid),
-        queryFn: () => apiFetch(`${getAPIUrl()}assignments/assignment_${assignment_uuid}/submissions`, access_token),
+        // Paged fetch — see fetchAllAssignmentSubmissions: a single unpaginated
+        // request only ever returned the newest 50 rows.
+        queryFn: () => fetchAllAssignmentSubmissions(assignment_uuid, access_token),
         enabled: !!(assignment_uuid && access_token),
         // Keep the submissions view in near real-time: poll every 10s so
         // auto-graded submissions show up without a manual page refresh.
@@ -61,13 +103,23 @@ function AssignmentSubmissionsSubPage({ assignment_uuid }: { assignment_uuid: st
         refetchOnReconnect: true,
     });
 
+    // We only ever stop early on a short page, so landing exactly on the cap
+    // means there are probably more rows we did not load. Say so out loud
+    // instead of hiding students behind a silently truncated list.
+    const isTruncated = !!assignmentSubmissions && assignmentSubmissions.length >= SUBMISSIONS_FETCH_CAP;
+
     const stats = useMemo(() => {
-        if (!assignmentSubmissions) return { total: 0, late: 0, submitted: 0, graded: 0 };
+        if (!assignmentSubmissions) return { total: 0, late: 0, submitted: 0, graded: 0, pending: 0, not_submitted: 0 };
+        // Every status the API can return gets its own bucket so the pills add
+        // up to `total`. PENDING/NOT_SUBMITTED used to fall through and be
+        // rendered (and counted) as "Submitted".
         return {
             total: assignmentSubmissions.length,
             late: assignmentSubmissions.filter((s: any) => s.submission_status === 'LATE').length,
             submitted: assignmentSubmissions.filter((s: any) => s.submission_status === 'SUBMITTED').length,
             graded: assignmentSubmissions.filter((s: any) => s.submission_status === 'GRADED').length,
+            pending: assignmentSubmissions.filter((s: any) => s.submission_status === 'PENDING').length,
+            not_submitted: assignmentSubmissions.filter((s: any) => s.submission_status === 'NOT_SUBMITTED').length,
         };
     }, [assignmentSubmissions]);
 
@@ -76,6 +128,11 @@ function AssignmentSubmissionsSubPage({ assignment_uuid }: { assignment_uuid: st
         { key: 'LATE', label: t('dashboard.assignments.submissions.status.late'), count: stats.late, icon: <Clock size={13} />, activeClass: 'bg-rose-600/80 text-white' },
         { key: 'SUBMITTED', label: t('dashboard.assignments.submissions.status.submitted'), count: stats.submitted, icon: <SendHorizonal size={13} />, activeClass: 'bg-amber-600/80 text-white' },
         { key: 'GRADED', label: t('dashboard.assignments.submissions.status.graded'), count: stats.graded, icon: <CheckCircle2 size={13} />, activeClass: 'bg-emerald-600/80 text-white' },
+        // Only surfaced when they actually occur — most assignments have none of
+        // these and the toolbar is already crowded. Kept visible while selected
+        // so the pill can never vanish and strand the user on an empty list.
+        ...(stats.pending > 0 || statusFilter === 'PENDING' ? [{ key: 'PENDING' as StatusFilter, label: t('dashboard.assignments.submissions.status.pending', { defaultValue: 'In progress' }), count: stats.pending, icon: <Hourglass size={13} />, activeClass: 'bg-slate-500/80 text-white' }] : []),
+        ...(stats.not_submitted > 0 || statusFilter === 'NOT_SUBMITTED' ? [{ key: 'NOT_SUBMITTED' as StatusFilter, label: t('dashboard.assignments.submissions.preview.not_submitted'), count: stats.not_submitted, icon: <CircleDashed size={13} />, activeClass: 'bg-slate-500/80 text-white' }] : []),
     ];
 
     const sortOptions: { field: SortField; label: string }[] = [
@@ -221,6 +278,17 @@ function AssignmentSubmissionsSubPage({ assignment_uuid }: { assignment_uuid: st
 
             {/* Submissions list */}
             <div className="flex-1 overflow-y-auto px-10 pb-6">
+                {isTruncated && (
+                    <div className="flex items-center gap-2 mb-3 px-3.5 py-2.5 rounded-lg bg-amber-50 text-amber-800 text-xs font-semibold ring-1 ring-inset ring-amber-200/60">
+                        <AlertTriangle size={14} className="shrink-0" />
+                        <span>
+                            {t('dashboard.assignments.submissions.truncated_warning', {
+                                max: SUBMISSIONS_FETCH_CAP,
+                                defaultValue: 'Only the first {{max}} submissions are shown. Some submissions are not listed here.',
+                            })}
+                        </span>
+                    </div>
+                )}
                 <SubmissionsList
                     submissions={assignmentSubmissions}
                     assignment_uuid={assignment_uuid}
@@ -250,6 +318,27 @@ function SubmissionsList({
     sortDirection: SortDirection;
 }) {
     const { t } = useTranslation();
+    const session = useLHSession() as any;
+    const access_token = session?.data?.tokens?.access_token;
+
+    // Prefetch every submitter at list level. These use the exact same query
+    // key as the rows did, so react-query dedupes them — no extra requests —
+    // but having the names here is what makes a real "sort by name" and a
+    // list-level search predicate possible at all.
+    const userQueries = useQueries({
+        queries: (submissions || []).map((s: any) => ({
+            queryKey: ['users', 'id', s.user_id],
+            queryFn: () => apiFetch(`${getAPIUrl()}users/id/${s.user_id}`, access_token),
+            enabled: !!(s.user_id && access_token),
+            staleTime: 60_000,
+        })),
+    });
+
+    const usersById = new Map<number, any>();
+    (submissions || []).forEach((s: any, i: number) => {
+        const u = userQueries[i]?.data;
+        if (u) usersById.set(s.user_id, u);
+    });
 
     if (!submissions) {
         return (
@@ -269,21 +358,39 @@ function SubmissionsList({
     }
 
     // Priority tables used by the status-based sorts. Lower numbers come first
-    // when `sortDirection === 'asc'`.
-    const statusOrder: Record<string, number> = { LATE: 0, SUBMITTED: 1, GRADED: 2 };
+    // when `sortDirection === 'asc'`. PENDING/NOT_SUBMITTED sit last everywhere:
+    // there is nothing submitted to review on those rows.
+    const statusOrder: Record<string, number> = { LATE: 0, SUBMITTED: 1, GRADED: 2, PENDING: 3, NOT_SUBMITTED: 4 };
     // needsGradingOrder: ungraded (LATE + SUBMITTED) before GRADED
-    const needsGradingOrder: Record<string, number> = { LATE: 0, SUBMITTED: 0, GRADED: 1 };
+    const needsGradingOrder: Record<string, number> = { LATE: 0, SUBMITTED: 0, GRADED: 1, PENDING: 2, NOT_SUBMITTED: 2 };
     // lateFirstOrder: LATE first, everything else after
-    const lateFirstOrder: Record<string, number> = { LATE: 0, SUBMITTED: 1, GRADED: 1 };
+    const lateFirstOrder: Record<string, number> = { LATE: 0, SUBMITTED: 1, GRADED: 1, PENDING: 2, NOT_SUBMITTED: 2 };
     // recentlyGradedOrder: GRADED first, then everything else
-    const recentlyGradedOrder: Record<string, number> = { GRADED: 0, LATE: 1, SUBMITTED: 1 };
+    const recentlyGradedOrder: Record<string, number> = { GRADED: 0, LATE: 1, SUBMITTED: 1, PENDING: 2, NOT_SUBMITTED: 2 };
 
     const dateMs = (s: any) => new Date(s.creation_date).getTime();
+
+    // Search lives here rather than inside the row: when the rows filtered
+    // themselves out, `filtered.length` stayed >0 so the empty state never
+    // rendered (blank list area) and `isLast` pointed at a hidden row (stray
+    // bottom border).
+    const q = searchQuery.trim().toLowerCase();
+    const matchesSearch = (s: any) => {
+        if (!q) return true;
+        const user = usersById.get(s.user_id);
+        // Keep the row until its user record lands, otherwise everything
+        // disappears for a frame on every refetch.
+        if (!user) return true;
+        const fullName = `${user.first_name || ''} ${user.last_name || ''}`.toLowerCase();
+        const username = (user.username || '').toLowerCase();
+        const email = (user.email || '').toLowerCase();
+        return fullName.includes(q) || username.includes(q) || email.includes(q);
+    };
 
     const filtered = submissions
         .filter((s: any) => {
             if (statusFilter !== 'ALL' && s.submission_status !== statusFilter) return false;
-            return true;
+            return matchesSearch(s);
         })
         .sort((a: any, b: any) => {
             let cmp = 0;
@@ -317,10 +424,20 @@ function SubmissionsList({
                 cmp = (recentlyGradedOrder[a.submission_status] ?? 1) - (recentlyGradedOrder[b.submission_status] ?? 1);
                 // Inside the graded bucket, newest updates first
                 if (cmp === 0) cmp = dateMs(b) - dateMs(a);
+            } else if (sortField === 'name') {
+                // Real name sort, now that the users are prefetched above.
+                // Rows whose user hasn't loaded yet sort to the end instead of
+                // jumping around as each request resolves.
+                const aName = displayNameOf(usersById.get(a.user_id));
+                const bName = displayNameOf(usersById.get(b.user_id));
+                if (!aName || !bName) {
+                    if (aName !== bName) return aName ? -1 : 1;
+                } else {
+                    cmp = aName.localeCompare(bName, undefined, { sensitivity: 'base' });
+                }
+                if (cmp === 0) cmp = dateMs(a) - dateMs(b);
             } else {
-                // name and any unknown: delegate to date as a safe fallback
-                // (name sort happens inside the row component since user data
-                // is fetched there)
+                // Any unknown field: delegate to date as a safe fallback.
                 cmp = dateMs(a) - dateMs(b);
             }
             return sortDirection === 'asc' ? cmp : -cmp;
@@ -344,7 +461,7 @@ function SubmissionsList({
                     key={submission.assignmentusersubmission_uuid || submission.id}
                     submission={submission}
                     assignment_uuid={assignment_uuid}
-                    searchQuery={searchQuery}
+                    user={usersById.get(submission.user_id)}
                     isLast={index === filtered.length - 1}
                 />
             ))}
@@ -355,39 +472,24 @@ function SubmissionsList({
 function SubmissionRow({
     assignment_uuid,
     submission,
-    searchQuery,
+    user,
     isLast,
 }: {
     assignment_uuid: string;
     submission: any;
-    searchQuery: string;
+    user: any;
     isLast: boolean;
 }) {
     const { t } = useTranslation();
-    const session = useLHSession() as any;
-    const access_token = session?.data?.tokens?.access_token;
     const { track } = useLHAnalytics('dashboard');
     const [gradeModalOpen, setGradeModalOpen] = useState(false);
 
-    const { data: user } = useQuery({
-        queryKey: ['users', 'id', submission.user_id],
-        queryFn: () => apiFetch(`${getAPIUrl()}users/id/${submission.user_id}`, access_token),
-        enabled: !!(submission.user_id && access_token),
-        staleTime: 60_000,
-    });
-
-    const matchesSearch = useMemo(() => {
-        if (!searchQuery) return true;
-        if (!user) return true;
-        const q = searchQuery.toLowerCase();
-        const fullName = `${user.first_name || ''} ${user.last_name || ''}`.toLowerCase();
-        const username = (user.username || '').toLowerCase();
-        const email = (user.email || '').toLowerCase();
-        return fullName.includes(q) || username.includes(q) || email.includes(q);
-    }, [searchQuery, user]);
-
-    if (!matchesSearch) return null;
-
+    // Every status the API can return is listed explicitly. The old fallback
+    // to SUBMITTED painted a mid-retry PENDING row with the amber "Submitted"
+    // badge, so a teacher would open Evaluate on a student who had submitted
+    // nothing and grading it would zero their in-flight retry. It also broke
+    // the filter, which compares the real status and therefore hid the very
+    // row that claimed to be "Submitted".
     const statusConfig: Record<string, { label: string; className: string; icon: React.ReactNode }> = {
         LATE: {
             label: t('dashboard.assignments.submissions.status.late'),
@@ -404,9 +506,25 @@ function SubmissionRow({
             className: 'bg-emerald-50 text-emerald-700',
             icon: <CheckCircle2 size={11} />,
         },
+        PENDING: {
+            label: t('dashboard.assignments.submissions.status.pending', { defaultValue: 'In progress' }),
+            className: 'bg-slate-100 text-slate-600',
+            icon: <Hourglass size={11} />,
+        },
+        NOT_SUBMITTED: {
+            label: t('dashboard.assignments.submissions.preview.not_submitted'),
+            className: 'bg-slate-100 text-slate-600',
+            icon: <CircleDashed size={11} />,
+        },
     };
 
-    const status = statusConfig[submission.submission_status] || statusConfig['SUBMITTED'];
+    // Unrecognised statuses degrade to a neutral chip that shows the raw value
+    // rather than claiming the student submitted.
+    const status = statusConfig[submission.submission_status] || {
+        label: submission.submission_status || t('common.unknown'),
+        className: 'bg-slate-100 text-slate-600',
+        icon: <CircleDashed size={11} />,
+    };
     const submittedDate = new Date(submission.creation_date);
     const dateStr = submittedDate.toLocaleDateString('en-UK', {
         year: 'numeric',

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/subpages/Modals/EvaluateAssignment.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/subpages/Modals/EvaluateAssignment.tsx
@@ -20,6 +20,83 @@ import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics';
 
+function pctToLetterGrade(pct: number): string {
+    if (pct >= 90) return 'A';
+    if (pct >= 80) return 'B';
+    if (pct >= 70) return 'C';
+    if (pct >= 60) return 'D';
+    return 'F';
+}
+
+function pctToGpa(pct: number): string {
+    if (pct >= 93) return '4.0';
+    if (pct >= 90) return '3.7';
+    if (pct >= 87) return '3.3';
+    if (pct >= 83) return '3.0';
+    if (pct >= 80) return '2.7';
+    if (pct >= 77) return '2.3';
+    if (pct >= 73) return '2.0';
+    if (pct >= 70) return '1.7';
+    if (pct >= 67) return '1.3';
+    if (pct >= 63) return '1.0';
+    if (pct >= 60) return '0.7';
+    return '0.0';
+}
+
+// The GET /grade response mixes two sources of truth: `display_grade`,
+// `points_summary`, `percentage_display` and `passed` are derived from the
+// PERSISTED aggregate, while `tasks` is rebuilt live from the current task
+// submissions. Inline grading a task writes only the task row, so the header
+// banner kept reading e.g. "40/100 pts · 40.00% · Not passing" while the chip
+// directly below it flipped to 100% — one response contradicting itself.
+// Recompute the banner from the live task rows, mirroring the backend's
+// compute_assignment_grade() so both halves always agree.
+function buildLiveGrade(gradePreview: any) {
+    const tasks = Array.isArray(gradePreview?.tasks) ? gradePreview.tasks : null;
+    if (!tasks || tasks.length === 0) return gradePreview;
+
+    const max = tasks.reduce((acc: number, tb: any) => acc + (Number(tb.max_grade) || 0), 0);
+    const rawSum = tasks.reduce((acc: number, tb: any) => acc + (Number(tb.grade) || 0), 0);
+    // Same clamp the backend applies, so a buggy task sum can't report 120/100.
+    const raw = Math.max(Math.min(rawSum, max), 0);
+    const percentage = max > 0 ? Math.round((raw / max) * 10000) / 100 : 0;
+
+    const gradingType = gradePreview.grading_type || 'NUMERIC';
+    // Prefer the server's threshold (it honours a per-assignment override);
+    // only fall back to the grading-type defaults when it isn't present.
+    const threshold = typeof gradePreview.passing_threshold === 'number'
+        ? gradePreview.passing_threshold
+        : (gradingType === 'ALPHABET' || gradingType === 'GPA_SCALE' ? 60 : 50);
+    const passed = percentage >= threshold;
+    const percentage_display = `${percentage.toFixed(2)}%`;
+
+    let display_grade: string;
+    if (gradingType === 'ALPHABET') {
+        const letter = pctToLetterGrade(percentage);
+        display_grade = !passed ? 'F' : letter === 'F' ? 'D' : letter;
+    } else if (gradingType === 'PERCENTAGE') {
+        display_grade = percentage_display;
+    } else if (gradingType === 'PASS_FAIL') {
+        display_grade = passed ? 'Pass' : 'Fail';
+    } else if (gradingType === 'GPA_SCALE') {
+        const gpa = pctToGpa(percentage);
+        display_grade = !passed ? '0.0' : gpa === '0.0' ? '1.0' : gpa;
+    } else {
+        display_grade = `${Math.round(percentage)}/100`;
+    }
+
+    return {
+        ...gradePreview,
+        grade: raw,
+        max_grade: max,
+        percentage,
+        passed,
+        display_grade,
+        points_summary: `${raw}/${max} pts`,
+        percentage_display,
+    };
+}
+
 function EvaluateAssignment({ user_id }: any) {
     const { t } = useTranslation()
     const assignments = useAssignments() as any;
@@ -86,14 +163,16 @@ function EvaluateAssignment({ user_id }: any) {
             queryClient.invalidateQueries({ queryKey: queryKeys.assignments.analytics(rawUuid) })
         }
         else {
-            toast.error(res.data.message)
+            // FastAPI error bodies carry `detail`, never `message` — reading
+            // `.message` rendered a wordless red toast for 404/403/500 alike.
+            toast.error(res.data?.detail || t('common.something_went_wrong'))
         }
     }
 
     async function finalizeAndComplete() {
         const gradeRes = await putFinalGrade(user_id, assignmentUuid, access_token, feedback ?? null);
         if (!gradeRes.success) {
-            toast.error(gradeRes.data.message)
+            toast.error(gradeRes.data?.detail || t('common.something_went_wrong'))
             return
         }
         setGradePreview(gradeRes.data);
@@ -109,14 +188,17 @@ function EvaluateAssignment({ user_id }: any) {
             queryClient.invalidateQueries({ queryKey: queryKeys.assignments.analytics(rawUuid) })
             queryClient.invalidateQueries({ queryKey: queryKeys.assignments.submission(rawUuid) })
         } else {
-            toast.error(doneRes.data.message)
+            toast.error(doneRes.data?.detail || t('common.something_went_wrong'))
         }
     }
 
     async function rejectAssignment() {
         const res = await deleteUserSubmission(user_id, assignmentUuid, access_token)
         if (!res.success) {
-            toast.error(res.data?.detail || t('dashboard.assignments.submissions.toasts.reject_success'))
+            // Fall back to a generic error, not the *success* string this used
+            // to reuse — an error toast that reads "rejected successfully" is
+            // worse than no message at all.
+            toast.error(res.data?.detail || t('common.something_went_wrong'))
             return
         }
         toast.success(t('dashboard.assignments.submissions.toasts.reject_success'))
@@ -129,6 +211,10 @@ function EvaluateAssignment({ user_id }: any) {
     }
 
     const sortedTasks = assignments?.assignment_tasks?.slice().sort((a: any, b: any) => a.id - b.id) || [];
+
+    // Banner numbers derived from the live per-task rows in the same response
+    // (see buildLiveGrade) so the header can't contradict the chips below it.
+    const liveGrade = gradePreview ? buildLiveGrade(gradePreview) : null;
 
     // Build a uuid → per-task breakdown map from the backend's `tasks` array
     // so we can render "85%" badges next to each task header. Memoizing with
@@ -143,23 +229,23 @@ function EvaluateAssignment({ user_id }: any) {
     return (
         <div className='flex flex-col min-h-fit'>
             {/* Grade preview */}
-            {gradePreview && (
+            {liveGrade && (
                 <div className='flex items-center justify-between bg-white nice-shadow rounded-xl px-5 py-3 mb-4'>
                     <div className='flex items-center space-x-3'>
-                        <div className={`rounded-lg px-3 py-1.5 text-lg font-bold ${gradePreview.passed ? 'bg-emerald-50 text-emerald-700' : 'bg-rose-50 text-rose-700'}`}>
-                            {gradePreview.display_grade}
+                        <div className={`rounded-lg px-3 py-1.5 text-lg font-bold ${liveGrade.passed ? 'bg-emerald-50 text-emerald-700' : 'bg-rose-50 text-rose-700'}`}>
+                            {liveGrade.display_grade}
                         </div>
                         <div className='flex flex-col'>
                             <p className='text-[10px] uppercase tracking-wider font-semibold text-gray-400'>
                                 {t('dashboard.assignments.submissions.preview.current_grade')}
                             </p>
                             <p className='text-xs text-gray-600 font-medium'>
-                                {gradePreview.points_summary} · {gradePreview.percentage_display}
+                                {liveGrade.points_summary} · {liveGrade.percentage_display}
                             </p>
                         </div>
                     </div>
-                    <div className={`text-[10px] uppercase tracking-wider font-bold px-2 py-0.5 rounded-full ${gradePreview.passed ? 'bg-emerald-100 text-emerald-700' : 'bg-rose-100 text-rose-700'}`}>
-                        {gradePreview.passed
+                    <div className={`text-[10px] uppercase tracking-wider font-bold px-2 py-0.5 rounded-full ${liveGrade.passed ? 'bg-emerald-100 text-emerald-700' : 'bg-rose-100 text-rose-700'}`}>
+                        {liveGrade.passed
                             ? t('dashboard.assignments.submissions.preview.passing')
                             : t('dashboard.assignments.submissions.preview.not_passing')}
                     </div>

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/page.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/page.tsx
@@ -92,10 +92,25 @@ function AssignmentsHome() {
   const { data: courseAssignments } = useQuery({
     queryKey: ['assignments-all', ...courseUuids],
     queryFn: async () => {
-      const results = await Promise.all(
+      // allSettled, not all: a single rejected request (network blip, one bad
+      // course) used to take the whole dashboard down with it.
+      const settled = await Promise.allSettled(
         courseUuids.map((uuid: string) => getAssignmentsFromACourse(uuid, access_token))
       )
-      return results.map((res: any) => res.data)
+      // The response helper does not throw — a 404 resolves to
+      // `{ success: false, data: { detail: 'Course not found' } }`. That object
+      // is truthy, so the downstream `|| []` guards never fired and the error
+      // body reached `.filter(...)` during render, blanking the page (no error
+      // boundary under this segment) and counting as a phantom draft in the
+      // stats. Anything that isn't a real array collapses to an empty list —
+      // note we map rather than filter so the result stays index-aligned with
+      // `courseUuids` / `courses`, otherwise a single failing course would
+      // shift every later course's assignments onto the wrong course.
+      return settled.map((r: any) =>
+        r.status === 'fulfilled' && r.value?.success && Array.isArray(r.value.data)
+          ? r.value.data
+          : []
+      )
     },
     enabled: courseUuids.length > 0 && !!access_token,
     staleTime: 60_000,

--- a/apps/web/components/Landings/LandingClassic.tsx
+++ b/apps/web/components/Landings/LandingClassic.tsx
@@ -10,7 +10,8 @@ import ContentPlaceHolderIfUserIsNotAdmin from '@components/Objects/ContentPlace
 import Link from 'next/link'
 import { getUriWithOrg } from '@services/config/config'
 import { useTranslation } from 'react-i18next'
-import { BookCopy } from 'lucide-react'
+import { BookCopy, LogIn } from 'lucide-react'
+import { useLHSession } from '@components/Contexts/LHSessionContext'
 
 interface LandingClassicProps {
   courses: any[]
@@ -20,6 +21,8 @@ interface LandingClassicProps {
 
 function LandingClassic({ courses, orgslug, org_id }: LandingClassicProps) {
   const { t } = useTranslation()
+  const session = useLHSession() as any
+  const isAuthenticated = session?.status === 'authenticated'
 
   // Limit to 12 courses (4x3 grid) for the home page
   const displayedCourses = courses.slice(0, 12)
@@ -52,14 +55,38 @@ function LandingClassic({ courses, orgslug, org_id }: LandingClassicProps) {
             {courses.length === 0 && (
               <div className="col-span-full flex flex-col justify-center items-center py-12 px-4 border-2 border-dashed border-gray-100 rounded-2xl bg-gray-50/30">
                 <div className="p-4 bg-white rounded-full nice-shadow mb-4">
-                  <BookCopy className="w-8 h-8 text-gray-300" strokeWidth={1.5} />
+                  {isAuthenticated ? (
+                    <BookCopy className="w-8 h-8 text-gray-300" strokeWidth={1.5} />
+                  ) : (
+                    <LogIn className="w-8 h-8 text-gray-300" strokeWidth={1.5} />
+                  )}
                 </div>
                 <h1 className="text-xl font-bold text-gray-600 mb-2">
-                  {t('courses.no_courses')}
+                  {isAuthenticated
+                    ? t('courses.no_courses')
+                    : t('courses.sign_in_to_see_courses', 'Log in to see your courses')}
                 </h1>
+                {/* Anonymous visitors only ever receive PUBLIC courses from the API,
+                    so an empty list here usually means "sign in", not "empty academy". */}
                 <p className="text-md text-gray-400 mb-6 text-center max-w-xs">
-                  <ContentPlaceHolderIfUserIsNotAdmin text={t('courses.create_courses_placeholder')} />
+                  {isAuthenticated ? (
+                    <ContentPlaceHolderIfUserIsNotAdmin text={t('courses.create_courses_placeholder')} />
+                  ) : (
+                    t(
+                      'courses.sign_in_to_see_courses_description',
+                      'Courses in this academy may only be visible once you are signed in.',
+                    )
+                  )}
                 </p>
+                {!isAuthenticated && (
+                  <Link
+                    href={getUriWithOrg(orgslug, '/login')}
+                    className="inline-flex items-center gap-2 justify-center px-4 py-2 bg-gray-900 text-white rounded-lg text-sm font-semibold hover:bg-gray-800 transition-colors"
+                  >
+                    <LogIn size={16} />
+                    {t('auth.sign_in', 'Sign in')}
+                  </Link>
+                )}
               </div>
             )}
           </div>

--- a/apps/web/components/Objects/Activities/Assignment/AssignmentBoxUI.tsx
+++ b/apps/web/components/Objects/Activities/Assignment/AssignmentBoxUI.tsx
@@ -1,6 +1,6 @@
 import { useAssignmentSubmission } from '@components/Contexts/Assignments/AssignmentSubmissionContext'
 import { useAssignmentDirtyTasks } from '@components/Contexts/Assignments/AssignmentDirtyTasksContext'
-import { useAutoSave } from './useAutoSave'
+import { useAutoSave, type SaveResult } from './useAutoSave'
 import { BookPlus, BookUser, Check, Code2, EllipsisVertical, FileUp, ListTodo, Loader2, MessageSquare, Save, TriangleAlert, Type } from 'lucide-react'
 import React from 'react'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
@@ -17,7 +17,10 @@ type AssignmentBoxProps = {
     currentPoints?: number
     currentFeedback?: string
     saveFC?: () => void
-    submitFC?: (_opts?: TaskSubmitOptions) => void | Promise<boolean | void>
+    // A task may return 'blocked' to mean "refused by policy, do not retry"
+    // (e.g. a code task gated on passing its tests). useAutoSave treats that as
+    // terminal instead of looping a doomed save forever.
+    submitFC?: (_opts?: TaskSubmitOptions) => void | Promise<SaveResult | void>
     gradeFC?: () => void
     gradeCustomFC?: (_grade: number, _feedback?: string) => void
     autoGradable?: boolean
@@ -158,17 +161,34 @@ function AssignmentBoxUI({ type, view, currentPoints, currentFeedback, maxPoints
                     {/* Auto-save status — answers persist automatically. */}
                     {autoSaveEnabled && (auto.isDirty || auto.status !== 'idle') && (
                         <div className='flex space-x-1.5 items-center font-medium px-2 py-1 text-xs text-slate-400 sm:mr-2'>
-                            {auto.isError ? (
+                            {auto.isBlocked ? (
+                                // Refused by policy, not a transient failure — no retry
+                                // is coming, so promising one would be a lie. The task
+                                // itself explains what needs to change (e.g. tests must
+                                // pass before the answer can be saved).
+                                <>
+                                    <TriangleAlert size={13} className='text-rose-500' />
+                                    <p className='text-rose-600'>{t('activities.autosave_blocked', { defaultValue: "Can't be saved yet" })}</p>
+                                </>
+                            ) : auto.isError ? (
                                 // Failed save: show a distinct indicator (a retry
                                 // is already scheduled) instead of a stuck spinner.
                                 <>
                                     <TriangleAlert size={13} className='text-amber-500' />
                                     <p className='text-amber-600'>{t('activities.autosave_retry', { defaultValue: "Couldn't save — retrying…" })}</p>
                                 </>
-                            ) : (auto.isSaving || auto.isDirty) ? (
+                            ) : auto.isSaving ? (
                                 <>
                                     <Loader2 size={13} className='animate-spin' />
                                     <p>{t('activities.autosaving', { defaultValue: 'Saving…' })}</p>
+                                </>
+                            ) : (auto.isPending || auto.isDirty) ? (
+                                // Debounce timer armed but no request in flight. Showing
+                                // a spinner + "Saving…" here claimed work that had not
+                                // started, which is exactly when an unmount lost it.
+                                <>
+                                    <TriangleAlert size={13} className='text-slate-400' />
+                                    <p>{t('activities.autosave_unsaved', { defaultValue: 'Unsaved changes' })}</p>
                                 </>
                             ) : (
                                 <>

--- a/apps/web/components/Objects/Activities/Assignment/AssignmentStudentActivity.tsx
+++ b/apps/web/components/Objects/Activities/Assignment/AssignmentStudentActivity.tsx
@@ -10,13 +10,56 @@ import TaskCodeObject from 'app/orgs/[orgslug]/dash/assignments/[assignmentuuid]
 import TaskShortAnswerObject from 'app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskShortAnswerObject'
 import TaskNumberAnswerObject from 'app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskNumberAnswerObject'
 import toast from 'react-hot-toast';
-import { Backpack, Calendar, CheckCircle2, Download, EllipsisVertical, Info, MessageSquare, RotateCcw, XCircle } from 'lucide-react';
+import { AlarmClockOff, Backpack, Calendar, CheckCircle2, Download, EllipsisVertical, Info, MessageSquare, RotateCcw, XCircle } from 'lucide-react';
 import Link from 'next/link';
-import React, { useEffect } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next';
 
+type ParsedDueDate = { at: Date; hasTime: boolean }
+
+// Parse the assignment due date the SAME way the server does in
+// `_is_assignment_past_due` (apps/api/.../assignments.py):
+//   - the value is a free-form ISO-ish string; unparseable/empty means "no
+//     deadline" so a malformed value never locks a student out,
+//   - the server compares against a NAIVE `datetime.now()` and drops any
+//     timezone offset, so the wall-clock parts are what matter. We therefore
+//     build a LOCAL Date from those parts instead of letting `new Date(...)`
+//     treat a bare "2026-06-12" as UTC midnight — that shift alone could mark
+//     an assignment overdue a day early (or late) depending on the viewer's
+//     offset, disagreeing with the 403 the server actually enforces.
+export function parseDueDate(raw?: string | null): ParsedDueDate | null {
+  if (!raw || !String(raw).trim()) return null
+  const value = String(raw).trim()
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?/)
+  if (!match) return null
+  const [, year, month, day, hours, minutes, seconds] = match
+  const hasTime = hours !== undefined
+  const at = new Date(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hours ?? 0),
+    Number(minutes ?? 0),
+    Number(seconds ?? 0)
+  )
+  if (Number.isNaN(at.getTime())) return null
+  return { at, hasTime }
+}
+
+// Exported so the "Submit for grading" affordance (rendered outside this
+// component) can gate on the exact same rule instead of re-deriving it.
+export function isAssignmentPastDue(raw?: string | null, now: number = Date.now()): boolean {
+  const parsed = parseDueDate(raw)
+  if (!parsed) return false
+  const cutoff = new Date(parsed.at)
+  // A date-only deadline means "end of that day" server-side (the cutoff is
+  // shifted to the following midnight), so the due date itself is still on time.
+  if (!parsed.hasTime) cutoff.setDate(cutoff.getDate() + 1)
+  return cutoff.getTime() < now
+}
+
 function AssignmentStudentActivity() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const assignments = useAssignments() as any;
   const _course = useCourse() as any;
   const org = useOrg() as any;
@@ -55,6 +98,37 @@ function AssignmentStudentActivity() {
         ? 60
         : 50;
 
+  // Deadline state. Past the due date the server rejects EVERY write with a 403
+  // (see `_is_assignment_past_due`), so the learner needs to be told before
+  // auto-save starts failing behind their back.
+  const dueDateRaw = assignments?.assignment_object?.due_date as string | undefined;
+  const [now, setNow] = useState<number>(() => Date.now());
+  useEffect(() => {
+    if (!parseDueDate(dueDateRaw)) return;
+    if (isAssignmentPastDue(dueDateRaw, Date.now())) return;
+    // Re-evaluate while the page stays open so a deadline that passes mid-session
+    // flips the UI instead of leaving a stale "still open" state.
+    const interval = setInterval(() => {
+      setNow(Date.now());
+      if (isAssignmentPastDue(dueDateRaw, Date.now())) clearInterval(interval);
+    }, 60_000);
+    return () => clearInterval(interval);
+  }, [dueDateRaw]);
+  const isPastDue = useMemo(() => isAssignmentPastDue(dueDateRaw, now), [dueDateRaw, now]);
+
+  // Render the raw ISO-ish string as a readable, localized date. Falls back to
+  // the raw value when it can't be parsed (same tolerance as the server).
+  const dueDateLabel = useMemo(() => {
+    const parsed = parseDueDate(dueDateRaw);
+    if (!parsed) return dueDateRaw ?? '';
+    const locale = i18n.language === 'fr' ? 'fr-FR' : 'en-US';
+    return parsed.hasTime
+      ? parsed.at.toLocaleString(locale, {
+          year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+        })
+      : parsed.at.toLocaleDateString(locale, { year: 'numeric', month: 'short', day: 'numeric' });
+  }, [dueDateRaw, i18n.language]);
+
   useEffect(() => {
   }, [assignments, org])
 
@@ -71,13 +145,15 @@ function AssignmentStudentActivity() {
         <div>
           <div className='flex gap-2 items-center flex-wrap justify-center'>
             <EllipsisVertical className='text-slate-400 hidden md:block' size={18} />
-            <div className='flex gap-2 items-center'>
-              <div className='flex gap-1 md:space-x-2 text-xs items-center text-slate-400'>
-                <Calendar size={14} />
-                <p className='font-semibold'>{t('assignments.due_date')}</p>
-                <p className='font-semibold'>{assignments?.assignment_object?.due_date}</p>
+            {dueDateRaw && (
+              <div className='flex gap-2 items-center'>
+                <div className={`flex gap-1 md:space-x-2 text-xs items-center ${isPastDue ? 'text-rose-500' : 'text-slate-400'}`}>
+                  <Calendar size={14} />
+                  <p className='font-semibold'>{t('assignments.due_date')}</p>
+                  <p className='font-semibold'>{dueDateLabel}</p>
+                </div>
               </div>
-            </div>
+            )}
             {showAttemptBadge && (
               <div className='flex gap-1.5 items-center text-xs px-2.5 py-1 rounded-full bg-fuchsia-50 text-fuchsia-700 font-semibold nice-shadow'>
                 <RotateCcw size={12} />
@@ -97,6 +173,25 @@ function AssignmentStudentActivity() {
       
       
       
+      {/* Overdue notice. The server 403s every save/submit once the deadline has
+          passed, so say it plainly instead of letting auto-save fail silently. */}
+      {isPastDue && !isGraded && (
+        <div className='flex items-start gap-3 p-4 rounded-md bg-rose-50/70 border border-rose-200/70 nice-shadow'>
+          <AlarmClockOff size={16} className='shrink-0 mt-0.5 text-rose-500' />
+          <div className='flex flex-col space-y-1'>
+            <p className='text-sm font-semibold text-rose-700'>
+              {t('assignments.past_due_title', { defaultValue: 'Deadline passed' })}
+            </p>
+            <p className='text-xs leading-relaxed text-rose-600/90'>
+              {t('assignments.past_due_description', {
+                date: dueDateLabel,
+                defaultValue: 'This assignment was due on {{date}}. Answers can no longer be saved or submitted for grading.',
+              })}
+            </p>
+          </div>
+        </div>
+      )}
+
       {assignments?.assignment_object?.description && (
         <div className='flex flex-col space-y-2 p-4 md:p-6 bg-slate-100/30 rounded-md nice-shadow'>
           <div className='flex flex-col space-y-3'>

--- a/apps/web/components/Objects/Activities/Assignment/useAutoSave.ts
+++ b/apps/web/components/Objects/Activities/Assignment/useAutoSave.ts
@@ -1,4 +1,5 @@
 import React from 'react'
+import { createBeforeUnloadHandler } from '@components/Objects/Editor/unsavedChangesGuard'
 
 // Value-driven auto-save.
 //
@@ -10,25 +11,56 @@ import React from 'react'
 // immune to query refetches, window focus, submission-status changes, and
 // unrelated re-renders — the failure modes of the previous flag+poller design.
 
-export type AutoSaveStatus = 'idle' | 'saving' | 'saved' | 'error'
+export type AutoSaveStatus =
+  | 'idle'
+  // A debounced edit is waiting for the timer to elapse. Distinct from 'saving'
+  // so the UI doesn't claim a request is in flight while only a timer is armed.
+  | 'pending'
+  | 'saving'
+  | 'saved'
+  // Transient failure: a capped, backed-off retry is scheduled (or the cap has
+  // just been reached and the value stays dirty until the learner edits again).
+  | 'error'
+  // Permanent refusal (policy): retrying can never succeed, so we don't.
+  | 'blocked'
+
+// What a task's save callback reports back.
+//   true  / 'ok'      -> persisted
+//   false / 'retry'   -> transient failure, worth retrying
+//   'blocked'         -> the server/task refused on policy grounds (past-due
+//                        403, `require_passing_to_submit`, …). Retrying loops
+//                        forever and lies to the learner, so we stop.
+export type SaveOutcome = 'ok' | 'retry' | 'blocked'
+export type SaveResult = boolean | SaveOutcome
 
 type Args = {
   currentValue: string
   savedValue: string
-  save: (_opts?: { silent?: boolean }) => void | Promise<boolean | void>
+  save: (_opts?: { silent?: boolean }) => void | Promise<SaveResult | void>
   enabled: boolean
   debounceMs?: number
-  // Backoff before automatically retrying a failed save.
+  // Backoff before automatically retrying a failed save (doubles per attempt).
   retryMs?: number
+  // Hard cap on automatic retries for a given value. Without it a permanently
+  // failing write re-armed the debounce effect forever (~every 5s for the life
+  // of the mount) behind a "Couldn't save — retrying…" chip that never resolved.
+  maxRetries?: number
 }
 
 export type AutoSaveController = {
   status: AutoSaveStatus
   isDirty: boolean
   isSaving: boolean
-  // True when the last save attempt failed and a retry is pending. Used to show
-  // a distinct "couldn't save" indicator instead of a stuck "Saving…" spinner.
+  // True when the last save attempt did NOT reach the server-side row: either a
+  // transient failure (retry pending / cap reached) or a permanent refusal.
+  // Consumers that only know about this flag still show a warning instead of a
+  // stuck spinner; `isBlocked` below separates the terminal case.
   isError: boolean
+  // Terminal: the save was refused on policy grounds and will NOT be retried.
+  // Deserves distinct copy ("can't be saved") rather than "retrying…".
+  isBlocked: boolean
+  // A debounced edit exists but nothing has been sent yet.
+  isPending: boolean
   // Persist immediately if dirty. Used by the submit-for-grading flush.
   flush: () => Promise<boolean>
   // Manual save (non-silent, shows a toast). Routed through the same in-flight
@@ -38,6 +70,14 @@ export type AutoSaveController = {
   getIsDirty: () => boolean
 }
 
+// Callbacks predate the discriminated result and still return plain booleans
+// (or nothing at all), so normalize everything to a SaveOutcome here.
+function toOutcome(res: SaveResult | void): SaveOutcome {
+  if (res === 'blocked') return 'blocked'
+  if (res === false || res === 'retry') return 'retry'
+  return 'ok'
+}
+
 export function useAutoSave({
   currentValue,
   savedValue,
@@ -45,12 +85,21 @@ export function useAutoSave({
   enabled,
   debounceMs = 1000,
   retryMs = 4000,
+  maxRetries = 5,
 }: Args): AutoSaveController {
   const [status, setStatus] = React.useState<AutoSaveStatus>('idle')
   // Bumped after a failed save to re-arm the debounce effect (whose deps are
   // otherwise unchanged, so it would never retry on its own).
   const [retryTick, setRetryTick] = React.useState(0)
   const retryTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Failed attempts for the CURRENT value. Reset whenever the learner edits
+  // (a new value deserves a fresh budget) and on every success.
+  const attempts = React.useRef(0)
+  const lastAttemptedValue = React.useRef<string | null>(null)
+  // The exact value the server permanently refused. Kept so we don't replay a
+  // doomed write (on unmount, on tab hide, on a manual click) while the learner
+  // hasn't changed anything — but a real edit gets a fresh attempt.
+  const blockedValue = React.useRef<string | null>(null)
 
   // Always read the freshest value/baseline/save fn from refs so the debounce
   // timer and the flush never act on a stale closure.
@@ -64,21 +113,19 @@ export function useAutoSave({
   React.useEffect(() => { savedRef.current = savedValue })
   React.useEffect(() => { saveRef.current = save })
   React.useEffect(() => { enabledRef.current = enabled })
-  React.useEffect(() => () => {
-    mounted.current = false
-    if (retryTimer.current) clearTimeout(retryTimer.current)
-  }, [])
 
   // After a failed save, schedule a single re-arm of the debounce effect so the
   // still-dirty value is retried once the backoff elapses (the effect's string
   // deps don't change on failure, so nothing else would trigger a retry).
-  const scheduleRetry = React.useCallback(() => {
+  // Exponential so a server that is down doesn't get hammered every 4s.
+  const scheduleRetry = React.useCallback((attempt: number) => {
     if (retryTimer.current) clearTimeout(retryTimer.current)
+    const delay = Math.min(retryMs * 2 ** Math.max(0, attempt - 1), 60_000)
     retryTimer.current = setTimeout(() => {
       if (mounted.current && enabledRef.current && curRef.current !== savedRef.current) {
         setRetryTick((t) => t + 1)
       }
-    }, retryMs)
+    }, delay)
   }, [retryMs])
 
   const isDirty = enabled && currentValue !== savedValue
@@ -90,25 +137,48 @@ export function useAutoSave({
 
   // Tracks the currently running save so flush/manual can AWAIT it rather than
   // returning a false "success" while a request is still in flight.
-  const inFlightPromise = React.useRef<Promise<boolean> | null>(null)
+  const inFlightPromise = React.useRef<Promise<SaveOutcome> | null>(null)
 
-  const doSave = React.useCallback(async (silent: boolean): Promise<boolean> => {
+  const doSave = React.useCallback(async (silent: boolean): Promise<SaveOutcome> => {
     inFlight.current = true
+    const attemptedValue = curRef.current
+    // A brand-new value gets a fresh retry budget: the cap must bound retries of
+    // ONE failing payload, not the learner's whole editing session.
+    if (lastAttemptedValue.current !== attemptedValue) {
+      lastAttemptedValue.current = attemptedValue
+      attempts.current = 0
+      blockedValue.current = null
+    }
     if (mounted.current) setStatus('saving')
-    const p = (async () => {
+    const p = (async (): Promise<SaveOutcome> => {
       try {
-        const res = await saveRef.current({ silent })
-        const ok = res !== false
-        if (mounted.current) setStatus(ok ? 'saved' : 'error')
-        if (!ok) scheduleRetry()
-        return ok
+        const outcome = toOutcome(await saveRef.current({ silent }))
+        if (outcome === 'ok') {
+          attempts.current = 0
+          if (mounted.current) setStatus('saved')
+          return 'ok'
+        }
+        if (outcome === 'blocked') {
+          // Permanent policy refusal — a retry would fail identically forever.
+          // Surface a terminal state instead of an eternal "retrying…" chip.
+          if (retryTimer.current) clearTimeout(retryTimer.current)
+          blockedValue.current = attemptedValue
+          if (mounted.current) setStatus('blocked')
+          return 'blocked'
+        }
+        attempts.current += 1
+        if (mounted.current) setStatus('error')
+        if (attempts.current < maxRetries) scheduleRetry(attempts.current)
+        return 'retry'
       } catch {
         // A failed save must NOT reseed the baseline (the value isn't on the
         // server): mark 'error' so the UI shows a distinct indicator instead of
-        // a stuck spinner, and re-arm a retry so a transient failure recovers.
+        // a stuck spinner, and re-arm a retry so a transient failure recovers —
+        // but only while the attempt budget lasts.
+        attempts.current += 1
         if (mounted.current) setStatus('error')
-        scheduleRetry()
-        return false
+        if (attempts.current < maxRetries) scheduleRetry(attempts.current)
+        return 'retry'
       } finally {
         inFlight.current = false
         inFlightPromise.current = null
@@ -116,13 +186,15 @@ export function useAutoSave({
     })()
     inFlightPromise.current = p
     return p
-  }, [scheduleRetry])
+  }, [scheduleRetry, maxRetries])
 
   // Background debounce path: coalesce (skip while a save runs; the effect
   // re-arms when the baseline reseeds after that save).
-  const runAutoSave = React.useCallback(async (): Promise<boolean> => {
-    if (inFlight.current) return true
-    if (!getIsDirty()) return true
+  const runAutoSave = React.useCallback(async (): Promise<SaveOutcome> => {
+    if (inFlight.current) return 'ok'
+    if (!getIsDirty()) return 'ok'
+    // Don't replay a value the server already refused for good.
+    if (blockedValue.current !== null && blockedValue.current === curRef.current) return 'blocked'
     return doSave(true)
   }, [getIsDirty, doSave])
 
@@ -138,13 +210,14 @@ export function useAutoSave({
       let didSave = false
       for (let i = 0; i < 5; i++) {
         if (!getIsDirty()) break
-        const ok = await doSave(silent)
+        const outcome = await doSave(silent)
         didSave = true
-        if (!ok) return false
+        // 'blocked' is terminal: looping would just replay the same refusal.
+        if (outcome !== 'ok') return false
       }
       // Manual save with nothing dirty still does one save so the click gives
       // feedback and any never-persisted value is written.
-      if (force && !didSave) return doSave(silent)
+      if (force && !didSave) return (await doSave(silent)) === 'ok'
       return true
     },
     [getIsDirty, doSave]
@@ -155,11 +228,58 @@ export function useAutoSave({
   // to completion, then settling when currentValue === savedValue.
   React.useEffect(() => {
     if (!enabled || currentValue === savedValue) return
+    // Nothing is in flight yet — say so instead of showing "Saving…" for a
+    // request that hasn't been made. A failure indicator survives a re-arm of
+    // the SAME value (the retry tick), but a genuine new edit clears it.
+    setStatus((s) => {
+      if (s === 'saving') return s
+      if ((s === 'error' || s === 'blocked') && currentValue === lastAttemptedValue.current) return s
+      return 'pending'
+    })
     const id = setTimeout(() => { runAutoSave() }, debounceMs)
     return () => clearTimeout(id)
     // retryTick re-arms this effect after a failed save so a still-dirty value
     // is retried even though the value/baseline strings are unchanged.
   }, [currentValue, savedValue, enabled, debounceMs, runAutoSave, retryTick])
+
+  // Persist whatever the debounce timer hasn't sent yet when the component goes
+  // away. Continuous typing re-arms the 1000ms timer on every keystroke, so
+  // navigating away mid-burst used to discard the entire burst (the cleanup only
+  // cleared the timer). Fire-and-forget: the request is what matters, the
+  // unmounted component's state updates are no-ops.
+  React.useEffect(() => () => {
+    if (retryTimer.current) clearTimeout(retryTimer.current)
+    const isBlockedValue = blockedValue.current !== null && blockedValue.current === curRef.current
+    if (!inFlight.current && !isBlockedValue && enabledRef.current && curRef.current !== savedRef.current) {
+      void saveRef.current({ silent: true })
+    }
+    mounted.current = false
+  }, [])
+
+  // Same protection for a tab close / refresh / mobile backgrounding, which
+  // unmount cleanups don't reliably reach. `pagehide` covers unload + bfcache,
+  // `visibilitychange` covers iOS/Android where `pagehide` may not fire; the
+  // beforeunload guard (shared with the Editor) warns if the write can't finish.
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return
+    const flushPending = () => { void runAutoSave() }
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') flushPending()
+    }
+    // Don't nag about work that can never be persisted anyway (blocked value):
+    // staying on the page wouldn't save it.
+    const onBeforeUnload = createBeforeUnloadHandler(
+      () => getIsDirty() && blockedValue.current !== curRef.current
+    )
+    window.addEventListener('pagehide', flushPending)
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    window.addEventListener('beforeunload', onBeforeUnload)
+    return () => {
+      window.removeEventListener('pagehide', flushPending)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      window.removeEventListener('beforeunload', onBeforeUnload)
+    }
+  }, [runAutoSave, getIsDirty])
 
   const flush = React.useCallback(() => persist(true, false), [persist])
   const saveNow = React.useCallback(() => persist(false, true), [persist])
@@ -168,7 +288,9 @@ export function useAutoSave({
     status,
     isDirty,
     isSaving: status === 'saving',
-    isError: status === 'error',
+    isError: status === 'error' || status === 'blocked',
+    isBlocked: status === 'blocked',
+    isPending: status === 'pending',
     flush,
     saveNow,
     getIsDirty,

--- a/apps/web/components/Pages/Activity/CourseEndView.tsx
+++ b/apps/web/components/Pages/Activity/CourseEndView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect, useState } from 'react';
+import React, { useMemo, useEffect, useState, useRef } from 'react';
 import toast from 'react-hot-toast';
 import dynamic from 'next/dynamic';
 const ReactConfetti = dynamic(() => import('react-confetti'), { ssr: false });
@@ -11,6 +11,11 @@ import { useOrg } from '@components/Contexts/OrgContext';
 import { useLHSession } from '@components/Contexts/LHSessionContext';
 import { getUserCertificates } from '@services/courses/certifications';
 import CertificatePreview from '@components/Dashboard/Pages/Course/EditCourseCertification/CertificatePreview';
+import {
+  downloadCertificateNodeAsPdf,
+  certificateFileName,
+  CERTIFICATE_CAPTURE_WIDTH,
+} from '@services/courses/certificateDownload';
 import { useTranslation } from 'react-i18next';
 
 interface CourseEndViewProps {
@@ -37,6 +42,10 @@ const CourseEndView: React.FC<CourseEndViewProps> = ({
   const [userCertificate, setUserCertificate] = useState<any>(null);
   const [isLoadingCertificate, setIsLoadingCertificate] = useState(false);
   const [certificateError, setCertificateError] = useState<string | null>(null);
+  // Offscreen, fixed-width render of the certificate used as the PDF source.
+  // The visible copy is fluid (max-w-2xl and narrower on mobile), so capturing
+  // it directly would make the exported file depend on the viewer's screen.
+  const certificateCaptureRef = useRef<HTMLDivElement>(null);
 
   // Recipient's display name for the certificate (full name -> username ->
   // session user). Empty when unknown so the "Presented to" line is skipped.
@@ -129,289 +138,51 @@ const CourseEndView: React.FC<CourseEndViewProps> = ({
     fetchUserCertificate();
   }, [isCourseCompleted, courseUuid, session?.data?.tokens?.access_token, org?.id]);
 
-  // Generate PDF using canvas
+  // Generate the PDF from the SAME <CertificatePreview> the learner sees.
+  //
+  // This used to build a separate certificate out of a hand-written HTML
+  // string, which had drifted into a completely different design: no pattern
+  // artwork, no org logo or name, an emoji instead of the award mark, and its
+  // own colour palette. We now rasterise a hidden, fixed-width render of the
+  // real component (see `certificateCaptureRef` below), so the download always
+  // matches the on-screen and admin-preview certificate.
   const downloadCertificate = async () => {
     if (!userCertificate) return;
+    const node = certificateCaptureRef.current;
+    if (!node) return;
 
     try {
-      const [{ default: html2canvas }, { default: jsPDF }, QRCode] = await Promise.all([
-        // html2canvas-pro understands modern CSS color functions (oklch/lab/
-        // color-mix) emitted by Tailwind v4; classic html2canvas throws on them.
-        import('html2canvas-pro'),
-        import('jspdf'),
-        import('qrcode'),
-      ]);
-      // Create a temporary div for the certificate
-      const certificateDiv = document.createElement('div');
-      certificateDiv.style.position = 'absolute';
-      certificateDiv.style.left = '-9999px';
-      certificateDiv.style.top = '0';
-      certificateDiv.style.width = '800px';
-      certificateDiv.style.height = '600px';
-      certificateDiv.style.background = 'white';
-      certificateDiv.style.padding = '40px';
-      certificateDiv.style.fontFamily = 'Arial, sans-serif';
-      certificateDiv.style.textAlign = 'center';
-      certificateDiv.style.display = 'flex';
-      certificateDiv.style.flexDirection = 'column';
-      certificateDiv.style.justifyContent = 'center';
-      certificateDiv.style.alignItems = 'center';
-      certificateDiv.style.position = 'relative';
-      certificateDiv.style.overflow = 'hidden';
-
-      // Get theme colors based on pattern
-      const getPatternTheme = (pattern: string) => {
-        switch (pattern) {
-          case 'royal':
-            return { primary: '#b45309', secondary: '#d97706', icon: '#d97706' };
-          case 'tech':
-            return { primary: '#0e7490', secondary: '#0891b2', icon: '#0891b2' };
-          case 'nature':
-            return { primary: '#15803d', secondary: '#16a34a', icon: '#16a34a' };
-          case 'geometric':
-            return { primary: '#7c3aed', secondary: '#9333ea', icon: '#9333ea' };
-          case 'vintage':
-            return { primary: '#c2410c', secondary: '#ea580c', icon: '#ea580c' };
-          case 'waves':
-            return { primary: '#1d4ed8', secondary: '#2563eb', icon: '#2563eb' };
-          case 'minimal':
-            return { primary: '#374151', secondary: '#4b5563', icon: '#4b5563' };
-          case 'professional':
-            return { primary: '#334155', secondary: '#475569', icon: '#475569' };
-          case 'academic':
-            return { primary: '#3730a3', secondary: '#4338ca', icon: '#4338ca' };
-          case 'modern':
-            return { primary: '#1d4ed8', secondary: '#2563eb', icon: '#2563eb' };
-          default:
-            return { primary: '#374151', secondary: '#4b5563', icon: '#4b5563' };
-        }
-      };
-
-      const theme = getPatternTheme(userCertificate.certification.config.certificate_pattern);
-      const certificateId = userCertificate.certificate_user.user_certification_uuid;
-      const qrCodeData = qrCodeLink;
-
-      // Escape the learner-controlled name before injecting into innerHTML.
-      const escapeHtml = (s: string) =>
-        s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-         .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
-      const safeLearnerName = learnerName ? escapeHtml(learnerName) : '';
-
-      // Generate QR code
-      const qrCodeDataUrl = await QRCode.toDataURL(qrCodeData, {
-        width: 120,
-        margin: 2,
-        color: {
-          dark: '#000000',
-          light: '#FFFFFF'
-        },
-        errorCorrectionLevel: 'M',
-        type: 'image/png'
-      });
-
-      // Create certificate content
-      certificateDiv.innerHTML = `
-        <div style="
-          position: absolute;
-          top: 20px;
-          left: 20px;
-          font-size: 12px;
-          color: ${theme.secondary};
-          font-weight: 500;
-        ">ID: ${certificateId}</div>
-        
-        <div style="
-          position: absolute;
-          top: 20px;
-          right: 20px;
-          width: 80px;
-          height: 80px;
-          border: 2px solid ${theme.secondary};
-          border-radius: 8px;
-          background: white;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-        ">
-          <img src="${qrCodeDataUrl}" alt="QR Code" style="width: 100%; height: 100%; object-fit: contain;" />
-        </div>
-        
-        <div style="
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          gap: 8px;
-          margin-bottom: 30px;
-          font-size: 14px;
-          color: ${theme.secondary};
-          font-weight: 500;
-          text-transform: uppercase;
-          letter-spacing: 1px;
-        ">
-          <div style="width: 24px; height: 1px; background: linear-gradient(90deg, transparent, ${theme.secondary}, transparent);"></div>
-          ${t('certificate.certificate')}
-          <div style="width: 24px; height: 1px; background: linear-gradient(90deg, transparent, ${theme.secondary}, transparent);"></div>
-        </div>
-        
-        <div style="
-          width: 80px;
-          height: 80px;
-          background: linear-gradient(135deg, ${theme.icon}20 0%, ${theme.icon}40 100%);
-          border-radius: 50%;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          margin: 0 auto 30px;
-          font-size: 40px;
-          line-height: 1;
-        ">🏆</div>
-        
-        <div style="
-          font-size: 32px;
-          font-weight: bold;
-          color: ${theme.primary};
-          margin-bottom: 20px;
-          line-height: 1.2;
-          max-width: 600px;
-        ">${userCertificate.certification.config.certification_name}</div>
-
-        ${safeLearnerName ? `
-        <div style="margin-bottom: 14px;">
-          <div style="
-            font-size: 12px;
-            color: ${theme.secondary};
-            text-transform: uppercase;
-            letter-spacing: 1px;
-            margin-bottom: 3px;
-          ">${t('certificate.presented_to', { defaultValue: 'Presented to' })}</div>
-          <div style="
-            font-size: 22px;
-            font-weight: bold;
-            color: ${theme.primary};
-          ">${safeLearnerName}</div>
-        </div>` : ''}
-
-        <div style="
-          font-size: 18px;
-          color: #6b7280;
-          margin-bottom: 30px;
-          line-height: 1.5;
-          max-width: 500px;
-        ">${userCertificate.certification.config.certification_description || t('courses.successfully_completed')}</div>
-        
-        <div style="
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          gap: 4px;
-          margin: 20px 0;
-        ">
-          <div style="width: 8px; height: 1px; background: ${theme.secondary}; opacity: 0.5;"></div>
-          <div style="width: 4px; height: 4px; background: ${theme.primary}; border-radius: 50%; opacity: 0.6;"></div>
-          <div style="width: 8px; height: 1px; background: ${theme.secondary}; opacity: 0.5;"></div>
-        </div>
-        
-        <div style="
-          display: inline-flex;
-          align-items: center;
-          gap: 8px;
-          font-size: 16px;
-          color: ${theme.primary};
-          background: ${theme.icon}10;
-          padding: 12px 24px;
-          border-radius: 20px;
-          border: 1px solid ${theme.icon}20;
-          font-weight: 500;
-          margin-bottom: 30px;
-          white-space: nowrap;
-        ">
-          <span style="font-weight: bold; font-size: 18px;">✓</span>
-          <span>${userCertificate.certification.config.certification_type === 'completion' ? t('courses.course_completion') :
-            userCertificate.certification.config.certification_type === 'achievement' ? t('certificate.achievement_based') :
-            userCertificate.certification.config.certification_type === 'assessment' ? t('certificate.assessment_based') :
-            userCertificate.certification.config.certification_type === 'participation' ? t('certificate.participation') :
-            userCertificate.certification.config.certification_type === 'mastery' ? t('certificate.skill_mastery') :
-            userCertificate.certification.config.certification_type === 'professional' ? t('certificate.professional_development') :
-            userCertificate.certification.config.certification_type === 'continuing' ? t('certificate.continuing_education') :
-            userCertificate.certification.config.certification_type === 'workshop' ? t('certificate.workshop_attendance') :
-            userCertificate.certification.config.certification_type === 'specialization' ? t('certificate.specialization') : t('courses.course_completion')}</span>
-        </div>
-        
-        <div style="
-          margin-top: 30px;
-          padding: 24px;
-          background: #f8fafc;
-          border-radius: 8px;
-          border: 1px solid #e2e8f0;
-          max-width: 400px;
-        ">
-          <div style="margin: 8px 0; font-size: 14px; color: #374151;">
-            <strong style="color: ${theme.primary};">${t('certificate.certificate_id')}:</strong> ${certificateId}
-          </div>
-          <div style="margin: 8px 0; font-size: 14px; color: #374151;">
-            <strong style="color: ${theme.primary};">${t('certificate.awarded')}:</strong> ${new Date(userCertificate.certificate_user.created_at).toLocaleDateString(i18n.language === 'fr' ? 'fr-FR' : 'en-US', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric'
-            })}
-          </div>
-          ${userCertificate.certification.config.certificate_instructor ? 
-            `<div style="margin: 8px 0; font-size: 14px; color: #374151;">
-              <strong style="color: ${theme.primary};">${t('roles.instructor')}:</strong> ${userCertificate.certification.config.certificate_instructor}
-            </div>` : ''
-          }
-        </div>
-        
-        <div style="
-          margin-top: 20px;
-          font-size: 12px;
-          color: #6b7280;
-        ">
-          ${t('certificate.certificate_verify_message')} ${qrCodeLink}
-        </div>
-      `;
-
-      // Add to document temporarily
-      document.body.appendChild(certificateDiv);
-
-      // Convert to canvas
-      const canvas = await html2canvas(certificateDiv, {
-        width: 800,
-        height: 600,
-        scale: 2, // Higher resolution
-        useCORS: true,
-        allowTaint: true,
-        backgroundColor: '#ffffff'
-      });
-
-      // Remove temporary div
-      document.body.removeChild(certificateDiv);
-
-      // Create PDF
-      const imgData = canvas.toDataURL('image/png');
-      const pdf = new jsPDF('landscape', 'mm', 'a4');
-      
-      // Calculate dimensions to center the certificate
-      const pdfWidth = pdf.internal.pageSize.getWidth();
-      const pdfHeight = pdf.internal.pageSize.getHeight();
-      const imgWidth = 280; // mm
-      const imgHeight = 210; // mm
-      
-      // Center the image
-      const x = (pdfWidth - imgWidth) / 2;
-      const y = (pdfHeight - imgHeight) / 2;
-      
-      pdf.addImage(imgData, 'PNG', x, y, imgWidth, imgHeight);
-      
-      // Save the PDF
-      const fileName = `${userCertificate.certification.config.certification_name.replace(/[^a-zA-Z0-9]/g, '_')}_Certificate.pdf`;
-      pdf.save(fileName);
-
+      await downloadCertificateNodeAsPdf(
+        node,
+        certificateFileName(userCertificate.certification?.config?.certification_name),
+      );
     } catch (error) {
       console.error('Error generating PDF:', error);
-      toast.error('Failed to generate PDF. Please try again.');
+      toast.error(t('certificate.download_failed', 'Failed to generate PDF. Please try again.'));
     }
   };
+
+  // Single source of truth for the certificate's contents. Both the visible
+  // certificate and the offscreen one we rasterise into the PDF are rendered
+  // from this, so they cannot drift apart.
+  const certificatePreviewProps = useMemo(() => {
+    if (!userCertificate) return null;
+    const config = userCertificate.certification?.config || {};
+    return {
+      certificationName: config.certification_name,
+      certificationDescription: config.certification_description,
+      certificationType: config.certification_type,
+      certificatePattern: config.certificate_pattern,
+      certificateInstructor: config.certificate_instructor,
+      certificateId: userCertificate.certificate_user.user_certification_uuid,
+      learnerName,
+      awardedDate: new Date(userCertificate.certificate_user.created_at).toLocaleDateString(
+        i18n.language === 'fr' ? 'fr-FR' : 'en-US',
+        { year: 'numeric', month: 'long', day: 'numeric' },
+      ),
+      qrCodeLink,
+    };
+  }, [userCertificate, learnerName, qrCodeLink, i18n.language]);
 
   // Calculate progress for incomplete courses
   const progressInfo = useMemo(() => {
@@ -509,26 +280,25 @@ const CourseEndView: React.FC<CourseEndViewProps> = ({
                 {certificateError}
               </p>
             </div>
-          ) : userCertificate ? (
+          ) : userCertificate && certificatePreviewProps ? (
             <div className="space-y-4">
               <h2 className="text-2xl font-semibold text-gray-900">{t('certificate.your_certificate')}</h2>
               <div className="max-w-2xl mx-auto" id="certificate-preview">
                 <div id="certificate-content">
-                  <CertificatePreview
-                    certificationName={userCertificate.certification.config.certification_name}
-                    certificationDescription={userCertificate.certification.config.certification_description}
-                    certificationType={userCertificate.certification.config.certification_type}
-                    certificatePattern={userCertificate.certification.config.certificate_pattern}
-                    certificateInstructor={userCertificate.certification.config.certificate_instructor}
-                    certificateId={userCertificate.certificate_user.user_certification_uuid}
-                    learnerName={learnerName}
-                    awardedDate={new Date(userCertificate.certificate_user.created_at).toLocaleDateString(i18n.language === 'fr' ? 'fr-FR' : 'en-US', {
-                      year: 'numeric',
-                      month: 'long',
-                      day: 'numeric'
-                    })}
-                    qrCodeLink={qrCodeLink}
-                  />
+                  <CertificatePreview {...certificatePreviewProps} />
+                </div>
+              </div>
+              {/* PDF source. Identical props to the visible certificate above,
+                  just pinned to a fixed width so the export is the same on
+                  every screen. Kept in the layout (offscreen, not display:none)
+                  because html2canvas cannot measure a hidden subtree. */}
+              <div
+                aria-hidden="true"
+                className="pointer-events-none fixed top-0 left-0 -z-50 opacity-0"
+                style={{ transform: 'translateX(-200vw)' }}
+              >
+                <div ref={certificateCaptureRef} style={{ width: CERTIFICATE_CAPTURE_WIDTH }}>
+                  <CertificatePreview {...certificatePreviewProps} />
                 </div>
               </div>
               <div className="flex justify-center space-x-4">

--- a/apps/web/components/Pages/Activity/FixedActivitySecondaryBar.tsx
+++ b/apps/web/components/Pages/Activity/FixedActivitySecondaryBar.tsx
@@ -26,9 +26,13 @@ const NavigationButtons = memo(({
   nextActivity: any, 
   currentIndex: number, 
   allActivities: any[], 
-  navigateToActivity: (activity: any) => void 
+  navigateToActivity: (_activity: any) => void
 }) => {
   const { t } = useTranslation();
+  // On the final activity, Next leads to the course-end/certificate screen
+  // rather than being a dead button.
+  const isLastActivity =
+    allActivities.length > 0 && currentIndex === allActivities.length - 1;
   return (
     <div className="flex items-center space-x-2 sm:space-x-3">
       <button
@@ -57,13 +61,23 @@ const NavigationButtons = memo(({
       <button
         onClick={() => navigateToActivity(nextActivity)}
         className={`flex items-center space-x-1 sm:space-x-2 py-1.5 px-1.5 sm:px-2 rounded-md transition-all duration-200`}
-        disabled={!nextActivity}
-        title={nextActivity ? `${t('common.next')}: ${nextActivity.name}` : t('activities.no_next_activity')}
+        disabled={!nextActivity && !isLastActivity}
+        title={
+          nextActivity
+            ? `${t('common.next')}: ${nextActivity.name}`
+            : isLastActivity
+              ? t('course.finish_course', 'Finish course')
+              : t('activities.no_next_activity')
+        }
       >
         <div className="flex flex-col items-end hidden sm:flex">
           <span className={`text-xs ${nextActivity ? 'text-gray-500' : 'text-gray-500'}`}>{t('common.next')}</span>
           <span className="text-sm font-medium text-right truncate max-w-[100px] sm:max-w-[150px]">
-            {nextActivity ? nextActivity.name : t('activities.no_next_activity')}
+            {nextActivity
+              ? nextActivity.name
+              : isLastActivity
+                ? t('course.finish_course', 'Finish course')
+                : t('activities.no_next_activity')}
           </span>
         </div>
         <ChevronRight size={16} className="shrink-0 sm:w-5 sm:h-5" />
@@ -133,10 +147,19 @@ export default function FixedActivitySecondaryBar(props: FixedActivitySecondaryB
   const prevActivity = currentIndex > 0 ? allActivities[currentIndex - 1] : null;
   const nextActivity = currentIndex < allActivities.length - 1 ? allActivities[currentIndex + 1] : null;
   
+  // Past the last activity lies the course-end screen with the certificate.
+  // Next used to be disabled there, leaving the trophy icon as the only way in.
+  const isLastActivity = currentIndex >= 0 && !nextActivity;
+
   const navigateToActivity = (activity: any) => {
-    if (!activity) return;
-    
     const cleanCourseUuid = props.course.course_uuid?.replace('course_', '');
+    if (!activity) {
+      if (isLastActivity) {
+        router.push(getUriWithOrg(props.orgslug, '') + `/course/${cleanCourseUuid}/activity/end`);
+      }
+      return;
+    }
+
     router.push(getUriWithOrg(props.orgslug, '') + `/course/${cleanCourseUuid}/activity/${activity.cleanUuid}`);
   };
 

--- a/apps/web/components/Pages/Courses/ActivityIndicators.tsx
+++ b/apps/web/components/Pages/Courses/ActivityIndicators.tsx
@@ -199,8 +199,8 @@ const MobileChapterSelector = memo(({
   currentChapterIndex: number
   orgslug: string
   courseid: string
-  isActivityDone: (activity: any) => boolean
-  isActivityCurrent: (activity: any) => boolean
+  isActivityDone: (_activity: any) => boolean
+  isActivityCurrent: (_activity: any) => boolean
   t: any
 }) => {
   const [isOpen, setIsOpen] = useState(false)
@@ -358,11 +358,17 @@ function ActivityIndicators(props: Props) {
     }
   }
 
+  const isOnLastActivity =
+    allActivities.length > 0 && currentActivityIndex === allActivities.length - 1
+
   const navigateToNext = () => {
     if (currentActivityIndex < allActivities.length - 1) {
       const nextActivity = allActivities[currentActivityIndex + 1]
       const activityId = nextActivity.activity_uuid.replace('activity_', '')
       router.push(getUriWithOrg(orgslug, '') + `/course/${courseid}/activity/${activityId}`)
+    } else if (isOnLastActivity) {
+      // Same destination as the trophy badge — the course-end/certificate view.
+      router.push(getUriWithOrg(orgslug, '') + `/course/${courseid}/activity/end`)
     }
   }
 
@@ -446,7 +452,7 @@ function ActivityIndicators(props: Props) {
         {enableNavigation && (
           <button
             onClick={navigateToNext}
-            disabled={currentActivityIndex >= allActivities.length - 1}
+            disabled={currentActivityIndex > allActivities.length - 1}
             className="p-1.5 rounded-full bg-gray-50 hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors shrink-0"
             aria-label={t('activities.next_activity')}
           >
@@ -570,7 +576,7 @@ function ActivityIndicators(props: Props) {
         {enableNavigation && (
           <button
             onClick={navigateToNext}
-            disabled={currentActivityIndex >= allActivities.length - 1}
+            disabled={currentActivityIndex > allActivities.length - 1}
             className="p-1 rounded-full hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors shrink-0"
             aria-label={t('activities.next_activity')}
           >

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -663,7 +663,9 @@
       "filter_by_group": "Filter by group",
       "info_title": "User Group Filter",
       "info_description": "Filter courses by user group to see only courses assigned to a specific group. Useful for families or teams sharing the same organization."
-    }
+    },
+    "sign_in_to_see_courses": "Log in to see your courses",
+    "sign_in_to_see_courses_description": "Courses in this academy may only be visible once you are signed in."
   },
   "communities": {
     "title": "Communities",
@@ -1402,7 +1404,13 @@
     "copy_link": "Copy Link",
     "link_copied": "Link copied!",
     "embed": "Embed",
-    "embed_code_copied": "Embed code copied!"
+    "embed_code_copied": "Embed code copied!",
+    "autosave_blocked": "Can't be saved yet",
+    "autosave_retry": "Couldn't save — retrying…",
+    "autosave_unsaved": "Unsaved changes",
+    "autosaved": "Saved",
+    "autosaving": "Saving…",
+    "save_answers": "Save answers"
   },
   "embed": {
     "not_supported_title": "This activity is not supported",
@@ -1456,7 +1464,11 @@
       "half": "Half",
       "zero": "Zero"
     },
-    "task_feedback_placeholder": "Note for this task (saved with grade)"
+    "task_feedback_placeholder": "Note for this task (saved with grade)",
+    "no_task_submission_to_grade": "This student has not submitted a file for this task yet.",
+    "past_due": "Deadline passed",
+    "past_due_description": "This assignment was due on {{date}}. Answers can no longer be saved or submitted for grading.",
+    "past_due_title": "Deadline passed"
   },
   "certificate": {
     "certificate": "Certificate",
@@ -1483,7 +1495,8 @@
     "continuing_education": "Continuing Education",
     "workshop_attendance": "Workshop Attendance",
     "specialization": "Specialization",
-    "dedication_message": "Your dedication and hard work have paid off. You've mastered all the content in this course."
+    "dedication_message": "Your dedication and hard work have paid off. You've mastered all the content in this course.",
+    "download_failed": "Failed to generate PDF. Please try again."
   },
   "search": {
     "search_placeholder": "Search courses, users, folders...",
@@ -3901,7 +3914,8 @@
           "drafts": "Drafts",
           "auto_graded": "Auto-graded only",
           "hide_empty": "Hide empty courses"
-        }
+        },
+        "new_assignment": "New Assignment"
       },
       "detail": {
         "title": "Assignment Tools",
@@ -3977,7 +3991,8 @@
           "task_save_error": "Error saving task, please retry later.",
           "task_updated": "Task updated successfully",
           "task_update_error": "Error updating task, please retry later.",
-          "reminder": "When editing/adding your tasks, make sure to Unpublish your Assignment to avoid any issues with students, you can Publish it again when you are ready."
+          "reminder": "When editing/adding your tasks, make sure to Unpublish your Assignment to avoid any issues with students, you can Publish it again when you are ready.",
+          "no_submission_to_grade": "This student has no submission for this task yet, there is nothing to grade."
         },
         "task_editor": {
           "general": {
@@ -3997,7 +4012,9 @@
             "auth_required_submit": "Authentication required. Please sign in to submit your task.",
             "hint_optional": "Hint (optional)",
             "paste_blocked": "Pasting is disabled for this assignment",
-            "paste_blocked_hint": "Pasting is disabled — type your answer directly."
+            "paste_blocked_hint": "Pasting is disabled — type your answer directly.",
+            "upload_locked_graded": "This submission has been graded — your file can no longer be changed.",
+            "upload_locked_submitted": "You have submitted this assignment — your file can no longer be changed."
           },
           "short_answer": {
             "prompt_label": "Question prompt",
@@ -4054,15 +4071,24 @@
             "must_pass_hint": "All visible tests must pass before you can save.",
             "show_solution_label": "Reveal solution after submit",
             "show_solution_description": "Once the student has saved their work, show the teacher's reference solution as a collapsible panel.",
-            "reference_solution_label": "Reference solution"
+            "reference_solution_label": "Reference solution",
+            "locked_graded_hint": "This submission has been graded — your code is read-only.",
+            "locked_submitted_hint": "You have submitted this assignment — your code is read-only.",
+            "no_runnable_tests": "This task has no tests you can run — your code is checked at grading time."
           }
+        },
+        "generate_ai": "Generate tasks with AI",
+        "generate_ai_modal": {
+          "description": "Describe what you want and preview tasks grounded on the course content before adding them.",
+          "title": "Generate tasks with AI"
         }
       },
       "submissions": {
         "status": {
           "late": "Late",
           "submitted": "Submitted",
-          "graded": "Graded"
+          "graded": "Graded",
+          "pending": "In progress"
         },
         "filters": {
           "all": "All"
@@ -4118,7 +4144,8 @@
         "toasts": {
           "reject_success": "Assignment rejected successfully",
           "finalize_success": "Assignment graded and activity marked as complete"
-        }
+        },
+        "truncated_warning": "Only the first {{max}} submissions are shown. Some submissions are not listed here."
       },
       "analytics": {
         "loading": "Loading analytics...",
@@ -4266,6 +4293,18 @@
             "error": "Failed to create assignment"
           }
         }
+      },
+      "create_flow": {
+        "create_course": "Create a course",
+        "no_chapters_desc": "Add a chapter in the course editor, then create an assignment inside it.",
+        "no_chapters_title": "This course has no chapters yet",
+        "no_courses_desc": "Assignments live inside a course chapter. Create your first course, then come back to add an assignment.",
+        "no_courses_title": "Create a course first",
+        "open_editor": "Open course editor",
+        "pick_chapter": "Choose the chapter to place this assignment in.",
+        "pick_course": "Choose the course this assignment belongs to.",
+        "title": "New Assignment",
+        "untitled_chapter": "Untitled chapter"
       }
     },
     "search": {
@@ -5354,7 +5393,8 @@
     "accessDenied": "Unable to access this course",
     "backToCourses": "Back to Courses",
     "loadError": "This course could not be found or there was an error loading it.",
-    "noPermission": "You do not have permission to view this course."
+    "noPermission": "You do not have permission to view this course.",
+    "finish_course": "Finish course"
   },
   "pagination": {
     "next": "Next",

--- a/apps/web/services/courses/certificateDownload.ts
+++ b/apps/web/services/courses/certificateDownload.ts
@@ -1,0 +1,72 @@
+// Certificate PDF export.
+//
+// The PDF is produced by rasterising the SAME <CertificatePreview> React
+// component that is shown on screen and in the admin editor. It used to be
+// built from a separate hand-written HTML string, which drifted badly from the
+// component: the downloaded file lost the pattern artwork, the org logo and
+// name, used an emoji instead of the award mark, and re-derived its own colour
+// palette. Anything rendered here is by construction identical to the preview,
+// so the two can no longer diverge.
+//
+// Keep this as the only place that turns a certificate into a PDF.
+
+/** Width, in CSS pixels, of the offscreen node we rasterise. Roughly A4
+ *  landscape at 96dpi, so the capture is dense enough to stay crisp when
+ *  scaled into the page. */
+export const CERTIFICATE_CAPTURE_WIDTH = 1123
+
+/** Rasterise `node` and save it as a single-page PDF sized to the node's own
+ *  aspect ratio, centred on A4 with a small margin. */
+export async function downloadCertificateNodeAsPdf(
+  node: HTMLElement,
+  fileName: string,
+): Promise<void> {
+  const [{ default: html2canvas }, { default: jsPDF }] = await Promise.all([
+    // html2canvas-pro understands modern CSS color functions (oklch/lab/
+    // color-mix) emitted by Tailwind v4; classic html2canvas throws on them.
+    import('html2canvas-pro'),
+    import('jspdf'),
+  ])
+
+  const canvas = await html2canvas(node, {
+    scale: 2, // Higher resolution
+    useCORS: true, // org logo is served from the media host
+    allowTaint: true,
+    backgroundColor: '#ffffff',
+  })
+
+  const imgData = canvas.toDataURL('image/png')
+
+  // Match page orientation to the certificate so we don't letterbox a wide
+  // design into a tall page (or vice versa).
+  const isLandscape = canvas.width >= canvas.height
+  const pdf = new jsPDF(isLandscape ? 'landscape' : 'portrait', 'mm', 'a4')
+
+  const pageWidth = pdf.internal.pageSize.getWidth()
+  const pageHeight = pdf.internal.pageSize.getHeight()
+  const margin = 8 // mm
+
+  // Preserve aspect ratio: scale to whichever axis runs out of room first.
+  const maxWidth = pageWidth - margin * 2
+  const maxHeight = pageHeight - margin * 2
+  const scale = Math.min(maxWidth / canvas.width, maxHeight / canvas.height)
+  const imgWidth = canvas.width * scale
+  const imgHeight = canvas.height * scale
+
+  pdf.addImage(
+    imgData,
+    'PNG',
+    (pageWidth - imgWidth) / 2,
+    (pageHeight - imgHeight) / 2,
+    imgWidth,
+    imgHeight,
+  )
+
+  pdf.save(fileName)
+}
+
+/** Build a filesystem-safe PDF filename from the certification name. */
+export function certificateFileName(certificationName?: string): string {
+  const base = (certificationName || 'Certificate').replace(/[^a-zA-Z0-9]/g, '_')
+  return `${base}_Certificate.pdf`
+}


### PR DESCRIPTION
## Reported UX gaps

- **"No courses" when logged out.** The API returns an empty list to anonymous users rather than erroring, so the catalog and org landing page now prompt sign-in instead of implying the academy is empty.
- **Certificate only reachable via the trophy icon.** Next on the last activity now advances to it.
- **Quiz review marked every option, and showed correct answers as wrong.** The API strips the answer key while retries remain; the client rendered the missing key as "incorrect". Verdicts now apply only to the option the learner picked, and only when the key is actually present.
- **Downloaded certificate didn't match the UI.** It was built from a separate hand-written template that had drifted from the component on screen — no pattern artwork, no org logo or name, its own palette. It now rasterises the same `CertificatePreview` the admin editor renders.

## Assignment integrity

- Retry was the only learner write path not gated on the due date. It wipes answers, grade, trail step and certificate, and every resubmit path is deadline gated — so past the deadline it destroyed graded work with no way back.
- Task answers could be rewritten after `SUBMITTED`/`GRADED`; with the post-grade key reveal, a re-grade would score the replayed answers.
- Grading a task the learner never submitted wrote the grade to the instructor's own row, forced it to 0, and reported success.
- Finalising a grade on a `PENDING` (mid-retry) submission summed an empty task set, wrote 0, and locked the learner out of resubmitting.
- Signed thousands-grouped numbers (`-1,000`) parsed as decimals, marking correct answers wrong.
- The answer explanation was never stripped alongside the answer key.
- Deleting a task left graded submissions with a stored numerator that no longer matched the recomputed denominator.
- Draft assignments and their task contents were readable by any enrolled learner.

## Also

Reveal-gate fix extended to form/short-answer/number tasks; hidden test cases no longer 422 the whole code-execution batch; file and code tasks lock after grading; auto-save distinguishes permanent refusals from transient failures, caps retries, and flushes pending work on unmount; submissions and analytics page past the 50-row API default; the evaluate banner is computed from live task grades; assorted error-handling and empty-state fixes.

## Testing

- API suite passes (4021), including 11 new tests for the integrity guards.
- TypeScript clean, 0 eslint errors, web tests pass, production build compiles.
- **Not runtime-tested.** Worth a manual pass over submit → grade → retry, a code task with hidden tests, and grading a task the learner skipped.

## Note

The build's type-check step fails on a pre-existing issue unrelated to this change: `CatalogPagination.tsx` and `catalogPagination.ts` both exist and are both tracked, which only collides on case-insensitive filesystems. Worth cleaning up separately.