### PR TITLE
fix(certifications): stop deleting awarded certificates with the template

### DIFF
--- a/apps/api/src/routers/courses/certifications.py
+++ b/apps/api/src/routers/courses/certifications.py
@@ -126,11 +126,17 @@ async def api_update_certification(
 @router.delete(
     "/{certification_uuid}",
     summary="Delete certification",
-    description="Delete a certification template by its UUID. Existing awarded certificates are not removed.",
+    description=(
+        "Delete a certification template by its UUID. Only allowed while no "
+        "certificates have been awarded from it — deleting the template also "
+        "destroys every awarded certificate and invalidates their verification "
+        "links. Revoke awarded certificates individually first."
+    ),
     responses={
         200: {"description": "Certification deleted."},
         403: {"description": "Caller lacks permission to delete this certification"},
         404: {"description": "Certification not found"},
+        409: {"description": "Certificates have been awarded from this certification"},
     },
 )
 async def api_delete_certification(

--- a/apps/api/src/services/courses/certifications.py
+++ b/apps/api/src/services/courses/certifications.py
@@ -208,6 +208,34 @@ async def delete_certification(
     # RBAC check
     await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.DELETE)
 
+    # CertificateUser.certification_id is declared ON DELETE CASCADE, so deleting
+    # the template also destroys every certificate ever awarded from it — the
+    # learners' "my certificates" list empties and every verification link they
+    # shared, including the QR code printed on already-downloaded PDFs, starts
+    # reporting the certificate as revoked. That is irreversible: re-creating the
+    # template mints a new id, and nothing re-issues to past graduates.
+    #
+    # Refuse instead. Awarded certificates must be revoked deliberately, one at a
+    # time, through revoke_user_certificate — which also emits the revocation
+    # analytics and webhooks that a silent cascade skips entirely.
+    awarded_count = (await db_session.execute(
+        select(func.count(CertificateUser.id)).where(
+            CertificateUser.certification_id == certification.id
+        )
+    )).scalar_one()
+
+    if awarded_count:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"This certification has {awarded_count} awarded "
+                f"certificate{'s' if awarded_count != 1 else ''}. Deleting it would "
+                "permanently destroy them and break the verification links their "
+                "holders have shared. Disable the certification instead, or revoke "
+                "the certificates individually first."
+            ),
+        )
+
     await db_session.delete(certification)
     await db_session.commit()
 

--- a/apps/api/src/tests/services/test_certifications_service.py
+++ b/apps/api/src/tests/services/test_certifications_service.py
@@ -517,6 +517,45 @@ class TestDeleteCertification:
         )
 
     @pytest.mark.asyncio
