### PR TITLE
fix: shareable links, join flow, org emails, certificate PDF, SCORM assets, submit feedback

### DIFF
--- a/apps/api/src/services/admin/admin.py
+++ b/apps/api/src/services/admin/admin.py
@@ -41,6 +41,7 @@ from src.services.courses.certifications import (
     create_certificate_user,
 )
 from src.services.email.utils import get_base_url_from_request
+from src.services.orgs.join_notifications import notify_user_joined_org
 from src.services.analytics.analytics import track
 from src.services.analytics import events as analytics_events
 from src.services.webhooks.dispatch import dispatch_webhooks
@@ -1086,6 +1087,10 @@ async def provision_user(
             },
         )
 
+        await notify_user_joined_org(
+            request, db_session, existing_user, token_user.org_id
+        )
+
         return UserRead.model_validate(existing_user)
 
     if (await db_session.execute(select(User).where(User.username == username))).scalars().first():
@@ -1141,6 +1146,10 @@ async def provision_user(
             "signup_method": "admin_api",
         },
     )
+
+    # Admin-provisioned accounts skip the signup flow entirely, so this is the
+    # only mail they get: it tells them the org exists and where to log in.
+    await notify_user_joined_org(request, db_session, user, token_user.org_id)
 
     return UserRead.model_validate(user)
 

