### PR TITLE
fix(web): forward client IP, pass redirects through, resolve roles after SSO

### DIFF
--- a/apps/web/app/api/auth/[...path]/route.ts
+++ b/apps/web/app/api/auth/[...path]/route.ts
@@ -119,6 +119,18 @@ async function proxyRequest(
   const headers: HeadersInit = {}
   const cookieStore = await cookies()
 
+  // Forward the caller's IP. This proxy builds its headers from scratch, so
+  // without this the backend only ever sees the Next.js server's own address:
+  // every visitor collapses into a single per-IP rate-limit bucket and one busy
+  // deployment locks everyone out of login and token refresh. The backend only
+  // trusts these when the direct connection is from a private address (see
+  // get_client_ip), so forwarding what the ingress already set is the same
+  // contract the /api/v1 proxy honours by forwarding all headers.
+  for (const ipHeader of ['x-forwarded-for', 'x-real-ip']) {
+    const value = request.headers.get(ipHeader)
+    if (value) headers[ipHeader] = value
+  }
+
   // Forward content-type
   const contentType = request.headers.get('content-type')
   if (contentType) {

--- a/apps/web/app/api/v1/[...path]/route.ts
+++ b/apps/web/app/api/v1/[...path]/route.ts
@@ -40,6 +40,15 @@ async function proxyToBackend(request: NextRequest): Promise<Response> {
       method: request.method,
       headers,
       body,
+      // Pass redirects through to the browser instead of following them here.
+      // Following them server-side broke both callers that rely on a 302:
+      // the magic-link sign-in sets its auth cookies ON the redirect response,
+      // and only the final hop's headers survive, so the user landed signed out;
+      // and media streaming redirects to a presigned storage URL precisely so
+      // the browser fetches bytes directly from object storage (see
+      // _redirect_to_storage) — following it meant proxying every byte through
+      // this server and discarding the redirect's caching headers.
+      redirect: 'manual',
       // @ts-ignore — needed for streaming request bodies in Node.js
       duplex: 'half',
       signal: controller.signal,
@@ -57,8 +66,15 @@ async function proxyToBackend(request: NextRequest): Promise<Response> {
       const lkey = key.toLowerCase()
       if (SKIP_RESPONSE_HEADERS.has(lkey)) return
       if (lkey === 'content-length' && wasCompressed) return
+      // Set-Cookie is handled below: forEach collapses repeated headers into a
+      // single comma-joined value, which would merge the access and refresh
+      // cookies into one malformed header and set neither.
+      if (lkey === 'set-cookie') return
       responseHeaders.append(key, value)
     })
+    for (const cookie of backendResponse.headers.getSetCookie?.() ?? []) {
+      responseHeaders.append('set-cookie', cookie)
+    }
 
     // Stream the response body directly — no buffering
     // This preserves SSE streams, file downloads, and binary responses

--- a/apps/web/components/Contexts/AuthContext.tsx
+++ b/apps/web/components/Contexts/AuthContext.tsx
@@ -598,6 +598,29 @@ export function SessionProvider({
               timestamp: Date.now(),
             }
 
+            // Resolve the real org/role list, exactly as the password login below
+            // does. The SSO handoff only carries tokens and the user, so without
+            // this the session stayed `roles: []` — and because that empty list
+            // was written into the session cache, the user spent the cache window
+            // looking like a non-member of the org they had just signed in to:
+            // the "join this organization" banner instead of their courses.
+            // A failure here must not undo a successful sign-in, so we keep the
+            // role-less session and let the next session fetch fill it in.
+            try {
+              const fullSession = await fetchUserSession(options.sso_access_token, expiry)
+              if (fullSession) {
+                fullSession.tokens = newSession.tokens
+                setSession(fullSession)
+                sessionCacheRef.current = {
+                  data: fullSession,
+                  timestamp: Date.now(),
+                }
+              }
+            } catch {
+              // Transient failure — the cached role-less session is refreshed by
+              // the next /users/session read rather than blocking the redirect.
+            }
+
             // Notify other tabs
             broadcastChannelRef.current?.postMessage({ type: 'LOGIN' })
 


### PR DESCRIPTION
Three defects in the request path between the browser and the API.

### The auth proxy dropped the caller's IP

`apps/web/app/api/auth/[...path]/route.ts` builds its forwarded headers from scratch and never included `X-Forwarded-For` / `X-Real-IP`, so every backend per-IP rate limit saw only the Next.js server's own address — the entire deployment shared a single bucket for login and token refresh. The `/api/v1` proxy already forwards these headers by forwarding everything; this one now matches.

This is the mechanism behind the shared-bucket half of the unexpected-logout reports. #955 raised the refresh limit, which masked it; this removes the cause.

### The `/api/v1` proxy followed redirects instead of passing them on

`fetch` without `redirect: 'manual'` follows the backend's 302 server-side, and only the final hop's headers reach the browser. Both callers that answer with a 302 depend on the browser seeing it:

- magic-link sign-in sets its auth cookies **on** the redirect response (`routers/admin.py`), so the user landed signed out
- media streaming redirects to a presigned storage URL specifically so bytes stream from object storage rather than through this server (`_redirect_to_storage` in `routers/stream.py`) — following it proxied every byte and discarded the redirect's caching headers

Repeated `Set-Cookie` headers are now forwarded individually too: iterating headers collapses them into one comma-joined value, which would have merged the access and refresh cookies into a single malformed header and set neither.

### SSO sign-in published an empty role list

The SSO branch of `handleSignIn` built a session with `roles: []` and wrote it into the session cache, so for the length of the cache window a user who had just signed in appeared to be a non-member of the organization they signed in to — the "join this organization" banner instead of their courses. The password branch immediately below already resolved the full session; the SSO branch now does the same, and a failed lookup leaves the sign-in intact rather than blocking it.

## Note

`redirect: 'manual'` changes how media bytes are delivered — the browser now follows the presigned redirect directly, as the backend intended. Worth a look on a preview deploy with a video activity before merging.