### PR TITLE
fix(web): use nice-shadow on the grading-type cards instead of a border

### DIFF
--- a/apps/web/components/Objects/Modals/Activities/Create/NewActivityModal/AssignmentActivityModal.tsx
+++ b/apps/web/components/Objects/Modals/Activities/Create/NewActivityModal/AssignmentActivityModal.tsx
@@ -378,10 +378,10 @@ function GradingTypeSelector({ value, onChange, translationPrefix }: { value: st
             key={gt.value}
             type="button"
             onClick={() => onChange(gt.value)}
-            className={`relative flex flex-col items-center text-center p-3 rounded-xl border-2 transition-all cursor-pointer ${
+            className={`relative flex flex-col items-center text-center p-3 rounded-xl nice-shadow bg-white transition-all cursor-pointer ${
               isSelected
-                ? `${gt.selectedBorder} ${gt.selectedBg}`
-                : 'border-gray-100 bg-white hover:border-gray-200 hover:bg-gray-50/50'
+                ? `${gt.selectedBg} ring-2 ${gt.selectedBorder.replace('border-', 'ring-')}`
+                : 'hover:bg-gray-50/60'
             }`}
           >
             {isSelected && (


### PR DESCRIPTION
The grading-type cards in the new-assignment modal used a 2px border that turned solid-colored when selected, out of step with the rest of the modal's boxes, which sit on a soft nice-shadow. They now use nice-shadow on a white card with a colored ring + tint for selection, matching the edit-assignment modal's cards and the surrounding sections.

tsc and eslint clean. Not browser-verified.