### PR TITLE
fix(rbac): scope "Users Only" resources to their own organization

### DIFF
--- a/apps/api/src/security/rbac/resource_access.py
+++ b/apps/api/src/security/rbac/resource_access.py
@@ -806,12 +806,20 @@ class ResourceAccessChecker:
         )
         usergroup_resources = (await self.db_session.execute(usergroup_stmt)).scalars().all()
 
-        # If no UserGroups linked, resource is accessible to any authenticated user.
-        # UsersOnly semantics: public=false + no linked group = signed-in users only;
-        # the anonymous branch short-circuits above via user_id == 0.
+        # If no UserGroups linked, resource is accessible to any authenticated
+        # MEMBER OF ITS ORGANIZATION.
+        #
+        # UsersOnly semantics: public=false + no linked group = signed-in users
+        # only; the anonymous branch short-circuits above via user_id == 0.
+        # "Signed-in" alone is not enough: this returned True for any account on
+        # the deployment, so an admin who set a course, folder, media item, board
+        # or community to "Users Only" was in fact publishing it to every user of
+        # every other tenant. Membership in the owning org is what the setting is
+        # understood to mean.
         if not usergroup_resources:
-            self._usergroup_cache[cache_key] = True
-            return True
+            allowed = await self._is_member_of_resource_org(resource_uuid, user_id)
+            self._usergroup_cache[cache_key] = allowed
+            return allowed
 
         # Check if user is a member of any linked UserGroup
         usergroup_ids = [ugr.usergroup_id for ugr in usergroup_resources]
@@ -824,6 +832,39 @@ class ResourceAccessChecker:
         result = membership is not None
         self._usergroup_cache[cache_key] = result
         return result
+
+    async def _is_member_of_resource_org(self, resource_uuid: str, user_id: int) -> bool:
+        """Is the caller a member of the organization that owns this resource?
+
+        Used by the "signed-in users only" fallback, which must not treat an
+        account on another tenant as an authorized reader. Resources that carry
+        no org (or whose org cannot be resolved) fall back to the previous
+        signed-in-only behaviour rather than denying access, so this cannot
+        lock anyone out of a resource type it does not understand.
+        """
+        config = get_resource_config(resource_uuid)
+        if not config:
+            return True
+
+        resource = await self._get_resource(resource_uuid, config)
+        org_id = getattr(resource, "org_id", None) if resource else None
+
+        # Nested resources (chapters, activities…) carry no org_id of their own;
+        # resolve it from the parent the same way the rest of the checker does.
+        if org_id is None and resource is not None:
+            parent_uuid = await self._resolve_parent_resource_uuid(resource_uuid, config)
+            if parent_uuid:
+                parent_config = get_resource_config(parent_uuid)
+                if parent_config:
+                    parent = await self._get_resource(parent_uuid, parent_config)
+                    org_id = getattr(parent, "org_id", None) if parent else None
+
+        if org_id is None:
+            return True
+
+        from src.security.org_auth import is_org_member
+
+        return await is_org_member(user_id, org_id, self.db_session)
 
     async def _get_resource(self, resource_uuid: str, config: ResourceConfig):
         """Get the resource from the database with caching."""

--- a/apps/api/src/tests/security/test_rbac_cross_org.py
+++ b/apps/api/src/tests/security/test_rbac_cross_org.py
@@ -191,3 +191,50 @@ class TestCrossOrgRoleFallback:
             mock_request, alice.id, "create", "course_x", db
         )
         assert allowed is True
+
+
+class TestUsersOnlyIsOrgScoped:
+    """"Users Only" (public=false, no linked usergroup) means signed-in members
+    of the owning org — not every account on the deployment."""
+
+    @pytest.mark.asyncio
+    async def test_users_only_course_is_denied_to_another_orgs_member(
+        self, db, org, other_org, user_role, mock_request
+    ):
+        from src.security.rbac.resource_access import ResourceAccessChecker
+
+        outsider = _mk_user(db, uid=77, username="outsider", email="outsider@test.com")
+        _attach_role(db, user_id=outsider.id, org_id=other_org.id, role_id=user_role.id)
+
+        users_only = _mk_course(
+            db, cid=201, org_id=org.id, uuid="course_users_only", public=False
+        )
+
+        checker = ResourceAccessChecker(mock_request, db, outsider)
+        allowed = await checker._check_usergroup_membership(
+            users_only.course_uuid, is_public=False
+        )
+
+        assert allowed is False, (
+            "a signed-in member of another org must not reach a Users Only course"
+        )
+
+    @pytest.mark.asyncio
+    async def test_users_only_course_is_allowed_for_its_own_org_member(
+        self, db, org, user_role, mock_request
+    ):
+        from src.security.rbac.resource_access import ResourceAccessChecker
+
+        member = _mk_user(db, uid=78, username="insider", email="insider@test.com")
+        _attach_role(db, user_id=member.id, org_id=org.id, role_id=user_role.id)
+
+        users_only = _mk_course(
+            db, cid=202, org_id=org.id, uuid="course_users_only_own", public=False
+        )
+
+        checker = ResourceAccessChecker(mock_request, db, member)
+        allowed = await checker._check_usergroup_membership(
+            users_only.course_uuid, is_public=False
+        )
+
+        assert allowed is True, "the org's own member must still reach a Users Only course"


### PR DESCRIPTION
`_check_usergroup_membership` treated a resource with **no linked usergroup** as readable by any authenticated account on the deployment:

```python
# If no UserGroups linked, resource is accessible to any authenticated user.
if not usergroup_resources:
    return True
```

"Users Only" is exactly that state — `public=false` with no group attached. So an admin who set a course, folder, media item, board or community to Users Only was not restricting it to their organization; they were publishing it to every signed-in user of **every other tenant**. Anyone could create a free account on any org and read it.

The fallback now requires membership of the organization that owns the resource, which is what the setting is understood to mean.

Resources whose organization cannot be resolved (unknown resource type, missing row, no `org_id` on the resource or its parent) keep the previous signed-in-only behaviour rather than denying, so this cannot lock anyone out of a resource type the checker does not model. Nested resources resolve their org through the parent, the same way the rest of the checker does.

## Tests

Two new cases: a member of another org is denied a Users Only course; the owning org's own member still reaches it. Full API suite passes (4019) — the 4 `test_llm_ollama` failures are pre-existing and environmental.

## Scope

This is one root cause out of a verified backlog. Related cross-tenant findings still open, each needing its own change: unscoped `org_id` on the media library and folder listings, `create_media`/`create_folder` trusting a client-supplied `org_id`, the boards read path, playground usergroup listing, and `PUT/DELETE /users/{id}` across orgs.