### PR TITLE
fix(auth): join the organization on Google sign-up

### DIFF
--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -2,6 +2,7 @@ from datetime import timedelta, datetime, timezone
 from typing import Literal, Optional
 from fastapi import Depends, APIRouter, HTTPException, Response, status, Request, Form
 from pydantic import BaseModel, EmailStr
+from sqlalchemy import func
 from sqlmodel import select
 from src.db.users import AnonymousUser, User, UserRead
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -483,7 +484,10 @@ class ThirdPartyLogin(BaseModel):
     ),
     responses={
         200: {"description": "OAuth login successful; cookies set and body contains user + tokens."},
+        400: {"description": "Unknown org_id or unsupported provider"},
         401: {"description": "Third-party authentication failed"},
+        403: {"description": "Organization is invite-only and no valid invite was provided"},
+        503: {"description": "Invitation could not be verified; retry"},
     },
 )
 async def third_party_login(
@@ -491,6 +495,7 @@ async def third_party_login(
     response: Response,
     body: ThirdPartyLogin,
     org_id: Optional[int] = None,
+    invite_code: Optional[str] = None,
     current_user: AnonymousUser = Depends(get_current_user),
     db_session: AsyncSession = Depends(get_db_session),
 ):
@@ -498,13 +503,29 @@ async def third_party_login(
     import redis as _redis
     _logger = logging.getLogger(__name__)
 
-    # Validate org_id before passing it downstream: verify the org exists and
-    # that a pending invite exists for this email in that org.  If the org does
-    # not exist we reject the request. If the org exists but no invite is found
-    # we log a warning and clear org_id so the user is created without an org
-    # association (prevents unauthorized org membership via OAuth).
+    # Usergroup to attach the user to after sign-in, when they joined through an
+    # invite code that is linked to one (mirrors create_user_with_invite).
+    _invite_usergroup_id = None
+    # Pending email invite to mark as consumed once the user actually joins.
+    _consume_invite_key = None
+
+    # Validate org_id before passing it downstream. The rule must mirror the
+    # email/password signup endpoints, otherwise the same person gets a
+    # different outcome depending on which button they pressed:
+    #
+    #   open org       -> POST /users/{org_id}                (no invite needed)
+    #   inviteOnly org -> POST /users/{org_id}/invite/{code}  (invite required)
+    #
+    # Previously this endpoint required a pending *email* invite in Redis for
+    # every org regardless of its join mechanism, and silently dropped org_id
+    # when none was found. Signing up with Google into an open org — or through
+    # an invite *code* link — therefore created an account with no organization
+    # at all, while the equivalent form signup joined the org normally.
     if org_id is not None:
         from src.db.organizations import Organization
+        from src.services.orgs.orgs import get_org_join_mechanism
+        from src.services.orgs.invites import get_invite_code
+
         org_record = (await db_session.execute(
             select(Organization).where(Organization.id == org_id)
         )).scalars().first()
@@ -515,55 +536,104 @@ async def third_party_login(
                 detail="Invalid org_id",
             )
 
-        # SECURITY: resolve the identity from the Google-verified email, NOT
-        # from the attacker-controlled body.email. signWithGoogle keys the
-        # account on the Google-returned email but honors org_id to grant
-        # membership. If the invite gate trusted body.email, an attacker could
-        # supply a victim's invited address (passing the gate) while
-        # authenticating with their own Google token, and get their own account
-        # joined to an org they were never invited to. The invite must be
-        # checked against the same email that will own the account.
-        if body.provider == "google":
-            _google_user = await get_google_user_info(body.access_token)
-            _verified_email = _google_user.get("email")
-            if not _verified_email or not _google_user.get("email_verified"):
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Google did not return a verified email for this account",
+        join_mechanism = await get_org_join_mechanism(
+            request, org_id, current_user, db_session
+        )
+
+        # Open orgs: anyone may join, exactly as POST /users/{org_id} allows.
+        # inviteOnly orgs: the caller must prove an invite.
+        if join_mechanism == "inviteOnly":
+            # SECURITY: resolve the identity from the Google-verified email, NOT
+            # from the attacker-controlled body.email. signWithGoogle keys the
+            # account on the Google-returned email but honors org_id to grant
+            # membership. If the invite gate trusted body.email, an attacker could
+            # supply a victim's invited address (passing the gate) while
+            # authenticating with their own Google token, and get their own account
+            # joined to an org they were never invited to. The invite must be
+            # checked against the same email that will own the account.
+            if body.provider == "google":
+                _google_user = await get_google_user_info(body.access_token)
+                _verified_email = _google_user.get("email")
+                if not _verified_email or not _google_user.get("email_verified"):
+                    raise HTTPException(
+                        status_code=status.HTTP_401_UNAUTHORIZED,
+                        detail="Google did not return a verified email for this account",
+                    )
+                _invite_email = _verified_email.strip().lower()
+            else:
+                _invite_email = body.email.strip().lower()
+
+            _authorized = False
+
+            # 0. Already a member: this is a plain sign-in, not a join. The org
+            #    context cookie is set on the login page too, so requiring an
+            #    invite here would lock existing members out of their own org.
+            from src.db.user_organizations import UserOrganization
+
+            _existing_member = (await db_session.execute(
+                select(UserOrganization)
+                .join(User, User.id == UserOrganization.user_id)  # type: ignore[arg-type]
+                .where(
+                    (func.lower(User.email) == _invite_email)
+                    & (UserOrganization.org_id == org_id)
                 )
-            _invite_email = _verified_email.strip().lower()
-        else:
-            _invite_email = body.email
+            )).scalars().first()
+            if _existing_member:
+                _authorized = True
 
-        # Check that a pending email invite exists for this address in the org
-        _invite_found = False
-        _r = None
-        try:
-            _lh_config = get_learnhouse_config()
-            _redis_url = _lh_config.redis_config.redis_connection_string
-            if _redis_url:
-                _r = _redis.Redis.from_url(_redis_url)
-                _invite_key = f"invited_user:{_invite_email}:org:{org_record.org_uuid}"
-                _invite_found = bool(_r.get(_invite_key))
-        except Exception as e:
-            _logger.error("Redis unavailable for invite validation, org_id will be ignored: %s", e)
-        finally:
-            # Always release the Redis connection pool created by from_url;
-            # otherwise every OAuth login leaks a connection pool/socket and
-            # the API eventually exhausts file descriptors / Redis connections.
-            if _r is not None:
+            # 1. An invite code carried through the OAuth redirect, same code the
+            #    form signup would have posted to /users/{org_id}/invite/{code}.
+            if invite_code:
                 try:
-                    _r.close()
-                except Exception:
-                    pass
+                    _code_data = await get_invite_code(
+                        request, org_id, invite_code, current_user, db_session
+                    )
+                except HTTPException:
+                    _code_data = None
+                if _code_data:
+                    _authorized = True
+                    _invite_usergroup_id = _code_data.get("usergroup_id")
 
-        if not _invite_found:
-            _logger.warning(
-                "OAuth org_id=%s supplied for email=%s but no pending invite found; ignoring org_id",
-                org_id,
-                body.email,
-            )
-            org_id = None
+            # 2. Or a pending invite sent to this address from the org dashboard.
+            if not _authorized:
+                _r = None
+                try:
+                    _lh_config = get_learnhouse_config()
+                    _redis_url = _lh_config.redis_config.redis_connection_string
+                    if _redis_url:
+                        _r = _redis.Redis.from_url(_redis_url)
+                        _invite_key = f"invited_user:{_invite_email}:org:{org_record.org_uuid}"
+                        if _r.get(_invite_key):
+                            _authorized = True
+                            _consume_invite_key = _invite_key
+                except Exception as e:
+                    # Fail loudly. Continuing here used to create the account with
+                    # no org, which looks like a successful signup to the user but
+                    # leaves them outside the organization with nothing to retry.
+                    _logger.error("Redis unavailable for invite validation: %s", e)
+                    raise HTTPException(
+                        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                        detail="Could not verify your invitation right now, please try again.",
+                    )
+                finally:
+                    # Always release the Redis connection pool created by from_url;
+                    # otherwise every OAuth login leaks a connection pool/socket and
+                    # the API eventually exhausts file descriptors / Redis connections.
+                    if _r is not None:
+                        try:
+                            _r.close()
+                        except Exception:
+                            pass
+
+            if not _authorized:
+                _logger.warning(
+                    "OAuth org_id=%s supplied but no valid invite was found for the account",
+                    org_id,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="You need an invite to join this organization",
+                )
 
     user = None
 
@@ -585,6 +655,55 @@ async def third_party_login(
             detail="Incorrect Email or password",
             headers={"WWW-Authenticate": "Bearer"},
         )
+
+    # Finish the invite the same way the form signup does: attach the usergroup
+    # the invite code is linked to, and stop showing the invite as pending.
+    # Neither of these ran on the OAuth path before, so a user invited by email
+    # stayed "pending" in the org's member list after joining, and an invite code
+    # carrying a usergroup silently didn't apply it.
+    if _invite_usergroup_id and user.id is not None:
+        from src.db.users import InternalUser
+        from src.services.users.usergroups import add_users_to_usergroup
+
+        try:
+            await add_users_to_usergroup(
+                request,
+                db_session,
+                InternalUser(id=0),
+                int(_invite_usergroup_id),
+                str(user.id),
+            )
+        except Exception:
+            # The account exists and is in the org; a usergroup failure must not
+            # turn a completed sign-in into an error.
+            _logger.warning("Could not attach OAuth user to invite usergroup")
+
+    if _consume_invite_key:
+        _r = None
+        try:
+            _redis_url = get_learnhouse_config().redis_config.redis_connection_string
+            if _redis_url:
+                _r = _redis.Redis.from_url(_redis_url)
+                _invited_data = _r.get(_consume_invite_key)
+                if _invited_data:
+                    import json as _json
+
+                    _invited_record = _json.loads(_invited_data)
+                    _invited_record["pending"] = False
+                    _remaining_ttl = _r.ttl(_consume_invite_key)
+                    _r.set(
+                        _consume_invite_key,
+                        _json.dumps(_invited_record),
+                        ex=_remaining_ttl if _remaining_ttl > 0 else None,
+                    )
+        except Exception:
+            _logger.warning("Could not mark invitation as accepted")
+        finally:
+            if _r is not None:
+                try:
+                    _r.close()
+                except Exception:
+                    pass
 
     access_token = create_access_token(
         data={"sub": user.email},

--- a/apps/api/src/services/auth/utils.py
+++ b/apps/api/src/services/auth/utils.py
@@ -249,6 +249,16 @@ async def signWithGoogle(
             await db_session.refresh(user_organization)
             await increase_feature_usage("members", org_id, db_session)
 
+            # /users/session is served from a 10 minute Redis cache keyed on the
+            # user id, and it is what the frontend reads the org list from. Every
+            # other membership change busts it (join_org, role changes, removals);
+            # this one did not, so the user landed in the org they had just joined
+            # with the pre-join role list — no membership, member-only UI hidden —
+            # until the cache expired on its own.
+            from src.routers.users import _invalidate_session_cache
+
+            _invalidate_session_cache(user.id)
+
     # Update last login info
     client_ip = get_client_ip(request)
     await update_login_info(user, client_ip, db_session)

--- a/apps/api/src/tests/routers/test_auth_router.py
+++ b/apps/api/src/tests/routers/test_auth_router.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI, Response
 from httpx import ASGITransport, AsyncClient
 
 from src.core.events.database import get_db_session
+from src.db.organization_config import OrganizationConfig
 from src.db.users import AnonymousUser, User
 from src.routers.auth import (
     JWT_COOKIE_NAME,
@@ -21,6 +22,20 @@ from src.routers.auth import (
     unset_auth_cookies,
 )
 from src.security.auth import get_current_user
+
+
+async def _set_org_signup_mode(db, org_id: int, signup_mode: str):
+    """Give the org a config row so get_org_join_mechanism can resolve it."""
+    db.add(
+        OrganizationConfig(
+            org_id=org_id,
+            config={
+                "config_version": "1.0",
+                "features": {"members": {"signup_mode": signup_mode}},
+            },
+        )
+    )
+    await db.commit()
 
 
 def _mock_config(tenancy: str = "multi"):
@@ -554,18 +569,45 @@ class TestAuthRouter:
         assert response.status_code == 400
         assert response.json()["detail"] == "Invalid org_id"
 
-    async def test_oauth_org_id_valid_but_no_invite_clears_org_id(self, client, db, org):
-        mock_redis = Mock(get=Mock(return_value=None))
+    async def test_oauth_open_org_needs_no_invite(self, client, db, org):
+        """An open org is joinable by anyone, exactly as POST /users/{org_id} is.
+        No invite lookup happens at all, so Redis being untouched is part of the
+        contract here."""
+        await _set_org_signup_mode(db, org.id, "open")
+        sign_with_google = AsyncMock(return_value=None)
+        with patch("src.routers.auth.signWithGoogle", sign_with_google):
+            response = await client.post(
+                "/api/v1/auth/oauth",
+                params={"org_id": 1},
+                json={
+                    "email": "user@test.com",
+                    "provider": "google",
+                    "access_token": "google-token",
+                },
+            )
+        # signWithGoogle returning None is the "auth failed" path (401); what
+        # matters is that org_id survived the validation block instead of being
+        # silently dropped.
+        assert response.status_code == 401
+        assert sign_with_google.await_args.args[3] == org.id
+
+    async def test_oauth_invite_only_org_without_invite_returns_403(self, client, db, org):
+        await _set_org_signup_mode(db, org.id, "inviteOnly")
+        mock_redis = Mock(get=Mock(return_value=None), close=Mock())
         mock_config = SimpleNamespace(
             redis_config=SimpleNamespace(redis_connection_string="redis://localhost:6379")
         )
         with patch("src.routers.auth.get_learnhouse_config", return_value=mock_config), patch(
             "redis.Redis.from_url", return_value=mock_redis
         ), patch(
+            "src.routers.auth.get_google_user_info",
+            new_callable=AsyncMock,
+            return_value={"email": "user@test.com", "email_verified": True},
+        ), patch(
             "src.routers.auth.signWithGoogle",
             new_callable=AsyncMock,
             return_value=None,
-        ):
+        ) as sign_with_google:
             response = await client.post(
                 "/api/v1/auth/oauth",
                 params={"org_id": 1},
@@ -575,14 +617,21 @@ class TestAuthRouter:
                     "access_token": "google-token",
                 },
             )
-        assert response.status_code == 401
+        assert response.status_code == 403
+        # Rejected outright rather than signed in with no organization.
+        sign_with_google.assert_not_awaited()
 
-    async def test_oauth_org_id_redis_unavailable_clears_org_id(self, client, db, org):
+    async def test_oauth_invite_only_org_redis_unavailable_returns_503(self, client, db, org):
+        await _set_org_signup_mode(db, org.id, "inviteOnly")
         mock_config = SimpleNamespace(
             redis_config=SimpleNamespace(redis_connection_string="redis://localhost:6379")
         )
         with patch("src.routers.auth.get_learnhouse_config", return_value=mock_config), patch(
             "redis.Redis.from_url", side_effect=RuntimeError("Redis down")
+        ), patch(
+            "src.routers.auth.get_google_user_info",
+            new_callable=AsyncMock,
+            return_value={"email": "user@test.com", "email_verified": True},
         ), patch(
             "src.routers.auth.signWithGoogle",
             new_callable=AsyncMock,
@@ -597,11 +646,12 @@ class TestAuthRouter:
                     "access_token": "google-token",
                 },
             )
-        assert response.status_code == 401
+        assert response.status_code == 503
 
     async def test_oauth_org_id_google_unverified_email_returns_401(self, client, db, org):
-        """OAuth org_id invite gate for provider=google: when Google does not
-        return a verified email the request is rejected with 401 (lines 493-499)."""
+        """OAuth invite gate for provider=google: when Google does not return a
+        verified email the request is rejected with 401."""
+        await _set_org_signup_mode(db, org.id, "inviteOnly")
         with patch(
             "src.routers.auth.get_google_user_info",
             new_callable=AsyncMock,
@@ -622,13 +672,12 @@ class TestAuthRouter:
     async def test_oauth_org_id_google_verified_checks_invite_and_closes_redis(
         self, client, db, org
     ):
-        """Google returns a verified email -> the invite email is normalised
-        (line 500), the Redis invite key is read (lines 506-513) and the Redis
-        connection is closed in the finally block (lines 520-524). The invite is
-        not found here, so org_id is cleared and signWithGoogle returns None ->
-        401."""
+        """Google returns a verified email -> the invite email is normalised, the
+        Redis invite key is read and the Redis connection is closed in the finally
+        block. The invite is not found here, so the join is refused with 403."""
+        await _set_org_signup_mode(db, org.id, "inviteOnly")
         # close() raising must be swallowed by the finally block's
-        # ``except Exception: pass`` (lines 523-524).
+        # ``except Exception: pass``.
         close_mock = Mock(side_effect=RuntimeError("close failed"))
         mock_redis = Mock(get=Mock(return_value=None), close=close_mock)
         mock_config = SimpleNamespace(
@@ -657,7 +706,7 @@ class TestAuthRouter:
                 },
             )
 
-        assert response.status_code == 401
+        assert response.status_code == 403
         # Invite key was looked up using the lower-cased Google email.
         mock_redis.get.assert_called_once_with("invited_user:user@test.com:org:org_test")
         # The Redis connection from from_url was always closed (finally block).

--- a/apps/api/src/tests/routers/test_auth_third_party.py
+++ b/apps/api/src/tests/routers/test_auth_third_party.py
@@ -1,17 +1,38 @@
 """Tests for the third_party_login OAuth handler in src/routers/auth.py.
 
-Targets the `else: raise HTTPException(...)` branch (line ~497) that rejects any
-provider other than the supported ones (currently only "google").
+Covers the unsupported-provider guard and the org_id validation block, which
+must mirror the rules the email/password signup endpoints apply: an open org is
+joinable by anyone, an invite-only org requires an invite.
 """
 
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi import HTTPException, Response, status
 
-from src.db.users import AnonymousUser
+from src.db.organization_config import OrganizationConfig
+from src.db.user_organizations import UserOrganization
+from src.db.users import AnonymousUser, User
 from src.routers.auth import third_party_login
+
+
+async def _set_signup_mode(db, org_id: int, signup_mode: str):
+    db.add(
+        OrganizationConfig(
+            org_id=org_id,
+            config={
+                "config_version": "1.0",
+                "features": {"members": {"signup_mode": signup_mode}},
+            },
+        )
+    )
+    await db.commit()
+
+
+def _google_body(email="invitee@example.com"):
+    return SimpleNamespace(email=email, provider="google", access_token="tok")
 
 
 @pytest.mark.asyncio
@@ -39,39 +60,186 @@ async def test_third_party_login_rejects_unsupported_provider():
 
 
 @pytest.mark.asyncio
-async def test_third_party_login_non_google_org_id_uses_body_email(db, org):
-    """With a valid org_id but a non-google provider, the invite-email is taken
-    from ``body.email`` (the ``else`` branch, line 502), the Redis invite key is
-    read, and the Redis connection is closed in the finally block before the
-    unsupported-provider guard rejects the request with 400."""
-    body = SimpleNamespace(
-        email="invitee@example.com",
-        provider="facebook",
-        access_token="tok",
-    )
-    close_mock = Mock()
-    mock_redis = Mock(get=Mock(return_value=None), close=close_mock)
+async def test_third_party_login_rejects_unknown_org(db):
+    with pytest.raises(HTTPException) as exc_info:
+        await third_party_login(
+            request=SimpleNamespace(),
+            response=Response(),
+            body=_google_body(),
+            org_id=99999,
+            current_user=AnonymousUser(),
+            db_session=db,
+        )
+
+    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert exc_info.value.detail == "Invalid org_id"
+
+
+@pytest.mark.asyncio
+async def test_open_org_keeps_org_id_without_any_invite(db, org):
+    """The bug this endpoint used to have: an open org still required a pending
+    email invite, so a Google sign-up was created with no organization at all
+    while the equivalent form signup joined the org."""
+    await _set_signup_mode(db, org.id, "open")
+
+    sign_with_google = AsyncMock(return_value=SimpleNamespace(id=7, email="invitee@example.com"))
+
+    with patch("src.routers.auth.signWithGoogle", sign_with_google), patch(
+        "src.routers.auth.set_auth_cookies"
+    ), patch("src.routers.auth.UserRead") as user_read:
+        user_read.model_validate.side_effect = lambda u: u
+        await third_party_login(
+            request=SimpleNamespace(),
+            response=Response(),
+            body=_google_body(),
+            org_id=org.id,
+            current_user=AnonymousUser(),
+            db_session=db,
+        )
+
+    # org_id is passed through to the sign-in service instead of being dropped.
+    assert sign_with_google.await_args.args[3] == org.id
+
+
+@pytest.mark.asyncio
+async def test_invite_only_org_without_invite_is_rejected(db, org):
+    """No silent downgrade: the user is told they need an invite rather than
+    being signed in with no organization."""
+    await _set_signup_mode(db, org.id, "inviteOnly")
+
+    mock_redis = Mock(get=Mock(return_value=None), close=Mock())
     mock_config = SimpleNamespace(
         redis_config=SimpleNamespace(redis_connection_string="redis://localhost:6379")
     )
 
     with patch(
         "src.routers.auth.get_learnhouse_config", return_value=mock_config
-    ), patch("redis.Redis.from_url", return_value=mock_redis):
+    ), patch("redis.Redis.from_url", return_value=mock_redis), patch(
+        "src.routers.auth.get_google_user_info",
+        AsyncMock(return_value={"email": "invitee@example.com", "email_verified": True}),
+    ):
         with pytest.raises(HTTPException) as exc_info:
             await third_party_login(
                 request=SimpleNamespace(),
                 response=Response(),
-                body=body,
+                body=_google_body(),
                 org_id=org.id,
                 current_user=AnonymousUser(),
                 db_session=db,
             )
 
-    # Non-google providers key the invite on the raw body email.
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
     mock_redis.get.assert_called_once_with(
         f"invited_user:invitee@example.com:org:{org.org_uuid}"
     )
-    close_mock.assert_called_once()
-    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
-    assert exc_info.value.detail == "Unsupported provider"
+    mock_redis.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_invite_only_org_accepts_invite_code(db, org):
+    """An invite *code* link is proof of invitation, exactly as it is for
+    POST /users/{org_id}/invite/{code}."""
+    await _set_signup_mode(db, org.id, "inviteOnly")
+
+    sign_with_google = AsyncMock(return_value=SimpleNamespace(id=7, email="invitee@example.com"))
+
+    with patch("src.routers.auth.signWithGoogle", sign_with_google), patch(
+        "src.routers.auth.set_auth_cookies"
+    ), patch("src.routers.auth.UserRead") as user_read, patch(
+        "src.routers.auth.get_google_user_info",
+        AsyncMock(return_value={"email": "invitee@example.com", "email_verified": True}),
+    ), patch(
+        "src.services.orgs.invites.get_invite_code",
+        AsyncMock(return_value={"invite_code": "CODE123", "usergroup_id": None}),
+    ):
+        user_read.model_validate.side_effect = lambda u: u
+        await third_party_login(
+            request=SimpleNamespace(),
+            response=Response(),
+            body=_google_body(),
+            org_id=org.id,
+            invite_code="CODE123",
+            current_user=AnonymousUser(),
+            db_session=db,
+        )
+
+    assert sign_with_google.await_args.args[3] == org.id
+
+
+@pytest.mark.asyncio
+async def test_invite_only_org_lets_existing_member_sign_in(db, org):
+    """The org cookie is set on the login page too, so an existing member must
+    not be locked out of their own invite-only org."""
+    await _set_signup_mode(db, org.id, "inviteOnly")
+
+    user = User(
+        email="Member@Example.com",
+        username="member",
+        first_name="Test",
+        last_name="Member",
+        password="",
+        creation_date=str(datetime.now()),
+        update_date=str(datetime.now()),
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    db.add(
+        UserOrganization(
+            user_id=user.id,
+            org_id=org.id,
+            role_id=4,
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+    )
+    await db.commit()
+
+    sign_with_google = AsyncMock(return_value=SimpleNamespace(id=user.id, email=user.email))
+
+    with patch("src.routers.auth.signWithGoogle", sign_with_google), patch(
+        "src.routers.auth.set_auth_cookies"
+    ), patch("src.routers.auth.UserRead") as user_read, patch(
+        "src.routers.auth.get_google_user_info",
+        AsyncMock(return_value={"email": "member@example.com", "email_verified": True}),
+    ):
+        user_read.model_validate.side_effect = lambda u: u
+        await third_party_login(
+            request=SimpleNamespace(),
+            response=Response(),
+            body=_google_body("member@example.com"),
+            org_id=org.id,
+            current_user=AnonymousUser(),
+            db_session=db,
+        )
+
+    assert sign_with_google.await_args.args[3] == org.id
+
+
+@pytest.mark.asyncio
+async def test_invite_only_org_fails_loudly_when_redis_is_down(db, org):
+    """Continuing here used to create an org-less account that looked like a
+    successful signup."""
+    await _set_signup_mode(db, org.id, "inviteOnly")
+
+    mock_config = SimpleNamespace(
+        redis_config=SimpleNamespace(redis_connection_string="redis://localhost:6379")
+    )
+
+    with patch(
+        "src.routers.auth.get_learnhouse_config", return_value=mock_config
+    ), patch("redis.Redis.from_url", side_effect=OSError("connection refused")), patch(
+        "src.routers.auth.get_google_user_info",
+        AsyncMock(return_value={"email": "invitee@example.com", "email_verified": True}),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await third_party_login(
+                request=SimpleNamespace(),
+                response=Response(),
+                body=_google_body(),
+                org_id=org.id,
+                current_user=AnonymousUser(),
+                db_session=db,
+            )
+
+    assert exc_info.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE

--- a/apps/api/src/tests/services/test_auth_utils_service.py
+++ b/apps/api/src/tests/services/test_auth_utils_service.py
@@ -177,6 +177,57 @@ class TestAuthUtilsService:
         mock_update_login.assert_called_once_with(user, "10.0.0.7", db_session)
 
     @pytest.mark.asyncio
+    async def test_sign_with_google_existing_user_join_busts_session_cache(self):
+        """/users/session is Redis-cached for 10 minutes and holds the org list, so
+        joining an org without invalidating it leaves the user looking like a
+        non-member of the org they just joined."""
+        request = Mock(spec=Request)
+        request.client = SimpleNamespace(host="10.0.0.7")
+        user = User(
+            id=1,
+            username="existing",
+            first_name="Existing",
+            last_name="User",
+            email="existing@test.com",
+            password="hashed",
+            user_uuid="user_existing",
+            email_verified=True,
+            signup_method="google",
+            creation_date=str(datetime.now(timezone.utc)),
+            update_date=str(datetime.now(timezone.utc)),
+        )
+        db_session = AsyncMock()
+        # First lookup returns the user, the membership lookup returns nothing.
+        user_result = MagicMock()
+        user_result.scalars.return_value.first.return_value = user
+        membership_result = MagicMock()
+        membership_result.scalars.return_value.first.return_value = None
+        db_session.execute.side_effect = [user_result, membership_result]
+
+        with patch(
+            "src.services.auth.utils.get_google_user_info",
+            return_value={"email": "existing@test.com", "email_verified": True},
+        ), patch("src.services.auth.utils.get_client_ip", return_value="10.0.0.7"), patch(
+            "src.services.auth.utils.update_login_info"
+        ), patch(
+            "src.security.features_utils.usage.check_limits_with_usage", AsyncMock()
+        ), patch(
+            "src.security.features_utils.usage.increase_feature_usage", AsyncMock()
+        ), patch(
+            "src.routers.users._invalidate_session_cache"
+        ) as mock_invalidate:
+            await signWithGoogle(
+                request=request,
+                access_token="access-token",
+                email="existing@test.com",
+                org_id=10,
+                current_user=Mock(),
+                db_session=db_session,
+            )
+
+        mock_invalidate.assert_called_once_with(user.id)
+
+    @pytest.mark.asyncio
     async def test_sign_with_google_username_fallback_to_user(self):
         """Covers line 76 — username_parts.append('user') when name parts are absent
         and the email has no '@', so the prefix-based branch is also skipped."""

--- a/apps/web/app/auth/callback/google/page.tsx
+++ b/apps/web/app/auth/callback/google/page.tsx
@@ -109,8 +109,9 @@ export default function GoogleCallbackPage() {
 
       const callbackUrl = stateValidation.callbackUrl
 
-      // Get org_id from cookie if set
+      // Get org_id (and, for invite-only orgs, the invite code) from cookies if set
       let orgId: number | undefined
+      let inviteCode: string | undefined
       try {
         const cookies = document.cookie.split(';')
         for (const cookie of cookies) {
@@ -120,7 +121,8 @@ export default function GoogleCallbackPage() {
             if (isNaN(orgId)) {
               orgId = undefined
             }
-            break
+          } else if (name === 'LH_oauth_invite_code' && value) {
+            inviteCode = decodeURIComponent(value)
           }
         }
       } catch {
@@ -132,7 +134,7 @@ export default function GoogleCallbackPage() {
       try {
         const topDomain = getLEARNHOUSE_TOP_DOMAIN_VAL()
         const domainAttr = topDomain && topDomain !== 'localhost' ? `; domain=.${topDomain}` : ''
-        for (const n of ['LH_oauth_org_id', 'LH_oauth_orgslug']) {
+        for (const n of ['LH_oauth_org_id', 'LH_oauth_orgslug', 'LH_oauth_invite_code']) {
           document.cookie = `${n}=; path=/; max-age=0`
           if (domainAttr) document.cookie = `${n}=; path=/; max-age=0${domainAttr}`
         }
@@ -195,8 +197,11 @@ export default function GoogleCallbackPage() {
         }
 
         // Call Next.js API route to ensure cookies are set properly
-        const oauthUrl = orgId
-          ? `/api/auth/oauth?org_id=${orgId}`
+        const oauthParams = new URLSearchParams()
+        if (orgId) oauthParams.set('org_id', String(orgId))
+        if (orgId && inviteCode) oauthParams.set('invite_code', inviteCode)
+        const oauthUrl = oauthParams.toString()
+          ? `/api/auth/oauth?${oauthParams.toString()}`
           : '/api/auth/oauth'
 
         const oauthResponse = await fetch(oauthUrl, {

--- a/apps/web/app/auth/signup/InviteOnlySignUp.tsx
+++ b/apps/web/app/auth/signup/InviteOnlySignUp.tsx
@@ -133,6 +133,13 @@ function InviteOnlySignUpComponent(props: InviteOnlySignUpProps) {
       const domainAttr = (topDomain === 'localhost' || isOnCustomDomain()) ? '' : `; domain=.${topDomain}`;
       document.cookie = `LH_oauth_orgslug=${org.slug}${baseAttributes}${domainAttr}`;
       document.cookie = `LH_oauth_org_id=${org.id}${baseAttributes}${domainAttr}`;
+      // Invite-only orgs need the invite code itself, not just the org: the
+      // backend requires the same proof the form signup posts to
+      // /users/{org_id}/invite/{code}. Without it a Google sign-up through an
+      // invite link is refused instead of joining the org.
+      if (props.inviteCode) {
+        document.cookie = `LH_oauth_invite_code=${encodeURIComponent(props.inviteCode)}${baseAttributes}${domainAttr}`;
+      }
     }
     // Use absolute URL with current origin for custom domain support
     signIn('google', { callbackUrl: buildCallbackUrl() });


### PR DESCRIPTION
Signing up with Google did not add the user to the organization; the same person using the signup form did.

## Cause

`POST /auth/oauth` only honoured the `org_id` it was given when a pending **email** invite existed for that address, and silently dropped it otherwise — the account was then created with no organization.

That rule does not match the signup endpoints:

| | form | Google (before) |
|---|---|---|
| open org | joins (`POST /users/{org_id}`) | no org |
| invite-code link | joins (`POST /users/{org_id}/invite/{code}`) | no org |
| email invite | joins | joins |

## Change

- open orgs: `org_id` is honoured, no invite required
- invite-only orgs: an invite code is accepted, carried through the OAuth redirect alongside the org context
- invite-only joins without a valid invite are refused outright instead of signing the user in with no organization — including when the invite store is unreachable, which used to degrade to the same silent drop
- existing members can still sign in without an invite
- the invite code's usergroup is applied and the invitation stops showing as pending, matching the form signup
- the cached session is invalidated on join, so the organization is visible immediately instead of after the cache expires

## Tests

New coverage for open orgs, invite-only with and without an invite, existing members, invite-store failure, and the cache invalidation. Full API suite passes.