+    async def test_delete_certification_refuses_when_certificates_awarded(
+        self, db, course, admin_user, regular_user, mock_request
+    ):
+        """CertificateUser cascades on certification delete, so removing the
+        template would destroy awarded certificates and break the verification
+        links their holders have shared."""
+        certification = await _create_certification(db, course, cert_uuid="cert_awarded")
+        await _create_certificate_user(db, certification, regular_user)
+
+        with patch(
+            "src.services.courses.certifications.check_resource_access",
+            new_callable=AsyncMock,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await delete_certification(
+                    mock_request,
+                    certification.certification_uuid,
+                    admin_user,
+                    db,
+                )
+
+        assert exc_info.value.status_code == 409
+        # The template and the awarded certificate both survive.
+        assert (
+            await db.execute(
+                select(Certifications).where(
+                    Certifications.certification_uuid == certification.certification_uuid
+                )
+            )
+        ).scalars().first() is not None
+        assert (
+            await db.execute(
+                select(CertificateUser).where(
+                    CertificateUser.certification_id == certification.id
+                )
+            )
+        ).scalars().first() is not None
+
+    @pytest.mark.asyncio
     async def test_delete_certification_missing_certification(
         self, db, admin_user, mock_request
     ):

--- a/apps/web/components/Dashboard/Pages/Course/EditCourseCertification/EditCourseCertification.tsx
+++ b/apps/web/components/Dashboard/Pages/Course/EditCourseCertification/EditCourseCertification.tsx
@@ -52,11 +52,11 @@ const validate = (values: any, t: any) => {
   return errors;
 };
 
-function EditCourseCertification(props: EditCourseCertificationProps) {
+function EditCourseCertification(_props: EditCourseCertificationProps) {
   const { t } = useTranslation()
   const [error, setError] = useState('');
   const [isCreating, setIsCreating] = useState(false);
-  const course = useCourse() as any;
+  const _course = useCourse() as any;
   const session = useLHSession() as any;
   const org = useOrg() as any;
   const access_token = session?.data?.tokens?.access_token;
@@ -126,7 +126,7 @@ function EditCourseCertification(props: EditCourseCertificationProps) {
   const formik = useFormik({
     initialValues: getInitialValues(),
     validate: (values) => validate(values, t),
-    onSubmit: async values => {
+    onSubmit: async _values => {
       // This is no longer used - saving is handled by the main Save button
     },
     enableReinitialize: true,
@@ -163,7 +163,7 @@ function EditCourseCertification(props: EditCourseCertificationProps) {
         } else {
           throw new Error('Failed to create certification');
         }
-      } catch (e) {
+      } catch (_e) {
         setError(t('dashboard.courses.certification.errors.create_failed'));
         toast.error(t('dashboard.courses.certification.toasts.create_error'));
         formik.setFieldValue('enable_certification', false);
@@ -188,7 +188,16 @@ function EditCourseCertification(props: EditCourseCertificationProps) {
           throw new Error('Failed to delete certification');
         }
       } catch (e) {
-        setError(t('dashboard.courses.certification.errors.remove_failed'));
+        // The backend refuses to delete a certification that has already awarded
+        // certificates, because deleting it destroys them and breaks the
+        // verification links their holders have shared. Show that reason instead
+        // of a generic failure — it tells the teacher what to do next.
+        const detail = (e as any)?.detail ?? (e as any)?.message;
+        setError(
+          typeof detail === 'string' && detail
+            ? detail
+            : t('dashboard.courses.certification.errors.remove_failed')
+        );
         toast.error(t('dashboard.courses.certification.toasts.remove_error'));
         formik.setFieldValue('enable_certification', true);
       }


### PR DESCRIPTION
`CertificateUser.certification_id` is declared `ON DELETE CASCADE`, so deleting a course's certification template also deletes every certificate ever awarded from it.

Turning the certification toggle off in the course dashboard is a single unconfirmed click that issues exactly that delete (`EditCourseCertification.tsx` → `deleteCertification`).

For the people holding those certificates:

- the certificate disappears from their trail page
- every verification link they shared — including the QR code printed on PDFs they already downloaded — starts telling the viewer the certificate has been revoked

None of it is recoverable. Re-enabling the toggle mints a template with a new id, and the only issuance trigger (`check_course_completion_and_create_certificate`) only fires on activity completion or grading, which a learner who already finished never hits again.

Two things made it worse:

- the endpoint's own OpenAPI description said *"Existing awarded certificates are not removed"*
- the deliberate single-certificate path (`revoke_user_certificate`) emits `CERTIFICATE_REVOKED` analytics and webhooks precisely so downstream systems learn a credential died; the cascade emitted nothing, so integrations kept treating the destroyed certificates as valid

## Change

`delete_certification` now refuses with 409 when certificates have been awarded, naming how many. The dashboard surfaces that message instead of a generic failure, so the teacher is told what to do next. Certificates must be revoked individually, which keeps the revocation events intact. Deleting a template that has awarded nothing is unchanged.

The misleading endpoint description is corrected.

## Tests

New case asserting the refusal leaves both the template and the awarded certificate in place. Existing delete-path tests still pass (63 in the certifications suite; 587 across certifications + routers + trail).