### PR TITLE
fix(invites): key invites on the normalised address and count only pending ones

### DIFF
--- a/apps/api/src/services/orgs/users.py
+++ b/apps/api/src/services/orgs/users.py
@@ -867,7 +867,12 @@ async def invite_batch_users(
         if not _looks_like_email(candidate):
             invalid_results.append({"email": candidate, "status": "invalid_email"})
             continue
-        invite_list.append(candidate)
+        # Key invites on the lower-cased address. Every reader lower-cases before
+        # looking the key up (the OAuth invite gate, signup's invite consumption),
+        # so storing the admin's typed casing made an invite to "Jane.Doe@x.com"
+        # permanently unmatchable: the invitee could never consume it, it stayed
+        # "Pending" in the dashboard forever, and it kept occupying a member seat.
+        invite_list.append(candidate.lower())
 
     if len(invite_list) > INVITE_MAX_BATCH_SIZE:
         raise HTTPException(
@@ -891,9 +896,22 @@ async def invite_batch_users(
     # Count pending invites toward the member limit (not just joined members),
     # so a free org can't queue invitations that would exceed its cap once
     # accepted. Existing pending + new invites are both counted.
-    existing_pending = len(list(
-        r.scan_iter(match=f"invited_user:*:org:{org.org_uuid}", count=1000)
-    ))
+    #
+    # Only the ones still PENDING, though. Accepted invites keep their Redis key
+    # (flipped to pending=False) for the full 60 day TTL, so counting every key
+    # charged an accepted invitee twice — once as a real member and once as a
+    # phantom pending invite — and an org that had filled its seats through
+    # invitations was told it had hit the member limit while well under it.
+    existing_pending = 0
+    for key in r.scan_iter(match=f"invited_user:*:org:{org.org_uuid}", count=1000):
+        try:
+            record = json.loads(r.get(key))
+            if record.get("pending", True):
+                existing_pending += 1
+        except Exception:
+            # Unreadable record: count it, so a corrupt entry can't be used to
+            # slip past the cap.
+            existing_pending += 1
     await check_members_limit_with_pending(
         org.id, existing_pending + len(new_emails), db_session
     )
@@ -1074,6 +1092,11 @@ async def remove_invited_user(
             status_code=500,
             detail="Could not connect to Redis",
         )
+
+    # Invites are keyed on the lower-cased address (see invite_batch_users), so
+    # normalise here too — otherwise an admin who typed the address with any
+    # capitals could never withdraw the invitation they had just sent.
+    email = email.strip().lower()
 
     invited_user = r.get(f"invited_user:{email}:org:{org.org_uuid}")
 

--- a/apps/api/src/services/users/users.py
+++ b/apps/api/src/services/users/users.py
@@ -331,7 +331,14 @@ async def create_user_with_invite(
             statement = select(Organization).where(Organization.id == org_id)
             org = (await db_session.execute(statement)).scalars().first()
             if org:
-                redis_key = f"invited_user:{user_object.email}:org:{org.org_uuid}"
+                # Invites are keyed on the lower-cased address; without
+                # normalising here a signup that typed the address with
+                # different capitals left the invitation showing as "Pending"
+                # forever even though the person had joined.
+                redis_key = (
+                    f"invited_user:{user_object.email.strip().lower()}"
+                    f":org:{org.org_uuid}"
+                )
                 invited_data = r.get(redis_key)
                 if invited_data:
                     invited_record = json.loads(invited_data)


### PR DESCRIPTION
Two problems that made an organisation look full — and its invitations permanently stuck — while it was under its member limit.

## Mixed-case addresses were unmatchable

`invite_batch_users` stored the invite under the address exactly as the admin typed it, but every reader lower-cases first (the OAuth invite gate in `routers/auth.py`, invite consumption in `services/users/users.py`).

So an invitation to an address with any capital letter — `Jane.Doe@acme.com` — could never be matched:

- the invitee could not consume it
- it stayed badged **Pending** in the dashboard after they had already joined
- the admin could not withdraw it (`remove_invited_user` looked up the un-normalised key and 404'd)
- it kept occupying a member seat for the full 60-day TTL

Invites are now keyed on the normalised address on both sides — writing, consumption, and removal.

## Accepted invites were counted against the member cap

The limit check counted every `invited_user:*` key, but an accepted invite keeps its key (flipped to `pending: False`) until it expires. An accepted invitee was therefore charged twice: once as a real member in the database, once as a phantom pending invite.

An organisation that had filled its seats through invitations got *"Usage Limit has been reached for Members"* while well under its actual cap — and it stayed wrong for 60 days.

Only invites that are still pending count now. An unreadable record is still counted, so a corrupt entry cannot be used to slip past the limit.

## Tests

Full API suite passes (4017). The 4 `test_llm_ollama` failures are pre-existing and environmental — they call a local Ollama that has no model installed.