### PR TITLE
fix(courses): activity access gates and learner progress tracking

### DIFF
--- a/apps/api/src/services/courses/activities/activities.py
+++ b/apps/api/src/services/courses/activities/activities.py
@@ -139,6 +139,18 @@ async def get_activity(
     # RBAC check
     await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
 
+    # Drafts are author-only. This path applied the paid and lock gates but never
+    # consulted `published`, so a draft's full body was served to anyone who
+    # could READ the parent course. The author bypass matters: this same function
+    # backs the editor, which must keep loading unpublished activities.
+    if not activity.published and not await can_see_unpublished_activities(
+        request, course.course_uuid, current_user, db_session
+    ):
+        raise HTTPException(
+            status_code=404,
+            detail="Activity not found",
+        )
+
     # Paid access check (via EE hook with fallback to True if EE not available)
     has_paid_access = await check_ee_activity_paid_access(
         request=request,
@@ -251,6 +263,32 @@ async def get_editor_bootstrap(
     )
 
 
+async def can_see_unpublished_activities(
+    request: Request,
+    course_uuid: str,
+    current_user,
+    db_session: AsyncSession,
+) -> bool:
+    """Whether this principal may see draft (unpublished) activities.
+
+    Only users who can EDIT the course — authors/admins — see drafts; everyone
+    else gets the published subset. Mirrors the downgrade the course-meta router
+    applies to its client-controlled ``with_unpublished_activities`` flag, so
+    every read path agrees on the rule instead of each re-deriving it.
+
+    Non-raising: callers use it to filter, not to reject.
+    """
+    decision = await check_resource_access(
+        request,
+        db_session,
+        current_user,
+        course_uuid,
+        AccessAction.UPDATE,
+        raise_on_deny=False,
+    )
+    return bool(decision.allowed)
+
+
 async def _apply_activity_lock(
     activity_read: ActivityRead,
     activity: Activity,
@@ -353,7 +391,33 @@ async def get_activityby_id(
     # RBAC check
     await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
 
-    return ActivityRead.model_validate(activity)
+    # SECURITY: this endpoint returns the same ActivityRead for the same resource
+    # as get_activity(), so it must apply the same three gates. It previously
+    # applied only RBAC — which is course-scoped and delegates activities to the
+    # parent course, so it can never enforce a per-activity lock or a purchase.
+    # Fetching by numeric id instead of uuid therefore handed over paid content,
+    # usergroup-locked content, and unpublished drafts in full.
+    if not activity.published and not await can_see_unpublished_activities(
+        request, course.course_uuid, current_user, db_session
+    ):
+        raise HTTPException(
+            status_code=404,
+            detail="Activity not found",
+        )
+
+    has_paid_access = await check_ee_activity_paid_access(
+        request=request,
+        activity_id=activity.id,
+        user=current_user,
+        db_session=db_session,
+    )
+
+    activity_read = ActivityRead.model_validate(activity)
+    activity_read.content = activity_read.content if has_paid_access else {"paid_access": False}
+
+    await _apply_activity_lock(activity_read, activity, course, current_user, db_session)
+
+    return activity_read
 
 
 async def update_activity(
@@ -534,4 +598,19 @@ async def get_activities(
     _, chapter, course = results[0]
     await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
 
-    return [ActivityRead.model_validate(activity) for activity, _, _ in results]
+    # Locks are enforced in the service layer, never by RBAC (which resolves an
+    # activity up to its parent course and so cannot see per-activity
+    # lock_type). Both sibling read paths strip locked bodies —
+    # _apply_locks_to_chapters for the chapter tree, _apply_activity_lock for a
+    # single activity — but this list endpoint returned the same ActivityRead
+    # shape with neither, making the lock a UI-only gate here: the API handed
+    # over the very content it was supposed to withhold.
+    activity_reads: list[ActivityRead] = []
+    for activity, _, _ in results:
+        activity_read = ActivityRead.model_validate(activity)
+        await _apply_activity_lock(
+            activity_read, activity, course, current_user, db_session, parent_chapter=chapter
+        )
+        activity_reads.append(activity_read)
+
+    return activity_reads

--- a/apps/api/src/services/courses/certifications.py
+++ b/apps/api/src/services/courses/certifications.py
@@ -636,12 +636,23 @@ async def are_course_assignments_passed(
     # Assignments that belong to activities actually in this course. Use an
     # IN-subquery (not a join) so an activity reused across chapters isn't
     # double-counted.
+    #
+    # Only assignments a learner can actually reach count toward the gate. This
+    # previously included assignments whose activity is unpublished (and drafts
+    # of the assignment itself), which the learner is never served — so an
+    # unfinishable requirement sat in front of the certificate forever. This
+    # mirrors is_course_fully_completed, which filters `Activity.published` for
+    # exactly the same reason.
     assignments = (await db_session.execute(
         select(Assignment).where(
             Assignment.course_id == course_id,
+            Assignment.published == True,  # noqa: E712
             Assignment.activity_id.in_(
-                select(ChapterActivity.activity_id).where(
-                    ChapterActivity.course_id == course_id
+                select(ChapterActivity.activity_id)
+                .join(Activity, Activity.id == ChapterActivity.activity_id)
+                .where(
+                    ChapterActivity.course_id == course_id,
+                    Activity.published == True,  # noqa: E712
                 )
             ),
         )

--- a/apps/api/src/services/courses/chapters.py
+++ b/apps/api/src/services/courses/chapters.py
@@ -121,13 +121,27 @@ async def get_chapter(
     # RBAC check
     await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
 
-    # Get activities for this chapter
+    # Get activities for this chapter.
+    #
+    # Drafts are author-only, and this was the one chapter/activity read path
+    # that ignored that: get_course_chapters gates on with_unpublished_activities
+    # and get_activities filters `published` outright, but this endpoint returned
+    # unpublished activities — with full content — to anyone who could READ the
+    # course. The author bypass keeps the editor working.
+    from src.services.courses.activities.activities import can_see_unpublished_activities
+
+    include_unpublished = await can_see_unpublished_activities(
+        request, course.course_uuid, current_user, db_session
+    )
+
     statement = (
         select(Activity)
         .join(ChapterActivity, Activity.id == ChapterActivity.activity_id) # type: ignore
         .where(ChapterActivity.chapter_id == chapter_id)
         .distinct(Activity.id) # type: ignore
     )
+    if not include_unpublished:
+        statement = statement.where(Activity.published == True)  # noqa: E712
 
     activities = (await db_session.execute(statement)).scalars().all()
 

--- a/apps/api/src/services/trail/trail.py
+++ b/apps/api/src/services/trail/trail.py
@@ -47,9 +47,24 @@ async def _build_trail_read(
     # Batch fetch chapter activity counts per course (for total_steps)
     course_total_steps_map: dict[int, int] = {}
     if with_course_info and course_ids:
+        # Only PUBLISHED activities count toward the total, matching
+        # is_course_fully_completed (services/courses/certifications.py). That
+        # check deliberately joins Activity and filters `published`, noting that
+        # counting drafts "would make the course impossible to complete". This
+        # denominator did not, so the two disagreed: a course containing any
+        # draft activity showed e.g. 4/5 (80%) on the trail page forever, even
+        # though the backend considered it complete and had issued the
+        # certificate. Because the trail card gates its certificate row on
+        # progress === 100, the learner's earned certificate never appeared
+        # there — and no amount of work could fix it, since drafts are never
+        # served to learners in the first place.
         step_counts = (await db_session.execute(
             select(ChapterActivity.course_id, func.count(ChapterActivity.id))  # type: ignore
-            .where(ChapterActivity.course_id.in_(course_ids))  # type: ignore
+            .join(Activity, Activity.id == ChapterActivity.activity_id)  # type: ignore
+            .where(
+                ChapterActivity.course_id.in_(course_ids),  # type: ignore
+                Activity.published == True,  # noqa: E712
+            )
             .group_by(ChapterActivity.course_id)
         )).all()
         course_total_steps_map = {row[0]: row[1] for row in step_counts}

--- a/apps/api/src/tests/services/test_activities_service.py
+++ b/apps/api/src/tests/services/test_activities_service.py
@@ -413,3 +413,95 @@ class TestGetActivities:
             result = await get_activities(mock_request, chapter.id, admin_user, db)
         assert isinstance(result, list)
         assert len(result) >= 1
+
+
+class TestDraftAndLockGatesOnReadPaths:
+    """The three activity read paths must agree on who sees what.
+
+    They return the same ActivityRead for the same rows, but each applied a
+    different subset of the published / paid / lock gates — so picking a
+    different endpoint handed over content the others withheld.
+    """
+
+    @staticmethod
+    def _access(allowed: bool):
+        """check_resource_access stub whose non-raising decision is controllable."""
+        return AsyncMock(return_value=MagicMock(allowed=allowed))
+
+    @pytest.mark.asyncio
+    async def test_get_activityby_id_hides_draft_from_non_author(
+        self, mock_request, db, org, course, chapter, activity, admin_user
+    ):
+        activity.published = False
+        db.add(activity)
+        await db.commit()
+        with patch(
+            "src.services.courses.activities.activities.check_resource_access",
+            self._access(False),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await get_activityby_id(mock_request, activity.id, admin_user, db)
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_activityby_id_shows_draft_to_author(
+        self, mock_request, db, org, course, chapter, activity, admin_user
+    ):
+        activity.published = False
+        db.add(activity)
+        await db.commit()
+        with patch(
+            "src.services.courses.activities.activities.check_resource_access",
+            self._access(True),
+        ):
+            result = await get_activityby_id(mock_request, activity.id, admin_user, db)
+        assert isinstance(result, ActivityRead)
+        assert result.id == activity.id
+
+    @pytest.mark.asyncio
+    async def test_get_activity_hides_draft_from_non_author(
+        self, mock_request, db, org, course, chapter, activity, admin_user
+    ):
+        activity.published = False
+        db.add(activity)
+        await db.commit()
+        with patch(
+            "src.services.courses.activities.activities.check_resource_access",
+            self._access(False),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await get_activity(mock_request, activity.activity_uuid, admin_user, db)
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_activity_shows_draft_to_author(
+        self, mock_request, db, org, course, chapter, activity, admin_user
+    ):
+        """The editor loads unpublished activities through this path — the draft
+        filter must never lock authors out of their own work."""
+        activity.published = False
+        db.add(activity)
+        await db.commit()
+        with patch(
+            "src.services.courses.activities.activities.check_resource_access",
+            self._access(True),
+        ):
+            result = await get_activity(mock_request, activity.activity_uuid, admin_user, db)
+        assert isinstance(result, ActivityRead)
+
+    @pytest.mark.asyncio
+    async def test_get_activities_applies_lock_stripping(
+        self, mock_request, db, org, course, chapter, activity, admin_user
+    ):
+        """Locks are enforced in the service layer, not by RBAC, so a list
+        endpoint that skips _apply_activity_lock leaks the withheld body."""
+        with patch(
+            "src.services.courses.activities.activities.check_resource_access",
+            self._access(True),
+        ), patch(
+            "src.services.courses.activities.activities._apply_activity_lock",
+            new_callable=AsyncMock,
+        ) as lock_mock:
+            results = await get_activities(mock_request, chapter.id, admin_user, db)
+        assert len(results) >= 1
+        assert lock_mock.await_count == len(results)

--- a/apps/api/src/tests/services/test_chapters_service.py
+++ b/apps/api/src/tests/services/test_chapters_service.py
@@ -858,3 +858,76 @@ class TestApplyLocksToChapters:
                     with_unpublished_activities=True, slim=False, course=course,
                 )
         assert len(full_result[0].activities) == 1
+
+
+class TestGetChapterDraftFiltering:
+    """get_chapter was the one chapter/activity read path that ignored
+    `published`, returning drafts with full content to any course reader."""
+
+    @staticmethod
+    def _access(allowed: bool):
+        from unittest.mock import MagicMock
+        return AsyncMock(return_value=MagicMock(allowed=allowed))
+
+    async def _add_draft(self, db, org, course, chapter):
+        from datetime import datetime
+        draft = Activity(
+            name="Draft Activity",
+            activity_type=ActivityTypeEnum.TYPE_DYNAMIC,
+            activity_sub_type=ActivitySubTypeEnum.SUBTYPE_DYNAMIC_PAGE,
+            activity_uuid="activity_draft_gate_test",
+            org_id=org.id,
+            course_id=course.id,
+            published=False,
+            content={"secret": "unreleased exam"},
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(draft)
+        await db.commit()
+        await db.refresh(draft)
+        db.add(ChapterActivity(
+            chapter_id=chapter.id,
+            activity_id=draft.id,
+            course_id=course.id,
+            org_id=org.id,
+            order=99,
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        ))
+        await db.commit()
+        return draft
+
+    @pytest.mark.asyncio
+    async def test_draft_hidden_from_non_author(
+        self, mock_request, db, org, course, chapter, activity, admin_user
+    ):
+        draft = await self._add_draft(db, org, course, chapter)
+        with patch(
+            "src.services.courses.chapters.check_resource_access", self._access(False)
+        ), patch(
+            "src.services.courses.activities.activities.check_resource_access",
+            self._access(False),
+        ), patch(
+            "src.services.courses.chapters._apply_locks_to_chapters",
+            new_callable=AsyncMock,
+        ):
+            result = await get_chapter(mock_request, chapter.id, admin_user, db)
+        assert draft.id not in [a.id for a in result.activities]
+
+    @pytest.mark.asyncio
+    async def test_draft_visible_to_author(
+        self, mock_request, db, org, course, chapter, activity, admin_user
+    ):
+        draft = await self._add_draft(db, org, course, chapter)
+        with patch(
+            "src.services.courses.chapters.check_resource_access", self._access(True)
+        ), patch(
+            "src.services.courses.activities.activities.check_resource_access",
+            self._access(True),
+        ), patch(
+            "src.services.courses.chapters._apply_locks_to_chapters",
+            new_callable=AsyncMock,
+        ):
+            result = await get_chapter(mock_request, chapter.id, admin_user, db)
+        assert draft.id in [a.id for a in result.activities]

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/course/[courseuuid]/activity/[activityid]/activity.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/course/[courseuuid]/activity/[activityid]/activity.tsx
@@ -290,6 +290,26 @@ function ActivityClient(props: ActivityClientProps) {
 
   // Memoize activity position calculation
   const { allActivities, currentIndex } = useActivityPosition(course, activityid);
+
+  // Focus-mode progress. Computed once and shared by the ring, the % label and
+  // the "N of M" text, which previously each inlined the same lookup — and each
+  // matched `run.course_uuid`, a field TrailRunRead does not have (the course
+  // uuid lives at `run.course.course_uuid`). Every match failed, so the ring sat
+  // at 0% and the text read "0 of M" no matter how much the learner completed,
+  // while the normal progress bar on the same page showed the truth.
+  const focusProgress = useMemo(() => {
+    const cleanCourseUuid = course?.course_uuid?.replace('course_', '');
+    const run = trailData?.runs?.find(
+      (r: any) => r.course?.course_uuid?.replace('course_', '') === cleanCourseUuid
+    );
+    const completed = run?.steps?.filter((step: any) => step.complete)?.length || 0;
+    const total =
+      course?.chapters?.reduce(
+        (acc: number, chapter: any) => acc + (chapter.activities?.length || 0),
+        0
+      ) || 0;
+    return { completed, total, percent: total > 0 ? Math.round((completed / total) * 100) : 0 };
+  }, [trailData, course]);
   
   // Get previous and next activities
   const prevActivity = currentIndex > 0 ? allActivities[currentIndex - 1] : null;
@@ -589,17 +609,17 @@ function ActivityClient(props: ActivityClientProps) {
                                 fill="none"
                                 strokeLinecap="round"
                                 strokeDasharray={2 * Math.PI * 14}
-                                strokeDashoffset={2 * Math.PI * 14 * (1 - (trailData?.runs?.find((run: any) => run.course_uuid === course.course_uuid)?.steps?.filter((step: any) => step.complete)?.length || 0) / (course.chapters?.reduce((acc: number, chapter: any) => acc + chapter.activities.length, 0) || 1))}
+                                strokeDashoffset={2 * Math.PI * 14 * (1 - focusProgress.percent / 100)}
                               />
                             </svg>
                             <div className="absolute inset-0 flex items-center justify-center">
                               <span className="text-xs font-bold text-gray-800">
-                                {Math.round(((trailData?.runs?.find((run: any) => run.course_uuid === course.course_uuid)?.steps?.filter((step: any) => step.complete)?.length || 0) / (course.chapters?.reduce((acc: number, chapter: any) => acc + chapter.activities.length, 0) || 1)) * 100)}%
+                                {focusProgress.percent}%
                               </span>
                             </div>
                           </div>
                           <div className="text-xs text-gray-600">
-                            {trailData?.runs?.find((run: any) => run.course_uuid === course.course_uuid)?.steps?.filter((step: any) => step.complete)?.length || 0} {t('common.of')} {course.chapters?.reduce((acc: number, chapter: any) => acc + chapter.activities.length, 0) || 0}
+                            {focusProgress.completed} {t('common.of')} {focusProgress.total}
                           </div>
                         </motion.div>
                         
@@ -1120,9 +1140,21 @@ export function MarkStatus(props: {
     </svg>
   );
 
+  // Whether marking the CURRENT activity complete will finish the course.
+  //
+  // Both lookups here were wrong against the actual trail payload: runs were
+  // matched on `run.course_uuid` (TrailRunRead has no such field — the uuid is
+  // nested at `run.course.course_uuid`) and steps on `step.activity_uuid`
+  // (TrailStep carries `activity_id`). The run lookup therefore always failed
+  // and this returned false for everyone, so a learner who finished their last
+  // remaining activity out of order was routed to an activity they had already
+  // done instead of the course-end screen, and the CourseCompleted analytics
+  // event could never fire. isActivityCompleted just below gets both right —
+  // this now matches it.
   const areAllActivitiesCompleted = () => {
+    const cleanCourseUuid = props.course.course_uuid?.replace('course_', '');
     const run = props.trailData?.runs?.find(
-      (run: any) => run.course_uuid === props.course.course_uuid
+      (run: any) => run.course?.course_uuid?.replace('course_', '') === cleanCourseUuid
     );
     if (!run) return false;
 
@@ -1132,8 +1164,8 @@ export function MarkStatus(props: {
     props.course.chapters.forEach((chapter: any) => {
       chapter.activities.forEach((activity: any) => {
         totalActivities++;
-        const isCompleted = run.steps.find(
-          (step: any) => step.activity_uuid === activity.activity_uuid && step.complete === true
+        const isCompleted = run.steps?.find(
+          (step: any) => step.activity_id === activity.id && step.complete === true
         );
         if (isCompleted) {
           completedActivities++;
@@ -1141,6 +1173,8 @@ export function MarkStatus(props: {
       });
     });
 
+    // -1 is deliberate: this runs BEFORE the current activity's step is written,
+    // so "everything except this one" means this one finishes the course.
     return completedActivities >= totalActivities - 1;
   };
 

--- a/apps/web/components/Pages/Certificate/CertificateVerificationPage.tsx
+++ b/apps/web/components/Pages/Certificate/CertificateVerificationPage.tsx
@@ -306,8 +306,15 @@ const CertificateVerificationPage: React.FC<CertificateVerificationPageProps> = 
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1">Certification Type</label>
                   <div className="bg-gray-50 p-3 rounded-lg">
+                    {/* certification_type is free-form JSON config and is absent on
+                        certificates issued before it existed (and on any course whose
+                        certification was set up without it). Calling .replace on
+                        undefined threw and blanked the whole public verification page —
+                        the one page that must never fail to load. */}
                     <span className="text-gray-900 capitalize">
-                      {certificateData.certification.config.certification_type.replace('_', ' ')}
+                      {certificateData.certification.config?.certification_type
+                        ? certificateData.certification.config.certification_type.replace('_', ' ')
+                        : '—'}
                     </span>
                   </div>
                 </div>

--- a/apps/web/components/Pages/Trail/TrailCourseCard.tsx
+++ b/apps/web/components/Pages/Trail/TrailCourseCard.tsx
@@ -37,7 +37,13 @@ function TrailCourseCard(props: TrailCourseCardProps) {
   const course = props.course
   const router = useRouter()
   const course_total_steps = props.run.course_total_steps
-  const course_completed_steps = props.run.steps.length
+  // Only steps actually marked complete count. `steps` is the raw TrailStep
+  // list and genuinely contains incomplete rows — rejecting an assignment or
+  // starting a retry flips a step back to complete=False rather than deleting
+  // it. Counting the raw length showed a rejected learner "100% · Completed"
+  // while the course page correctly showed the work as outstanding, so they had
+  // no reason to resubmit. Every other progress consumer filters this way.
+  const course_completed_steps = props.run.steps.filter((step: any) => step.complete).length
   const orgID = org?.id
   const course_progress = course_total_steps > 0
     ? Math.round((course_completed_steps / course_total_steps) * 100)
@@ -56,7 +62,7 @@ function TrailCourseCard(props: TrailCourseCardProps) {
   }
 
   async function quitCourse(course_uuid: string) {
-    let activity = await removeCourse(course_uuid, props.orgslug, access_token)
+    await removeCourse(course_uuid, props.orgslug, access_token)
     await revalidateTags(['courses'], props.orgslug)
     router.refresh()
     if (orgID) {

--- a/apps/web/components/Pages/Trail/TrailCourseElement.tsx
+++ b/apps/web/components/Pages/Trail/TrailCourseElement.tsx
@@ -30,7 +30,13 @@ function TrailCourseElement(props: TrailCourseElementProps) {
   const course = props.course
   const router = useRouter()
   const course_total_steps = props.run.course_total_steps
-  const course_completed_steps = props.run.steps.length
+  // Only steps actually marked complete count. `steps` is the raw TrailStep
+  // list and genuinely contains incomplete rows — rejecting an assignment or
+  // starting a retry flips a step back to complete=False rather than deleting
+  // it. Counting the raw length showed a rejected learner "100% · Completed"
+  // while the course page correctly showed the work as outstanding, so they had
+  // no reason to resubmit. Every other progress consumer filters this way.
+  const course_completed_steps = props.run.steps.filter((step: any) => step.complete).length
   const orgID = org?.id
   const course_progress = course_total_steps > 0
     ? Math.round((course_completed_steps / course_total_steps) * 100)
@@ -50,7 +56,7 @@ function TrailCourseElement(props: TrailCourseElementProps) {
 
   async function quitCourse(course_uuid: string) {
     // Close activity
-    let activity = await removeCourse(course_uuid, props.orgslug, access_token)
+    await removeCourse(course_uuid, props.orgslug, access_token)
     // Mutate course
     await revalidateTags(['courses'], props.orgslug)
     router.refresh()


### PR DESCRIPTION
> Stacks on #956 — based on `fix/learner-ux-feedback`, so the diff stays reviewable. Retarget to `dev` once #956 merges.

## Activity access gates

Three read paths return the same `ActivityRead` for the same rows, but each applied a different subset of the published / paid-access / usergroup-lock gates, so picking a different endpoint returned content the others withheld. RBAC cannot cover this — it resolves an activity up to its parent course and never sees per-activity `lock_type` or a purchase.

- `get_activityby_id` applied only RBAC: fetching by numeric id instead of uuid returned paid content, usergroup-locked content and unpublished drafts in full.
- `get_chapter` never filtered `published`, returning drafts with their content to anyone who could read the course.
- `get_activities` filtered `published` but skipped lock stripping, making the lock UI-only on that endpoint.
- `get_activity` applied the paid and lock gates but never consulted `published`.

Adds a shared `can_see_unpublished_activities()` helper so every path derives "drafts are author-only" from one place. Authors keep seeing their drafts, which the editor depends on.

## Progress tracking

`TrailRunRead` exposes the course nested at `run.course.course_uuid` and `TrailStep` carries `activity_id`, but five call sites in the activity player matched `run.course_uuid` / `step.activity_uuid`, so every lookup failed silently:

- Focus-mode progress (ring, percentage, "N of M") was permanently stuck at 0% while the normal bar on the same page showed the real figure.
- `areAllActivitiesCompleted()` could never return true, so a learner finishing their last remaining activity out of order was routed to an activity they had already done rather than the course-end screen holding their certificate. The `CourseCompleted` event never fired for anyone.

Both now match the convention used by the ten other call sites, including `isActivityCompleted` directly below the second one.

Progress also counted work that was not done, or could not be done:

- Trail cards counted every `TrailStep` as complete, ignoring `step.complete`. Rejecting an assignment flips a step back rather than deleting it, so a learner whose work was rejected still saw "100% · Completed" and had no reason to resubmit.
- The trail denominator counted unpublished activities. `is_course_fully_completed` filters `Activity.published`, noting drafts "would make the course impossible to complete" — the trail page did not, so a course with any draft sat below 100% forever and its certificate row (gated on 100%) never appeared.
- The certificate gate required passing assignments on unpublished activities, which learners are never served.

Also stops the public certificate verification page throwing when a config has no `certification_type`.

## Testing

API suite passes (4028), including 7 new tests for the gates. Typecheck clean, 0 eslint errors, web tests pass. Not exercised in a browser.

## Not addressed

Two certificate org-scoping questions are left open deliberately, as product decisions rather than clear bugs: whether one org's public verify page should validate another org's certificate (verification is currently global by design), and whether "My Certificates" should be org-scoped (it lists the user's own certificates, so no data leak — but with the current org's media path).