--- a/apps/api/src/services/auth/utils.py
+++ b/apps/api/src/services/auth/utils.py
@@ -259,6 +259,13 @@ async def signWithGoogle(
 
             _invalidate_session_cache(user.id)
 
+            # Existing account joining a new org: the account-creation welcome
+            # only fires for brand new users, so without this the OAuth-invite
+            # path lands them in an org they were never told about.
+            from src.services.orgs.join_notifications import notify_user_joined_org
+
+            await notify_user_joined_org(request, db_session, user, org_id)
+
     # Update last login info
     client_ip = get_client_ip(request)
     await update_login_info(user, client_ip, db_session)

--- a/apps/api/src/services/email/translations.py
+++ b/apps/api/src/services/email/translations.py
@@ -67,6 +67,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.cta": "Join {org_name}",
         "invitation.footer": "This invitation was sent by @{inviter}. If you weren't expecting this, you can safely ignore it.",
 
+        "org_join.subject": "Welcome to {org_name}",
+        "org_join.heading": "You're in, {username}!",
+        "org_join.body": "You're now a member of {org_name}. Open your home page to browse courses and pick up where you left off.",
+        "org_join.cta": "Go to my courses",
+        "org_join.footer": "You're receiving this because you joined {org_name} on LearnHouse.",
+
         "role_changed.subject": "Your role in {org_name} has been updated",
         "role_changed.heading": "Your role has been updated",
         "role_changed.body_1": "Hi {username}, your role in <strong>{org_name}</strong> has been changed to <strong>{role}</strong>.",
@@ -105,6 +111,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.no_code_hint": "Cliquez sur le bouton ci-dessous pour commencer.",
         "invitation.cta": "Rejoindre {org_name}",
         "invitation.footer": "Cette invitation a été envoyée par @{inviter}. Si vous ne l'attendiez pas, vous pouvez l'ignorer.",
+
+        "org_join.subject": "Bienvenue chez {org_name}",
+        "org_join.heading": "Vous y êtes, {username} !",
+        "org_join.body": "Vous êtes désormais membre de {org_name}. Ouvrez votre page d'accueil pour parcourir les cours et reprendre là où vous en étiez.",
+        "org_join.cta": "Voir mes cours",
+        "org_join.footer": "Vous recevez cet e-mail parce que vous avez rejoint {org_name} sur LearnHouse.",
 
         "role_changed.subject": "Votre rôle dans {org_name} a été mis à jour",
         "role_changed.heading": "Votre rôle a été mis à jour",
@@ -145,6 +157,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.cta": "{org_name} beitreten",
         "invitation.footer": "Diese Einladung wurde von @{inviter} gesendet. Falls du sie nicht erwartet hast, kannst du sie ignorieren.",
 
+        "org_join.subject": "Willkommen bei {org_name}",
+        "org_join.heading": "Du bist dabei, {username}!",
+        "org_join.body": "Du bist jetzt Mitglied von {org_name}. Öffne deine Startseite, um Kurse zu entdecken und dort weiterzumachen, wo du aufgehört hast.",
+        "org_join.cta": "Zu meinen Kursen",
+        "org_join.footer": "Du erhältst diese E-Mail, weil du {org_name} auf LearnHouse beigetreten bist.",
+
         "role_changed.subject": "Deine Rolle in {org_name} wurde aktualisiert",
         "role_changed.heading": "Deine Rolle wurde aktualisiert",
         "role_changed.body_1": "Hallo {username}, deine Rolle in <strong>{org_name}</strong> wurde auf <strong>{role}</strong> geändert.",
@@ -183,6 +201,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.no_code_hint": "Haz clic en el botón de abajo para empezar.",
         "invitation.cta": "Unirse a {org_name}",
         "invitation.footer": "Esta invitación fue enviada por @{inviter}. Si no la esperabas, puedes ignorarla.",
+
+        "org_join.subject": "Bienvenido a {org_name}",
+        "org_join.heading": "¡Ya estás dentro, {username}!",
+        "org_join.body": "Ya eres miembro de {org_name}. Abre tu página de inicio para explorar los cursos y continuar donde lo dejaste.",
+        "org_join.cta": "Ver mis cursos",
+        "org_join.footer": "Recibes este correo porque te has unido a {org_name} en LearnHouse.",
 
         "role_changed.subject": "Tu rol en {org_name} ha sido actualizado",
         "role_changed.heading": "Tu rol ha sido actualizado",
@@ -223,6 +247,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.cta": "الانضمام إلى {org_name}",
         "invitation.footer": "أُرسلت هذه الدعوة من قِبل @{inviter}. إذا لم تكن تتوقعها، يمكنك تجاهلها.",
 
+        "org_join.subject": "مرحبًا بك في {org_name}",
+        "org_join.heading": "أهلاً بك، {username}!",
+        "org_join.body": "أنت الآن عضو في {org_name}. افتح صفحتك الرئيسية لتصفح الدورات ومتابعة ما بدأته.",
+        "org_join.cta": "الذهاب إلى دوراتي",
+        "org_join.footer": "تصلك هذه الرسالة لأنك انضممت إلى {org_name} على LearnHouse.",
+
         "role_changed.subject": "تم تحديث دورك في {org_name}",
         "role_changed.heading": "تم تحديث دورك",
         "role_changed.body_1": "مرحبًا {username}، تم تغيير دورك في <strong>{org_name}</strong> إلى <strong>{role}</strong>.",
@@ -261,6 +291,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.no_code_hint": "下のボタンから始めてください。",
         "invitation.cta": "{org_name}に参加",
         "invitation.footer": "この招待は@{inviter}さんから送信されました。心当たりがない場合は無視してかまいません。",
+
+        "org_join.subject": "{org_name} へようこそ",
+        "org_join.heading": "{username} さん、参加が完了しました！",
+        "org_join.body": "{org_name} のメンバーになりました。ホームからコースを探して、続きから学習を始めましょう。",
+        "org_join.cta": "コースを見る",
+        "org_join.footer": "このメールは、LearnHouse で {org_name} に参加したため送信されています。",
 
         "role_changed.subject": "{org_name}でのロールが更新されました",
         "role_changed.heading": "ロールが更新されました",
@@ -301,6 +337,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.cta": "Entrar em {org_name}",
         "invitation.footer": "Este convite foi enviado por @{inviter}. Se não estava à espera dele, pode ignorá-lo.",
 
+        "org_join.subject": "Bem-vindo à {org_name}",
+        "org_join.heading": "Você entrou, {username}!",
+        "org_join.body": "Agora você é membro da {org_name}. Abra sua página inicial para explorar os cursos e continuar de onde parou.",
+        "org_join.cta": "Ver meus cursos",
+        "org_join.footer": "Você está recebendo este e-mail porque entrou na {org_name} no LearnHouse.",
+
         "role_changed.subject": "A sua função em {org_name} foi atualizada",
         "role_changed.heading": "A sua função foi atualizada",
         "role_changed.body_1": "Olá {username}, a sua função em <strong>{org_name}</strong> foi alterada para <strong>{role}</strong>.",
@@ -339,6 +381,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.no_code_hint": "Нажмите на кнопку ниже, чтобы начать.",
         "invitation.cta": "Вступить в {org_name}",
         "invitation.footer": "Это приглашение отправлено @{inviter}. Если вы его не ожидали, его можно проигнорировать.",
+
+        "org_join.subject": "Добро пожаловать в {org_name}",
+        "org_join.heading": "Вы с нами, {username}!",
+        "org_join.body": "Теперь вы участник {org_name}. Откройте главную страницу, чтобы посмотреть курсы и продолжить обучение.",
+        "org_join.cta": "Мои курсы",
+        "org_join.footer": "Вы получили это письмо, потому что присоединились к {org_name} в LearnHouse.",
 
         "role_changed.subject": "Ваша роль в {org_name} обновлена",
         "role_changed.heading": "Ваша роль обновлена",
@@ -379,6 +427,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.cta": "加入 {org_name}",
         "invitation.footer": "此邀请由 @{inviter} 发出。如果您并未预期，可忽略此邮件。",
 
+        "org_join.subject": "欢迎加入 {org_name}",
+        "org_join.heading": "{username}，你已加入！",
+        "org_join.body": "你现在是 {org_name} 的成员。打开主页浏览课程，继续之前的学习。",
+        "org_join.cta": "查看我的课程",
+        "org_join.footer": "你收到这封邮件是因为你在 LearnHouse 加入了 {org_name}。",
+
         "role_changed.subject": "您在 {org_name} 中的角色已更新",
         "role_changed.heading": "您的角色已更新",
         "role_changed.body_1": "您好 {username}，您在 <strong>{org_name}</strong> 中的角色已变更为 <strong>{role}</strong>。",
@@ -417,6 +471,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.no_code_hint": "शुरू करने के लिए नीचे बटन पर क्लिक करें।",
         "invitation.cta": "{org_name} में शामिल हों",
         "invitation.footer": "यह निमंत्रण @{inviter} द्वारा भेजा गया था। यदि आप इसकी अपेक्षा नहीं कर रहे थे, तो आप इसे अनदेखा कर सकते हैं।",
+
+        "org_join.subject": "{org_name} में आपका स्वागत है",
+        "org_join.heading": "आप जुड़ गए हैं, {username}!",
+        "org_join.body": "अब आप {org_name} के सदस्य हैं। कोर्स देखने और जहाँ छोड़ा था वहीं से शुरू करने के लिए अपना होम पेज खोलें।",
+        "org_join.cta": "मेरे कोर्स देखें",
+        "org_join.footer": "आपको यह ईमेल इसलिए मिला है क्योंकि आप LearnHouse पर {org_name} से जुड़े हैं।",
 
         "role_changed.subject": "{org_name} में आपकी भूमिका अपडेट कर दी गई है",
         "role_changed.heading": "आपकी भूमिका अपडेट की गई",
@@ -457,6 +517,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.cta": "{org_name} 참여",
         "invitation.footer": "이 초대는 @{inviter}님이 보냈습니다. 예상하지 못한 초대라면 무시하셔도 됩니다.",
 
+        "org_join.subject": "{org_name}에 오신 것을 환영합니다",
+        "org_join.heading": "{username}님, 가입이 완료되었어요!",
+        "org_join.body": "이제 {org_name}의 멤버입니다. 홈에서 코스를 둘러보고 이어서 학습해 보세요.",
+        "org_join.cta": "내 코스 보기",
+        "org_join.footer": "LearnHouse에서 {org_name}에 참여하여 이 메일을 받았습니다.",
+
         "role_changed.subject": "{org_name}에서의 역할이 변경되었습니다",
         "role_changed.heading": "역할이 변경되었습니다",
         "role_changed.body_1": "안녕하세요 {username}님, <strong>{org_name}</strong>에서의 역할이 <strong>{role}</strong>(으)로 변경되었습니다.",
@@ -495,6 +561,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.no_code_hint": "Clicca sul pulsante qui sotto per iniziare.",
         "invitation.cta": "Unisciti a {org_name}",
         "invitation.footer": "Questo invito è stato inviato da @{inviter}. Se non te lo aspettavi, puoi ignorarlo.",
+
+        "org_join.subject": "Benvenuto in {org_name}",
+        "org_join.heading": "Ci sei, {username}!",
+        "org_join.body": "Ora fai parte di {org_name}. Apri la tua home per esplorare i corsi e riprendere da dove avevi lasciato.",
+        "org_join.cta": "Vai ai miei corsi",
+        "org_join.footer": "Ricevi questa email perché ti sei unito a {org_name} su LearnHouse.",
 
         "role_changed.subject": "Il tuo ruolo in {org_name} è stato aggiornato",
         "role_changed.heading": "Il tuo ruolo è stato aggiornato",
@@ -535,6 +607,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.cta": "{org_name} organizasyonuna katıl",
         "invitation.footer": "Bu davet @{inviter} tarafından gönderildi. Beklemediysen yok sayabilirsin.",
 
+        "org_join.subject": "{org_name} organizasyonuna hoş geldiniz",
+        "org_join.heading": "Aramızdasınız, {username}!",
+        "org_join.body": "Artık {org_name} üyesisiniz. Kursları keşfetmek ve kaldığınız yerden devam etmek için ana sayfanızı açın.",
+        "org_join.cta": "Kurslarıma git",
+        "org_join.footer": "Bu e-postayı LearnHouse'ta {org_name} organizasyonuna katıldığınız için alıyorsunuz.",
+
         "role_changed.subject": "{org_name} organizasyonundaki rolün güncellendi",
         "role_changed.heading": "Rolün güncellendi",
         "role_changed.body_1": "Merhaba {username}, <strong>{org_name}</strong> organizasyonundaki rolün <strong>{role}</strong> olarak değiştirildi.",
@@ -573,6 +651,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.no_code_hint": "Nhấn vào nút bên dưới để bắt đầu.",
         "invitation.cta": "Tham gia {org_name}",
         "invitation.footer": "Lời mời này được gửi bởi @{inviter}. Nếu bạn không mong đợi nhận được lời mời này, bạn có thể bỏ qua.",
+
+        "org_join.subject": "Chào mừng bạn đến với {org_name}",
+        "org_join.heading": "Bạn đã tham gia, {username}!",
+        "org_join.body": "Bạn đã là thành viên của {org_name}. Mở trang chủ để khám phá các khóa học và tiếp tục từ chỗ bạn đang dở.",
+        "org_join.cta": "Xem khóa học của tôi",
+        "org_join.footer": "Bạn nhận được email này vì bạn đã tham gia {org_name} trên LearnHouse.",
 
         "role_changed.subject": "Vai trò của bạn trong {org_name} đã được cập nhật",
         "role_changed.heading": "Vai trò của bạn đã được cập nhật",
@@ -613,6 +697,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.cta": "Gabung {org_name}",
         "invitation.footer": "Undangan ini dikirim oleh @{inviter}. Jika Anda tidak mengharapkannya, Anda dapat mengabaikannya.",
 
+        "org_join.subject": "Selamat datang di {org_name}",
+        "org_join.heading": "Kamu sudah bergabung, {username}!",
+        "org_join.body": "Kamu kini anggota {org_name}. Buka halaman utama untuk menjelajahi kursus dan melanjutkan dari tempat terakhir.",
+        "org_join.cta": "Lihat kursus saya",
+        "org_join.footer": "Kamu menerima email ini karena bergabung dengan {org_name} di LearnHouse.",
+
         "role_changed.subject": "Peran Anda di {org_name} telah diperbarui",
         "role_changed.heading": "Peran Anda telah diperbarui",
         "role_changed.body_1": "Halo {username}, peran Anda di <strong>{org_name}</strong> telah diubah menjadi <strong>{role}</strong>.",
@@ -651,6 +741,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.no_code_hint": "Kliknij przycisk poniżej, aby rozpocząć.",
         "invitation.cta": "Dołącz do {org_name}",
         "invitation.footer": "To zaproszenie zostało wysłane przez @{inviter}. Jeśli się go nie spodziewałeś, możesz je zignorować.",
+
+        "org_join.subject": "Witamy w {org_name}",
+        "org_join.heading": "Jesteś już z nami, {username}!",
+        "org_join.body": "Jesteś teraz członkiem {org_name}. Otwórz stronę główną, aby przeglądać kursy i kontynuować naukę.",
+        "org_join.cta": "Przejdź do moich kursów",
+        "org_join.footer": "Otrzymujesz tę wiadomość, ponieważ dołączyłeś do {org_name} w LearnHouse.",
 
         "role_changed.subject": "Twoja rola w {org_name} została zaktualizowana",
         "role_changed.heading": "Twoja rola została zaktualizowana",
@@ -691,6 +787,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.cta": "Приєднатися до {org_name}",
         "invitation.footer": "Це запрошення надіслав @{inviter}. Якщо ви цього не очікували, можете проігнорувати його.",
 
+        "org_join.subject": "Ласкаво просимо до {org_name}",
+        "org_join.heading": "Ви приєдналися, {username}!",
+        "org_join.body": "Тепер ви учасник {org_name}. Відкрийте головну сторінку, щоб переглянути курси та продовжити навчання.",
+        "org_join.cta": "Мої курси",
+        "org_join.footer": "Ви отримали цей лист, тому що приєдналися до {org_name} у LearnHouse.",
+
         "role_changed.subject": "Вашу роль у {org_name} оновлено",
         "role_changed.heading": "Вашу роль оновлено",
         "role_changed.body_1": "Вітаємо, {username}! Вашу роль у <strong>{org_name}</strong> змінено на <strong>{role}</strong>.",
@@ -729,6 +831,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.no_code_hint": "Klik op de knop hieronder om te beginnen.",
         "invitation.cta": "Word lid van {org_name}",
         "invitation.footer": "Deze uitnodiging is verzonden door @{inviter}. Verwachtte je hem niet, dan kun je hem negeren.",
+
+        "org_join.subject": "Welkom bij {org_name}",
+        "org_join.heading": "Je doet mee, {username}!",
+        "org_join.body": "Je bent nu lid van {org_name}. Open je startpagina om cursussen te bekijken en verder te gaan waar je gebleven was.",
+        "org_join.cta": "Naar mijn cursussen",
+        "org_join.footer": "Je ontvangt deze e-mail omdat je bent toegetreden tot {org_name} op LearnHouse.",
 
         "role_changed.subject": "Je rol in {org_name} is bijgewerkt",
         "role_changed.heading": "Je rol is bijgewerkt",
@@ -769,6 +877,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.cta": "เข้าร่วม {org_name}",
         "invitation.footer": "คำเชิญนี้ถูกส่งโดย @{inviter} หากคุณไม่ได้คาดหวัง สามารถละเว้นได้",
 
+        "org_join.subject": "ยินดีต้อนรับสู่ {org_name}",
+        "org_join.heading": "คุณเข้าร่วมแล้ว {username}!",
+        "org_join.body": "ตอนนี้คุณเป็นสมาชิกของ {org_name} แล้ว เปิดหน้าแรกเพื่อดูคอร์สและเรียนต่อจากที่ค้างไว้",
+        "org_join.cta": "ไปที่คอร์สของฉัน",
+        "org_join.footer": "คุณได้รับอีเมลนี้เพราะคุณเข้าร่วม {org_name} บน LearnHouse",
+
         "role_changed.subject": "บทบาทของคุณใน {org_name} ได้รับการอัปเดต",
         "role_changed.heading": "บทบาทของคุณได้รับการอัปเดต",
         "role_changed.body_1": "สวัสดี {username} บทบาทของคุณใน <strong>{org_name}</strong> ถูกเปลี่ยนเป็น <strong>{role}</strong>",
@@ -807,6 +921,12 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
         "invitation.no_code_hint": "শুরু করতে নিচের বোতামে ক্লিক করুন।",
         "invitation.cta": "{org_name}-এ যোগ দিন",
         "invitation.footer": "এই আমন্ত্রণটি পাঠিয়েছেন @{inviter}। আপনি যদি এটি প্রত্যাশা না করে থাকেন, তাহলে নিরাপদে উপেক্ষা করতে পারেন।",
+
+        "org_join.subject": "{org_name}-এ স্বাগতম",
+        "org_join.heading": "আপনি যুক্ত হয়েছেন, {username}!",
+        "org_join.body": "আপনি এখন {org_name}-এর সদস্য। কোর্স দেখতে এবং যেখানে থেমেছিলেন সেখান থেকে শুরু করতে আপনার হোম পেজ খুলুন।",
+        "org_join.cta": "আমার কোর্স দেখুন",
+        "org_join.footer": "আপনি এই ইমেলটি পাচ্ছেন কারণ আপনি LearnHouse-এ {org_name}-এ যোগ দিয়েছেন।",
 
         "role_changed.subject": "{org_name}-এ আপনার ভূমিকা আপডেট হয়েছে",
         "role_changed.heading": "আপনার ভূমিকা আপডেট হয়েছে",

--- a/apps/api/src/services/orgs/join.py
+++ b/apps/api/src/services/orgs/join.py
@@ -12,6 +12,7 @@ from src.security.features_utils.usage import (
     increase_feature_usage,
 )
 from src.services.orgs.invites import get_invite_code
+from src.services.orgs.join_notifications import notify_user_joined_org
 from src.services.orgs.orgs import get_org_join_mechanism
 from src.services.users.usergroups import add_users_to_usergroup
 
@@ -123,6 +124,8 @@ async def join_org(
             from src.routers.users import _invalidate_session_cache
             _invalidate_session_cache(user.id)
 
+            await notify_user_joined_org(request, db_session, user, org.id, org=org)
+
             # Add user to UserGroup if invite code is linked to one
             if inviteCode.get("usergroup_id"):
                 await add_users_to_usergroup(
@@ -159,6 +162,8 @@ async def join_org(
             _invalidate_session_cache(user.id)
 
             await increase_feature_usage("members", org.id, db_session)
+
+            await notify_user_joined_org(request, db_session, user, org.id, org=org)
 
             return "Great, You're part of the Organization"
 

--- a/apps/api/src/services/orgs/join_notifications.py
+++ b/apps/api/src/services/orgs/join_notifications.py
@@ -1,0 +1,81 @@
+"""Notification sent when an account becomes a member of an organization.
+
+Every membership path funnels through :func:`notify_user_joined_org` so a user
+who joins an org gets the same greeting regardless of how they got in — invite
+code, open join, an OAuth invite accepted with an existing account, or admin
+provisioning.
+
+Brand-new signups are the one exception: ``send_account_creation_email``
+already welcomes them into the org they registered in, so those paths must not
+call this as well or the user receives two near-identical emails.
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import Request
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.db.organization_config import OrganizationConfig
+from src.db.organizations import Organization
+from src.db.users import User
+
+logger = logging.getLogger(__name__)
+
+
+async def notify_user_joined_org(
+    request: Request,
+    db_session: AsyncSession,
+    user: User,
+    org_id: int,
+    org: Optional[Organization] = None,
+) -> None:
+    """Email ``user`` a greeting and a link into the org they just joined.
+
+    Best-effort: every failure is swallowed and logged. Joining an
+    organization must never fail because a mail server is down.
+    """
+    try:
+        if not user or not getattr(user, "email", None):
+            return
+
+        if org is None:
+            org = (
+                await db_session.execute(
+                    select(Organization).where(Organization.id == org_id)
+                )
+            ).scalars().first()
+        if org is None:
+            return
+
+        org_config = (
+            await db_session.execute(
+                select(OrganizationConfig).where(OrganizationConfig.org_id == org_id)
+            )
+        ).scalars().first()
+
+        # Imported here: these modules pull in org services that import this one.
+        from src.services.email.utils import get_org_logo_url, get_org_signup_base_url
+        from src.services.orgs.orgs import get_org_default_language
+        from src.services.users.emails import send_org_join_email
+
+        base_url = await get_org_signup_base_url(
+            org.slug, request, db_session=db_session, org_id=org_id
+        )
+
+        send_org_join_email(
+            email=user.email,
+            username=user.username,
+            org_name=org.name,
+            cta_url=f"{base_url.rstrip('/')}/home",
+            lang=get_org_default_language(org_config),
+            logo_url=get_org_logo_url(org, request),
+        )
+    except Exception:
+        logger.warning(
+            "Failed to send org join email to user %s for org %s",
+            getattr(user, "id", None),
+            org_id,
+            exc_info=True,
+        )

--- a/apps/api/src/services/users/emails.py
+++ b/apps/api/src/services/users/emails.py
@@ -371,6 +371,54 @@ def send_invitation_email(
     )
 
 
+def send_org_join_email(
+    email: EmailStr,
+    username: str,
+    org_name: str,
+    cta_url: str,
+    lang: str = "en",
+    logo_url: str | None = None,
+):
+    """Greeting sent when an EXISTING account becomes a member of an organization.
+
+    Complements ``send_account_creation_email``, which only fires for brand new
+    accounts: a user who already had an account and then joined a second org
+    (invite code, open join, OAuth invite, admin provisioning) previously got no
+    mail at all and had to find their way to the org on their own.
+
+    Always white-labeled to the org — the user is being welcomed into that
+    academy, not onto LearnHouse — with the org's logo when it has one.
+    """
+    safe_username = html.escape(username)
+    safe_org_name = html.escape(org_name)
+
+    heading = t(lang, "org_join.heading", username=safe_username)
+    body_text = t(lang, "org_join.body", org_name=safe_org_name)
+    cta = t(lang, "org_join.cta")
+
+    body_content = f"""
+        <h1 style="{STYLES['h1']}">{heading}</h1>
+        <p style="{STYLES['p']}">
+            {body_text}
+        </p>
+        <a href="{html.escape(cta_url)}" style="{STYLES['button']}">
+            {cta}
+        </a>
+        <p style="{STYLES['link_text']}">{html.escape(cta_url)}</p>
+    """
+
+    return send_email(
+        to=email,
+        subject=t(lang, "org_join.subject", org_name=safe_org_name),
+        body=_email_layout(
+            title=heading,
+            body_content=body_content,
+            footer_note=t(lang, "org_join.footer", org_name=safe_org_name),
+            logo_html=_org_logo_img(logo_url, org_name) if logo_url else LOGO_SVG,
+        ),
+    )
+
+
 def send_role_changed_email(
     email: EmailStr,
     username: str,

--- a/apps/api/src/tests/services/conftest.py
+++ b/apps/api/src/tests/services/conftest.py
@@ -132,3 +132,17 @@ async def task_submission(db, assignment_task, regular_user):
     await db.commit()
     await db.refresh(ts)
     return ts
+
+
+@pytest.fixture(autouse=True)
+def _no_outbound_email():
+    """Never let a service test reach a real mail provider.
+
+    Membership and account flows send mail as a side effect; without this an
+    unpatched test would issue a live Resend/SMTP call. Tests that assert on
+    the mail itself patch the same target locally, which still wins.
+    """
+    from unittest.mock import patch
+
+    with patch("src.services.users.emails.send_email", return_value=True):
+        yield

--- a/apps/api/src/tests/services/test_emails_service.py
+++ b/apps/api/src/tests/services/test_emails_service.py
@@ -11,6 +11,7 @@ from src.services.users.emails import (
     send_invitation_email,
     send_org_created_email,
     send_org_deleted_email,
+    send_org_join_email,
     send_password_reset_email,
     send_password_reset_email_platform,
     send_role_changed_email,
@@ -114,6 +115,48 @@ class TestEmailsService:
         assert "<svg" in call["body"]
         assert "Acme" in call["subject"]
         assert "Powered by LearnHouse" in call["body"]
+
+    def test_org_join_email_is_whitelabeled_and_links_to_the_org(self):
+        with patch("src.services.users.emails.send_email", return_value=True) as send_email:
+            assert send_org_join_email(
+                email="user@test.com",
+                username="user<script>",
+                org_name="Acme & Co",
+                cta_url="https://acme.test/home",
+                logo_url="https://api.test/content/orgs/org_uuid/logos/logo.png",
+            ) is True
+        call = send_email.call_args.kwargs
+        # Named after the org, with the org's own logo, not the LearnHouse mark.
+        assert "Acme &amp; Co" in call["subject"]
+        assert '<img src="https://api.test/content/orgs/org_uuid/logos/logo.png"' in call["body"]
+        # The whole point of the email: a working way back into the org.
+        assert "https://acme.test/home" in call["body"]
+        # Hostile username/org names are escaped, never rendered as markup.
+        assert "<script>" not in call["body"]
+
+    def test_org_join_email_falls_back_to_learnhouse_mark_without_logo(self):
+        with patch("src.services.users.emails.send_email", return_value=True) as send_email:
+            send_org_join_email(
+                email="user@test.com",
+                username="learner",
+                org_name="Acme",
+                cta_url="https://acme.test/home",
+            )
+        call = send_email.call_args.kwargs
+        assert "<img" not in call["body"]
+        assert "<svg" in call["body"]
+
+    def test_org_join_email_translates(self):
+        with patch("src.services.users.emails.send_email", return_value=True) as send_email:
+            send_org_join_email(
+                email="user@test.com",
+                username="learner",
+                org_name="Acme",
+                cta_url="https://acme.test/home",
+                lang="fr",
+            )
+        call = send_email.call_args.kwargs
+        assert "Bienvenue" in call["subject"]
 
     def test_send_password_reset_email_variants_encode_params(self):
         with patch("src.services.users.emails.send_email", return_value=True) as send_email:

--- a/apps/api/src/tests/services/test_org_join_notifications.py
+++ b/apps/api/src/tests/services/test_org_join_notifications.py
@@ -1,0 +1,77 @@
+"""Tests for src/services/orgs/join_notifications.py."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.db.users import User
+from src.services.orgs.join_notifications import notify_user_joined_org
+
+
+async def _make_user(db, **overrides):
+    user = User(
+        username=overrides.pop("username", "joiner"),
+        first_name="Join",
+        last_name="User",
+        email=overrides.pop("email", "joiner@test.com"),
+        password="hashed",
+        user_uuid=overrides.pop("user_uuid", "user_notify"),
+        email_verified=True,
+        signup_method="email",
+        creation_date=str(datetime.now()),
+        update_date=str(datetime.now()),
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+class TestNotifyUserJoinedOrg:
+    @pytest.mark.asyncio
+    async def test_sends_org_scoped_greeting(self, mock_request, db, org):
+        user = await _make_user(db)
+
+        with patch(
+            "src.services.email.utils.get_org_signup_base_url",
+            new=AsyncMock(return_value="https://acme.test/"),
+        ), patch(
+            "src.services.users.emails.send_email", return_value=True
+        ) as send_email:
+            await notify_user_joined_org(mock_request, db, user, org.id)
+
+        call = send_email.call_args.kwargs
+        assert call["to"] == "joiner@test.com"
+        assert org.name in call["subject"]
+        # Lands the user in the org they just joined, on the org's own host.
+        assert "https://acme.test/home" in call["body"]
+
+    @pytest.mark.asyncio
+    async def test_skips_user_without_email(self, mock_request, db, org):
+        user = await _make_user(db, email="", user_uuid="user_no_email")
+
+        with patch("src.services.users.emails.send_email") as send_email:
+            await notify_user_joined_org(mock_request, db, user, org.id)
+
+        send_email.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unknown_org_sends_nothing(self, mock_request, db):
+        user = await _make_user(db, user_uuid="user_no_org")
+
+        with patch("src.services.users.emails.send_email") as send_email:
+            await notify_user_joined_org(mock_request, db, user, 999999)
+
+        send_email.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mail_failure_never_propagates(self, mock_request, db, org):
+        """A dead mail provider must not fail the join it is reporting on."""
+        user = await _make_user(db, user_uuid="user_mail_down")
+
+        with patch(
+            "src.services.users.emails.send_email",
+            side_effect=RuntimeError("provider down"),
+        ):
+            await notify_user_joined_org(mock_request, db, user, org.id)

--- a/apps/web/app/api/podcast/[podcastuuid]/feed/route.ts
+++ b/apps/web/app/api/podcast/[podcastuuid]/feed/route.ts
@@ -24,7 +24,15 @@ export async function GET(
     }
 
     const { podcast, episodes } = podcastMeta
-    const baseUrl = getUriWithOrg(orgSlug, '/')
+    // RSS requires absolute URLs, and the host the feed was fetched on is the
+    // right one (org subdomain or custom domain). `getUriWithOrg` would hand
+    // back a relative path in single tenancy, producing an invalid feed.
+    const forwardedHost = request.headers.get('x-forwarded-host') || request.headers.get('host')
+    const forwardedProto = request.headers.get('x-forwarded-proto')
+      || (forwardedHost?.startsWith('localhost') || forwardedHost?.startsWith('127.') ? 'http' : 'https')
+    const origin = forwardedHost ? `${forwardedProto}://${forwardedHost}` : request.nextUrl.origin
+    const relativeBase = getUriWithOrg(orgSlug, '/')
+    const baseUrl = /^https?:\/\//i.test(relativeBase) ? relativeBase : `${origin}/`
     const podcastUrl = `${baseUrl}podcast/${podcastuuid}`
 
     const imageUrl = podcast.thumbnail_image
@@ -97,7 +105,7 @@ ${episodeItems}
         'Cache-Control': 'public, max-age=3600, s-maxage=3600',
       },
     })
-  } catch (error) {
+  } catch {
     return NextResponse.json({ error: 'Failed to generate feed' }, { status: 500 })
   }
 }

