### PR TITLE
fix(web): show the org logo for standard and pro plans, not just enterprise

### DIFF
--- a/apps/web/components/Dashboard/Menus/DashLeftMenu.tsx
+++ b/apps/web/components/Dashboard/Menus/DashLeftMenu.tsx
@@ -79,6 +79,7 @@ import { getAssignmentsFromACourse } from '@services/courses/assignments'
 import { getDeploymentMode } from '@services/config/config'
 import PlanBadge from '@components/Dashboard/Shared/PlanRestricted/PlanBadge'
 import { usePlan } from '@components/Hooks/usePlan'
+import { planMeetsRequirement } from '@services/plans/plans'
 import useAdminStatus from '@components/Hooks/useAdminStatus'
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
 import OnboardingSidebarBox from '@components/Dashboard/Onboarding/OnboardingSidebarBox'
@@ -251,7 +252,7 @@ function DashLeftMenu() {
           className={cn("flex items-center transition-opacity hover:opacity-70", isCollapsed ? "" : "space-x-3")}
           href={'/'}
         >
-          {plan === 'enterprise' && org?.logo_image ? (
+          {planMeetsRequirement(plan, 'standard') && org?.logo_image ? (
             <img
               src={getOrgLogoMediaDirectory(org.org_uuid, org.logo_image)}
               alt={org?.name}

--- a/apps/web/components/Dashboard/Menus/DashMobileMenu.tsx
+++ b/apps/web/components/Dashboard/Menus/DashMobileMenu.tsx
@@ -41,6 +41,7 @@ import { AVAILABLE_LANGUAGES } from '@/lib/languages'
 import { getOrgLogoMediaDirectory } from '@services/media/media'
 import { cn } from '@/lib/utils'
 import { usePlan } from '@components/Hooks/usePlan'
+import { planMeetsRequirement } from '@services/plans/plans'
 import { FeedbackModal } from '@components/Objects/Modals/FeedbackModal'
 import { useCommandPalette } from '@components/Dashboard/CommandPalette/CommandPaletteContext'
 
@@ -188,7 +189,7 @@ function DashMobileMenu() {
             >
               {/* Org header */}
               <div className="flex items-center gap-3 px-4 py-3.5">
-                {plan === 'enterprise' && org?.logo_image ? (
+                {planMeetsRequirement(plan, 'standard') && org?.logo_image ? (
                   <img
                     src={getOrgLogoMediaDirectory(org.org_uuid, org.logo_image)}
                     alt={org?.name}


### PR DESCRIPTION
The dashboard sidebar only showed the organization's own logo on the enterprise plan; every other paid plan got the generic LearnHouse mark. Custom branding is part of standard and pro too, so the logo now shows for standard and up, using the shared plan-hierarchy helper instead of an exact enterprise check. Same fix in the mobile menu.

Not browser-verified. tsc and eslint clean on the two changed files.