### PR TITLE
fix(api): correct stale member/credit limits in plan config

### DIFF
--- a/apps/api/src/security/features_utils/plans.py
+++ b/apps/api/src/security/features_utils/plans.py
@@ -143,7 +143,7 @@ PLAN_FEATURE_CONFIGS: dict[str, dict] = {
             "collaboration": {"enabled": True, "limit": 0},
             "courses": {"enabled": True, "limit": 0},
 
-            "members": {"admin_limit": 2, "enabled": True, "limit": 500},
+            "members": {"admin_limit": 2, "enabled": True, "limit": 200},
             "payments": {"enabled": True},
 
             "usergroups": {"enabled": True, "limit": 0},
@@ -164,14 +164,14 @@ PLAN_FEATURE_CONFIGS: dict[str, dict] = {
     },
     "pro": {
         "features": {
-            "ai": {"enabled": True, "limit": 3000},
+            "ai": {"enabled": True, "limit": 2000},
             "analytics": {"enabled": True, "limit": 0},
             "api": {"enabled": True, "limit": 0},
             "assignments": {"enabled": True, "limit": 0},
             "collaboration": {"enabled": True, "limit": 0},
             "courses": {"enabled": True, "limit": 0},
 
-            "members": {"admin_limit": 10, "enabled": True, "limit": 1000},
+            "members": {"admin_limit": 10, "enabled": True, "limit": 500},
             "payments": {"enabled": True},
 
             "usergroups": {"enabled": True, "limit": 0},
@@ -241,7 +241,7 @@ AI_CREDIT_LIMITS: dict[str, int] = {
     "personal": 500,
     "personal-family": 3000,
     "standard": 1000,
-    "pro": 3000,
+    "pro": 2000,
     "enterprise": -1,
 }
 

--- a/apps/api/src/tests/security/test_feature_plans.py
+++ b/apps/api/src/tests/security/test_feature_plans.py
@@ -36,7 +36,7 @@ class TestFeaturePlans:
             "enterprise",
         ]
         assert FEATURE_PLAN_REQUIREMENTS["boards"] == "personal"
-        assert PLAN_LIMITS["standard"]["members"] == 500
+        assert PLAN_LIMITS["standard"]["members"] == 200
         assert AI_CREDIT_LIMITS["enterprise"] == -1
         assert PLAN_FEATURE_CONFIGS["free"]["cloud"]["plan"] == "free"
 
@@ -70,8 +70,8 @@ class TestFeaturePlans:
     @pytest.mark.parametrize(
         ("mode", "plan", "feature", "expected"),
         [
-            ("saas", "standard", "members", 500),
-            ("saas", "pro", "ai", 3000),
+            ("saas", "standard", "members", 200),
+            ("saas", "pro", "ai", 2000),
             ("saas", "missing", "ai", 0),
             ("saas", "free", "missing", 0),
             ("ee", "standard", "members", 0),
@@ -102,7 +102,7 @@ class TestFeaturePlans:
     @pytest.mark.parametrize(
         ("mode", "plan", "feature", "expected"),
         [
-            ("saas", "standard", "members", 500),
+            ("saas", "standard", "members", 200),
             ("saas", "pro", "admin_seats", 10),
             ("saas", "missing", "members", 10),
             ("saas", "free", "missing", 0),


### PR DESCRIPTION
Pricing page showed old numbers: Standard 500 members, Pro 1,000 members / 3,000 AI credits, instead of the current 200 / 500 / 2,000.

Root cause: the static HTML is correct, but after hydration the client calls `GET /plans` and `applyPlanLimits()` overwrites those labels with whatever the backend returns. `PLAN_FEATURE_CONFIGS` in `apps/api/src/security/features_utils/plans.py` still held the pre-repricing numbers, so the backend was the real source of the stale display.

It looked EU-specific because it was reproduced with the `LH_region=eur` cookie, but that cookie only swaps the currency symbol and Stripe price amounts. The member/credit override applies regardless of region.

Changes in `plans.py`:
- Standard members.limit: 500 -> 200
- Pro members.limit: 1000 -> 500
- Pro ai.limit and `AI_CREDIT_LIMITS["pro"]`: 3000 -> 2000
- Personal and Family tiers untouched, already correct

Updated 3 assertions in `test_feature_plans.py`. `uv run pytest src/tests/security/test_feature_plans.py` passes (33 tests). Not re-tested against the live pricing page, only via pytest.

Deploy note: `members.limit` also drives enforcement via `get_plan_limit()`, not just display. Orgs between the old and new caps become over-limit once this deploys and fall under the $1/active-user overage model. Frontend commit `cfda359` (already on main) fixed stale JSON-LD and llms.txt copies but didn't touch the live pricing cards. This backend change is the actual fix for what users see.