--- a/apps/web/components/Dashboard/Pages/Org/OrgEditSEO/OrgEditSEO.tsx
+++ b/apps/web/components/Dashboard/Pages/Org/OrgEditSEO/OrgEditSEO.tsx
@@ -20,7 +20,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query/keys'
 import { getOrgOgImageMediaDirectory } from '@services/media/media'
 import { Copy, ExternalLink, Upload, X } from 'lucide-react'
-import { getCanonicalUrl } from '@/lib/seo/utils'
+import { useAbsoluteUrl } from '@/lib/seo/useAbsoluteUrl'
 import FeatureGate from '@components/Dashboard/Shared/FeatureGate/FeatureGate'
 
 const OrgEditSEO: React.FC = () => {
@@ -44,8 +44,9 @@ const OrgEditSEO: React.FC = () => {
     noindex_communities: seoConfig.noindex_communities || false,
   }
 
-  const sitemapUrl = getCanonicalUrl(org?.slug, '/sitemap.xml')
-  const robotsUrl = getCanonicalUrl(org?.slug, '/robots.txt')
+  // Absolute: these are handed to Google Search Console, not clicked in-app
+  const sitemapUrl = useAbsoluteUrl(org?.slug, '/sitemap.xml')
+  const robotsUrl = useAbsoluteUrl(org?.slug, '/robots.txt')
 
   const copyToClipboard = (text: string) => {
     navigator.clipboard.writeText(text)

--- a/apps/web/components/Dashboard/Pages/Podcast/PodcastDistribution/PodcastDistribution.tsx
+++ b/apps/web/components/Dashboard/Pages/Podcast/PodcastDistribution/PodcastDistribution.tsx
@@ -1,13 +1,11 @@
 'use client'
 import React from 'react'
 import { usePodcast } from '@components/Contexts/PodcastContext'
-import { useOrg } from '@components/Contexts/OrgContext'
-import { getCanonicalUrl } from '@/lib/seo/utils'
+import { useAbsoluteUrl } from '@/lib/seo/useAbsoluteUrl'
 import { Copy, ExternalLink, Rss } from 'lucide-react'
 import { SiApplepodcasts, SiSpotify, SiYoutubemusic, SiAudible } from '@icons-pack/react-simple-icons'
 import { Button } from '@components/ui/button'
 import { Input } from '@components/ui/input'
-import { Label } from '@components/ui/label'
 import toast from 'react-hot-toast'
 
 interface PodcastDistributionProps {
@@ -17,10 +15,10 @@ interface PodcastDistributionProps {
 
 function PodcastDistribution({ orgslug, podcastuuid }: PodcastDistributionProps) {
   const { podcast } = usePodcast()
-  const org = useOrg() as any
 
   const shortUuid = podcastuuid.replace('podcast_', '')
-  const feedUrl = getCanonicalUrl(orgslug, `/podcast/${shortUuid}/feed`)
+  // Absolute: this URL is pasted into Apple Podcasts / Spotify, not clicked in-app
+  const feedUrl = useAbsoluteUrl(orgslug, `/podcast/${shortUuid}/feed`)
 
   const copyToClipboard = (text: string) => {
     navigator.clipboard.writeText(text)

--- a/apps/web/components/Dashboard/Pages/Users/OrgAccess/OrgAccess.tsx
+++ b/apps/web/components/Dashboard/Pages/Users/OrgAccess/OrgAccess.tsx
@@ -1,7 +1,7 @@
 import { useOrg } from '@components/Contexts/OrgContext'
 import PageLoading from '@components/Objects/Loaders/PageLoading'
 import ConfirmationModal from '@components/Objects/StyledElements/ConfirmationModal/ConfirmationModal'
-import { getAPIUrl, getUriWithOrg } from '@services/config/config'
+import { getAPIUrl, getAbsoluteUriWithOrg } from '@services/config/config'
 import { apiFetch } from '@services/utils/ts/requests'
 import { Check, Copy, Globe, Ticket, UserSquare, Users, X } from 'lucide-react'
 import Link from 'next/link'
@@ -211,11 +211,11 @@ function OrgAccess() {
                             <Link
                               className="outline bg-gray-50 text-gray-600 px-2 py-1 rounded-md outline-gray-300 outline-dashed outline-1 text-xs truncate max-w-[200px] sm:max-w-[300px]"
                               target="_blank"
-                              href={getUriWithOrg(org.slug, `/signup?inviteCode=${invite.invite_code}`)}
+                              href={getAbsoluteUriWithOrg(org.slug, `/signup?inviteCode=${invite.invite_code}`)}
                             >
-                              {getUriWithOrg(org.slug, `/signup?inviteCode=${invite.invite_code}`)}
+                              {getAbsoluteUriWithOrg(org.slug, `/signup?inviteCode=${invite.invite_code}`)}
                             </Link>
-                            <CopyButton text={getUriWithOrg(org.slug, `/signup?inviteCode=${invite.invite_code}`)} />
+                            <CopyButton text={getAbsoluteUriWithOrg(org.slug, `/signup?inviteCode=${invite.invite_code}`)} />
                           </div>
                         </td>
                         <td className="py-3 px-4 sm:px-6">

--- a/apps/web/components/Pages/Activity/CourseEndView.tsx
+++ b/apps/web/components/Pages/Activity/CourseEndView.tsx
@@ -4,7 +4,7 @@ import dynamic from 'next/dynamic';
 const ReactConfetti = dynamic(() => import('react-confetti'), { ssr: false });
 import { Trophy, ArrowLeft, BookOpen, Target, Download, Shield } from 'lucide-react';
 import Link from 'next/link';
-import { getUriWithOrg } from '@services/config/config';
+import { getUriWithOrg, getAbsoluteUriWithOrg } from '@services/config/config';
 import { getCourseThumbnailMediaDirectory } from '@services/media/media';
 import { useWindowSize } from 'usehooks-ts';
 import { useOrg } from '@components/Contexts/OrgContext';
@@ -59,7 +59,8 @@ const CourseEndView: React.FC<CourseEndViewProps> = ({
     return sessionFull || s?.username || '';
   };
   const learnerName = getLearnerName();
-  const qrCodeLink = getUriWithOrg(orgslug, `/certificates/${userCertificate?.certificate_user.user_certification_uuid}/verify`);
+  // Absolute: encoded in the QR code on the certificate PDF, scanned outside the app
+  const qrCodeLink = getAbsoluteUriWithOrg(orgslug, `/certificates/${userCertificate?.certificate_user.user_certification_uuid}/verify`);
 
 
 

--- a/apps/web/components/Pages/Certificate/CertificatePage.tsx
+++ b/apps/web/components/Pages/Certificate/CertificatePage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import toast from 'react-hot-toast';
 import { useLHSession } from '@components/Contexts/LHSessionContext';
 import { useOrg } from '@components/Contexts/OrgContext';
@@ -10,6 +10,11 @@ import { ArrowLeft, Download, Share2, Copy, Check } from 'lucide-react';
 import Link from 'next/link';
 import { getUriWithOrg } from '@services/config/config';
 import { useLHAnalytics, useTrackView, AnalyticsEvent } from '@services/analytics';
+import {
+  CERTIFICATE_CAPTURE_WIDTH,
+  certificateFileName,
+  downloadCertificateNodeAsPdf,
+} from '@services/courses/certificateDownload';
 
 interface CertificatePageProps {
   orgslug: string;
@@ -24,6 +29,7 @@ const CertificatePage: React.FC<CertificatePageProps> = ({ orgslug, courseid, qr
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [linkCopied, setLinkCopied] = useState(false);
+  const certificateCaptureRef = useRef<HTMLDivElement>(null);
   const { track } = useLHAnalytics('learner');
 
   useTrackView(AnalyticsEvent.CertificateViewed, {}, !!userCertificate);
@@ -81,290 +87,51 @@ const CertificatePage: React.FC<CertificatePageProps> = ({ orgslug, courseid, qr
 
 
 
-  // Generate PDF using canvas
+  // Single source of truth for the certificate's contents. Both the visible
+  // certificate and the offscreen one we rasterise into the PDF are rendered
+  // from this, so they cannot drift apart.
+  const certificatePreviewProps = useMemo(() => {
+    if (!userCertificate) return null;
+    const config = userCertificate.certification?.config || {};
+    return {
+      certificationName: config.certification_name,
+      certificationDescription: config.certification_description,
+      certificationType: config.certification_type,
+      certificatePattern: config.certificate_pattern,
+      certificateInstructor: config.certificate_instructor,
+      certificateId: userCertificate.certificate_user.user_certification_uuid,
+      learnerName,
+      awardedDate: new Date(userCertificate.certificate_user.created_at).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      }),
+      qrCodeLink,
+    };
+  }, [userCertificate, learnerName, qrCodeLink]);
+
+  // Generate the PDF from the SAME <CertificatePreview> the learner sees.
+  //
+  // This used to build its own certificate out of a hand-written HTML string,
+  // which had drifted into a different design: no pattern artwork, no org logo
+  // or name, an emoji instead of the award mark, Arial instead of the app's
+  // type. We now rasterise a hidden, fixed-width render of the real component
+  // (`certificateCaptureRef` below), the same way CourseEndView does, so the
+  // download always matches the certificate on screen.
   const downloadCertificate = async () => {
     if (!userCertificate) return;
+    const node = certificateCaptureRef.current;
+    if (!node) return;
 
     try {
-      const [{ default: html2canvas }, { default: jsPDF }, QRCode] = await Promise.all([
-        // html2canvas-pro understands modern CSS color functions (oklch/lab/
-        // color-mix) emitted by Tailwind v4; classic html2canvas throws on them.
-        import('html2canvas-pro'),
-        import('jspdf'),
-        import('qrcode'),
-      ]);
-      // Create a temporary div for the certificate
-      const certificateDiv = document.createElement('div');
-      certificateDiv.style.position = 'absolute';
-      certificateDiv.style.left = '-9999px';
-      certificateDiv.style.top = '0';
-      certificateDiv.style.width = '800px';
-      certificateDiv.style.height = '600px';
-      certificateDiv.style.background = 'white';
-      certificateDiv.style.padding = '40px';
-      certificateDiv.style.fontFamily = 'Arial, sans-serif';
-      certificateDiv.style.textAlign = 'center';
-      certificateDiv.style.display = 'flex';
-      certificateDiv.style.flexDirection = 'column';
-      certificateDiv.style.justifyContent = 'center';
-      certificateDiv.style.alignItems = 'center';
-      certificateDiv.style.position = 'relative';
-      certificateDiv.style.overflow = 'hidden';
-
-      // Get theme colors based on pattern
-      const getPatternTheme = (pattern: string) => {
-        switch (pattern) {
-          case 'royal':
-            return { primary: '#b45309', secondary: '#d97706', icon: '#d97706' };
-          case 'tech':
-            return { primary: '#0e7490', secondary: '#0891b2', icon: '#0891b2' };
-          case 'nature':
-            return { primary: '#15803d', secondary: '#16a34a', icon: '#16a34a' };
-          case 'geometric':
-            return { primary: '#7c3aed', secondary: '#9333ea', icon: '#9333ea' };
-          case 'vintage':
-            return { primary: '#c2410c', secondary: '#ea580c', icon: '#ea580c' };
-          case 'waves':
-            return { primary: '#1d4ed8', secondary: '#2563eb', icon: '#2563eb' };
-          case 'minimal':
-            return { primary: '#374151', secondary: '#4b5563', icon: '#4b5563' };
-          case 'professional':
-            return { primary: '#334155', secondary: '#475569', icon: '#475569' };
-          case 'academic':
-            return { primary: '#3730a3', secondary: '#4338ca', icon: '#4338ca' };
-          case 'modern':
-            return { primary: '#1d4ed8', secondary: '#2563eb', icon: '#2563eb' };
-          default:
-            return { primary: '#374151', secondary: '#4b5563', icon: '#4b5563' };
-        }
-      };
-
-      const theme = getPatternTheme(userCertificate.certification.config.certificate_pattern);
-      const certificateId = userCertificate.certificate_user.user_certification_uuid;
-      const qrCodeData = qrCodeLink ;
-
-      // Escape the learner-controlled name before injecting into innerHTML.
-      const escapeHtml = (s: string) =>
-        s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-         .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
-      const safeLearnerName = learnerName ? escapeHtml(learnerName) : '';
-
-      // Generate QR code
-      const qrCodeDataUrl = await QRCode.toDataURL(qrCodeData, {
-        width: 120,
-        margin: 2,
-        color: {
-          dark: '#000000',
-          light: '#FFFFFF'
-        },
-        errorCorrectionLevel: 'M',
-        type: 'image/png'
-      });
-
-      // Create certificate content
-      certificateDiv.innerHTML = `
-        <div style="
-          position: absolute;
-          top: 20px;
-          left: 20px;
-          font-size: 12px;
-          color: ${theme.secondary};
-          font-weight: 500;
-        ">ID: ${certificateId}</div>
-        
-        <div style="
-          position: absolute;
-          top: 20px;
-          right: 20px;
-          width: 80px;
-          height: 80px;
-          border: 2px solid ${theme.secondary};
-          border-radius: 8px;
-          background: white;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-        ">
-          <img src="${qrCodeDataUrl}" alt="QR Code" style="width: 100%; height: 100%; object-fit: contain;" />
-        </div>
-        
-        <div style="
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          gap: 8px;
-          margin-bottom: 30px;
-          font-size: 14px;
-          color: ${theme.secondary};
-          font-weight: 500;
-          text-transform: uppercase;
-          letter-spacing: 1px;
-        ">
-          <div style="width: 24px; height: 1px; background: linear-gradient(90deg, transparent, ${theme.secondary}, transparent);"></div>
-          Certificate
-          <div style="width: 24px; height: 1px; background: linear-gradient(90deg, transparent, ${theme.secondary}, transparent);"></div>
-        </div>
-        
-        <div style="
-          width: 80px;
-          height: 80px;
-          background: linear-gradient(135deg, ${theme.icon}20 0%, ${theme.icon}40 100%);
-          border-radius: 50%;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          margin: 0 auto 30px;
-          font-size: 40px;
-          line-height: 1;
-        ">🏆</div>
-        
-        <div style="
-          font-size: 32px;
-          font-weight: bold;
-          color: ${theme.primary};
-          margin-bottom: 20px;
-          line-height: 1.2;
-          max-width: 600px;
-        ">${userCertificate.certification.config.certification_name}</div>
-
-        ${safeLearnerName ? `
-        <div style="
-          margin-bottom: 14px;
-        ">
-          <div style="
-            font-size: 12px;
-            color: ${theme.secondary};
-            text-transform: uppercase;
-            letter-spacing: 1px;
-            margin-bottom: 3px;
-          ">Presented to</div>
-          <div style="
-            font-size: 22px;
-            font-weight: bold;
-            color: ${theme.primary};
-          ">${safeLearnerName}</div>
-        </div>` : ''}
-
-        <div style="
-          font-size: 18px;
-          color: #6b7280;
-          margin-bottom: 30px;
-          line-height: 1.5;
-          max-width: 500px;
-        ">${userCertificate.certification.config.certification_description || 'This is to certify that the course has been successfully completed.'}</div>
-        
-        <div style="
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          gap: 4px;
-          margin: 20px 0;
-        ">
-          <div style="width: 8px; height: 1px; background: ${theme.secondary}; opacity: 0.5;"></div>
-          <div style="width: 4px; height: 4px; background: ${theme.primary}; border-radius: 50%; opacity: 0.6;"></div>
-          <div style="width: 8px; height: 1px; background: ${theme.secondary}; opacity: 0.5;"></div>
-        </div>
-        
-        <div style="
-          display: inline-flex;
-          align-items: center;
-          gap: 8px;
-          font-size: 16px;
-          color: ${theme.primary};
-          background: ${theme.icon}10;
-          padding: 12px 24px;
-          border-radius: 20px;
-          border: 1px solid ${theme.icon}20;
-          font-weight: 500;
-          margin-bottom: 30px;
-          white-space: nowrap;
-        ">
-          <span style="font-weight: bold; font-size: 18px;">✓</span>
-          <span>${userCertificate.certification.config.certification_type === 'completion' ? 'Course Completion' :
-            userCertificate.certification.config.certification_type === 'achievement' ? 'Achievement Based' :
-            userCertificate.certification.config.certification_type === 'assessment' ? 'Assessment Based' :
-            userCertificate.certification.config.certification_type === 'participation' ? 'Participation' :
-            userCertificate.certification.config.certification_type === 'mastery' ? 'Skill Mastery' :
-            userCertificate.certification.config.certification_type === 'professional' ? 'Professional Development' :
-            userCertificate.certification.config.certification_type === 'continuing' ? 'Continuing Education' :
-            userCertificate.certification.config.certification_type === 'workshop' ? 'Workshop Attendance' :
-            userCertificate.certification.config.certification_type === 'specialization' ? 'Specialization' : 'Course Completion'}</span>
-        </div>
-        
-        <div style="
-          margin-top: 30px;
-          padding: 24px;
-          background: #f8fafc;
-          border-radius: 8px;
-          border: 1px solid #e2e8f0;
-          max-width: 400px;
-        ">
-          <div style="margin: 8px 0; font-size: 14px; color: #374151;">
-            <strong style="color: ${theme.primary};">Certificate ID:</strong> ${certificateId}
-          </div>
-          <div style="margin: 8px 0; font-size: 14px; color: #374151;">
-            <strong style="color: ${theme.primary};">Awarded:</strong> ${new Date(userCertificate.certificate_user.created_at).toLocaleDateString('en-US', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric'
-            })}
-          </div>
-          ${userCertificate.certification.config.certificate_instructor ? 
-            `<div style="margin: 8px 0; font-size: 14px; color: #374151;">
-              <strong style="color: ${theme.primary};">Instructor:</strong> ${userCertificate.certification.config.certificate_instructor}
-            </div>` : ''
-          }
-        </div>
-        
-        <div style="
-          margin-top: 20px;
-          font-size: 12px;
-          color: #6b7280;
-        ">
-          This certificate can be verified at ${qrCodeData.replace('https://', '').replace('http://', '')}
-        </div>
-      `;
-
-      // Add to document temporarily
-      document.body.appendChild(certificateDiv);
-
-      // Convert to canvas
-      const canvas = await html2canvas(certificateDiv, {
-        width: 800,
-        height: 600,
-        scale: 2, // Higher resolution
-        useCORS: true,
-        allowTaint: true,
-        backgroundColor: '#ffffff'
-      });
-
-      // Remove temporary div
-      document.body.removeChild(certificateDiv);
-
-      // Create PDF
-      const imgData = canvas.toDataURL('image/png');
-      const pdf = new jsPDF('landscape', 'mm', 'a4');
-      
-      // Calculate dimensions to center the certificate
-      const pdfWidth = pdf.internal.pageSize.getWidth();
-      const pdfHeight = pdf.internal.pageSize.getHeight();
-      const imgWidth = 280; // mm
-      const imgHeight = 210; // mm
-      
-      // Center the image
-      const x = (pdfWidth - imgWidth) / 2;
-      const y = (pdfHeight - imgHeight) / 2;
-      
-      pdf.addImage(imgData, 'PNG', x, y, imgWidth, imgHeight);
-      
-      // Save the PDF
-      const fileName = `${userCertificate.certification.config.certification_name.replace(/[^a-zA-Z0-9]/g, '_')}_Certificate.pdf`;
-      pdf.save(fileName);
+      await downloadCertificateNodeAsPdf(
+        node,
+        certificateFileName(userCertificate.certification?.config?.certification_name),
+      );
 
       track(AnalyticsEvent.CertificateDownloaded, {
         certification_type: userCertificate.certification.config.certification_type,
       });
-
     } catch (error) {
       console.error('Error generating PDF:', error);
       toast.error('Failed to generate PDF. Please try again.');
@@ -511,23 +278,25 @@ const CertificatePage: React.FC<CertificatePageProps> = ({ orgslug, courseid, qr
         {/* Certificate Display */}
         <div className="bg-white rounded-2xl shadow-lg p-8">
           <div className="max-w-2xl mx-auto">
-            <CertificatePreview
-              certificationName={userCertificate.certification.config.certification_name}
-              certificationDescription={userCertificate.certification.config.certification_description}
-              certificationType={userCertificate.certification.config.certification_type}
-              certificatePattern={userCertificate.certification.config.certificate_pattern}
-              certificateInstructor={userCertificate.certification.config.certificate_instructor}
-              certificateId={userCertificate.certificate_user.user_certification_uuid}
-              learnerName={learnerName}
-              awardedDate={new Date(userCertificate.certificate_user.created_at).toLocaleDateString('en-US', {
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric'
-              })}
-              qrCodeLink={qrCodeLink}
-            />
+            {certificatePreviewProps && <CertificatePreview {...certificatePreviewProps} />}
           </div>
         </div>
+
+        {/* PDF source. Identical props to the visible certificate above, just
+            pinned to a fixed width so the export is the same on every screen.
+            Kept in the layout (offscreen, not display:none) because html2canvas
+            cannot measure a hidden subtree. */}
+        {certificatePreviewProps && (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none fixed top-0 left-0 -z-50 opacity-0"
+            style={{ transform: 'translateX(-200vw)' }}
+          >
+            <div ref={certificateCaptureRef} style={{ width: CERTIFICATE_CAPTURE_WIDTH }}>
+              <CertificatePreview {...certificatePreviewProps} />
+            </div>
+          </div>
+        )}
 
         {/* Instructions */}
         <div className="mt-8 text-center text-gray-600">

--- a/apps/web/components/Pages/Certificate/CertificateVerificationPage.tsx
+++ b/apps/web/components/Pages/Certificate/CertificateVerificationPage.tsx
@@ -5,7 +5,7 @@ import { getCertificateByUuid } from '@services/courses/certifications';
 import CertificatePreview from '@components/Dashboard/Pages/Course/EditCourseCertification/CertificatePreview';
 import { Shield, CheckCircle, XCircle, AlertTriangle, ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
-import { getUriWithOrg } from '@services/config/config';
+import { getUriWithOrg, getAbsoluteUriWithOrg } from '@services/config/config';
 import { getCourseThumbnailMediaDirectory } from '@services/media/media';
 import { useOrg } from '@components/Contexts/OrgContext';
 import { useTrackView, AnalyticsEvent } from '@services/analytics';
@@ -155,7 +155,8 @@ const CertificateVerificationPage: React.FC<CertificateVerificationPageProps> = 
     return null;
   }
 
-  const qrCodeLink = getUriWithOrg(org?.org_slug || '', `/certificates/${certificateData.certificate_user.user_certification_uuid}/verify`);
+  // Absolute: encoded in the QR code and copied out of the app, so it must carry the host
+  const qrCodeLink = getAbsoluteUriWithOrg(org?.org_slug || '', `/certificates/${certificateData.certificate_user.user_certification_uuid}/verify`);
 
   return (
     <div className="min-h-screen bg-gray-50 py-8">

--- a/apps/web/lib/seo/useAbsoluteUrl.ts
+++ b/apps/web/lib/seo/useAbsoluteUrl.ts
@@ -1,0 +1,29 @@
+'use client'
+import { useSyncExternalStore } from 'react'
+import { getAbsoluteUriWithOrg } from '@services/config/config'
+import { getCanonicalUrl } from './utils'
+
+/** Nothing to subscribe to: whether we're on the client never changes after hydration. */
+const subscribe = () => () => {}
+
+/**
+ * Absolute, shareable URL for a path on the current org — for links the user
+ * copies out of the app (RSS feeds, sitemap/robots, invite links) rather than
+ * navigates with.
+ *
+ * The absolute form depends on `window.location`, which doesn't exist during
+ * SSR, so the server render (and the hydrating render) falls back to the same
+ * value the server would produce. Without that, server and client markup
+ * disagree and React reports a hydration mismatch.
+ */
+export function useAbsoluteUrl(orgslug: string, path: string): string {
+  const isHydrated = useSyncExternalStore(
+    subscribe,
+    () => true,
+    () => false,
+  )
+
+  return isHydrated
+    ? getAbsoluteUriWithOrg(orgslug, path).replace(/\/+$/, '')
+    : getCanonicalUrl(orgslug, path)
+}

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -334,12 +334,33 @@ export default async function proxy(req: NextRequest) {
   // -------------------------------------------------------------------------
   const authPaths = ['/login', '/signup', '/reset', '/forgot', '/verify-email']
   if (authPaths.includes(pathname)) {
-    // A logged-in user has no business on /login or /signup — bounce them to the
-    // hub (the page itself re-verifies, so this is a best-effort UX shortcut).
-    if ((pathname === '/login' || pathname === '/signup') && req.cookies.get('LH_session')?.value) {
+    const hasSession = !!req.cookies.get('LH_session')?.value
+
+    // A logged-in user has no business on /login — bounce them to the hub (the
+    // page itself re-verifies, so this is a best-effort UX shortcut).
+    if (pathname === '/login' && hasSession) {
       return NextResponse.redirect(new URL('/home', req.url))
     }
+
     const resolved = await resolveTenant(req, instance)
+
+    // `/signup` is NOT only a signup page: for a signed-in user on an org host
+    // it is the JOIN screen (the "Join this organization" banner and every
+    // invite link point at it). Bouncing them to /home dropped them on the org
+    // picker instead — and silently threw away any ?inviteCode. So only send a
+    // signed-in visitor to the hub when there is genuinely no org to join here:
+    // the org-less apex, with no invite code in hand.
+    if (pathname === '/signup' && hasSession) {
+      const onOrgHost =
+        instance.tenancy === 'single'
+        || resolved.source === 'subdomain'
+        || resolved.source === 'custom-domain'
+      const hasInviteCode = !!req.nextUrl.searchParams.get('inviteCode')
+      if (!onOrgHost && !hasInviteCode) {
+        return NextResponse.redirect(new URL('/home', req.url))
+      }
+    }
+
     const requestHeaders = tenantRequestHeaders(req, resolved, instance)
     const response = NextResponse.rewrite(
       new URL(`/auth${pathname}${search}`, req.url),

--- a/apps/web/services/config/config.ts
+++ b/apps/web/services/config/config.ts
@@ -343,6 +343,37 @@ export const getUriWithOrg = (orgslug: string, path: string) => {
   return path
 }
 
+/**
+ * Same as `getUriWithOrg`, but always returns an absolute URL.
+ *
+ * `getUriWithOrg` intentionally returns a relative path when navigation stays
+ * on the current origin. That is right for in-app links, but wrong for links
+ * meant to be shared outside the app (invite/signup links copied to the
+ * clipboard, emails, ...) where the host must be part of the URL.
+ */
+export const getAbsoluteUriWithOrg = (orgslug: string, path: string) => {
+  const uri = getUriWithOrg(orgslug, path)
+
+  // Already absolute (crossing subdomains, or server-side with a known domain)
+  if (/^https?:\/\//i.test(uri)) {
+    return uri
+  }
+
+  // Client-side: the dashboard is served from the org's own host, so the
+  // current origin is the correct one for the shared link.
+  if (typeof window !== 'undefined') {
+    return `${window.location.origin}${uri}`
+  }
+
+  // Server-side fallback
+  const explicitDomain = getConfig('NEXT_PUBLIC_LEARNHOUSE_DOMAIN')
+  if (explicitDomain) {
+    const protocol = getLEARNHOUSE_HTTP_PROTOCOL()
+    return `${protocol}${explicitDomain}${uri}`
+  }
+  return uri
+}
+
 export const getUriWithoutOrg = (path: string) => {
   // Client-side: always use current origin
   if (typeof window !== 'undefined') {


### PR DESCRIPTION
**Shareable links were relative.** `getUriWithOrg` returns a relative path, correct for in-app nav but not for anything meant to leave the app. Copying an invite link gave `/signup?inviteCode=XXXX` with no host. Same bug hit certificate QR codes (course-end and verification pages), the podcast RSS URL shown in the dashboard, sitemap.xml/robots.txt in SEO settings, and the RSS feed's own `<link>` tags. Added `getAbsoluteUriWithOrg` and a hydration-safe `useAbsoluteUrl` hook, fixed all five. Course, folder/media, and activity share/embed links were already correct.

**No email when an existing account joined an org.** Only brand-new signups got mail; invite code, open join, OAuth invite, and admin provisioning sent nothing. All paths now route through one `notify_user_joined_org` helper, org-white-labeled with the org's logo, skipped for signups so nobody gets double mail. Best-effort, so a dead mail provider can't block a join. All 20 locales translated.

**Welcome emails deroute users.** They linked to `{host}/home`, the platform org picker, even on org subdomains and custom domains. "Get Started" from an academy's email dropped people on a list of all their orgs. Account-creation and join emails now link to the org's own landing page; the org-created email also had its host wrong, since orgs are created from the platform apex. It now resolves the org's real host (custom domain if verified).

**Certificate PDF didn't match the UI.** The standalone page built its PDF from a hand-written HTML string that had drifted: no artwork, no org logo, an emoji in place of the award mark. It now rasterises the same CertificatePreview component learners see. 546 lines down to 314.

**Joining while signed in was impossible.** The proxy bounced every signed-in visitor off `/signup`, but that's the join screen for signed-in users, and it dropped `?inviteCode` in the process. Bounce now applies only on the org-less apex with no invite code.

**Gzipped SCORM assets were truncated.** The proxy forwarded the upstream content-length after undici had already decompressed the body, so browsers stopped early. modernizr.js and scriptLoader.js failed with "Unexpected end of input." Length is now forwarded only when the body wasn't decoded.

**Assignment submit gave no feedback.** The confirm modal fired the save-and-grade action without awaiting it and closed immediately, leaving the button clickable for a second submit. It now awaits: spinner, disabled state, stays open on failure, activity bar shows "Submitting…".

Tests: 93 API tests pass (new coverage for the join email and mail-provider failure), tsc/eslint clean. Not verified in a browser: join flow, certificate download, SCORM playback, assignment submit. Separately found that submit latency is server-side (grading/certificate recompute), not addressed here.