### PR TITLE
fix(auth): forward the client IP through the auth proxy, and log refresh outcomes

### DIFF
--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import timedelta, datetime, timezone
 from typing import Literal, Optional
 from fastapi import Depends, APIRouter, HTTPException, Response, status, Request, Form
@@ -192,6 +193,67 @@ def unset_auth_cookies(response: Response, request: Request = None):
     response.delete_cookie(key=JWT_REFRESH_COOKIE_NAME, domain=cookie_domain)
 
 
+_refresh_logger = logging.getLogger("learnhouse.auth.refresh")
+
+
+def _token_age_seconds(payload: dict | None) -> int | None:
+    """Seconds since the presented refresh token was issued, or None.
+
+    The key disambiguator for replay detection: a benign desync (two tabs, a
+    server-rendered page racing the client) re-presents a token seconds old,
+    while a genuinely stolen token is reused hours or days later.
+    """
+    if not payload:
+        return None
+    iat = payload.get("iat")
+    if not iat:
+        return None
+    try:
+        issued = datetime.fromtimestamp(iat, tz=timezone.utc)
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None
+    return int((datetime.now(timezone.utc) - issued).total_seconds())
+
+
+def _log_refresh_outcome(
+    outcome: str,
+    *,
+    user_id: int | None = None,
+    token_age_seconds: int | None = None,
+    level: int = logging.INFO,
+) -> None:
+    """Emit one structured line per refresh attempt, tagged with its outcome.
+
+    Exists because this endpoint had NO telemetry: when users reported being
+    randomly signed out, there was no way to tell an expired token from a
+    revocation from replay detection, and diagnosing it required reading the
+    code instead of querying. Outcomes are a closed set —
+    ``ok``, ``grace_reused``, ``rate_limited``, ``cookie_missing``,
+    ``undecodable``, ``no_subject``, ``user_not_found``, ``password_changed``,
+    ``revoked_before``, ``replay_detected`` — so they can be counted and alerted
+    on. A rising ``replay_detected`` or ``revoked_before`` rate is the signal
+    that sessions are being destroyed rather than expiring.
+
+    Never raises: telemetry must not be able to break authentication.
+    """
+    try:
+        _refresh_logger.log(
+            level,
+            "auth.refresh outcome=%s user_id=%s token_age_seconds=%s",
+            outcome,
+            user_id if user_id is not None else "-",
+            token_age_seconds if token_age_seconds is not None else "-",
+            extra={
+                "event": "auth.refresh",
+                "outcome": outcome,
+                "user_id": user_id,
+                "token_age_seconds": token_age_seconds,
+            },
+        )
+    except Exception:  # pragma: no cover - telemetry must never break auth
+        pass
+
+
 @router.get(
     "/refresh",
     summary="Refresh access token",
@@ -218,10 +280,14 @@ async def refresh(
     ``get_current_user`` — a refresh must not outlive either. Rotates the
     refresh cookie on every call; the old token's ``jti`` is marked consumed
     in Redis, and replay is treated as theft (all sessions revoked).
+
+    Every exit path emits an ``auth.refresh`` log line tagged with its outcome —
+    see :func:`_log_refresh_outcome`.
     """
     # Rate limit refresh endpoint to prevent brute force attacks
     is_allowed, retry_after = check_refresh_rate_limit(request)
     if not is_allowed:
+        _log_refresh_outcome("rate_limited")
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail={
@@ -239,18 +305,24 @@ async def refresh(
 
     refresh_token = request.cookies.get(JWT_REFRESH_COOKIE_NAME)
     if not refresh_token:
+        _log_refresh_outcome("cookie_missing")
         raise credentials_exception
 
     payload = decode_refresh_token(refresh_token)
     if not payload:
+        # Bad signature, wrong token type, or — overwhelmingly the common case —
+        # naturally expired.
+        _log_refresh_outcome("undecodable")
         raise credentials_exception
 
     email = payload.get("sub")
     if not email:
+        _log_refresh_outcome("no_subject")
         raise credentials_exception
 
     user = await security_get_user(request, db_session, email=email)
     if user is None or user.id is None:
+        _log_refresh_outcome("user_not_found", token_age_seconds=_token_age_seconds(payload))
         raise credentials_exception
 
     # Enforce password-change cutover: tokens minted before the user's last
@@ -267,9 +339,17 @@ async def refresh(
     if isinstance(pca_raw, datetime) and issued_at is not None:
         pca = pca_raw if pca_raw.tzinfo else pca_raw.replace(tzinfo=timezone.utc)
         if issued_at < pca:
+            _log_refresh_outcome(
+                "password_changed", user_id=user.id, token_age_seconds=_token_age_seconds(payload)
+            )
             raise credentials_exception
 
     if _is_token_revoked_for_user(user.id, issued_at):
+        # The user's sessions were revoked after this token was issued — by an
+        # explicit logout, or by replay detection firing on another request.
+        _log_refresh_outcome(
+            "revoked_before", user_id=user.id, token_age_seconds=_token_age_seconds(payload)
+        )
         raise credentials_exception
 
     # One-time-use rotation with replay detection and a benign-replay grace
@@ -297,6 +377,16 @@ async def refresh(
                 await _asyncio.sleep(0.1)
             if reused_pair is None:
                 # No live grace entry → replay outside the window → theft.
+                # This is the single most destructive outcome (it revokes every
+                # session on every device), so it is logged at WARNING with the
+                # token's age — a benign desync shows up as a young token, real
+                # theft as an old one.
+                _log_refresh_outcome(
+                    "replay_detected",
+                    user_id=user.id,
+                    token_age_seconds=_token_age_seconds(payload),
+                    level=logging.WARNING,
+                )
                 revoke_user_sessions_before(user.id)
                 raise credentials_exception
 
@@ -334,6 +424,12 @@ async def refresh(
         domain=cookie_domain,
         max_age=int(JWT_REFRESH_TOKEN_EXPIRES.total_seconds()),
     )
+    _log_refresh_outcome(
+        "grace_reused" if reused_pair is not None else "ok",
+        user_id=user.id,
+        token_age_seconds=_token_age_seconds(payload),
+    )
+
     # Return the rotated refresh token in the body so a Next.js route handler
     # acting as a proxy can mirror the rotation onto its own cookies. Without
     # this, browsers behind a proxy keep the OLD refresh token (now consumed

--- a/apps/api/src/tests/routers/test_auth_router.py
+++ b/apps/api/src/tests/routers/test_auth_router.py
@@ -1,6 +1,7 @@
 """Router tests for src/routers/auth.py."""
 
-from datetime import datetime, timedelta
+import logging
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -685,3 +686,121 @@ class TestAuthRouter:
         ):
             response = await client.delete("/api/v1/auth/logout")
         assert response.status_code == 401
+
+
+class TestRefreshOutcomeTelemetry:
+    """Every exit path from /auth/refresh must emit one tagged outcome.
+
+    Added after an unexplained wave of sign-outs could not be diagnosed from
+    telemetry — there was none on this endpoint — and required a code audit.
+    A rising replay_detected/revoked_before rate is the signal that sessions are
+    being destroyed rather than expiring naturally.
+    """
+
+    async def test_missing_cookie_logs_cookie_missing(self, client, caplog):
+        with patch(
+            "src.routers.auth.check_refresh_rate_limit", return_value=(True, None)
+        ):
+            with caplog.at_level(logging.INFO, logger="learnhouse.auth.refresh"):
+                response = await client.get("/api/v1/auth/refresh")
+        assert response.status_code == 401
+        assert any(getattr(r, "outcome", None) == "cookie_missing" for r in caplog.records)
+
+    async def test_rate_limited_logs_rate_limited(self, client, caplog):
+        with patch(
+            "src.routers.auth.check_refresh_rate_limit", return_value=(False, 60)
+        ):
+            with caplog.at_level(logging.INFO, logger="learnhouse.auth.refresh"):
+                response = await client.get("/api/v1/auth/refresh")
+        assert response.status_code == 429
+        assert any(getattr(r, "outcome", None) == "rate_limited" for r in caplog.records)
+
+    async def test_undecodable_token_logs_undecodable(self, client, caplog):
+        with patch(
+            "src.routers.auth.check_refresh_rate_limit", return_value=(True, None)
+        ), patch("src.routers.auth.decode_refresh_token", return_value=None):
+            with caplog.at_level(logging.INFO, logger="learnhouse.auth.refresh"):
+                response = await client.get(
+                    "/api/v1/auth/refresh",
+                    cookies={JWT_REFRESH_COOKIE_NAME: "refresh-token"},
+                )
+        assert response.status_code == 401
+        assert any(getattr(r, "outcome", None) == "undecodable" for r in caplog.records)
+
+    async def test_replay_logs_replay_detected_at_warning_with_token_age(
+        self, client, auth_user, caplog
+    ):
+        """Replay is the most destructive outcome — it revokes every session on
+        every device — so it is logged at WARNING with the token's age, which is
+        what separates a benign desync from real theft."""
+        issued_at = int((datetime.now(timezone.utc) - timedelta(hours=3)).timestamp())
+        with patch(
+            "src.routers.auth.check_refresh_rate_limit", return_value=(True, None)
+        ), patch(
+            "src.routers.auth.decode_refresh_token",
+            return_value={
+                "sub": auth_user.email,
+                "iat": issued_at,
+                "exp": 9_999_999_999,
+                "jti": "replayed-jti",
+            },
+        ), patch(
+            "src.routers.auth.security_get_user",
+            new_callable=AsyncMock,
+            return_value=auth_user,
+        ), patch(
+            "src.routers.auth._is_token_revoked_for_user", return_value=False
+        ), patch(
+            "src.routers.auth._mark_refresh_jti_used", return_value=False
+        ), patch(
+            "src.routers.auth._get_refresh_grace", return_value=None
+        ), patch(
+            "src.routers.auth.revoke_user_sessions_before"
+        ):
+            with caplog.at_level(logging.INFO, logger="learnhouse.auth.refresh"):
+                response = await client.get(
+                    "/api/v1/auth/refresh",
+                    cookies={JWT_REFRESH_COOKIE_NAME: "refresh-token"},
+                )
+        assert response.status_code == 401
+        record = next(
+            (r for r in caplog.records if getattr(r, "outcome", None) == "replay_detected"),
+            None,
+        )
+        assert record is not None
+        assert record.levelno == logging.WARNING
+        # ~3 hours old — old enough to look like theft rather than a tab race.
+        assert record.token_age_seconds is not None
+        assert record.token_age_seconds > 3000
+
+    async def test_success_logs_ok(self, client, auth_user, caplog):
+        with patch(
+            "src.routers.auth.check_refresh_rate_limit", return_value=(True, None)
+        ), patch(
+            "src.routers.auth.decode_refresh_token",
+            return_value={
+                "sub": auth_user.email,
+                "iat": int(datetime.now(timezone.utc).timestamp()),
+                "exp": 9_999_999_999,
+                "jti": "legit-jti",
+            },
+        ), patch(
+            "src.routers.auth.security_get_user",
+            new_callable=AsyncMock,
+            return_value=auth_user,
+        ), patch(
+            "src.routers.auth._is_token_revoked_for_user", return_value=False
+        ), patch(
+            "src.routers.auth._mark_refresh_jti_used", return_value=True
+        ), patch(
+            "src.routers.auth.get_cookie_domain_for_request", return_value=None
+        ), patch(
+            "src.routers.auth.is_request_secure", return_value=False
+        ):
+            with caplog.at_level(logging.INFO, logger="learnhouse.auth.refresh"):
+                response = await client.get(
+                    "/api/v1/auth/refresh",
+                    cookies={JWT_REFRESH_COOKIE_NAME: "refresh-token"},
+                )
+        assert response.status_code == 200
+        assert any(getattr(r, "outcome", None) == "ok" for r in caplog.records)

--- a/apps/web/app/api/auth/[...path]/route.ts
+++ b/apps/web/app/api/auth/[...path]/route.ts
@@ -104,6 +104,29 @@ function appendClearAuthCookies(response: NextResponse, request: NextRequest) {
   }
 }
 
+// Headers that identify the ORIGINAL caller, relayed to the backend untouched.
+//
+// This proxy is server-to-server: with nothing forwarded, the backend sees the
+// Next.js pod as the client for EVERY request. Its per-IP limits — login
+// (30/5min), signup (10/hour), refresh (600/min) — then share ONE bucket across
+// the whole deployment instead of being per caller. A single person retrying a
+// password could lock every user out of signing in, and the limits stop being
+// brute-force protection at all because they cannot tell callers apart. The
+// account-lockout bookkeeping records the attempting IP too, so it was logging
+// this pod for every failed login.
+//
+// Relayed verbatim rather than parsed: the backend's get_client_ip already owns
+// the chain-parsing rules (and only trusts these at all when the connection
+// comes from a private address). Re-deriving a single IP here would mean the
+// same header is interpreted two different ways in two places.
+//
+// NOTE: this inherits the deployment requirement the backend already documents
+// — the ingress MUST overwrite, not append to, a client-supplied
+// X-Forwarded-For. Otherwise a caller can prepend a fake IP and evade the
+// limits. That requirement is unchanged by this proxy; it applies equally to
+// requests that reach the API directly.
+const CLIENT_IDENTITY_HEADERS = ['x-forwarded-for', 'x-real-ip', 'user-agent']
+
 async function proxyRequest(
   request: NextRequest,
   method: string
@@ -129,6 +152,11 @@ async function proxyRequest(
   const authHeader = request.headers.get('authorization')
   if (authHeader) {
     headers['Authorization'] = authHeader
+  }
+
+  for (const name of CLIENT_IDENTITY_HEADERS) {
+    const value = request.headers.get(name)
+    if (value) headers[name] = value
   }
 
   // Forward cookies to backend


### PR DESCRIPTION
## Client IP

The `/api/auth/*` proxy is server-to-server and forwarded nothing identifying the original caller, so the backend saw the Next.js pod as the client for every login, signup, refresh and oauth request. Its per-IP limits — login 30/5min, signup 10/hour, refresh 600/min — therefore shared **one bucket across the whole deployment** instead of being per caller: one person retrying a password could lock every user out of signing in, and the limits gave no brute-force protection because they could not tell callers apart. Account-lockout bookkeeping was recording the pod's address for every failed attempt too.

The sibling `token-exchange` route already forwarded these headers; this path did not.

Relays `x-forwarded-for` / `x-real-ip` / `user-agent` verbatim rather than parsing them, so the backend's `get_client_ip` keeps sole ownership of the chain-parsing rules — otherwise the same header is interpreted two different ways in two places.

**Deployment note:** this inherits the requirement the backend already documents — the ingress must *overwrite*, not append to, a client-supplied `X-Forwarded-For`, or a caller can prepend a fake IP and evade the limits. That constraint is unchanged by this proxy (it applies equally to requests reaching the API directly), but worth confirming on the ingress config.

## Refresh telemetry

`/auth/refresh` had no telemetry at all. Diagnosing a wave of unexplained sign-outs previously required reading the code, because nothing distinguished an expired token from a revocation from replay detection.

Every exit path now emits one structured `auth.refresh` line from a closed set of outcomes — `ok`, `grace_reused`, `rate_limited`, `cookie_missing`, `undecodable`, `no_subject`, `user_not_found`, `password_changed`, `revoked_before`, `replay_detected` — plus the presented token's age. `replay_detected` logs at WARNING: it revokes every session on every device, and the token age is what separates a benign tab race (seconds) from real theft (hours).

A rising `replay_detected` or `revoked_before` rate is the signal that sessions are being destroyed rather than expiring.

## Testing

API suite passes (4021), including 5 new tests pinning the outcome tags. Typecheck and lint clean on the proxy.