### PR TITLE
fix: content-path IDOR and confirmation-modal close-on-error (review follow-ups to #965)

### DIFF
--- a/apps/api/src/routers/local_content.py
+++ b/apps/api/src/routers/local_content.py
@@ -243,11 +243,16 @@ async def serve_local_content(
     if not (safe_real == base_real or safe_real.startswith(base_real + os.sep)):
         raise HTTPException(status_code=400, detail="Invalid path")
 
-    # Run the access check against the content-relative path, not the raw
-    # ``file_path``: an attacker could URL-encode segments so the access-control
-    # pattern matching fails to recognise private activity/podcast content while
-    # the resolved path still points at the real file (auth bypass / IDOR).
-    await _check_content_access(rel_path, current_user, db_session, request=request)
+    # Run the access check against the CANONICAL content-relative path derived
+    # from the resolved file, never the request string. `_normalize_content_relpath`
+    # rejects `..` but leaves `.`/`//` segments intact, so a path like
+    # `orgs/./{uuid}/courses/...` would shift `_check_content_access`'s segment
+    # indices, miss every private pattern, and fall through to the public branch
+    # while realpath still serves the real private file (auth bypass / IDOR).
+    # Deriving the path from `safe_real` keeps the access check and the
+    # filesystem touch looking at exactly the same, collapsed, path.
+    canonical_rel = os.path.relpath(safe_real, base_real).replace(os.sep, '/')
+    await _check_content_access(canonical_rel, current_user, db_session, request=request)
 
     if not os.path.isfile(safe_real):
         raise HTTPException(status_code=404, detail="File not found")
@@ -295,8 +300,11 @@ async def head_local_content(
     if not (safe_real == base_real or safe_real.startswith(base_real + os.sep)):
         raise HTTPException(status_code=400, detail="Invalid path")
 
-    # Access check against the content-relative path, not the raw request path.
-    await _check_content_access(rel_path, current_user, db_session, request=request)
+    # Access check against the CANONICAL path from safe_real, not the request
+    # string — see serve_local_content: a `.`/`//` segment would otherwise slip
+    # private content past the pattern matching (auth bypass / IDOR).
+    canonical_rel = os.path.relpath(safe_real, base_real).replace(os.sep, '/')
+    await _check_content_access(canonical_rel, current_user, db_session, request=request)
 
     if not os.path.isfile(safe_real):
         raise HTTPException(status_code=404, detail="File not found")

--- a/apps/api/src/tests/routers/test_local_content_router.py
+++ b/apps/api/src/tests/routers/test_local_content_router.py
@@ -131,6 +131,61 @@ class TestLocalContentRouter:
         assert ok_response.status_code == 200
         assert ok_response.headers["content-type"] == "video/mp4"
 
+    async def test_dot_segment_cannot_bypass_the_access_check(
+        self, client, db, org, regular_user, app, tmp_path
+    ):
+        # A `.` segment survives normalization (only `..` is rejected) but is
+        # collapsed by realpath. The access check must run on the CANONICAL path
+        # derived from the resolved file, not the request string — otherwise
+        # `orgs/./{uuid}/courses/...` shifts the segment indices, misses the
+        # private-course pattern, falls through to the public branch, and serves
+        # a private file to an anonymous user.
+        course = Course(
+            id=11,
+            name="Private Course",
+            description="Desc",
+            public=False,
+            published=True,
+            open_to_contributors=False,
+            org_id=org.id,
+            course_uuid="course_dotseg",
+            creation_date="2024-01-01",
+            update_date="2024-01-01",
+        )
+        db.add(course)
+        await db.commit()
+
+        content_root = tmp_path / "content"
+        file_path = (
+            content_root / "orgs" / org.org_uuid / "courses" / course.course_uuid
+            / "activities" / "activity_x" / "secret.mp4"
+        )
+        file_path.parent.mkdir(parents=True)
+        file_path.write_bytes(b"secret")
+
+        from src.routers import local_content
+
+        original_dir = local_content.CONTENT_DIR
+        local_content.CONTENT_DIR = content_root
+        try:
+            app.dependency_overrides[get_current_user] = lambda: AnonymousUser()
+            # Same file, reached through a `.` segment after `orgs`.
+            sneaky = await client.get(
+                f"/content/orgs/./{org.org_uuid}/courses/{course.course_uuid}"
+                "/activities/activity_x/secret.mp4"
+            )
+            # And double-URL-encoded (`%252e` -> `%2e` -> `.`).
+            sneaky_encoded = await client.get(
+                f"/content/orgs/%252e/{org.org_uuid}/courses/{course.course_uuid}"
+                "/activities/activity_x/secret.mp4"
+            )
+        finally:
+            local_content.CONTENT_DIR = original_dir
+
+        # The anonymous caller must be challenged, never handed the file (200).
+        assert sneaky.status_code in (400, 401)
+        assert sneaky_encoded.status_code in (400, 401)
+
     async def test_api_token_scope_and_invalid_paths(
         self, client, db, org, other_org, app, tmp_path
     ):

--- a/apps/web/components/Objects/StyledElements/ConfirmationModal/ConfirmationModal.tsx
+++ b/apps/web/components/Objects/StyledElements/ConfirmationModal/ConfirmationModal.tsx
@@ -28,20 +28,25 @@ const ConfirmationModal = (params: ModalParams) => {
   // pending answer and then grades it server-side. The modal used to close the
   // instant you clicked, leaving the user staring at an unchanged page with no
   // sign anything was happening, free to click through and fire it again. So
-  // wait for the action: the button shows it is working, and the modal stays up
-  // until it finishes. `await` on a non-promise is a no-op, so callers that
-  // pass a synchronous function behave exactly as before.
+  // wait for the action: the button shows it is working and can't be clicked
+  // twice, and the modal stays up until it finishes. `await` on a non-promise
+  // is a no-op, so callers that pass a synchronous function behave as before.
+  //
+  // The modal always closes once the action settles, success or failure — many
+  // confirm handlers report their own errors with a toast and never throw, and
+  // the few that let a network error propagate previously still closed the
+  // modal. Keeping it open on an unexpected throw would strand those on a modal
+  // with no message, so close either way and let the handler's toast speak.
   const handleConfirm = React.useCallback(async () => {
     if (isPending) return
     setIsPending(true)
     try {
       await params.functionToExecute()
-      setIsDialogOpen(false)
     } catch {
-      // Leave the modal open so the failure toast lands on the screen the user
-      // is still looking at, and they can retry without reopening.
+      // The confirmed action owns its own error reporting.
     } finally {
       setIsPending(false)
+      setIsDialogOpen(false)
     }
   }, [params, isPending])
 


### PR DESCRIPTION
Two regressions an adversarial review of #965 turned up, both after it merged.

**Content-path access check ran on a non-canonical path (high).** #965 split path validation into a string normalizer plus an inline realpath resolve, then passed the pre-realpath string to `_check_content_access`. The normalizer rejects `..` but leaves `.` and `//` segments, and realpath collapses them, so the access check and the filesystem lookup no longer saw the same path.

`orgs/./{uuid}/courses/{private}/activities/{act}/secret.mp4` (or double-encoded `orgs/%252e/...`) shifted the access check's segments — `parts[2]` was the org uuid, not `courses` — so every private pattern missed and it fell through to the public branch, while realpath still served the real private file to any caller, anonymous included. Both handlers now derive the relative path from the resolved, containment-checked path and check that. New test: an anonymous `.`-segment request to a private file is challenged.

**Confirmation modal could stay open on a network error (low).** #965 made the modal await its action and stay open if it threw. Most confirm handlers toast their own errors and never throw; the few that let a network error propagate used to close regardless. Staying open stranded those on a modal with no message and a spinning toast. The modal now closes once the action settles either way; the spinner + disabled-button + no-double-submit + no-mid-flight-dismiss parts that fixed the original bug stay.

Tests: 48 content/security tests pass, tsc/eslint clean. The `.`-segment test fails on the pre-fix code (verified). Not browser-verified.