### PR TITLE
fix(api): don't block an instructor from saving their own quiz answers

### DIFF
--- a/apps/api/src/services/courses/activities/assignments.py
+++ b/apps/api/src/services/courses/activities/assignments.py
@@ -1895,8 +1895,10 @@ async def handle_assignment_task_submission(
                 detail="Assignment Task Submission not found",
             )
     elif is_instructor and (
-        assignment_task_submission_object.grade is not None
-        or assignment_task_submission_object.task_submission_grade_feedback is not None
+        (assignment_task_submission_object.grade is not None
+         and assignment_task_submission_object.grade != 0)
+        or (assignment_task_submission_object.task_submission_grade_feedback is not None
+            and assignment_task_submission_object.task_submission_grade_feedback != "")
     ):
         # An instructor writing a GRADE without naming a target submission has
         # nothing to grade. Falling through to the save-progress lookup below
@@ -1905,9 +1907,14 @@ async def handle_assignment_task_submission(
         # 0 by the create branch) while the UI reported success and the learner's
         # grade never moved. There is no safe target to guess: fail loudly.
         #
-        # Narrowed to grade-bearing payloads on purpose: an instructor who is
-        # also taking their own course legitimately saves ANSWERS through this
-        # same path with no uuid, and that must keep working.
+        # An instructor who is also taking their own course saves ANSWERS through
+        # this same path with no uuid, and that must keep working. The quiz
+        # autosave sends grade=0 and feedback="" on every keystroke, so match the
+        # "actual value" test the student branch above uses (grade != 0, feedback
+        # != "") — a zeroed placeholder is a save, only a real grade or real
+        # feedback is a grading attempt. Every UI grading path always carries a
+        # target uuid and is handled by the branch above, so this stays a
+        # defense-in-depth guard, never the normal grade route.
         raise HTTPException(
             status_code=400,
             detail=(

--- a/apps/api/src/tests/services/test_assignments_service.py
+++ b/apps/api/src/tests/services/test_assignments_service.py
@@ -620,6 +620,44 @@ class TestHandleAssignmentTaskSubmission:
         assert exc.value.status_code == 403
         assert "grade" in exc.value.detail.lower()
 
+    async def test_instructor_autosave_with_zero_grade_saves_progress(
+        self, mock_request, db, assignment_task, regular_user
+    ):
+        # An instructor taking their own course autosaves quiz answers through
+        # this path with no target uuid. The quiz autosave sends grade=0 and
+        # feedback="" — a placeholder, not a grade — and it must save, not raise
+        # "the learner has no submission for it".
+        obj = AssignmentTaskSubmissionUpdate(
+            task_submission={"answer": "hello"},
+            grade=0,
+            task_submission_grade_feedback="",
+        )
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, return_value=True):
+            result = await handle_assignment_task_submission(
+                mock_request, assignment_task.assignment_task_uuid, obj, regular_user, db
+            )
+        assert isinstance(result, AssignmentTaskSubmissionRead)
+
+    async def test_instructor_real_grade_without_target_still_rejected(
+        self, mock_request, db, assignment_task, regular_user
+    ):
+        # The integrity guard stays: a real grade with no target submission uuid
+        # would otherwise write a phantom instructor-owned row while the learner's
+        # grade never moves, so it must fail loudly.
+        obj = AssignmentTaskSubmissionUpdate(
+            task_submission={"answer": "x"},
+            grade=80,
+        )
+        with patch(_PATCH_RBAC, new_callable=AsyncMock), \
+             patch(_PATCH_AUTH_ROLES, new_callable=AsyncMock, return_value=True):
+            with pytest.raises(HTTPException) as exc:
+                await handle_assignment_task_submission(
+                    mock_request, assignment_task.assignment_task_uuid, obj, regular_user, db
+                )
+        assert exc.value.status_code == 400
+        assert "no submission" in exc.value.detail.lower()
+
 
 # ---------------------------------------------------------------------------
 # read_assignment_submissions


### PR DESCRIPTION
An instructor taking their own course saves quiz answers through the same task-submission endpoint learners use, with no target submission uuid. The quiz autosave sends `grade=0` and `feedback=""` on every save, and the integrity guard added in a recent assignments fix checked `grade is not None` — which `0` satisfies — so every autosave failed with:

```
Cannot grade this task: the learner has no submission for it. A target submission is required to record a grade.
```

The guard now matches the actual-value test the student branch already uses: only a non-zero grade or non-empty feedback counts as a grading attempt; a zeroed placeholder is a save. Both UI grading paths (`gradeCustomFC`, `gradeFC`) always carry a target uuid and bail without one, so they never reach this branch — the integrity protection stays, proven by a test that a real grade with no target is still rejected 400.

Regression from `a04102ae`, which added the guard without a test for the instructor-saving-own-answer case. This PR adds both.

Not browser-verified.