### PR TITLE
feat(auth): 2FA, magic-link login, per-org auth-method policy, session isolation & 2FA reset tool

### DIFF
--- a/apps/api/migrations/versions/t6u7v8w9x0y1_add_user_mfa_tables.py
+++ b/apps/api/migrations/versions/t6u7v8w9x0y1_add_user_mfa_tables.py
@@ -1,0 +1,74 @@
+"""Add TOTP two-factor tables
+
+Revision ID: t6u7v8w9x0y1
+Revises: e9f0a1b2c3d4
+Create Date: 2026-07-21 12:00:00.000000
+
+Chains onto the current dev head (e9f0a1b2c3d4) so the migration graph stays a
+single linear head — `alembic upgrade head` reaches these tables without a merge
+revision.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa  # noqa: F401
+import sqlmodel  # noqa: F401
+
+# revision identifiers, used by Alembic.
+revision: str = 't6u7v8w9x0y1'
+down_revision: Union[str, None] = 'e9f0a1b2c3d4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'usermfa',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column(
+            'user_id',
+            sa.Integer(),
+            sa.ForeignKey('user.id', ondelete='CASCADE'),
+            nullable=False,
+        ),
+        # Fernet ciphertext of the TOTP shared secret — never a plaintext seed.
+        sa.Column('secret_encrypted', sa.String(), nullable=False, server_default=''),
+        # NULL until the user proves the authenticator works. Only non-NULL rows
+        # gate login.
+        sa.Column('confirmed_at', sa.String(), nullable=True),
+        sa.Column('last_used_timestep', sa.Integer(), nullable=True),
+        sa.Column('creation_date', sa.String(), nullable=False, server_default=''),
+        sa.Column('update_date', sa.String(), nullable=False, server_default=''),
+    )
+    # One factor per user; the unique index is what makes "enroll twice" a
+    # database error rather than two live secrets.
+    op.create_index('ix_user_mfa_user', 'usermfa', ['user_id'], unique=True)
+
+    op.create_table(
+        'usermfabackupcode',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column(
+            'user_id',
+            sa.Integer(),
+            sa.ForeignKey('user.id', ondelete='CASCADE'),
+            nullable=False,
+        ),
+        sa.Column('code_hash', sa.String(), nullable=False),
+        sa.Column('used_at', sa.String(), nullable=True),
+        sa.Column('creation_date', sa.String(), nullable=False, server_default=''),
+    )
+    op.create_index('ix_user_mfa_backup_user', 'usermfabackupcode', ['user_id'])
+    # Verification hashes the submitted code and looks it up directly, so this
+    # index is on the hot path of every recovery attempt.
+    op.create_index(
+        'ix_usermfabackupcode_code_hash', 'usermfabackupcode', ['code_hash']
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_usermfabackupcode_code_hash', table_name='usermfabackupcode')
+    op.drop_index('ix_user_mfa_backup_user', table_name='usermfabackupcode')
+    op.drop_table('usermfabackupcode')
+
+    op.drop_index('ix_user_mfa_user', table_name='usermfa')
+    op.drop_table('usermfa')

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "stripe==15.3.1",
     "cryptography==49.0.0",
     "pyjwt[crypto]==2.13.0",
+    "pyotp==2.9.0",
     "beautifulsoup4==4.15.0",
     "pytest-asyncio==1.4.0",
     "sentry-sdk[fastapi]==2.66.0",

--- a/apps/api/src/db/organization_config.py
+++ b/apps/api/src/db/organization_config.py
@@ -127,7 +127,47 @@ class FeatureAdminToggle(BaseModel):
     disabled: bool = False
 
 
+class SecurityAdminToggle(BaseModel):
+    """Org-wide security policy.
+
+    Lives in the config JSON blob, so enabling it needs no migration.
+
+    ``require_2fa_enabled_at`` is the anchor the grace period counts from. Each
+    member's personal deadline is
+    ``max(require_2fa_enabled_at, their join date) + require_2fa_grace_days``;
+    without the ``max`` a member who joins after the policy was set would land
+    with an already-expired deadline and be locked out on their first day.
+    """
+
+    require_2fa: bool = False
+    require_2fa_grace_days: int = 0
+    # ISO timestamp of when an admin last switched require_2fa on.
+    require_2fa_enabled_at: Optional[str] = None
+    # Users authenticated by an external IdP already presented whatever factors
+    # that IdP demands; requiring a second app-level TOTP on top is redundant
+    # and, for a SAML-only org, would be unsatisfiable.
+    exempt_external_auth: bool = True
+
+    # Which sign-in methods this org accepts. Members of the org must have
+    # authenticated with one of these to access it. The default lists all
+    # methods, i.e. no restriction — the policy is a no-op until an admin removes
+    # one. Values are drawn from
+    # src.security.session_context.POLICY_AUTH_METHODS:
+    # "password" | "magic_login" | "google" | "sso". Empty list is treated as
+    # "unrestricted" too, so a mis-save can never lock every method out.
+    allowed_auth_methods: list[str] = Field(
+        default_factory=lambda: ["password", "magic_login", "google", "sso"]
+    )
+    # Whether a session established on the central apex (learnhouse.io) or for a
+    # different org may be used to access this org directly. Default True keeps
+    # today's behavior (one session works everywhere the user is a member). When
+    # False, a member arriving with a foreign/central session is refused and must
+    # sign in again from this org using an allowed method.
+    allow_central_session_sharing: bool = True
+
+
 class AdminToggles(BaseModel):
+    security: SecurityAdminToggle = SecurityAdminToggle()
     ai: AIAdminToggle = AIAdminToggle()
     analytics: FeatureAdminToggle = FeatureAdminToggle()
     api: FeatureAdminToggle = FeatureAdminToggle()

--- a/apps/api/src/db/user_mfa.py
+++ b/apps/api/src/db/user_mfa.py
@@ -1,0 +1,69 @@
+from typing import Optional
+from sqlalchemy import Column, ForeignKey, Index, Integer
+from sqlmodel import Field, SQLModel
+
+
+class UserMFA(SQLModel, table=True):
+    """TOTP enrollment for a single user.
+
+    A row exists from the moment enrollment *starts*, but the factor is only
+    live once ``confirmed_at`` is set — i.e. once the user has proven the
+    authenticator app actually works by submitting a valid code. Unconfirmed
+    rows are meaningless and are overwritten if enrollment is restarted.
+    """
+
+    __table_args__ = (
+        Index("ix_user_mfa_user", "user_id", unique=True),
+        {"extend_existing": True},
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("user.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+            index=True,
+        )
+    )
+    # Fernet-encrypted TOTP shared secret. See services/auth/mfa.py — this is
+    # never stored, returned or logged in plaintext after enrollment setup.
+    secret_encrypted: str = ""
+    confirmed_at: Optional[str] = None
+    # Highest TOTP timestep already accepted for this user. A code is rejected
+    # if its timestep is <= this value, so an observed code cannot be replayed
+    # within its own 30s validity window (or the +/-1 step drift allowance).
+    last_used_timestep: Optional[int] = None
+    creation_date: str = ""
+    update_date: str = ""
+
+
+class UserMFABackupCode(SQLModel, table=True):
+    """Single-use recovery codes, issued in a batch at confirmation time.
+
+    Codes are stored as SHA-256(pepper || code) rather than Argon2. That is a
+    deliberate deviation from password storage: these are 100+ bits of
+    server-generated entropy, so there is nothing to brute-force, and a fast
+    keyed digest lets verification be a single indexed lookup instead of N
+    Argon2 verifies (which at 8-10 codes per user would add ~half a second to
+    every recovery attempt). Same reasoning as the API-token hashing path.
+    """
+
+    __table_args__ = (
+        Index("ix_user_mfa_backup_user", "user_id"),
+        {"extend_existing": True},
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("user.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        )
+    )
+    code_hash: str = Field(index=True)
+    used_at: Optional[str] = None
+    creation_date: str = ""

--- a/apps/api/src/router.py
+++ b/apps/api/src/router.py
@@ -9,6 +9,7 @@ from src.routers import instance
 from src.routers import plans
 from src.routers import usergroups
 from src.routers import dev, trail, users, auth, orgs, roles, search
+from src.routers import mfa as mfa_router_module
 from src.routers import monitoring
 from src.routers import stream
 from src.routers import api_tokens
@@ -86,6 +87,8 @@ v1_router.include_router(
     ],
 )
 v1_router.include_router(auth.router, prefix="/auth", tags=["auth"])
+# Two-factor: enrollment/management plus the /auth/login/mfa challenge.
+v1_router.include_router(mfa_router_module.router, prefix="/auth", tags=["auth"])
 v1_router.include_router(
     orgs.router,
     prefix="/orgs",

--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -6,6 +6,7 @@ All endpoints are scoped by org_slug and require API token authentication
 """
 
 from typing import Any, Dict, List, Optional
+from urllib.parse import quote
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, Response
 from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import BaseModel, EmailStr, Field
@@ -994,7 +995,7 @@ async def api_admin_magic_consume(
     db_session: AsyncSession = Depends(get_db_session),
 ):
     try:
-        _user, access_token, refresh_token, redirect_to = await consume_magic_link_token(
+        _user, access_token, refresh_token, redirect_to, mfa_token = await consume_magic_link_token(
             token=token,
             db_session=db_session,
         )
@@ -1005,6 +1006,16 @@ async def api_admin_magic_consume(
         )
 
     target = redirect_to or "/"
+
+    if mfa_token:
+        # No cookies set — the link only gets the user as far as the code
+        # challenge. The login page picks the pending token up from the query
+        # string and opens directly on the second-factor step.
+        challenge_url = f"/auth/login?mfa_token={quote(mfa_token, safe='')}"
+        if redirect_to:
+            challenge_url += f"&redirect_to={quote(redirect_to, safe='')}"
+        return RedirectResponse(url=challenge_url, status_code=302)
+
     redirect = RedirectResponse(url=target, status_code=302)
     set_auth_cookies(redirect, access_token, refresh_token, request)
     return redirect

--- a/apps/api/src/routers/ai/assignment_gen.py
+++ b/apps/api/src/routers/ai/assignment_gen.py
@@ -19,7 +19,7 @@ from src.db.organizations import Organization
 from src.db.users import PublicUser
 from src.security.auth import get_authenticated_user
 from src.security.features_utils.usage import refund_ai_credit, reserve_ai_credit
-from src.security.org_auth import is_org_member
+from src.security.org_auth import is_org_member, enforce_org_mfa
 from src.security.rbac import check_resource_access, AccessAction
 from src.services.ai.assignment_gen import generate_assignment_plan
 from src.services.ai.generations import (
@@ -50,6 +50,8 @@ async def _authorize_org(org_id: int, user: PublicUser, db_session: AsyncSession
         raise HTTPException(status_code=404, detail="Organization not found")
     if not await is_org_member(user.id, org.id, db_session):
         raise HTTPException(status_code=403, detail="User is not a member of this organization")
+    # Org-wide two-factor policy, applied after the membership gate.
+    await enforce_org_mfa(user.id, org.id, db_session)
     return org
 
 

--- a/apps/api/src/routers/ai/audio.py
+++ b/apps/api/src/routers/ai/audio.py
@@ -22,7 +22,7 @@ from src.db.courses.blocks import BlockRead
 from src.db.users import PublicUser
 from src.security.auth import get_authenticated_user
 from src.security.features_utils.usage import refund_ai_credit, reserve_ai_credit
-from src.security.org_auth import is_org_member
+from src.security.org_auth import is_org_member, enforce_org_mfa
 from src.services.ai.audio.generator import (
     OUTPUT_EXT,
     Speaker,
@@ -58,6 +58,8 @@ async def _resolve_org_id_for_activity(activity_uuid: str, current_user: PublicU
         raise HTTPException(status_code=404, detail="Activity not found")
     if not await is_org_member(current_user.id, activity.org_id, db_session):
         raise HTTPException(status_code=403, detail="User is not a member of this organization")
+    # Org-wide two-factor policy, applied after the membership gate.
+    await enforce_org_mfa(current_user.id, activity.org_id, db_session)
     return activity.org_id
 
 

--- a/apps/api/src/routers/ai/courseplanning.py
+++ b/apps/api/src/routers/ai/courseplanning.py
@@ -18,7 +18,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from src.core.events.database import get_db_session
 from src.db.users import PublicUser, AnonymousUser, APITokenUser
 from src.security.auth import get_current_user, resolve_acting_user_id
-from src.security.org_auth import is_org_member
+from src.security.org_auth import is_org_member, enforce_org_mfa
 from src.security.features_utils.usage import (
     reserve_ai_credit,
 )
@@ -83,7 +83,10 @@ async def get_org_ai_model(org_id: int, db_session: AsyncSession) -> str:
 
 async def verify_user_org_membership(user_id: int, org_id: int, db_session: AsyncSession) -> bool:
     """Verify that the user is a member of the organization (superadmins bypass)."""
-    return await is_org_member(user_id, org_id, db_session)
+    member = await is_org_member(user_id, org_id, db_session)
+    if member:
+        await enforce_org_mfa(user_id, org_id, db_session)
+    return member
 
 
 @router.post(

--- a/apps/api/src/routers/ai/images.py
+++ b/apps/api/src/routers/ai/images.py
@@ -26,7 +26,7 @@ from src.db.organizations import Organization
 from src.db.users import PublicUser
 from src.security.auth import get_authenticated_user
 from src.security.features_utils.usage import refund_ai_credit, reserve_ai_credit
-from src.security.org_auth import is_org_member
+from src.security.org_auth import is_org_member, enforce_org_mfa
 from src.services.ai.generations import (
     delete_generation,
     list_generations,
@@ -79,6 +79,8 @@ async def _load_org_and_authorize(
         raise HTTPException(
             status_code=403, detail="User is not a member of this organization"
         )
+    # Org-wide two-factor policy, applied after the membership gate.
+    await enforce_org_mfa(user.id, org.id, db_session)
     return org
 
 

--- a/apps/api/src/routers/ai/magicblocks.py
+++ b/apps/api/src/routers/ai/magicblocks.py
@@ -11,7 +11,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from src.core.events.database import get_db_session
 from src.db.users import PublicUser, AnonymousUser, APITokenUser
 from src.security.auth import get_current_user, get_authenticated_user, resolve_acting_user_id
-from src.security.org_auth import is_org_member
+from src.security.org_auth import is_org_member, enforce_org_mfa
 from src.security.features_utils.usage import (
     reserve_ai_credit,
     refund_ai_credit,
@@ -149,6 +149,8 @@ async def start_magicblock_session(
             detail="You are not a member of this organization",
         )
 
+    # Org-wide two-factor policy, applied after the membership gate.
+    await enforce_org_mfa(acting_user_id, org.id, db_session)
     # F-9: per-user + per-org rate limit before any compute / credit spend.
     from src.services.security.rate_limiting import enforce_ai_rate_limit
     enforce_ai_rate_limit(acting_user_id, org.id)
@@ -259,6 +261,8 @@ async def iterate_magicblock_session(
             detail="You are not a member of this organization",
         )
 
+    # Org-wide two-factor policy, applied after the membership gate.
+    await enforce_org_mfa(acting_user_id, org.id, db_session)
     # F-9: per-user + per-org rate limit before any compute / credit spend.
     from src.services.security.rate_limiting import enforce_ai_rate_limit
     enforce_ai_rate_limit(acting_user_id, org.id)

--- a/apps/api/src/routers/ai/quiz.py
+++ b/apps/api/src/routers/ai/quiz.py
@@ -19,7 +19,7 @@ from src.db.organizations import Organization
 from src.db.users import PublicUser
 from src.security.auth import get_authenticated_user
 from src.security.features_utils.usage import refund_ai_credit, reserve_ai_credit
-from src.security.org_auth import is_org_member
+from src.security.org_auth import is_org_member, enforce_org_mfa
 from src.security.rbac import check_resource_access, AccessAction
 from src.services.ai.generations import (
     delete_generation,
@@ -50,6 +50,8 @@ async def _authorize_org(org_id: int, user: PublicUser, db_session: AsyncSession
         raise HTTPException(status_code=404, detail="Organization not found")
     if not await is_org_member(user.id, org.id, db_session):
         raise HTTPException(status_code=403, detail="User is not a member of this organization")
+    # Org-wide two-factor policy, applied after the membership gate.
+    await enforce_org_mfa(user.id, org.id, db_session)
     return org
 
 

--- a/apps/api/src/routers/ai/rag.py
+++ b/apps/api/src/routers/ai/rag.py
@@ -21,7 +21,7 @@ from src.db.organizations import Organization
 from src.db.users import PublicUser, AnonymousUser, APITokenUser
 from src.security.auth import get_current_user, get_authenticated_user, resolve_acting_user_id
 from src.security.features_utils.usage import reserve_ai_credit
-from src.security.org_auth import is_org_member, require_org_admin
+from src.security.org_auth import is_org_member, require_org_admin, enforce_org_mfa
 from src.services.ai.base import (
     get_chat_session_history,
     save_message_to_history,
@@ -207,6 +207,8 @@ async def api_rag_chat(
             status_code=403,
             detail="You are not a member of this organization",
         )
+    # Org-wide two-factor policy, applied after the membership gate.
+    await enforce_org_mfa(resolve_acting_user_id(current_user), org_id, db_session)
 
     # Check if copilot is enabled for this org
     org_config = (await db_session.execute(

--- a/apps/api/src/routers/ai/scenario.py
+++ b/apps/api/src/routers/ai/scenario.py
@@ -18,7 +18,7 @@ from src.db.organizations import Organization
 from src.db.users import PublicUser
 from src.security.auth import get_authenticated_user
 from src.security.features_utils.usage import refund_ai_credit, reserve_ai_credit
-from src.security.org_auth import is_org_member
+from src.security.org_auth import is_org_member, enforce_org_mfa
 from src.services.ai.generations import (
     delete_generation,
     list_generations,
@@ -48,6 +48,8 @@ async def _authorize_org(org_id: int, user: PublicUser, db_session: AsyncSession
         raise HTTPException(status_code=404, detail="Organization not found")
     if not await is_org_member(user.id, org.id, db_session):
         raise HTTPException(status_code=403, detail="User is not a member of this organization")
+    # Org-wide two-factor policy, applied after the membership gate.
+    await enforce_org_mfa(user.id, org.id, db_session)
     return org
 
 

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -50,6 +50,26 @@ from src.services.users.email_verification import (
     verify_email_token,
     resend_verification_email,
 )
+from src.services.auth.session import issue_session_or_challenge
+from src.security.session_context import (
+    AMR_CLAIM,
+    AUTH_METHOD_GOOGLE,
+    AUTH_METHOD_PASSWORD,
+    SORG_CLAIM,
+    session_claims,
+)
+from src.db.organizations import Organization
+
+
+async def _resolve_org_id_from_slug(org_slug: Optional[str], db_session: AsyncSession) -> Optional[int]:
+    """Map an optional login-page org slug to an org id, for the session's
+    ``sorg`` binding. Unknown/absent slug → None (a central/apex login)."""
+    if not org_slug:
+        return None
+    org = (
+        await db_session.execute(select(Organization).where(Organization.slug == org_slug))
+    ).scalars().first()
+    return org.id if org else None
 
 
 def get_token_expiry_ms() -> Optional[int]:
@@ -397,11 +417,15 @@ async def refresh(
         new_access_token = reused_pair["access_token"]
         new_refresh_token = reused_pair["refresh_token"]
     else:
+        # Carry the session's provenance across rotation. Without this a refresh
+        # would silently launder a method-bound/org-bound session into a
+        # claim-less one that bypasses the org auth-method / sharing policy.
+        carried = session_claims(payload.get(AMR_CLAIM), payload.get(SORG_CLAIM))
         new_access_token = create_access_token(
-            data={"sub": email},
+            data={"sub": email, **carried},
             expires_delta=JWT_ACCESS_TOKEN_EXPIRES,
         )
-        new_refresh_token = create_refresh_token(data={"sub": email})
+        new_refresh_token = create_refresh_token(data={"sub": email, **carried})
         if jti:
             _store_refresh_grace(
                 user.id, jti, new_access_token, new_refresh_token
@@ -466,6 +490,7 @@ async def login(
     response: Response,
     username: str = Form(...),
     password: str = Form(...),
+    org_slug: Optional[str] = Form(None),
     db_session: AsyncSession = Depends(get_db_session),
 ):
     # Step 1: Check rate limit (IP-based)
@@ -554,22 +579,29 @@ async def login(
         metadata={"method": "password"},
     )
 
-    # Step 6: Issue tokens
-    access_token = create_access_token(
-        data={"sub": username},
-        expires_delta=JWT_ACCESS_TOKEN_EXPIRES
+    # Step 6: Issue a session — unless the account carries a second factor, in
+    # which case this returns a short-lived pending token instead and the caller
+    # must complete /auth/login/mfa. No cookies and no user object are returned
+    # on that branch: nothing is authenticated until the code is verified.
+    session_org_id = await _resolve_org_id_from_slug(org_slug, db_session)
+    issue = await issue_session_or_challenge(
+        db_session, user, amr=AUTH_METHOD_PASSWORD, org_id=session_org_id
     )
-    refresh_token = create_refresh_token(data={"sub": username})
+    if issue.mfa_required:
+        return {
+            "mfa_required": True,
+            "mfa_token": issue.mfa_token,
+        }
 
-    set_auth_cookies(response, access_token, refresh_token, request)
+    set_auth_cookies(response, issue.access_token, issue.refresh_token, request)
 
     user = UserRead.model_validate(user)
 
     result = {
         "user": user,
         "tokens": {
-            "access_token": access_token,
-            "refresh_token": refresh_token,
+            "access_token": issue.access_token,
+            "refresh_token": issue.refresh_token,
             "expiry": get_token_expiry_ms(),
         },
     }
@@ -813,11 +845,16 @@ async def third_party_login(
                 except Exception:
                     pass
 
+    # Google OAuth mints directly (it does not carry a second factor). Stamp the
+    # session's provenance so the org auth-method / sharing policy can see it.
+    google_claims = session_claims(AUTH_METHOD_GOOGLE, org_id)
     access_token = create_access_token(
-        data={"sub": user.email},
+        data={"sub": user.email, "purpose": "session", **google_claims},
         expires_delta=JWT_ACCESS_TOKEN_EXPIRES
     )
-    refresh_token = create_refresh_token(data={"sub": user.email})
+    refresh_token = create_refresh_token(
+        data={"sub": user.email, "purpose": "session", **google_claims}
+    )
 
     set_auth_cookies(response, access_token, refresh_token, request)
 
@@ -832,6 +869,130 @@ async def third_party_login(
         },
     }
     return result
+
+
+class MagicLinkLoginRequest(BaseModel):
+    email: EmailStr
+    org_slug: Optional[str] = None
+
+
+class MagicLinkVerifyRequest(BaseModel):
+    token: str
+
+
+@router.post(
+    "/magic-link/request",
+    summary="Request a passwordless login link by email",
+    description=(
+        "Emails a one-time, short-lived login link to the address if an account "
+        "exists. Always returns 200 with the same body regardless of whether the "
+        "account exists, so it cannot be used to enumerate users."
+    ),
+    responses={200: {"description": "If the account exists, a link has been sent."}, 429: {"description": "Too many requests"}},
+)
+async def magic_link_request(
+    request: Request,
+    body: MagicLinkLoginRequest,
+    db_session: AsyncSession = Depends(get_db_session),
+):
+    from src.services.auth.magic_login import (
+        issue_magic_login_token,
+        resolve_org,
+        send_magic_login_email,
+    )
+    from src.services.orgs.auth_policy import get_org_auth_policy
+    from src.security.session_context import AUTH_METHOD_MAGIC_LOGIN
+    from src.services.email.utils import get_base_url_from_request
+
+    is_allowed, retry_after = check_login_rate_limit(request)
+    if not is_allowed:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={"code": "RATE_LIMITED", "message": "Too many requests. Please try again later.", "retry_after": retry_after},
+        )
+
+    generic = {"detail": "If an account exists for that email, a login link has been sent."}
+
+    org = await resolve_org(body.org_slug, db_session)
+    # If the request is scoped to an org that does not offer magic-link login,
+    # do not send one — the link would only be refused at the org gate anyway.
+    if org is not None:
+        policy = await get_org_auth_policy(db_session, org.id)
+        if policy.method_restricted and AUTH_METHOD_MAGIC_LOGIN not in set(policy.allowed_auth_methods):
+            return generic
+
+    user = (
+        await db_session.execute(select(User).where(User.email == str(body.email)))
+    ).scalars().first()
+    if user is None:
+        return generic
+    # In SaaS mode an unverified account can't log in by password; keep parity so
+    # a magic link can't be a verification-bypass side channel.
+    if not user.email_verified and get_deployment_mode() == "saas":
+        return generic
+
+    try:
+        token = issue_magic_login_token(user.email, org.id if org else None)
+        send_magic_login_email(
+            UserRead.model_validate(user),
+            user.email,
+            get_base_url_from_request(request),
+            token,
+        )
+    except Exception:
+        import logging
+        logging.getLogger(__name__).exception("Failed to send magic-login email")
+    return generic
+
+
+@router.post(
+    "/magic-link/verify",
+    summary="Complete a passwordless login",
+    description=(
+        "Exchange a one-time login-link token for a session. If the account has "
+        "two-factor enabled, returns an `mfa_token` instead and no cookies are set "
+        "until the code is verified at /auth/login/mfa."
+    ),
+    responses={200: {"description": "Login successful, or a second factor is required."}, 410: {"description": "Link invalid or already used"}},
+)
+async def magic_link_verify(
+    request: Request,
+    response: Response,
+    body: MagicLinkVerifyRequest,
+    db_session: AsyncSession = Depends(get_db_session),
+):
+    from src.services.auth.magic_login import consume_magic_login_token
+    from src.security.session_context import AUTH_METHOD_MAGIC_LOGIN
+
+    email, org_id = consume_magic_login_token(body.token)
+
+    user = (
+        await db_session.execute(select(User).where(User.email == email))
+    ).scalars().first()
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail={"code": "MAGIC_LINK_INVALID", "message": "This login link is no longer valid."},
+        )
+
+    client_ip = get_client_ip(request)
+    await update_login_info(user, client_ip, db_session)
+
+    issue = await issue_session_or_challenge(
+        db_session, user, amr=AUTH_METHOD_MAGIC_LOGIN, org_id=org_id
+    )
+    if issue.mfa_required:
+        return {"mfa_required": True, "mfa_token": issue.mfa_token}
+
+    set_auth_cookies(response, issue.access_token, issue.refresh_token, request)
+    return {
+        "user": UserRead.model_validate(user),
+        "tokens": {
+            "access_token": issue.access_token,
+            "refresh_token": issue.refresh_token,
+            "expiry": get_token_expiry_ms(),
+        },
+    }
 
 
 @router.delete(
@@ -942,20 +1103,26 @@ async def api_verify_email(
         org_uuid=body.org_uuid,
     )
 
-    # Auto sign-in: issue a session exactly like /login (sub = email).
-    access_token = create_access_token(
-        data={"sub": user.email},
-        expires_delta=JWT_ACCESS_TOKEN_EXPIRES,
-    )
-    refresh_token = create_refresh_token(data={"sub": user.email})
-    set_auth_cookies(response, access_token, refresh_token, request)
+    # Auto sign-in: issue a session exactly like /login (sub = email), and go
+    # through the same second-factor gate. A brand-new user cannot have MFA yet,
+    # but an existing user re-verifying their address can — and without this the
+    # verification link would be a way around their own second factor.
+    issue = await issue_session_or_challenge(db_session, user)
+    if issue.mfa_required:  # pragma: no cover - same 2FA branch as /login, exercised there
+        return {
+            "message": message,
+            "mfa_required": True,
+            "mfa_token": issue.mfa_token,
+        }
+
+    set_auth_cookies(response, issue.access_token, issue.refresh_token, request)
 
     return {
         "message": message,
         "user": UserRead.model_validate(user),
         "tokens": {
-            "access_token": access_token,
-            "refresh_token": refresh_token,
+            "access_token": issue.access_token,
+            "refresh_token": issue.refresh_token,
             "expiry": get_token_expiry_ms(),
         },
     }

--- a/apps/api/src/routers/boards/boards_playground.py
+++ b/apps/api/src/routers/boards/boards_playground.py
@@ -13,7 +13,7 @@ from src.security.auth import get_current_user, get_authenticated_user, resolve_
 from src.security.features_utils.usage import (
     reserve_ai_credit,
 )
-from src.security.org_auth import is_org_member
+from src.security.org_auth import is_org_member, enforce_org_mfa
 from src.services.ai.llm import model_for_tier
 from src.services.boards.boards_playground import (
     get_boards_playground_session,
@@ -88,6 +88,8 @@ async def start_boards_playground_session(
             detail="You are not a member of this organization",
         )
 
+    # Org-wide two-factor policy, applied after the membership gate.
+    await enforce_org_mfa(start_acting_user_id, org.id, db_session)
     # F-9: per-user + per-org rate limit before any compute / credit spend.
     from src.services.security.rate_limiting import enforce_ai_rate_limit
     enforce_ai_rate_limit(start_acting_user_id, org.id)
@@ -173,6 +175,8 @@ async def iterate_boards_playground_session(
             detail="You are not a member of this organization",
         )
 
+    # Org-wide two-factor policy, applied after the membership gate.
+    await enforce_org_mfa(iterate_acting_user_id, org.id, db_session)
     # F-9: per-user + per-org rate limit before any compute / credit spend.
     from src.services.security.rate_limiting import enforce_ai_rate_limit
     enforce_ai_rate_limit(iterate_acting_user_id, org.id)
@@ -245,6 +249,8 @@ async def get_session_state(
             detail="You are not a member of this organization",
         )
 
+    # Org-wide two-factor policy, applied after the membership gate.
+    await enforce_org_mfa(acting_user_id, org.id, db_session)
     return BoardsPlaygroundSessionResponse(
         session_uuid=session.session_uuid,
         iteration_count=session.iteration_count,

--- a/apps/api/src/routers/mfa.py
+++ b/apps/api/src/routers/mfa.py
@@ -1,0 +1,738 @@
+"""Two-factor authentication: enrollment, management and the login challenge.
+
+Mounted under ``/api/v1/auth`` alongside the main auth router. The login
+challenge deliberately lives at ``/auth/login/mfa`` so the web app's auth proxy
+(``TOKEN_RESPONSE_PATHS``, which matches on prefix) mirrors its cookies without
+needing a separate allowlist entry.
+"""
+
+from datetime import datetime
+from typing import Optional, Union
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from pydantic import BaseModel
+from sqlalchemy.orm.attributes import flag_modified
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.core.events.database import get_db_session
+from src.db.user_mfa import UserMFA
+from src.db.users import APITokenUser, PublicUser, SuperadminAPITokenUser, User, UserRead
+from src.security.auth import get_authenticated_user
+from src.security.security import security_verify_password
+from src.services.auth.mfa import (
+    build_provisioning_uri,
+    consume_backup_code,
+    count_unused_backup_codes,
+    decrypt_secret,
+    disable_mfa,
+    encrypt_secret,
+    generate_totp_secret,
+    get_user_mfa,
+    replace_backup_codes,
+    verify_and_consume_totp,
+    verify_totp_code,
+)
+from src.services.auth.session import (
+    decode_mfa_pending_token,
+    decode_mfa_pending_provenance,
+    mint_session_tokens,
+)
+from src.services.orgs.mfa_policy import evaluate_mfa_compliance, get_org_mfa_policy
+from src.services.security.rate_limiting import check_rate_limit, get_client_ip
+from src.security.org_auth import is_org_admin
+from src.db.organization_config import OrganizationConfig
+from src.db.user_organizations import UserOrganization
+from src.routers.auth import get_token_expiry_ms, set_auth_cookies
+
+router = APIRouter()
+
+
+### 🔒 Request models ##############################################################
+
+
+class MFASetupRequest(BaseModel):
+    password: Optional[str] = None
+
+
+class MFACodeRequest(BaseModel):
+    code: str
+
+
+class MFADisableRequest(BaseModel):
+    password: Optional[str] = None
+    code: str
+
+
+class MFALoginRequest(BaseModel):
+    mfa_token: str
+    code: str
+    is_backup_code: bool = False
+
+
+### 🔒 Helpers ##############################################################
+
+
+async def _require_human_user(
+    current_user: Union[PublicUser, APITokenUser, SuperadminAPITokenUser],
+    db_session: AsyncSession,
+) -> User:
+    """Resolve the acting principal to a real User row.
+
+    API tokens are rejected outright: a machine credential must not be able to
+    enroll, and more importantly must not be able to *remove* a second factor
+    from a human's account.
+    """
+    if isinstance(current_user, (APITokenUser, SuperadminAPITokenUser)):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": "API_TOKEN_NOT_ALLOWED",
+                "message": "Two-factor settings can only be changed from a signed-in session.",
+            },
+        )
+
+    user = (
+        await db_session.execute(select(User).where(User.id == current_user.id))
+    ).scalars().first()
+    if user is None:  # pragma: no cover - defensive: authenticated principal always resolves
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return user
+
+
+def _verify_password_if_set(user: User, password: Optional[str]) -> None:
+    """Re-authenticate before a security-sensitive change.
+
+    Users provisioned purely through Google/SSO have no local password; for them
+    possession of the session is the only credential available, so the check is
+    skipped rather than making the feature unreachable.
+    """
+    if not user.password:
+        return
+    if not password or not security_verify_password(password, user.password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"code": "INVALID_PASSWORD", "message": "Incorrect password."},
+        )
+
+
+def _check_mfa_rate_limit(request: Request, scope: str, identifier: str) -> None:
+    """Throttle code submission. Keyed on both the account and the source IP so
+    neither a single account nor a single host can be used to grind codes."""
+    for key in (f"mfa:{scope}:{identifier}", f"mfa:{scope}:ip:{get_client_ip(request)}"):
+        is_allowed, _count, retry_after = check_rate_limit(
+            key=key, max_attempts=10, window_seconds=5 * 60
+        )
+        if not is_allowed:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail={
+                    "code": "RATE_LIMITED",
+                    "message": "Too many attempts. Please wait before trying again.",
+                    "retry_after": retry_after,
+                },
+            )
+
+
+### 🔒 Status ##############################################################
+
+
+@router.get(
+    "/mfa/status",
+    summary="Get the caller's two-factor status",
+    tags=["auth"],
+)
+async def api_mfa_status(
+    db_session: AsyncSession = Depends(get_db_session),
+    current_user=Depends(get_authenticated_user),
+):
+    user = await _require_human_user(current_user, db_session)
+    mfa = await get_user_mfa(db_session, user.id)
+    enabled = mfa is not None and mfa.confirmed_at is not None
+    return {
+        "enabled": enabled,
+        "confirmed_at": mfa.confirmed_at if mfa else None,
+        "backup_codes_remaining": (
+            await count_unused_backup_codes(db_session, user.id) if enabled else 0
+        ),
+        "has_password": bool(user.password),
+    }
+
+
+### 🔒 Enrollment ##############################################################
+
+
+@router.post(
+    "/mfa/setup",
+    summary="Begin two-factor enrollment",
+    description=(
+        "Generate a TOTP secret and return the `otpauth://` provisioning URI. "
+        "The factor is NOT active until confirmed with a valid code."
+    ),
+    tags=["auth"],
+    responses={
+        401: {"description": "Incorrect password"},
+        409: {"description": "Two-factor is already enabled"},
+    },
+)
+async def api_mfa_setup(
+    form: MFASetupRequest,
+    db_session: AsyncSession = Depends(get_db_session),
+    current_user=Depends(get_authenticated_user),
+):
+    user = await _require_human_user(current_user, db_session)
+    _verify_password_if_set(user, form.password)
+
+    existing = await get_user_mfa(db_session, user.id)
+    if existing is not None and existing.confirmed_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "MFA_ALREADY_ENABLED",
+                "message": "Two-factor authentication is already enabled. Disable it first to re-enroll.",
+            },
+        )
+
+    secret = generate_totp_secret()
+    now = str(datetime.now())
+
+    if existing is not None:
+        # Restarting an abandoned enrollment — overwrite the unconfirmed secret
+        # so the QR the user is looking at is the one we will verify against.
+        existing.secret_encrypted = encrypt_secret(secret)
+        existing.last_used_timestep = None
+        existing.update_date = now
+        db_session.add(existing)
+    else:
+        db_session.add(
+            UserMFA(
+                user_id=user.id,
+                secret_encrypted=encrypt_secret(secret),
+                creation_date=now,
+                update_date=now,
+            )
+        )
+    await db_session.commit()
+
+    return {
+        "secret": secret,
+        "provisioning_uri": build_provisioning_uri(secret, user.email),
+    }
+
+
+@router.post(
+    "/mfa/confirm",
+    summary="Confirm and activate two-factor enrollment",
+    description="Verify a code from the authenticator app, activate the factor, and return single-use backup codes. The codes are shown exactly once.",
+    tags=["auth"],
+    responses={
+        400: {"description": "No enrollment in progress, or invalid code"},
+        429: {"description": "Too many attempts"},
+    },
+)
+async def api_mfa_confirm(
+    request: Request,
+    form: MFACodeRequest,
+    db_session: AsyncSession = Depends(get_db_session),
+    current_user=Depends(get_authenticated_user),
+):
+    user = await _require_human_user(current_user, db_session)
+    _check_mfa_rate_limit(request, "confirm", str(user.id))
+
+    mfa = await get_user_mfa(db_session, user.id)
+    if mfa is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "NO_ENROLLMENT", "message": "Start enrollment before confirming."},
+        )
+    if mfa.confirmed_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"code": "MFA_ALREADY_ENABLED", "message": "Two-factor is already enabled."},
+        )
+
+    secret = decrypt_secret(mfa.secret_encrypted)
+    if secret is None:  # pragma: no cover - defensive: only a rotated encryption key hits this
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"code": "MFA_SECRET_UNREADABLE", "message": "Could not read the enrollment secret. Please restart setup."},
+        )
+
+    # Burn the timestep atomically before activating, so the very code used to
+    # confirm cannot then be replayed at /auth/login/mfa within its window.
+    consumed = await verify_and_consume_totp(
+        db_session, user.id, secret, form.code, mfa.last_used_timestep
+    )
+    if not consumed:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "INVALID_CODE",
+                "message": "That code isn't right. Check your device's clock is set automatically, then try the next code.",
+            },
+        )
+
+    now = str(datetime.now())
+    mfa.confirmed_at = now
+    mfa.update_date = now
+    db_session.add(mfa)
+    await db_session.commit()
+
+    codes = await replace_backup_codes(db_session, user.id)
+    return {"enabled": True, "backup_codes": codes}
+
+
+@router.post(
+    "/mfa/disable",
+    summary="Disable two-factor authentication",
+    description="Requires both the current password (when the account has one) and a valid code, so a hijacked session alone cannot strip the factor.",
+    tags=["auth"],
+    responses={400: {"description": "Invalid code"}, 401: {"description": "Incorrect password"}},
+)
+async def api_mfa_disable(
+    request: Request,
+    form: MFADisableRequest,
+    db_session: AsyncSession = Depends(get_db_session),
+    current_user=Depends(get_authenticated_user),
+):
+    user = await _require_human_user(current_user, db_session)
+    _check_mfa_rate_limit(request, "disable", str(user.id))
+    _verify_password_if_set(user, form.password)
+
+    mfa = await get_user_mfa(db_session, user.id)
+    if mfa is None or mfa.confirmed_at is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "MFA_NOT_ENABLED", "message": "Two-factor is not enabled."},
+        )
+
+    secret = decrypt_secret(mfa.secret_encrypted)
+    # A backup code is accepted here too: someone who has lost their device
+    # still needs a way to turn the factor off rather than being stuck with it.
+    accepted = False
+    if secret is not None:
+        accepted, _ = verify_totp_code(secret, form.code, mfa.last_used_timestep)
+    if not accepted:
+        accepted = await consume_backup_code(db_session, user.id, form.code)
+    if not accepted:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "INVALID_CODE", "message": "That code isn't right."},
+        )
+
+    await disable_mfa(db_session, user.id)
+    return {"enabled": False}
+
+
+@router.post(
+    "/mfa/backup-codes/regenerate",
+    summary="Regenerate backup codes",
+    description="Invalidates all existing codes and returns a fresh batch, shown exactly once.",
+    tags=["auth"],
+)
+async def api_mfa_regenerate_backup_codes(
+    request: Request,
+    form: MFACodeRequest,
+    db_session: AsyncSession = Depends(get_db_session),
+    current_user=Depends(get_authenticated_user),
+):
+    user = await _require_human_user(current_user, db_session)
+    _check_mfa_rate_limit(request, "regen", str(user.id))
+
+    mfa = await get_user_mfa(db_session, user.id)
+    if mfa is None or mfa.confirmed_at is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "MFA_NOT_ENABLED", "message": "Two-factor is not enabled."},
+        )
+
+    secret = decrypt_secret(mfa.secret_encrypted)
+    is_valid = False
+    if secret is not None:
+        is_valid = await verify_and_consume_totp(
+            db_session, user.id, secret, form.code, mfa.last_used_timestep
+        )
+    if not is_valid:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "INVALID_CODE", "message": "That code isn't right."},
+        )
+
+    codes = await replace_backup_codes(db_session, user.id)
+    return {"backup_codes": codes}
+
+
+### 🔒 Login challenge ##############################################################
+
+
+@router.post(
+    "/login/mfa",
+    summary="Complete login with a second factor",
+    description=(
+        "Exchange the short-lived `mfa_token` returned by `/auth/login` plus a "
+        "TOTP or backup code for a real session."
+    ),
+    tags=["auth"],
+    responses={
+        401: {"description": "Expired or invalid pending token, or invalid code"},
+        429: {"description": "Too many attempts"},
+    },
+)
+async def api_login_mfa(
+    request: Request,
+    response: Response,
+    form: MFALoginRequest,
+    db_session: AsyncSession = Depends(get_db_session),
+):
+    email = decode_mfa_pending_token(form.mfa_token)
+    if not email:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={
+                "code": "MFA_SESSION_EXPIRED",
+                "message": "That took too long — please sign in again.",
+            },
+        )
+
+    _check_mfa_rate_limit(request, "login", email)
+
+    # Provenance (how the user authenticated, which org for) was stamped into the
+    # pending token at the password/magic-link/SSO step; carry it into the real
+    # session so the org auth-method / sharing policy sees the true method.
+    pending_amr, pending_org_id = decode_mfa_pending_provenance(form.mfa_token)
+
+    user = (
+        await db_session.execute(select(User).where(User.email == email))
+    ).scalars().first()
+    if user is None:  # pragma: no cover - defensive: pending token only issued for a real user
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"code": "MFA_SESSION_EXPIRED", "message": "Please sign in again."},
+        )
+
+    mfa = await get_user_mfa(db_session, user.id)
+    if mfa is None or mfa.confirmed_at is None:
+        # The factor was removed between password step and code step. Nothing
+        # left to verify, so fall through to a normal session rather than
+        # stranding the user at a challenge they can never satisfy.
+        result = mint_session_tokens(user.email, pending_amr, pending_org_id)
+    else:
+        accepted = False
+        if form.is_backup_code:
+            accepted = await consume_backup_code(db_session, user.id, form.code)
+        else:
+            secret = decrypt_secret(mfa.secret_encrypted)
+            if secret is not None:
+                accepted = await verify_and_consume_totp(
+                    db_session, user.id, secret, form.code, mfa.last_used_timestep
+                )
+            if not accepted:
+                # Let a backup code through even if the user didn't tick the
+                # box — they are unambiguously distinguishable from 6 digits.
+                accepted = await consume_backup_code(db_session, user.id, form.code)
+
+        if not accepted:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail={
+                    "code": "INVALID_CODE",
+                    "message": "That code isn't right. Check your device's clock is set automatically, then try the next code.",
+                },
+            )
+
+        result = mint_session_tokens(user.email, pending_amr, pending_org_id)
+
+    set_auth_cookies(response, result.access_token, result.refresh_token, request)
+
+    return {
+        "user": UserRead.model_validate(user),
+        "tokens": {
+            "access_token": result.access_token,
+            "refresh_token": result.refresh_token,
+            "expiry": get_token_expiry_ms(),
+        },
+        "backup_codes_remaining": await count_unused_backup_codes(db_session, user.id),
+    }
+
+
+### 🔒 Org-wide policy ##############################################################
+
+
+class OrgMFAPolicyUpdate(BaseModel):
+    require_2fa: bool
+    require_2fa_grace_days: int = 0
+    exempt_external_auth: bool = True
+    # Auth-method / session-sharing policy. Optional so an older client that only
+    # sends the 2FA fields leaves these untouched.
+    allowed_auth_methods: Optional[list[str]] = None
+    allow_central_session_sharing: Optional[bool] = None
+
+
+@router.get(
+    "/mfa/org-policy/{org_id}",
+    summary="Get the caller's two-factor compliance state for an org",
+    description=(
+        "Drives the in-app banner and the blocking interstitial. `blocking` is "
+        "true only once the grace deadline has passed without enrollment."
+    ),
+    tags=["auth"],
+)
+async def api_org_mfa_compliance(
+    org_id: int,
+    db_session: AsyncSession = Depends(get_db_session),
+    current_user=Depends(get_authenticated_user),
+):
+    user = await _require_human_user(current_user, db_session)
+    state = await evaluate_mfa_compliance(db_session, user, org_id)
+    return state.to_dict()
+
+
+@router.put(
+    "/mfa/org-policy/{org_id}",
+    summary="Set the org-wide two-factor requirement",
+    description=(
+        "Admin/maintainer only. Enabling the policy requires the calling admin "
+        "to already have two-factor enabled themselves."
+    ),
+    tags=["auth"],
+    responses={
+        403: {"description": "Not an org admin, or admin has not enrolled themselves"},
+    },
+)
+async def api_set_org_mfa_policy(
+    org_id: int,
+    form: OrgMFAPolicyUpdate,
+    db_session: AsyncSession = Depends(get_db_session),
+    current_user=Depends(get_authenticated_user),
+):
+    user = await _require_human_user(current_user, db_session)
+
+    if not await is_org_admin(user.id, org_id, db_session):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"code": "NOT_ORG_ADMIN", "message": "Only org admins can change this setting."},
+        )
+
+    # Self-lockout guard. With grace_days=0 an admin without a second factor
+    # would be blocked from their own org the instant this saves — and there
+    # would be no admin left able to turn it back off.
+    if form.require_2fa:
+        mfa = await get_user_mfa(db_session, user.id)
+        if mfa is None or mfa.confirmed_at is None:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "code": "ADMIN_MFA_REQUIRED_FIRST",
+                    "message": "Enable two-factor on your own account before requiring it for the organization.",
+                },
+            )
+
+    row = (
+        await db_session.execute(
+            select(OrganizationConfig).where(OrganizationConfig.org_id == org_id)
+        )
+    ).scalars().first()
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organization config not found")
+
+    config = dict(row.config or {})
+    toggles = dict(config.get("admin_toggles") or {})
+    security = dict(toggles.get("security") or {})
+
+    was_enabled = bool(security.get("require_2fa", False))
+
+    security["require_2fa"] = form.require_2fa
+    security["require_2fa_grace_days"] = max(0, form.require_2fa_grace_days)
+    security["exempt_external_auth"] = form.exempt_external_auth
+    # Only re-anchor when switching off→on. Re-saving an already-active policy
+    # (e.g. to tweak the grace length) must not silently restart everyone's
+    # countdown.
+    if form.require_2fa and not was_enabled:
+        security["require_2fa_enabled_at"] = datetime.now().isoformat()
+    elif not form.require_2fa:
+        security["require_2fa_enabled_at"] = None
+
+    # Auth-method / session-sharing policy, with self-lockout guards so an admin
+    # cannot save a policy that would refuse their own current session.
+    from src.security.session_context import POLICY_AUTH_METHODS, get_session_provenance
+    from src.security.superadmin import is_user_superadmin
+
+    is_super = await is_user_superadmin(user.id, db_session)
+    provenance = get_session_provenance()
+
+    if form.allowed_auth_methods is not None:
+        methods = [m for m in form.allowed_auth_methods if m in POLICY_AUTH_METHODS]
+        restrictive = bool(methods) and not set(POLICY_AUTH_METHODS).issubset(methods)
+        if (
+            restrictive
+            and not is_super
+            and provenance is not None
+            and provenance.amr in POLICY_AUTH_METHODS
+            and provenance.amr not in methods
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "code": "AUTH_METHOD_SELF_LOCKOUT",
+                    "message": "That would lock you out — the method you're signed in with isn't in the allowed list. Keep it, or sign in with an allowed method first.",
+                },
+            )
+        security["allowed_auth_methods"] = methods
+
+    if form.allow_central_session_sharing is not None:
+        if (
+            form.allow_central_session_sharing is False
+            and not is_super
+            and (provenance is None or provenance.org_id != org_id)
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "code": "SESSION_SHARING_SELF_LOCKOUT",
+                    "message": "Sign in from this organization's own login page before turning off session sharing, otherwise your current session would be locked out.",
+                },
+            )
+        security["allow_central_session_sharing"] = form.allow_central_session_sharing
+
+    toggles["security"] = security
+    config["admin_toggles"] = toggles
+    row.config = config
+    # SQLAlchemy does not track in-place mutation of a JSON column; without an
+    # explicit flag the reassignment above can be dropped on commit.
+    flag_modified(row, "config")
+    row.update_date = str(datetime.now())
+    db_session.add(row)
+    await db_session.commit()
+
+    policy = await get_org_mfa_policy(db_session, org_id)
+    from src.services.orgs.auth_policy import get_org_auth_policy
+    auth_policy = await get_org_auth_policy(db_session, org_id)
+    return {
+        "require_2fa": policy.require_2fa,
+        "require_2fa_grace_days": policy.grace_days,
+        "require_2fa_enabled_at": policy.enabled_at,
+        "exempt_external_auth": policy.exempt_external_auth,
+        "allowed_auth_methods": auth_policy.allowed_auth_methods,
+        "allow_central_session_sharing": auth_policy.allow_central_session_sharing,
+    }
+
+
+@router.get(
+    "/mfa/org-compliance/{org_id}",
+    summary="List members and whether they have two-factor enabled",
+    description=(
+        "Admin/maintainer only. Intended to be checked BEFORE switching the "
+        "policy on — enabling it blind is how an org locks out its own staff."
+    ),
+    tags=["auth"],
+)
+async def api_org_mfa_compliance_list(
+    org_id: int,
+    db_session: AsyncSession = Depends(get_db_session),
+    current_user=Depends(get_authenticated_user),
+):
+    user = await _require_human_user(current_user, db_session)
+
+    if not await is_org_admin(user.id, org_id, db_session):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"code": "NOT_ORG_ADMIN", "message": "Only org admins can view this."},
+        )
+
+    rows = (
+        await db_session.execute(
+            select(User, UserMFA)
+            .join(UserOrganization, UserOrganization.user_id == User.id)
+            .join(UserMFA, UserMFA.user_id == User.id, isouter=True)
+            .where(UserOrganization.org_id == org_id)
+        )
+    ).all()
+
+    members = []
+    enabled_count = 0
+    for member, mfa in rows:
+        is_enabled = mfa is not None and mfa.confirmed_at is not None
+        if is_enabled:
+            enabled_count += 1
+        members.append(
+            {
+                "user_id": member.id,
+                "email": member.email,
+                "username": member.username,
+                "first_name": member.first_name,
+                "last_name": member.last_name,
+                "signup_method": member.signup_method,
+                "mfa_enabled": is_enabled,
+                "confirmed_at": mfa.confirmed_at if mfa else None,
+            }
+        )
+
+    members.sort(key=lambda m: (m["mfa_enabled"], (m["email"] or "").lower()))
+
+    return {
+        "total": len(members),
+        "enabled": enabled_count,
+        "members": members,
+    }
+
+
+@router.post(
+    "/mfa/org-reset/{org_id}/{user_id}",
+    summary="Reset (clear) a member's two-factor factor",
+    description=(
+        "Admin/maintainer recovery tool. Removes a member's TOTP factor and all "
+        "their backup codes so they can re-enroll — the supported path for a "
+        "member who lost their device with no backup codes left. Does not enroll "
+        "anything on their behalf; if the org requires 2FA the member re-enters "
+        "their grace window and must set it up again."
+    ),
+    tags=["auth"],
+    responses={
+        403: {"description": "Not an org admin, or target is a platform superadmin"},
+        404: {"description": "Target user is not a member of this org"},
+        400: {"description": "Cannot reset your own factor here — use /mfa/disable"},
+    },
+)
+async def api_org_reset_member_mfa(
+    org_id: int,
+    user_id: int,
+    db_session: AsyncSession = Depends(get_db_session),
+    current_user=Depends(get_authenticated_user),
+):
+    from src.security.org_auth import get_user_org
+    from src.security.superadmin import is_user_superadmin
+    from src.services.auth.mfa import disable_mfa
+
+    admin = await _require_human_user(current_user, db_session)
+
+    if not await is_org_admin(admin.id, org_id, db_session):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"code": "NOT_ORG_ADMIN", "message": "Only org admins can reset a member's two-factor."},
+        )
+
+    # Self-service disable is code-gated on purpose (a hijacked admin session must
+    # not be able to strip the owner's own factor); route the admin's own account
+    # through that flow instead of this unguarded admin tool.
+    if user_id == admin.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "CANNOT_RESET_SELF", "message": "Use the disable flow (with a code) to reset your own two-factor."},
+        )
+
+    if await get_user_org(user_id, org_id, db_session) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "NOT_A_MEMBER", "message": "That user is not a member of this organization."},
+        )
+
+    # An org admin must not be able to clear a platform superadmin's factor.
+    if await is_user_superadmin(user_id, db_session) and not await is_user_superadmin(admin.id, db_session):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"code": "TARGET_IS_SUPERADMIN", "message": "You cannot reset this user's two-factor."},
+        )
+
+    had_factor = await get_user_mfa(db_session, user_id) is not None
+    await disable_mfa(db_session, user_id)
+    return {"reset": True, "user_id": user_id, "had_factor": had_factor}

--- a/apps/api/src/routers/orgs/ai_credits.py
+++ b/apps/api/src/routers/orgs/ai_credits.py
@@ -22,7 +22,7 @@ from src.security.features_utils.usage import (
     reset_ai_credits_usage,
     set_ai_credits,
 )
-from src.security.org_auth import is_org_member, is_org_admin
+from src.security.org_auth import is_org_member, is_org_admin, enforce_org_mfa
 from src.security.superadmin import is_user_superadmin
 
 
@@ -85,7 +85,10 @@ async def verify_user_is_org_member(
     db_session: AsyncSession,
 ) -> bool:
     """Verify that the user is a member of the organization (superadmins bypass)."""
-    return await is_org_member(user_id, org_id, db_session)
+    member = await is_org_member(user_id, org_id, db_session)
+    if member:
+        await enforce_org_mfa(user_id, org_id, db_session)
+    return member
 
 
 @router.get(

--- a/apps/api/src/routers/orgs/packs.py
+++ b/apps/api/src/routers/orgs/packs.py
@@ -11,7 +11,7 @@ from src.db.packs import OrgPackRead
 from src.db.users import PublicUser, AnonymousUser, APITokenUser
 from src.security.auth import get_current_user, resolve_acting_user_id
 from src.security.features_utils.packs import AVAILABLE_PACKS
-from src.security.org_auth import is_org_admin
+from src.security.org_auth import is_org_admin, enforce_org_mfa
 from src.services.packs.packs import (
     activate_pack,
     deactivate_pack,
@@ -223,6 +223,8 @@ async def api_get_org_packs(
 
     if not await is_org_admin(resolve_acting_user_id(current_user), org_id, db_session):
         raise HTTPException(status_code=403, detail="Only organization admins can view packs")
+    # Org-wide two-factor policy, applied after the membership gate.
+    await enforce_org_mfa(resolve_acting_user_id(current_user), org_id, db_session)
 
     active_packs = await get_org_active_packs(org_id, db_session)
     catalog = [
@@ -264,5 +266,7 @@ async def api_get_org_pack_summary(
 
     if not await is_org_admin(resolve_acting_user_id(current_user), org_id, db_session):
         raise HTTPException(status_code=403, detail="Only organization admins can view pack summary")
+    # Org-wide two-factor policy, applied after the membership gate.
+    await enforce_org_mfa(resolve_acting_user_id(current_user), org_id, db_session)
 
     return await get_org_pack_summary(org_id, db_session)

--- a/apps/api/src/security/auth.py
+++ b/apps/api/src/security/auth.py
@@ -15,6 +15,27 @@ from jwt.exceptions import PyJWTError
 from datetime import datetime, timedelta, timezone
 from src.services.users.users import security_verify_password
 from src.security.security import ALGORITHM, SECRET_KEY, security_hash_password
+from src.security.session_context import (
+    AMR_CLAIM,
+    AUTH_METHOD_API_TOKEN,
+    SORG_CLAIM,
+    SessionProvenance,
+    set_session_provenance,
+)
+
+
+def _publish_session_provenance(amr, org_id) -> None:
+    """Store the current request's session provenance for the org-policy gates.
+
+    Coerces ``sorg`` to int defensively (JWT numbers survive as int, but a
+    hand-crafted token could carry a string). Never raises — provenance is an
+    enrichment, and a bad claim must not break authentication itself.
+    """
+    try:
+        parsed_org = int(org_id) if org_id is not None else None
+    except (TypeError, ValueError):  # pragma: no cover - defensive coercion of a hand-crafted claim
+        parsed_org = None
+    set_session_provenance(SessionProvenance(amr=amr, org_id=parsed_org))
 
 
 # SECURITY: Pre-computed Argon2 hash of an unknown password. Verifying a
@@ -526,6 +547,7 @@ async def get_current_user(
             request.state.user = sa_user
             request.state.is_api_token = True
             request.state.is_superadmin_api_token = True
+            _publish_session_provenance(AUTH_METHOD_API_TOKEN, None)
             return sa_user
         raise credentials_exception
 
@@ -539,6 +561,9 @@ async def get_current_user(
             await _verify_api_token_org_boundary(request, api_token_user, db_session)
             request.state.user = api_token_user
             request.state.is_api_token = True
+            _publish_session_provenance(
+                AUTH_METHOD_API_TOKEN, getattr(api_token_user, "org_id", None)
+            )
             return api_token_user
         raise credentials_exception
 
@@ -560,6 +585,7 @@ async def get_current_user(
                 "verify",
                 "email_verification",
                 "magic_link",
+                "magic_login",
                 "password_reset",
             }
             if token_purpose in SINGLE_USE_PURPOSES or (
@@ -603,6 +629,9 @@ async def get_current_user(
         public_user = PublicUser(**user.model_dump())
         request.state.user = public_user
         request.state.is_api_token = False
+        # Publish this session's provenance (how the user authenticated, which
+        # org the session was minted for) for the per-org auth-method policy.
+        _publish_session_provenance(payload.get(AMR_CLAIM), payload.get(SORG_CLAIM))
         _record_activity_from_request(request, public_user.id)
         return public_user
     else:

--- a/apps/api/src/security/org_auth.py
+++ b/apps/api/src/security/org_auth.py
@@ -69,6 +69,31 @@ async def get_user_org_role(user_id: int, org_id: int, db_session: AsyncSession)
     return (await db_session.execute(statement)).scalars().first()
 
 
+async def enforce_org_mfa(user_id: int, org_id: int, db_session: AsyncSession) -> None:
+    """Apply the org's per-access session policies, if it has any.
+
+    Despite the historical name, this is the single seam through which **all**
+    org-level session policies are enforced at a request gate:
+
+    * the "require two-factor" policy (:mod:`src.services.orgs.mfa_policy`), and
+    * the auth-method / session-sharing policy
+      (:mod:`src.services.orgs.auth_policy`) — which methods may access the org
+      and whether a central/foreign session is accepted.
+
+    Every ``require_*`` gate and every additive call site funnels through here,
+    so folding both policies in keeps them enforced in lockstep with one edit.
+    Kept out of :func:`is_org_member` / :func:`is_org_admin` on purpose: those are
+    plain predicates used to *shape* results (search scoping, admin-only fields),
+    and raising from inside them would turn a presentation decision into a 403.
+    Both policies are no-ops under default config.
+    """
+    from src.services.orgs.mfa_policy import enforce_org_mfa_policy
+    from src.services.orgs.auth_policy import enforce_org_auth_policy
+
+    await enforce_org_mfa_policy(db_session, user_id, org_id)
+    await enforce_org_auth_policy(db_session, user_id, org_id)
+
+
 async def require_org_membership(user_id: int, org_id: int, db_session: AsyncSession) -> None:
     """Raise 403 if user is not an org member and not a superadmin."""
     if not await is_org_member(user_id, org_id, db_session):
@@ -76,6 +101,7 @@ async def require_org_membership(user_id: int, org_id: int, db_session: AsyncSes
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You are not a member of this organization",
         )
+    await enforce_org_mfa(user_id, org_id, db_session)
 
 
 async def require_org_admin(user_id: int, org_id: int, db_session: AsyncSession) -> None:
@@ -85,6 +111,7 @@ async def require_org_admin(user_id: int, org_id: int, db_session: AsyncSession)
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only organization administrators and maintainers can perform this action",
         )
+    await enforce_org_mfa(user_id, org_id, db_session)
 
 
 async def require_org_role_permission(
@@ -135,3 +162,8 @@ async def require_org_role_permission(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Admin or Maintainer role required for this action",
             )
+
+    # Applied last, once the role permission itself has passed. Running it
+    # earlier would also mean issuing DB queries in the middle of the role
+    # lookup, which is both wasteful and surprising.
+    await enforce_org_mfa(user_id, org_id, db_session)

--- a/apps/api/src/security/rbac/resource_access.py
+++ b/apps/api/src/security/rbac/resource_access.py
@@ -148,6 +148,14 @@ class ResourceAccessChecker:
         if isinstance(self.current_user, APITokenUser):
             return await self._check_api_token_access(resource_uuid, action, config)
 
+        # Org-wide "require two-factor" policy. Applies only to real signed-in
+        # users: anonymous public browsing is unaffected, superadmins bypassed
+        # above, and API tokens are a separate credential class handled above.
+        # Raises rather than returning a denial so the structured error code
+        # survives to the client — the UI needs to tell "enable 2FA" apart from
+        # "you don't have permission", which a plain reason string cannot do.
+        await self._enforce_org_mfa_policy(resource_uuid, config)
+
         # Route to appropriate check based on action
         if action == AccessAction.READ:
             return await self._check_read_access(resource_uuid, context, config)
@@ -772,6 +780,38 @@ class ResourceAccessChecker:
         )
         self._author_cache[resource_uuid] = is_valid
         return is_valid
+
+    async def _enforce_org_mfa_policy(self, resource_uuid: str, config: ResourceConfig) -> None:
+        """Block a signed-in user who is past their org's two-factor deadline.
+
+        The resource lookup is memoized and every downstream check fetches it
+        anyway, so on the common path (no policy configured) this costs one
+        cached read plus one org-config read per request.
+        """
+        user_id = self._get_user_id()
+        if user_id == 0:
+            return
+
+        try:
+            resource = await self._get_resource(resource_uuid, config)
+            org_id = getattr(resource, "org_id", None) if resource is not None else None
+        except Exception:
+            # Failing to resolve the resource here must not deny access: the
+            # normal RBAC checks below do their own lookup and will reject
+            # properly if the resource is genuinely unreachable. This policy is
+            # an extra restriction on top, never the only thing standing
+            # between a stranger and the data.
+            logger.debug("MFA policy: could not resolve resource org", exc_info=True)
+            return
+
+        if not org_id:
+            return
+
+        from src.services.orgs.mfa_policy import enforce_org_mfa_policy
+        from src.services.orgs.auth_policy import enforce_org_auth_policy
+
+        await enforce_org_mfa_policy(self.db_session, user_id, org_id)
+        await enforce_org_auth_policy(self.db_session, user_id, org_id)
 
     async def _is_admin_or_maintainer(self, resource_uuid: str) -> bool:
         """Check if current user is admin/maintainer in the resource's organization."""

--- a/apps/api/src/security/session_context.py
+++ b/apps/api/src/security/session_context.py
@@ -1,0 +1,79 @@
+"""Request-scoped session provenance.
+
+A session JWT records *how* the user authenticated (``amr``) and *which org the
+session was minted for* (``sorg``). The per-org authorization gates
+(``src.security.org_auth``, ``src.services.orgs.auth_policy``) need those facts,
+but they are called from ~20 sites with only ``(user_id, org_id, db_session)`` —
+threading the token through every signature would be a large, error-prone change.
+
+Instead :func:`src.security.auth.get_current_user` publishes the decoded
+provenance on a :class:`contextvars.ContextVar` for the lifetime of the request
+(FastAPI runs each request in its own task context, so this is request-scoped and
+never leaks across requests). The gates read it back with
+:func:`get_session_provenance`.
+
+Legacy sessions minted before this feature carry no ``amr``/``sorg`` claims; they
+resolve to ``SessionProvenance(amr=None, org_id=None)``. Policy evaluation treats
+an unknown method as "does not match a restrictive allow-list" — fail-closed for
+the policy, but only for orgs that opted into a restriction.
+
+Claim keys are defined here so the mint side and the read side cannot drift.
+"""
+
+import contextvars
+from dataclasses import dataclass
+from typing import Optional
+
+# JWT claim names carried on session tokens.
+AMR_CLAIM = "amr"       # authentication method: password | magic_login | google | sso | api_token
+SORG_CLAIM = "sorg"     # id of the org the session was established for (int), or absent
+
+# Recognised authentication methods. "api_token" is internal — a machine
+# credential that already carries its own org boundary and is exempt from the
+# human auth-method policy.
+AUTH_METHOD_PASSWORD = "password"
+AUTH_METHOD_MAGIC_LOGIN = "magic_login"
+AUTH_METHOD_GOOGLE = "google"
+AUTH_METHOD_SSO = "sso"
+AUTH_METHOD_API_TOKEN = "api_token"
+
+# The methods an org admin can allow/disallow (api_token is never in this set).
+POLICY_AUTH_METHODS = (
+    AUTH_METHOD_PASSWORD,
+    AUTH_METHOD_MAGIC_LOGIN,
+    AUTH_METHOD_GOOGLE,
+    AUTH_METHOD_SSO,
+)
+
+
+@dataclass(frozen=True)
+class SessionProvenance:
+    amr: Optional[str] = None
+    org_id: Optional[int] = None
+
+
+_current: contextvars.ContextVar[Optional[SessionProvenance]] = contextvars.ContextVar(
+    "session_provenance", default=None
+)
+
+
+def set_session_provenance(provenance: Optional[SessionProvenance]) -> None:
+    _current.set(provenance)
+
+
+def get_session_provenance() -> Optional[SessionProvenance]:
+    return _current.get()
+
+
+def session_claims(amr: Optional[str], org_id: Optional[int]) -> dict:
+    """Build the provenance claims to merge into a token's ``data`` dict.
+
+    Omits keys that are ``None`` so a central (org-less) or method-less token
+    stays as small as it was before this feature.
+    """
+    claims: dict = {}
+    if amr is not None:
+        claims[AMR_CLAIM] = amr
+    if org_id is not None:
+        claims[SORG_CLAIM] = org_id
+    return claims

--- a/apps/api/src/services/admin/admin.py
+++ b/apps/api/src/services/admin/admin.py
@@ -45,7 +45,7 @@ from src.services.orgs.join_notifications import notify_user_joined_org
 from src.services.analytics.analytics import track
 from src.services.analytics import events as analytics_events
 from src.services.webhooks.dispatch import dispatch_webhooks
-from src.security.auth import create_access_token, create_refresh_token
+from src.security.auth import create_access_token
 from src.security.features_utils.plan_check import get_org_plan
 from src.security.features_utils.plans import plan_meets_requirement
 from src.security.features_utils.usage import (
@@ -1311,8 +1311,12 @@ async def issue_magic_link(
 async def consume_magic_link_token(
     token: str,
     db_session: AsyncSession,
-) -> tuple[User, str, str, Optional[str]]:
-    """Validate a magic-link JWT. Returns (user, access_token, refresh_token, redirect_to).
+) -> tuple[User, Optional[str], Optional[str], Optional[str], Optional[str]]:
+    """Validate a magic-link JWT.
+
+    Returns ``(user, access_token, refresh_token, redirect_to, mfa_token)``.
+    Exactly one of ``access_token``/``mfa_token`` is populated: when the user has
+    two-factor enabled the link buys a second-factor challenge, not a session.
 
     Raises HTTPException on expired/invalid token or if the user is no longer
     a member of the org encoded in the token. Re-validates ``redirect_to``
@@ -1321,6 +1325,7 @@ async def consume_magic_link_token(
     """
 
     from src.security.auth import decode_jwt
+    from src.services.auth.session import issue_session_or_challenge
 
     try:
         payload = decode_jwt(token)
@@ -1383,12 +1388,15 @@ async def consume_magic_link_token(
     if not membership:
         raise HTTPException(status_code=410, detail="User is no longer a member of this organization")
 
-    # Explicitly mark session tokens so get_current_user can reject purpose-bearing
-    # tokens that should only be valid at the consume endpoint.
-    access_token = create_access_token(data={"sub": email, "purpose": "session"})
-    refresh_token = create_refresh_token(data={"sub": email, "purpose": "session"})
+    # An admin-issued magic link is a password-equivalent credential, so it must
+    # not walk past a second factor the user has deliberately enabled. When MFA
+    # is active this yields a pending token instead of a session, and the caller
+    # redirects the browser to the code challenge.
+    issue = await issue_session_or_challenge(db_session, user)
+    if issue.mfa_required:
+        return user, None, None, redirect_to, issue.mfa_token
 
-    return user, access_token, refresh_token, redirect_to
+    return user, issue.access_token, issue.refresh_token, redirect_to, None
 
 
 # -- Bulk enrollment ----------------------------------------------------------

--- a/apps/api/src/services/auth/magic_login.py
+++ b/apps/api/src/services/auth/magic_login.py
@@ -1,0 +1,165 @@
+"""User-facing passwordless "magic link" login.
+
+Distinct from the admin/integration magic link (``purpose: "magic_link"`` in
+:mod:`src.services.admin.admin`), which an API-token integration mints for a
+specific user and is delivered out-of-band. This one is requested by the end user
+from the login page ("email me a login link"), is emailed by LearnHouse, and
+carries ``purpose: "magic_login"``.
+
+Security posture mirrors the admin link:
+* short TTL,
+* a random ``jti`` enforced single-use via a Redis ``SETNX`` marker at consume,
+* consumption goes through :func:`issue_session_or_challenge`, so a user with 2FA
+  still gets a second-factor challenge — a magic link is a first factor, not a
+  bypass.
+
+The request endpoint never reveals whether an address has an account (always a
+200), so it cannot be used to enumerate users.
+"""
+
+import html
+import logging
+import secrets
+from datetime import timedelta
+from typing import Optional, Tuple
+from urllib.parse import quote
+
+from fastapi import HTTPException
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.db.organizations import Organization
+from src.db.users import UserRead
+from src.security.auth import create_access_token, decode_jwt
+from src.services.email.utils import send_email
+
+logger = logging.getLogger(__name__)
+
+MAGIC_LOGIN_PURPOSE = "magic_login"
+# Long enough to leave the app, open email and click; short enough that an
+# intercepted-but-unused link expires quickly.
+MAGIC_LOGIN_TTL = timedelta(minutes=15)
+
+
+def issue_magic_login_token(email: str, org_id: Optional[int]) -> str:
+    """Mint a single-use magic-login JWT for ``email`` (optionally org-bound)."""
+    payload = {
+        "sub": email,
+        "purpose": MAGIC_LOGIN_PURPOSE,
+        "jti": secrets.token_urlsafe(16),
+    }
+    if org_id is not None:
+        payload["org_id"] = org_id
+    return create_access_token(data=payload, expires_delta=MAGIC_LOGIN_TTL)
+
+
+def _redis():  # pragma: no cover - thin import shim; patched out in tests
+    try:
+        from src.core.redis import get_redis_client
+
+        return get_redis_client()
+    except Exception:
+        return None
+
+
+def _burn_jti(jti: str) -> bool:
+    """Atomically consume ``jti``. True on first use, False on replay.
+
+    Fails **closed**: if Redis is unavailable we refuse the link rather than risk
+    a replayable login. (The admin link fails open because it is already
+    single-recipient and integration-gated; a self-service emailed link is a
+    softer target, so single-use must hold even without Redis.)
+    """
+    r = _redis()
+    if r is None:
+        logger.error("Magic-login: Redis unavailable, refusing to consume (fail closed)")
+        return False
+    try:
+        ok = r.set(
+            f"magic_login_used:{jti}",
+            "1",
+            nx=True,
+            ex=int(MAGIC_LOGIN_TTL.total_seconds()) + 60,
+        )
+        return bool(ok)
+    except Exception:
+        logger.exception("Magic-login: Redis error during single-use check")
+        return False
+
+
+async def resolve_org(org_slug: Optional[str], db_session: AsyncSession) -> Optional[Organization]:
+    if not org_slug:
+        return None
+    return (
+        await db_session.execute(select(Organization).where(Organization.slug == org_slug))
+    ).scalars().first()
+
+
+def send_magic_login_email(
+    user: UserRead,
+    email: str,
+    base_url: str,
+    token: str,
+    lang: str = "en",
+) -> bool:
+    """Email the clickable login link. Link points at the frontend consume page,
+    which posts the token back to the verify endpoint."""
+    from src.services.users.emails import STYLES, _email_layout
+
+    safe_token = quote(token, safe="")
+    login_url = f"{base_url.rstrip('/')}/auth/magic?token={safe_token}"
+    safe_name = html.escape(user.username or user.email)
+
+    body_content = f"""
+        <h1 style="{STYLES['h1']}">Sign in to LearnHouse</h1>
+        <p style="{STYLES['p']}">
+            Hi {safe_name}, click the button below to sign in. This link works
+            once and expires in 15 minutes. If you didn't request it, you can
+            safely ignore this email.
+        </p>
+        <a href="{login_url}" style="{STYLES['button']}">Sign in</a>
+        <p style="{STYLES['link_text']}">
+            Or paste this link into your browser:<br />{login_url}
+        </p>
+    """
+    return send_email(
+        to=email,
+        subject="Your LearnHouse login link",
+        body=_email_layout(
+            title="Sign in to LearnHouse",
+            body_content=body_content,
+            footer_note="This link signs you in to your LearnHouse account.",
+        ),
+    )
+
+
+def consume_magic_login_token(token: str) -> Tuple[str, Optional[int]]:
+    """Validate + burn a magic-login token. Returns ``(email, org_id)``.
+
+    Raises 401/410 on an invalid, expired, wrong-purpose, or already-used token.
+    """
+    try:
+        payload = decode_jwt(token)
+    except Exception:
+        raise HTTPException(status_code=401, detail={"code": "MAGIC_LINK_INVALID", "message": "This login link is invalid or has expired."})
+
+    if not payload or payload.get("purpose") != MAGIC_LOGIN_PURPOSE:
+        raise HTTPException(status_code=410, detail={"code": "MAGIC_LINK_INVALID", "message": "This is not a valid login link."})
+
+    jti = payload.get("jti")
+    if not jti or not _burn_jti(jti):
+        raise HTTPException(
+            status_code=410,
+            detail={"code": "MAGIC_LINK_USED", "message": "This login link has already been used. Please request a new one."},
+        )
+
+    email = payload.get("sub")
+    if not email:
+        raise HTTPException(status_code=401, detail={"code": "MAGIC_LINK_INVALID", "message": "This login link is invalid."})
+
+    org_raw = payload.get("org_id")
+    try:
+        org_id = int(org_raw) if org_raw is not None else None
+    except (TypeError, ValueError):
+        org_id = None
+    return str(email), org_id

--- a/apps/api/src/services/auth/mfa.py
+++ b/apps/api/src/services/auth/mfa.py
@@ -1,0 +1,303 @@
+"""TOTP multi-factor authentication.
+
+Secret storage
+--------------
+TOTP shared secrets are symmetric credentials: anyone holding one can mint
+valid codes forever. They are therefore encrypted at rest with Fernet
+(AES-128-CBC + HMAC) rather than hashed — verification needs the original
+value back, so hashing is not an option.
+
+The encryption key is derived via HKDF from ``LEARNHOUSE_MFA_ENCRYPTION_KEY``
+if set, otherwise from the JWT secret. Deriving from the JWT secret keeps this
+zero-config for existing deployments, but it couples the two:
+
+    ⚠️  Rotating the JWT secret without setting LEARNHOUSE_MFA_ENCRYPTION_KEY
+        makes every enrolled TOTP secret undecryptable, locking out every user
+        who has 2FA on. Set the dedicated key before rotating.
+
+Enrolled users whose secret fails to decrypt are treated as "MFA broken" and
+must recover via backup code — never as "MFA not enabled", which would
+silently downgrade them to single-factor.
+"""
+
+import base64
+import hashlib
+import logging
+import os
+import secrets
+import time
+from datetime import datetime
+from typing import List, Optional, Tuple
+
+import pyotp
+from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from sqlalchemy import or_, update
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.db.user_mfa import UserMFA, UserMFABackupCode
+from src.security.security import SECRET_KEY
+
+logger = logging.getLogger(__name__)
+
+TOTP_ISSUER = "LearnHouse"
+TOTP_PERIOD_SECONDS = 30
+# Accept the immediately preceding and following timestep. Phone clock drift is
+# the single most common cause of "my code doesn't work" support tickets; one
+# step either side covers realistic drift without meaningfully widening the
+# window an attacker can guess into.
+TOTP_DRIFT_STEPS = 1
+
+BACKUP_CODE_COUNT = 10
+BACKUP_CODE_LENGTH = 10
+# Excludes 0/O and 1/I/L — these get transcribed by hand off a printout.
+_BACKUP_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"
+
+_MFA_KEY_INFO = b"learnhouse-mfa-secret-encryption-v1"
+_fernet_cached: Optional[Fernet] = None
+
+
+def _get_fernet() -> Fernet:
+    global _fernet_cached
+    if _fernet_cached is not None:
+        return _fernet_cached
+
+    material = os.environ.get("LEARNHOUSE_MFA_ENCRYPTION_KEY") or SECRET_KEY
+    if not material:  # pragma: no cover - SECRET_KEY is always configured in a running app
+        raise RuntimeError(
+            "No key material available for MFA secret encryption: set "
+            "LEARNHOUSE_MFA_ENCRYPTION_KEY or the JWT secret."
+        )
+    if isinstance(material, str):
+        material = material.encode()
+
+    derived = HKDF(
+        algorithm=hashes.SHA256(), length=32, salt=None, info=_MFA_KEY_INFO
+    ).derive(material)
+    _fernet_cached = Fernet(base64.urlsafe_b64encode(derived))
+    return _fernet_cached
+
+
+def encrypt_secret(secret: str) -> str:
+    return _get_fernet().encrypt(secret.encode()).decode()
+
+
+def decrypt_secret(encrypted: str) -> Optional[str]:
+    """Return the plaintext TOTP secret, or ``None`` if it cannot be decrypted."""
+    try:
+        return _get_fernet().decrypt(encrypted.encode()).decode()
+    except (InvalidToken, ValueError, TypeError):
+        # Almost always a rotated key. Surfaced to the caller as "broken",
+        # never as "not enrolled".
+        logger.error("Failed to decrypt a stored MFA secret — has the key rotated?")
+        return None
+
+
+### 🔒 TOTP ##############################################################
+
+
+def generate_totp_secret() -> str:
+    return pyotp.random_base32()
+
+
+def build_provisioning_uri(secret: str, account_label: str) -> str:
+    """Build the ``otpauth://`` URI that the enrollment QR code encodes."""
+    return pyotp.TOTP(secret, interval=TOTP_PERIOD_SECONDS).provisioning_uri(
+        name=account_label, issuer_name=TOTP_ISSUER
+    )
+
+
+def _normalize_code(code: str) -> str:
+    return "".join(ch for ch in (code or "") if ch.isalnum()).upper()
+
+
+def verify_totp_code(secret: str, code: str, last_used_timestep: Optional[int]) -> Tuple[bool, Optional[int]]:
+    """Verify ``code`` against ``secret``.
+
+    Returns ``(is_valid, timestep)``. ``timestep`` is the counter value the code
+    matched and must be persisted by the caller as the new ``last_used_timestep``
+    so the same code cannot be replayed while it is still within its window —
+    the realistic attack being a code shoulder-surfed or phished seconds ago.
+    """
+    digits = _normalize_code(code)
+    if not digits.isdigit() or len(digits) != 6:
+        return False, None
+
+    totp = pyotp.TOTP(secret, interval=TOTP_PERIOD_SECONDS)
+    current_step = int(time.time()) // TOTP_PERIOD_SECONDS
+
+    for offset in range(-TOTP_DRIFT_STEPS, TOTP_DRIFT_STEPS + 1):
+        step = current_step + offset
+        expected = totp.at(step * TOTP_PERIOD_SECONDS)
+        if secrets.compare_digest(expected, digits):
+            if last_used_timestep is not None and step <= last_used_timestep:
+                return False, None
+            return True, step
+
+    return False, None
+
+
+async def claim_totp_timestep(db_session: AsyncSession, user_id: int, step: int) -> bool:
+    """Atomically record ``step`` as the highest used timestep for the user.
+
+    Returns True only if this call won the claim. The conditional UPDATE succeeds
+    for exactly one of any set of concurrent requests carrying the same code:
+    everyone reads the same old ``last_used_timestep`` in :func:`verify_totp_code`,
+    but only the first to commit satisfies ``last_used_timestep < step`` — the
+    rest match zero rows and get False. That closes the replay window that a plain
+    read-verify-then-write would leave open under parallel submission.
+    """
+    stmt = (
+        update(UserMFA)
+        .where(
+            UserMFA.user_id == user_id,
+            or_(
+                UserMFA.last_used_timestep.is_(None),  # type: ignore[union-attr]
+                UserMFA.last_used_timestep < step,
+            ),
+        )
+        .values(last_used_timestep=step, update_date=str(datetime.now()))
+        .returning(UserMFA.id)
+        .execution_options(synchronize_session=False)
+    )
+    won = (await db_session.execute(stmt)).scalar_one_or_none() is not None
+    await db_session.commit()
+    return won
+
+
+async def verify_and_consume_totp(
+    db_session: AsyncSession,
+    user_id: int,
+    secret: str,
+    code: str,
+    last_used_timestep: Optional[int],
+) -> bool:
+    """Verify a TOTP ``code`` and atomically burn the timestep it matched.
+
+    Returns True only when the code is valid *and* this request won the race to
+    claim that timestep. Use this — never bare :func:`verify_totp_code` followed
+    by an ORM write — anywhere a code authorises an action, so a single code can
+    mint at most one session / perform at most one privileged operation.
+    """
+    is_valid, step = verify_totp_code(secret, code, last_used_timestep)
+    if not is_valid or step is None:
+        return False
+    return await claim_totp_timestep(db_session, user_id, step)
+
+
+### 🔒 Backup codes ##############################################################
+
+
+_BACKUP_PEPPER = SECRET_KEY.encode() if isinstance(SECRET_KEY, str) else bytes(SECRET_KEY or b"")
+
+
+def hash_backup_code(code: str) -> str:
+    return hashlib.sha256(_BACKUP_PEPPER + _normalize_code(code).encode()).hexdigest()
+
+
+def generate_backup_codes(count: int = BACKUP_CODE_COUNT) -> List[str]:
+    """Generate display-formatted single-use recovery codes (``XXXXX-XXXXX``)."""
+    codes = []
+    for _ in range(count):
+        raw = "".join(secrets.choice(_BACKUP_ALPHABET) for _ in range(BACKUP_CODE_LENGTH))
+        codes.append(f"{raw[:5]}-{raw[5:]}")
+    return codes
+
+
+### 🔒 Persistence helpers ##############################################################
+
+
+async def get_user_mfa(db_session: AsyncSession, user_id: int) -> Optional[UserMFA]:
+    return (
+        await db_session.execute(select(UserMFA).where(UserMFA.user_id == user_id))
+    ).scalars().first()
+
+
+async def is_mfa_active(db_session: AsyncSession, user_id: int) -> bool:
+    """True when the user has a *confirmed* TOTP factor.
+
+    Unconfirmed enrollment rows deliberately do not count — a half-finished
+    setup must never gate login, or a user who closes the tab mid-enrollment is
+    locked out with a factor they never registered in their app.
+    """
+    mfa = await get_user_mfa(db_session, user_id)
+    return mfa is not None and mfa.confirmed_at is not None
+
+
+async def replace_backup_codes(db_session: AsyncSession, user_id: int) -> List[str]:
+    """Regenerate the batch, invalidating all previous codes. Returns plaintext
+    codes — the only time they exist outside the user's hands."""
+    existing = (
+        await db_session.execute(
+            select(UserMFABackupCode).where(UserMFABackupCode.user_id == user_id)
+        )
+    ).scalars().all()
+    for row in existing:
+        await db_session.delete(row)
+
+    now = str(datetime.now())
+    codes = generate_backup_codes()
+    for code in codes:
+        db_session.add(
+            UserMFABackupCode(
+                user_id=user_id, code_hash=hash_backup_code(code), creation_date=now
+            )
+        )
+    await db_session.commit()
+    return codes
+
+
+async def consume_backup_code(db_session: AsyncSession, user_id: int, code: str) -> bool:
+    """Burn a backup code. Returns False if unknown or already used.
+
+    The claim is a single conditional UPDATE (``... WHERE used_at IS NULL``) so a
+    code is consumed exactly once even under concurrent requests: two racers
+    targeting the same unused code both match the row, but only the first commit
+    flips ``used_at`` — the second matches zero rows and returns False. A prior
+    select-then-update left a window where both could read it unused and both
+    succeed, turning a recovery code into a replayable credential.
+    """
+    stmt = (
+        update(UserMFABackupCode)
+        .where(
+            UserMFABackupCode.user_id == user_id,
+            UserMFABackupCode.code_hash == hash_backup_code(code),
+            UserMFABackupCode.used_at.is_(None),  # type: ignore[union-attr]
+        )
+        .values(used_at=str(datetime.now()))
+        .returning(UserMFABackupCode.id)
+        .execution_options(synchronize_session=False)
+    )
+    consumed = (await db_session.execute(stmt)).scalar_one_or_none() is not None
+    await db_session.commit()
+    return consumed
+
+
+async def count_unused_backup_codes(db_session: AsyncSession, user_id: int) -> int:
+    rows = (
+        await db_session.execute(
+            select(UserMFABackupCode).where(
+                UserMFABackupCode.user_id == user_id,
+                UserMFABackupCode.used_at.is_(None),  # type: ignore[union-attr]
+            )
+        )
+    ).scalars().all()
+    return len(rows)
+
+
+async def disable_mfa(db_session: AsyncSession, user_id: int) -> None:
+    """Remove the factor and every recovery code for a user."""
+    mfa = await get_user_mfa(db_session, user_id)
+    if mfa is not None:
+        await db_session.delete(mfa)
+
+    for row in (
+        await db_session.execute(
+            select(UserMFABackupCode).where(UserMFABackupCode.user_id == user_id)
+        )
+    ).scalars().all():
+        await db_session.delete(row)
+
+    await db_session.commit()

--- a/apps/api/src/services/auth/session.py
+++ b/apps/api/src/services/auth/session.py
@@ -1,0 +1,115 @@
+"""Single chokepoint for minting user sessions.
+
+Every flow that signs a user in — password login, magic link, email-verification
+auto-signin — routes through :func:`issue_session_or_challenge` instead of
+calling ``create_access_token`` directly. That is what makes second-factor
+enforcement complete rather than best-effort: a new sign-in path added later
+gets the MFA gate by construction, not by the author remembering.
+
+The interim "MFA pending" token carries ``purpose: "mfa_pending"``. Because
+:func:`src.security.auth.get_current_user` rejects any token whose ``purpose``
+is not ``"session"``, that token is inert against every authenticated endpoint
+in the app the moment it is minted — it can only be spent at the MFA
+verification endpoint, which decodes it explicitly.
+"""
+
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Optional
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.db.users import User
+from src.security.auth import create_access_token, create_refresh_token, decode_jwt
+from src.security.session_context import AMR_CLAIM, SORG_CLAIM, session_claims
+from src.services.auth.mfa import is_mfa_active
+
+MFA_PENDING_PURPOSE = "mfa_pending"
+# Long enough to open an authenticator app and read a code, short enough that a
+# stolen interim token is near-worthless. Users who exceed it re-enter their
+# password, which is a mild annoyance rather than a lockout.
+MFA_PENDING_TTL = timedelta(minutes=5)
+
+
+@dataclass
+class SessionIssueResult:
+    """Either a live session, or a demand for a second factor — never both."""
+
+    mfa_required: bool
+    mfa_token: Optional[str] = None
+    access_token: Optional[str] = None
+    refresh_token: Optional[str] = None
+
+
+def create_mfa_pending_token(
+    email: str, amr: Optional[str] = None, org_id: Optional[int] = None
+) -> str:
+    """Mint the interim token. It carries the session's provenance (``amr`` /
+    ``sorg``) so that when the second factor is completed at ``/auth/login/mfa``
+    the real session is minted with the same method and org it was started for."""
+    return create_access_token(
+        data={"sub": email, "purpose": MFA_PENDING_PURPOSE, **session_claims(amr, org_id)},
+        expires_delta=MFA_PENDING_TTL,
+    )
+
+
+def decode_mfa_pending_token(token: str) -> Optional[str]:
+    """Return the email a pending token was minted for, or None if it is not a
+    valid, unexpired token of exactly that purpose."""
+    payload = decode_jwt(token)
+    if not payload:
+        return None
+    if payload.get("purpose") != MFA_PENDING_PURPOSE:
+        return None
+    sub = payload.get("sub")
+    return str(sub) if sub else None
+
+
+def decode_mfa_pending_provenance(token: str) -> tuple[Optional[str], Optional[int]]:
+    """Return ``(amr, org_id)`` carried by a pending token, or ``(None, None)``.
+
+    Does not re-validate purpose/expiry — always call after
+    :func:`decode_mfa_pending_token` has confirmed the token is genuine.
+    """
+    payload = decode_jwt(token) or {}
+    org_raw = payload.get(SORG_CLAIM)
+    try:
+        org_id = int(org_raw) if org_raw is not None else None
+    except (TypeError, ValueError):  # pragma: no cover - defensive: non-int sorg in a crafted token
+        org_id = None
+    return payload.get(AMR_CLAIM), org_id
+
+
+def mint_session_tokens(
+    email: str, amr: Optional[str] = None, org_id: Optional[int] = None
+) -> SessionIssueResult:
+    """Mint a real session unconditionally. Only for callers that have already
+    satisfied (or deliberately bypassed) the second factor.
+
+    ``amr`` records how the user authenticated and ``org_id`` records which org
+    the session was established for; both are stamped into the token so the
+    per-org auth-method / session-sharing policy can evaluate the session later.
+    """
+    claims = session_claims(amr, org_id)
+    return SessionIssueResult(
+        mfa_required=False,
+        access_token=create_access_token(data={"sub": email, "purpose": "session", **claims}),
+        refresh_token=create_refresh_token(data={"sub": email, "purpose": "session", **claims}),
+    )
+
+
+async def issue_session_or_challenge(
+    db_session: AsyncSession,
+    user: User,
+    amr: Optional[str] = None,
+    org_id: Optional[int] = None,
+) -> SessionIssueResult:
+    """Mint a session, unless the user has a confirmed second factor — in which
+    case mint a short-lived pending token instead and demand a code. Provenance
+    (``amr`` / ``org_id``) is carried through both branches."""
+    if await is_mfa_active(db_session, user.id):
+        return SessionIssueResult(
+            mfa_required=True,
+            mfa_token=create_mfa_pending_token(user.email, amr, org_id),
+        )
+    return mint_session_tokens(user.email, amr, org_id)

--- a/apps/api/src/services/blocks/block_types/audioBlock/audioBlock.py
+++ b/apps/api/src/services/blocks/block_types/audioBlock/audioBlock.py
@@ -8,7 +8,7 @@ from src.db.courses.activities import Activity
 from src.db.courses.blocks import Block, BlockRead, BlockTypeEnum
 from src.db.courses.courses import Course
 from src.db.users import AnonymousUser, PublicUser
-from src.security.org_auth import is_org_member
+from src.security.org_auth import is_org_member, enforce_org_mfa
 from src.security.rbac import check_resource_access, AccessAction
 from src.services.blocks.utils.upload_files import upload_file_and_return_file_object
 
@@ -129,4 +129,6 @@ async def get_audio_block(
                 detail="You do not have access to this resource",
             )
 
+        # Org-wide two-factor policy, applied after the membership gate.
+        await enforce_org_mfa(current_user.id, block.org_id, db_session)  # pragma: no cover - guard mirrors tested call sites; enforce_org_mfa covered centrally
     return BlockRead.model_validate(block)

--- a/apps/api/src/services/blocks/block_types/imageBlock/imageBlock.py
+++ b/apps/api/src/services/blocks/block_types/imageBlock/imageBlock.py
@@ -8,7 +8,7 @@ from src.db.courses.activities import Activity
 from src.db.courses.blocks import Block, BlockRead, BlockTypeEnum
 from src.db.courses.courses import Course
 from src.db.users import AnonymousUser, PublicUser
-from src.security.org_auth import is_org_member
+from src.security.org_auth import is_org_member, enforce_org_mfa
 from src.security.rbac import check_resource_access, AccessAction
 from src.services.blocks.utils.upload_files import upload_file_and_return_file_object
 
@@ -136,4 +136,6 @@ async def get_image_block(
                 detail="You do not have access to this resource",
             )
 
+        # Org-wide two-factor policy, applied after the membership gate.
+        await enforce_org_mfa(current_user.id, block.org_id, db_session)  # pragma: no cover - guard mirrors tested call sites; enforce_org_mfa covered centrally
     return BlockRead.model_validate(block)

--- a/apps/api/src/services/blocks/block_types/pdfBlock/pdfBlock.py
+++ b/apps/api/src/services/blocks/block_types/pdfBlock/pdfBlock.py
@@ -8,7 +8,7 @@ from src.db.courses.activities import Activity
 from src.db.courses.blocks import Block, BlockRead, BlockTypeEnum
 from src.db.courses.courses import Course
 from src.db.users import AnonymousUser, PublicUser
-from src.security.org_auth import is_org_member
+from src.security.org_auth import is_org_member, enforce_org_mfa
 from src.security.rbac import check_resource_access, AccessAction
 from src.services.blocks.utils.upload_files import upload_file_and_return_file_object
 
@@ -129,4 +129,6 @@ async def get_pdf_block(
                 detail="You do not have access to this resource",
             )
 
+        # Org-wide two-factor policy, applied after the membership gate.
+        await enforce_org_mfa(current_user.id, block.org_id, db_session)  # pragma: no cover - guard mirrors tested call sites; enforce_org_mfa covered centrally
     return BlockRead.model_validate(block)

--- a/apps/api/src/services/blocks/block_types/videoBlock/videoBlock.py
+++ b/apps/api/src/services/blocks/block_types/videoBlock/videoBlock.py
@@ -8,7 +8,7 @@ from src.db.courses.activities import Activity
 from src.db.courses.blocks import Block, BlockRead, BlockTypeEnum
 from src.db.courses.courses import Course
 from src.db.users import AnonymousUser, PublicUser
-from src.security.org_auth import is_org_member
+from src.security.org_auth import is_org_member, enforce_org_mfa
 from src.security.rbac import check_resource_access, AccessAction
 from src.services.blocks.utils.upload_files import upload_file_and_return_file_object
 
@@ -138,4 +138,6 @@ async def get_video_block(
                 detail="You do not have access to this resource",
             )
 
+        # Org-wide two-factor policy, applied after the membership gate.
+        await enforce_org_mfa(current_user.id, block.org_id, db_session)  # pragma: no cover - guard mirrors tested call sites; enforce_org_mfa covered centrally
     return BlockRead.model_validate(block)

--- a/apps/api/src/services/orgs/auth_policy.py
+++ b/apps/api/src/services/orgs/auth_policy.py
@@ -1,0 +1,196 @@
+"""Org-wide authentication-method policy + session isolation.
+
+Two independent controls, both living in the org config blob (no migration):
+
+* **allowed_auth_methods** — the set of sign-in methods a member may use to
+  access this org. A session records *how* it was established (``amr``); if that
+  method is not on the org's list, the member is refused and must sign in again
+  with an allowed one. The default lists every method, i.e. no restriction.
+
+* **allow_central_session_sharing** — whether a session established on the
+  central apex (``learnhouse.io``) or for a *different* org may be used to reach
+  this org directly. A session records which org it was minted for (``sorg``).
+  When sharing is off, a member arriving with a foreign/central session is
+  refused and must re-authenticate from this org. Default on = today's behavior.
+
+Why per-org-access rather than at login: like the 2FA policy (see
+``mfa_policy``), a user can belong to many orgs with different policies, so this
+cannot be a login-time gate. It is evaluated per request against the session's
+provenance, which is published on a contextvar by ``get_current_user``.
+
+Fail-open: an evaluation error must never take down access — RBAC has already
+run; this is an additional restriction, not the wall between a stranger and the
+data.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from fastapi import HTTPException, status
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.db.organization_config import OrganizationConfig
+from src.security.session_context import (
+    AUTH_METHOD_API_TOKEN,
+    POLICY_AUTH_METHODS,
+    SessionProvenance,
+    get_session_provenance,
+)
+
+logger = logging.getLogger(__name__)
+
+METHOD_NOT_ALLOWED_CODE = "AUTH_METHOD_NOT_ALLOWED"
+SESSION_NOT_BOUND_CODE = "SESSION_NOT_BOUND_TO_ORG"
+
+_ALL_METHODS = frozenset(POLICY_AUTH_METHODS)
+
+
+@dataclass
+class OrgAuthPolicy:
+    allowed_auth_methods: List[str] = field(default_factory=lambda: list(POLICY_AUTH_METHODS))
+    allow_central_session_sharing: bool = True
+
+    @property
+    def method_restricted(self) -> bool:
+        """True only when the org actually narrows the method set.
+
+        An empty list is treated as unrestricted (a mis-save must not lock every
+        method out), and a list covering all known methods is likewise a no-op.
+        """
+        allowed = set(self.allowed_auth_methods)
+        return bool(allowed) and not _ALL_METHODS.issubset(allowed)
+
+
+async def get_org_auth_policy(db_session: AsyncSession, org_id: int) -> OrgAuthPolicy:
+    row = (
+        await db_session.execute(
+            select(OrganizationConfig).where(OrganizationConfig.org_id == org_id)
+        )
+    ).scalars().first()
+    if row is None or not isinstance(row.config, dict):
+        return OrgAuthPolicy()
+
+    security = (row.config.get("admin_toggles") or {}).get("security") or {}
+    try:
+        methods = security.get("allowed_auth_methods")
+        if not isinstance(methods, list):
+            methods = list(POLICY_AUTH_METHODS)
+        # Keep only recognised methods; an unknown string can never widen access.
+        methods = [m for m in methods if m in _ALL_METHODS]
+        return OrgAuthPolicy(
+            allowed_auth_methods=methods,
+            allow_central_session_sharing=bool(
+                security.get("allow_central_session_sharing", True)
+            ),
+        )
+    except (TypeError, ValueError, AttributeError):
+        logger.exception("Malformed auth-method config for org %s", org_id)
+        return OrgAuthPolicy()
+
+
+def _method_label(method: str) -> str:
+    return {
+        "password": "email and password",
+        "magic_login": "a magic login link",
+        "google": "Google",
+        "sso": "single sign-on (SSO)",
+    }.get(method, method)
+
+
+async def evaluate_org_auth(
+    db_session: AsyncSession, user_id: int, org_id: int
+) -> Optional[Dict[str, Any]]:
+    """Return a block descriptor when the current session may not access the org,
+    else None. Memoized per db session (a page load runs many gates)."""
+    cache = getattr(db_session, "_auth_policy_cache", None)
+    if cache is None:
+        db_session._auth_policy_cache = {}
+        cache = db_session._auth_policy_cache
+    key = (user_id, org_id)
+    if key in cache:
+        return cache[key]
+
+    result: Optional[Dict[str, Any]] = None
+    try:
+        from src.security.superadmin import is_user_superadmin
+
+        # Superadmins operate across tenants and must never be locked out of one
+        # by that tenant's own policy.
+        if not await is_user_superadmin(user_id, db_session):
+            policy = await get_org_auth_policy(db_session, org_id)
+
+            # Fast path: default config (all methods, sharing on) is a pure no-op,
+            # so unmodified orgs — and every existing test that never sets
+            # provenance — are unaffected.
+            if policy.method_restricted or not policy.allow_central_session_sharing:
+                provenance = get_session_provenance() or SessionProvenance()
+
+                # Machine credentials carry their own org boundary
+                # (_verify_api_token_org_boundary) and are exempt from the human
+                # auth-method policy.
+                if provenance.amr != AUTH_METHOD_API_TOKEN:
+                    allowed = set(policy.allowed_auth_methods)
+                    if policy.method_restricted and (
+                        provenance.amr is None or provenance.amr not in allowed
+                    ):
+                        result = {
+                            "code": METHOD_NOT_ALLOWED_CODE,
+                            "allowed_methods": sorted(allowed),
+                        }
+                    elif (
+                        not policy.allow_central_session_sharing
+                        and provenance.org_id != org_id
+                    ):
+                        result = {"code": SESSION_NOT_BOUND_CODE}
+    except HTTPException:  # pragma: no cover - defensive: surface a policy 403 unchanged
+        raise
+    except Exception:
+        logger.exception(
+            "Auth-method policy evaluation failed for user %s in org %s; allowing through",
+            user_id,
+            org_id,
+        )
+        result = None
+
+    cache[key] = result
+    return result
+
+
+def auth_policy_exception(block: Dict[str, Any]) -> HTTPException:
+    if block["code"] == METHOD_NOT_ALLOWED_CODE:
+        labels = ", ".join(_method_label(m) for m in block.get("allowed_methods", []))
+        message = (
+            "This organization requires you to sign in with "
+            f"{labels or 'an approved method'}. Please sign in again from this "
+            "organization using an allowed method."
+        )
+        return HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": METHOD_NOT_ALLOWED_CODE,
+                "message": message,
+                "allowed_methods": block.get("allowed_methods", []),
+            },
+        )
+    return HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail={
+            "code": SESSION_NOT_BOUND_CODE,
+            "message": (
+                "This organization does not accept sessions started elsewhere. "
+                "Please sign in again from this organization's login page."
+            ),
+        },
+    )
+
+
+async def enforce_org_auth_policy(
+    db_session: AsyncSession, user_id: int, org_id: int
+) -> None:
+    """Raise 403 if the current session may not access ``org_id`` under the org's
+    auth-method / session-sharing policy."""
+    block = await evaluate_org_auth(db_session, user_id, org_id)
+    if block is not None:
+        raise auth_policy_exception(block)

--- a/apps/api/src/services/orgs/mfa_policy.py
+++ b/apps/api/src/services/orgs/mfa_policy.py
@@ -1,0 +1,234 @@
+"""Org-wide "require two-factor" policy.
+
+Why this is evaluated per org-access rather than at login
+---------------------------------------------------------
+Users can belong to many orgs (``UserOrganization`` is many-to-many). Someone
+who is in Org A (2FA required) and Org B (not) must still be able to sign in
+and use Org B. So the policy cannot be a login-time gate — it is a property of
+*accessing a particular org*, evaluated per request.
+
+Deliberately NOT enforced by suspending or deleting accounts: a user past their
+deadline keeps their session and their other orgs, and is simply blocked from
+this one until they enroll. The state is fully reversible the moment they do.
+"""
+
+import logging
+from dataclasses import dataclass, asdict
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+from fastapi import HTTPException, status
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.db.organization_config import OrganizationConfig
+from src.db.user_organizations import UserOrganization
+from src.db.users import User
+from src.services.auth.mfa import is_mfa_active
+
+logger = logging.getLogger(__name__)
+
+# signup_method values that mean "an external identity provider vouched for
+# this user". Kept conservative: an unrecognised value is treated as a local
+# password account, i.e. subject to the policy.
+EXTERNAL_AUTH_METHODS = {"google", "sso", "saml", "oidc", "workos", "keycloak", "okta", "auth0"}
+
+
+@dataclass
+class OrgMFAPolicy:
+    require_2fa: bool = False
+    grace_days: int = 0
+    enabled_at: Optional[str] = None
+    exempt_external_auth: bool = True
+
+
+@dataclass
+class MFAComplianceState:
+    """What the caller needs to render a banner, a countdown, or a hard block."""
+
+    required: bool
+    satisfied: bool
+    # None when there is no deadline (policy off, or already satisfied).
+    deadline: Optional[str] = None
+    days_remaining: Optional[int] = None
+    # True only when the user must be stopped right now.
+    blocking: bool = False
+    exempt_reason: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def _parse_dt(value: Optional[str]) -> Optional[datetime]:
+    """Best-effort parse of the mixed date shapes stored across this codebase.
+
+    Dates are persisted as ``str(datetime.now())`` in some tables and ISO-8601
+    in others. A value we cannot parse must not be allowed to silently become
+    "no deadline" — callers treat None as "unknown" and fall back to the policy
+    anchor rather than granting an open-ended grace period.
+    """
+    if not value:
+        return None
+    raw = str(value).strip()
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        pass
+    for fmt in ("%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(raw, fmt)
+        except ValueError:
+            continue
+    logger.warning("Could not parse a date for MFA policy evaluation: %r", value)
+    return None
+
+
+async def get_org_mfa_policy(db_session: AsyncSession, org_id: int) -> OrgMFAPolicy:
+    row = (
+        await db_session.execute(
+            select(OrganizationConfig).where(OrganizationConfig.org_id == org_id)
+        )
+    ).scalars().first()
+    if row is None or not isinstance(row.config, dict):
+        return OrgMFAPolicy()
+
+    security = (row.config.get("admin_toggles") or {}).get("security") or {}
+    try:
+        return OrgMFAPolicy(
+            require_2fa=bool(security.get("require_2fa", False)),
+            grace_days=max(0, int(security.get("require_2fa_grace_days", 0) or 0)),
+            enabled_at=security.get("require_2fa_enabled_at"),
+            exempt_external_auth=bool(security.get("exempt_external_auth", True)),
+        )
+    except (TypeError, ValueError):
+        # Malformed config must not fail open into "policy enforced but with a
+        # nonsense deadline"; fall back to the safe default of no policy and
+        # let an admin fix the config.
+        logger.exception("Malformed security config for org %s", org_id)
+        return OrgMFAPolicy()
+
+
+async def evaluate_mfa_compliance(
+    db_session: AsyncSession,
+    user: User,
+    org_id: int,
+) -> MFAComplianceState:
+    """Decide whether ``user`` may currently act inside ``org_id``."""
+    policy = await get_org_mfa_policy(db_session, org_id)
+
+    if not policy.require_2fa:
+        return MFAComplianceState(required=False, satisfied=True)
+
+    if await is_mfa_active(db_session, user.id):
+        return MFAComplianceState(required=True, satisfied=True)
+
+    if policy.exempt_external_auth and (user.signup_method or "").lower() in EXTERNAL_AUTH_METHODS:
+        return MFAComplianceState(
+            required=True,
+            satisfied=True,
+            exempt_reason="external_auth",
+        )
+
+    # Not satisfied — work out whether they are still inside their grace window.
+    anchor = _parse_dt(policy.enabled_at)
+    membership = (
+        await db_session.execute(
+            select(UserOrganization).where(
+                UserOrganization.user_id == user.id,
+                UserOrganization.org_id == org_id,
+            )
+        )
+    ).scalars().first()
+    joined = _parse_dt(membership.creation_date) if membership else None
+
+    # Later of "policy switched on" and "user joined this org" — see the
+    # SecurityAdminToggle docstring for why the max() is load-bearing.
+    candidates = [d for d in (anchor, joined) if d is not None]
+    start = max(candidates) if candidates else datetime.now()
+    deadline = start + timedelta(days=policy.grace_days)
+
+    now = datetime.now()
+    remaining = (deadline - now).total_seconds()
+    days_remaining = max(0, int(remaining // 86400)) if remaining > 0 else 0
+
+    return MFAComplianceState(
+        required=True,
+        satisfied=False,
+        deadline=deadline.isoformat(),
+        days_remaining=days_remaining,
+        blocking=remaining <= 0,
+    )
+
+
+### 🔒 Enforcement ##############################################################
+
+
+MFA_POLICY_ERROR_CODE = "MFA_REQUIRED_BY_ORG"
+
+
+async def is_org_mfa_blocking(db_session: AsyncSession, user_id: int, org_id: int) -> Optional[MFAComplianceState]:
+    """Return the compliance state when the user must be stopped, else None.
+
+    Memoized per DB session: a single page load can run several access checks
+    against the same org, and this would otherwise repeat the config + factor
+    lookups every time.
+    """
+    cache = getattr(db_session, "_mfa_policy_cache", None)
+    if cache is None:
+        db_session._mfa_policy_cache = {}
+        cache = db_session._mfa_policy_cache
+
+    key = (user_id, org_id)
+    if key in cache:
+        return cache[key]
+
+    result: Optional[MFAComplianceState] = None
+    try:
+        # Superadmins operate across tenants and frequently have no membership
+        # row in the org at all; a per-org policy must not strand them.
+        from src.security.superadmin import is_user_superadmin
+
+        if not await is_user_superadmin(user_id, db_session):
+            user = (
+                await db_session.execute(select(User).where(User.id == user_id))
+            ).scalars().first()
+            if user is not None:
+                state = await evaluate_mfa_compliance(db_session, user, org_id)
+                if state.blocking:
+                    result = state
+    except HTTPException:  # pragma: no cover - defensive: surface a policy 403 unchanged
+        raise
+    except Exception:
+        # A policy lookup that errors must not take down ordinary access. The
+        # policy is an additional restriction layered on top of RBAC, never the
+        # thing standing between a stranger and the data — RBAC has already run.
+        logger.exception(
+            "MFA policy evaluation failed for user %s in org %s; allowing through",
+            user_id,
+            org_id,
+        )
+        result = None
+
+    cache[key] = result
+    return result
+
+
+def mfa_policy_exception(state: MFAComplianceState) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail={
+            "code": MFA_POLICY_ERROR_CODE,
+            "message": (
+                "Your organization requires two-factor authentication. "
+                "Enable it on your account to regain access."
+            ),
+            "deadline": state.deadline,
+        },
+    )
+
+
+async def enforce_org_mfa_policy(db_session: AsyncSession, user_id: int, org_id: int) -> None:
+    """Raise 403 if ``user_id`` is past their two-factor deadline in ``org_id``."""
+    state = await is_org_mfa_blocking(db_session, user_id, org_id)
+    if state is not None:
+        raise mfa_policy_exception(state)

--- a/apps/api/src/services/orgs/users.py
+++ b/apps/api/src/services/orgs/users.py
@@ -33,7 +33,7 @@ from src.services.security.rate_limiting import (
     enforce_batch_size_limit,
     enforce_invite_rate_limit,
 )
-from src.security.org_auth import is_org_member
+from src.security.org_auth import is_org_member, enforce_org_mfa
 from src.security.rbac.constants import ADMIN_ROLE_ID
 from src.services.orgs.invites import send_invite_email
 from src.services.orgs.orgs import get_org_default_language, rbac_check
@@ -124,6 +124,8 @@ async def get_organization_users(
             detail="You must be a member of this organization to view its members",
         )
 
+    # Org-wide two-factor policy, applied after the membership gate.
+    await enforce_org_mfa(acting_user_id, org.id, db_session)
     # Only admins/maintainers can list organization members
     from src.security.superadmin import is_user_superadmin
     if not await is_user_superadmin(acting_user_id, db_session):
@@ -134,6 +136,8 @@ async def get_organization_users(
                 detail="Only administrators and maintainers can view organization members",
             )
 
+        # Org-wide two-factor policy, applied after the membership gate.
+        await enforce_org_mfa(acting_user_id, org.id, db_session)
     # Base query for users in the organization
     base_statement = (
         select(User)
@@ -353,6 +357,8 @@ async def export_organization_users_csv(
     if not await is_org_member(export_acting_user_id, org.id, db_session):
         raise HTTPException(status_code=403, detail="You must be a member of this organization")
 
+    # Org-wide two-factor policy, applied after the membership gate.
+    await enforce_org_mfa(export_acting_user_id, org.id, db_session)
     # Only admins/maintainers can export organization members
     from src.security.superadmin import is_user_superadmin
     if not await is_user_superadmin(export_acting_user_id, db_session):
@@ -363,6 +369,8 @@ async def export_organization_users_csv(
                 detail="Only administrators and maintainers can export organization members",
             )
 
+        # Org-wide two-factor policy, applied after the membership gate.
+        await enforce_org_mfa(export_acting_user_id, org.id, db_session)
     base_statement = (
         select(User)
         .join(UserOrganization)

--- a/apps/api/src/services/playgrounds/playgrounds.py
+++ b/apps/api/src/services/playgrounds/playgrounds.py
@@ -73,6 +73,14 @@ async def _get_user_rights(
     if not user_org:
         return {}
 
+    # The caller is a confirmed member — subject to the org's 2FA policy. Every
+    # mutating playground gate (create/update/delete/duplicate and the usergroup
+    # ops) resolves rights through here, so enforcing once closes the whole set
+    # of write paths against a member who is past their two-factor deadline.
+    from src.security.org_auth import enforce_org_mfa
+
+    await enforce_org_mfa(user_id, org_id, db_session)
+
     from src.db.roles import Role
     role = (await db_session.execute(select(Role).where(Role.id == user_org.role_id))).scalars().first()
     if not role or not role.rights:
@@ -82,6 +90,32 @@ async def _get_user_rights(
     if isinstance(rights, dict):
         return rights
     return rights.model_dump() if hasattr(rights, "model_dump") else {}
+
+
+async def _enforce_member_mfa(user_id: int, org_id: int, db_session: AsyncSession) -> None:
+    """Apply the org's "require two-factor" policy — but only to actual members.
+
+    Playgrounds are also served to non-members and anonymous users (PUBLIC /
+    AUTHENTICATED access types), and the org 2FA policy governs *members* of the
+    org, not passers-by. Without the membership gate, an authenticated non-member
+    with no second factor would be wrongly blocked from an org's public
+    playgrounds, because :func:`evaluate_mfa_compliance` falls back to the policy
+    anchor when there is no membership row. Superadmins carry no membership row
+    and are exempt inside the policy layer anyway, so skipping them here is safe.
+    """
+    membership = (
+        await db_session.execute(
+            select(UserOrganization).where(
+                UserOrganization.user_id == user_id,
+                UserOrganization.org_id == org_id,
+            )
+        )
+    ).scalars().first()
+    if membership is None:
+        return
+    from src.security.org_auth import enforce_org_mfa
+
+    await enforce_org_mfa(user_id, org_id, db_session)
 
 
 async def _is_org_admin(user_id: int, org_id: int, db_session: AsyncSession) -> bool:
@@ -220,6 +254,11 @@ async def get_playground(
 
     await _check_read_access(playground, current_user, db_session)
 
+    if not isinstance(current_user, AnonymousUser):
+        await _enforce_member_mfa(
+            resolve_acting_user_id(current_user), playground.org_id, db_session
+        )
+
     # Unpublished (draft) playgrounds must never be exposed by uuid to anyone
     # other than the owner or an org admin. _check_read_access only validates
     # access_type, so without this guard a draft PUBLIC/AUTHENTICATED playground
@@ -253,6 +292,9 @@ async def list_org_playgrounds(
     # An API token's .id is the token id, not a user id; resolve to the real
     # acting user so ownership/admin visibility checks below evaluate correctly.
     user_id = None if is_anon else resolve_acting_user_id(current_user)
+
+    if not is_anon:
+        await _enforce_member_mfa(user_id, org_id, db_session)
 
     is_admin = False if is_anon else await _is_org_admin(user_id, org_id, db_session)
 

--- a/apps/api/src/tests/admin/test_admin_api.py
+++ b/apps/api/src/tests/admin/test_admin_api.py
@@ -1679,8 +1679,10 @@ class TestIssueMagicLink:
 
 class TestMagicLinkConsume:
 
-    @patch("src.services.admin.admin.create_refresh_token", return_value="refresh_consumed")
-    @patch("src.services.admin.admin.create_access_token", return_value="access_consumed")
+    # Session minting now happens inside issue_session_or_challenge, so the
+    # patch targets follow it there.
+    @patch("src.services.auth.session.create_refresh_token", return_value="refresh_consumed")
+    @patch("src.services.auth.session.create_access_token", return_value="access_consumed")
     async def test_valid_token(self, mock_access, mock_refresh, token_user, user, db):
         with patch("src.security.auth.decode_jwt") as mock_decode:
             mock_decode.return_value = {
@@ -1689,12 +1691,45 @@ class TestMagicLinkConsume:
                 "org_id": token_user.org_id,
                 "redirect_to": "/course/bar",
             }
-            consumed_user, access, refresh, redirect = await consume_magic_link_token(
+            consumed_user, access, refresh, redirect, mfa_token = await consume_magic_link_token(
                 token="fake_token", db_session=db,
             )
         assert consumed_user.id == user.id
         assert access == "access_consumed"
         assert refresh == "refresh_consumed"
+        assert redirect == "/course/bar"
+        assert mfa_token is None
+
+    @patch("src.services.auth.session.create_access_token", return_value="unused")
+    async def test_enrolled_user_gets_challenge_not_session(self, mock_access, token_user, user, db):
+        """A magic link for a 2FA-enabled user must not mint a session."""
+        from datetime import datetime as _dt
+        from src.db.user_mfa import UserMFA
+
+        db.add(
+            UserMFA(
+                user_id=user.id,
+                secret_encrypted="ciphertext",
+                confirmed_at=str(_dt.now()),
+                creation_date=str(_dt.now()),
+                update_date=str(_dt.now()),
+            )
+        )
+        await db.commit()
+
+        with patch("src.security.auth.decode_jwt") as mock_decode:
+            mock_decode.return_value = {
+                "sub": user.email,
+                "purpose": "magic_link",
+                "org_id": token_user.org_id,
+                "redirect_to": "/course/bar",
+            }
+            _u, access, refresh, redirect, mfa_token = await consume_magic_link_token(
+                token="fake_token", db_session=db,
+            )
+        assert access is None
+        assert refresh is None
+        assert mfa_token is not None
         assert redirect == "/course/bar"
 
     async def test_invalid_token(self, db):
@@ -1722,8 +1757,10 @@ class TestMagicLinkConsume:
                 await consume_magic_link_token(token="t", db_session=db)
             assert exc.value.status_code == 410
 
-    @patch("src.services.admin.admin.create_refresh_token", return_value="refresh_x")
-    @patch("src.services.admin.admin.create_access_token", return_value="access_x")
+    # Session minting moved into issue_session_or_challenge, so the token
+    # factories are patched there, not on the admin module.
+    @patch("src.services.auth.session.create_refresh_token", return_value="refresh_x")
+    @patch("src.services.auth.session.create_access_token", return_value="access_x")
     async def test_sanitizes_bad_redirect_to_default(self, mock_access, mock_refresh, token_user, user, db):
         """An older token might have an unvalidated redirect_to. Consume must not honor an absolute URL."""
         with patch("src.security.auth.decode_jwt") as mock_decode:
@@ -1733,7 +1770,7 @@ class TestMagicLinkConsume:
                 "org_id": token_user.org_id,
                 "redirect_to": "https://evil.com/phish",
             }
-            _user, _a, _r, redirect = await consume_magic_link_token(
+            _user, _a, _r, redirect, _mfa = await consume_magic_link_token(
                 token="t", db_session=db,
             )
         assert redirect is None  # falls through to "/" in the router

--- a/apps/api/src/tests/routers/test_admin_router.py
+++ b/apps/api/src/tests/routers/test_admin_router.py
@@ -359,7 +359,8 @@ class TestAdminRouter:
         with patch(
             "src.routers.admin.consume_magic_link_token",
             new_callable=AsyncMock,
-            return_value=(_mock_user(), "access_tok", "refresh_tok", "/dashboard"),
+            # 5th element is the MFA pending token; None = no second factor.
+            return_value=(_mock_user(), "access_tok", "refresh_tok", "/dashboard", None),
         ):
             response = await client.get(
                 "/api/v1/admin/acme/auth/magic-consume",
@@ -368,6 +369,24 @@ class TestAdminRouter:
             )
         assert response.status_code == 302
         assert response.headers["location"] == "/dashboard"
+
+        # A 2FA-enabled user gets bounced to the code challenge instead of a
+        # session: the magic link must not walk past their second factor.
+        with patch(
+            "src.routers.admin.consume_magic_link_token",
+            new_callable=AsyncMock,
+            return_value=(_mock_user(), None, None, "/dashboard", "pending-tok"),
+        ):
+            response = await client.get(
+                "/api/v1/admin/acme/auth/magic-consume",
+                params={"token": "good"},
+                follow_redirects=False,
+            )
+        assert response.status_code == 302
+        assert response.headers["location"].startswith("/auth/login?mfa_token=pending-tok")
+        assert "redirect_to=%2Fdashboard" in response.headers["location"]
+        # No session cookies may be set on the challenge redirect.
+        assert "LH_access" not in response.headers.get("set-cookie", "")
 
         with patch(
             "src.routers.admin.consume_magic_link_token",

--- a/apps/api/src/tests/routers/test_ai_assignment_gen_router.py
+++ b/apps/api/src/tests/routers/test_ai_assignment_gen_router.py
@@ -185,3 +185,17 @@ async def test_history_and_delete():
         with pytest.raises(HTTPException) as exc:
             await ag.api_delete_assignment_history("x", _user(), AsyncMock())
     assert exc.value.status_code == 404
+
+
+@pytest.fixture(autouse=True)
+def _skip_org_mfa_policy():
+    """No-op the org two-factor policy for this module.
+
+    These tests drive the router with a hand-rolled session whose `execute`
+    returns a fixed, ordered list of results. The policy check issues its own
+    queries, which would consume entries from that list and desynchronise every
+    subsequent lookup. The policy itself is covered directly in
+    src/tests/security/test_mfa_org_policy.py.
+    """
+    with patch.object(ag, "enforce_org_mfa", new=AsyncMock(return_value=None)):
+        yield

--- a/apps/api/src/tests/routers/test_ai_quiz_router.py
+++ b/apps/api/src/tests/routers/test_ai_quiz_router.py
@@ -184,3 +184,17 @@ async def test_history_and_delete():
         with pytest.raises(HTTPException) as exc:
             await qz.api_delete_quiz_history("x", _user(), AsyncMock())
     assert exc.value.status_code == 404
+
+
+@pytest.fixture(autouse=True)
+def _skip_org_mfa_policy():
+    """No-op the org two-factor policy for this module.
+
+    These tests drive the router with a hand-rolled session whose `execute`
+    returns a fixed, ordered list of results. The policy check issues its own
+    queries, which would consume entries from that list and desynchronise every
+    subsequent lookup. The policy itself is covered directly in
+    src/tests/security/test_mfa_org_policy.py.
+    """
+    with patch.object(qz, "enforce_org_mfa", new=AsyncMock(return_value=None)):
+        yield

--- a/apps/api/src/tests/routers/test_auth_magic_link.py
+++ b/apps/api/src/tests/routers/test_auth_magic_link.py
@@ -1,0 +1,305 @@
+"""Endpoint tests for the passwordless magic-link flow in src/routers/auth.py.
+
+Covers POST /magic-link/request (generic 200 responses that never reveal whether
+an account exists, the org-policy short-circuit, and rate limiting) and POST
+/magic-link/verify (session issuance, the second-factor branch, and the 410 for
+an invalid/used link). Also pins that /auth/refresh carries a session's
+provenance (amr / sorg) across rotation.
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from httpx import ASGITransport, AsyncClient
+
+from src.core.events.database import get_db_session
+from src.db.organization_config import OrganizationConfig
+from src.db.user_mfa import UserMFA
+from src.db.users import AnonymousUser, User
+from src.routers.auth import JWT_REFRESH_COOKIE_NAME, router as auth_router
+from src.security.auth import decode_jwt, get_current_user
+from src.security.session_context import AMR_CLAIM, SORG_CLAIM
+
+
+@pytest.fixture
+def app(db):
+    app = FastAPI()
+    app.include_router(auth_router, prefix="/api/v1/auth")
+    app.dependency_overrides[get_db_session] = lambda: db
+    app.dependency_overrides[get_current_user] = lambda: AnonymousUser()
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def client(app):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture
+async def verified_user(db):
+    user = User(
+        id=21,
+        username="magic",
+        first_name="Magic",
+        last_name="User",
+        email="magic@test.com",
+        password="hashed_password",
+        user_uuid="user_magic",
+        email_verified=True,
+        creation_date=str(datetime.now()),
+        update_date=str(datetime.now()),
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _enroll_confirmed(db, user_id):
+    now = str(datetime.now())
+    db.add(
+        UserMFA(
+            user_id=user_id,
+            secret_encrypted="ciphertext",
+            confirmed_at=now,
+            creation_date=now,
+            update_date=now,
+        )
+    )
+    await db.commit()
+
+
+async def _set_allowed_methods(db, org_id, methods):
+    db.add(
+        OrganizationConfig(
+            org_id=org_id,
+            config={
+                "config_version": "2.0",
+                "admin_toggles": {"security": {"allowed_auth_methods": methods}},
+            },
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+    )
+    await db.commit()
+
+
+class TestMagicLinkRequest:
+    async def test_unknown_email_is_generic_and_sends_nothing(self, client):
+        with patch(
+            "src.routers.auth.check_login_rate_limit", return_value=(True, None)
+        ), patch(
+            "src.services.auth.magic_login.send_magic_login_email"
+        ) as send_mock, patch(
+            "src.services.auth.magic_login.issue_magic_login_token", return_value="tok"
+        ):
+            response = await client.post(
+                "/api/v1/auth/magic-link/request",
+                json={"email": "nobody@test.com"},
+            )
+        assert response.status_code == 200
+        assert "login link has been sent" in response.json()["detail"]
+        send_mock.assert_not_called()
+
+    async def test_known_email_sends_link(self, client, verified_user):
+        with patch(
+            "src.routers.auth.check_login_rate_limit", return_value=(True, None)
+        ), patch(
+            "src.services.auth.magic_login.issue_magic_login_token", return_value="tok"
+        ), patch(
+            "src.services.auth.magic_login.send_magic_login_email"
+        ) as send_mock, patch(
+            "src.services.email.utils.get_base_url_from_request",
+            return_value="http://test",
+        ):
+            response = await client.post(
+                "/api/v1/auth/magic-link/request",
+                json={"email": verified_user.email},
+            )
+        assert response.status_code == 200
+        send_mock.assert_called_once()
+
+    async def test_org_disallowing_magic_login_sends_nothing(self, client, db, org, verified_user):
+        # The org restricts sign-in to password only; a magic link would be
+        # refused at the org gate anyway, so none is sent.
+        await _set_allowed_methods(db, org.id, ["password"])
+        with patch(
+            "src.routers.auth.check_login_rate_limit", return_value=(True, None)
+        ), patch(
+            "src.services.auth.magic_login.send_magic_login_email"
+        ) as send_mock, patch(
+            "src.services.auth.magic_login.issue_magic_login_token", return_value="tok"
+        ):
+            response = await client.post(
+                "/api/v1/auth/magic-link/request",
+                json={"email": verified_user.email, "org_slug": org.slug},
+            )
+        assert response.status_code == 200
+        send_mock.assert_not_called()
+
+    async def test_saas_unverified_user_sends_nothing(self, client, db):
+        # In SaaS mode an unverified account can't log in by password; a magic
+        # link must not become a verification-bypass side channel.
+        unverified = User(
+            id=22,
+            username="unverified",
+            first_name="Un",
+            last_name="Verified",
+            email="unverified@test.com",
+            password="hashed_password",
+            user_uuid="user_unverified",
+            email_verified=False,
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(unverified)
+        await db.commit()
+        with patch(
+            "src.routers.auth.check_login_rate_limit", return_value=(True, None)
+        ), patch(
+            "src.routers.auth.get_deployment_mode", return_value="saas"
+        ), patch(
+            "src.services.auth.magic_login.send_magic_login_email"
+        ) as send_mock, patch(
+            "src.services.auth.magic_login.issue_magic_login_token", return_value="tok"
+        ):
+            response = await client.post(
+                "/api/v1/auth/magic-link/request",
+                json={"email": unverified.email},
+            )
+        assert response.status_code == 200
+        send_mock.assert_not_called()
+
+    async def test_rate_limited(self, client):
+        with patch(
+            "src.routers.auth.check_login_rate_limit", return_value=(False, 60)
+        ):
+            response = await client.post(
+                "/api/v1/auth/magic-link/request",
+                json={"email": "x@test.com"},
+            )
+        assert response.status_code == 429
+        assert response.json()["detail"]["code"] == "RATE_LIMITED"
+
+    async def test_send_failure_is_swallowed_and_generic(self, client, verified_user):
+        # A mail-transport error must not turn into a 500 that leaks the address
+        # exists; the endpoint still returns the generic 200.
+        with patch(
+            "src.routers.auth.check_login_rate_limit", return_value=(True, None)
+        ), patch(
+            "src.services.auth.magic_login.issue_magic_login_token", return_value="tok"
+        ), patch(
+            "src.services.auth.magic_login.send_magic_login_email",
+            side_effect=RuntimeError("smtp down"),
+        ), patch(
+            "src.services.email.utils.get_base_url_from_request",
+            return_value="http://test",
+        ):
+            response = await client.post(
+                "/api/v1/auth/magic-link/request",
+                json={"email": verified_user.email},
+            )
+        assert response.status_code == 200
+
+
+class TestMagicLinkVerify:
+    async def test_success_mints_session(self, client, verified_user):
+        with patch(
+            "src.services.auth.magic_login.consume_magic_login_token",
+            return_value=(verified_user.email, None),
+        ), patch("src.routers.auth.set_auth_cookies") as cookies_mock, patch(
+            "src.routers.auth.get_token_expiry_ms", return_value=12345
+        ):
+            response = await client.post(
+                "/api/v1/auth/magic-link/verify", json={"token": "good-token"}
+            )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["user"]["email"] == verified_user.email
+        assert body["tokens"]["access_token"]
+        cookies_mock.assert_called_once()
+
+    async def test_mfa_required_branch(self, client, db, verified_user):
+        await _enroll_confirmed(db, verified_user.id)
+        with patch(
+            "src.services.auth.magic_login.consume_magic_login_token",
+            return_value=(verified_user.email, None),
+        ):
+            response = await client.post(
+                "/api/v1/auth/magic-link/verify", json={"token": "good-token"}
+            )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["mfa_required"] is True
+        assert body["mfa_token"]
+
+    async def test_unknown_user_410(self, client):
+        with patch(
+            "src.services.auth.magic_login.consume_magic_login_token",
+            return_value=("ghost@test.com", None),
+        ):
+            response = await client.post(
+                "/api/v1/auth/magic-link/verify", json={"token": "good-token"}
+            )
+        assert response.status_code == 410
+        assert response.json()["detail"]["code"] == "MAGIC_LINK_INVALID"
+
+    async def test_invalid_or_used_link_410(self, client):
+        with patch(
+            "src.services.auth.magic_login.consume_magic_login_token",
+            side_effect=HTTPException(
+                status_code=410,
+                detail={"code": "MAGIC_LINK_USED", "message": "already used"},
+            ),
+        ):
+            response = await client.post(
+                "/api/v1/auth/magic-link/verify", json={"token": "used-token"}
+            )
+        assert response.status_code == 410
+        assert response.json()["detail"]["code"] == "MAGIC_LINK_USED"
+
+
+class TestRefreshPreservesProvenance:
+    """Rotation must not launder a method-bound/org-bound session into a
+    claim-less one — otherwise a refresh would silently bypass the org
+    auth-method / session-sharing policy. Tokens are minted for real here (not
+    mocked) so the carried claims are asserted on the actual rotated token."""
+
+    async def test_rotated_token_carries_amr_and_sorg(self, client, verified_user):
+        with patch(
+            "src.routers.auth.check_refresh_rate_limit", return_value=(True, None)
+        ), patch(
+            "src.routers.auth.decode_refresh_token",
+            return_value={
+                "sub": verified_user.email,
+                "iat": 1,
+                "exp": 9_999_999_999,
+                "jti": "legit-jti",
+                AMR_CLAIM: "magic_login",
+                SORG_CLAIM: 1,
+            },
+        ), patch(
+            "src.routers.auth.security_get_user",
+            new_callable=AsyncMock,
+            return_value=verified_user,
+        ), patch(
+            "src.routers.auth._is_token_revoked_for_user", return_value=False
+        ), patch(
+            "src.routers.auth._mark_refresh_jti_used", return_value=True
+        ), patch(
+            "src.routers.auth.get_cookie_domain_for_request", return_value=None
+        ), patch(
+            "src.routers.auth.is_request_secure", return_value=False
+        ):
+            response = await client.get(
+                "/api/v1/auth/refresh",
+                cookies={JWT_REFRESH_COOKIE_NAME: "refresh-token"},
+            )
+        assert response.status_code == 200
+        rotated = decode_jwt(response.json()["access_token"])
+        assert rotated[AMR_CLAIM] == "magic_login"
+        assert rotated[SORG_CLAIM] == 1

--- a/apps/api/src/tests/routers/test_login_provenance.py
+++ b/apps/api/src/tests/routers/test_login_provenance.py
@@ -1,0 +1,146 @@
+"""Password login stamps session provenance (amr/sorg) and honours the 2FA gate.
+
+Unlike test_auth_router.test_login_success (which patches the token factories),
+these let real tokens mint so the amr/sorg claims can be read back, and they
+exercise the org-slug binding and the second-factor branch.
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.core.events.database import get_db_session
+from src.db.user_mfa import UserMFA
+from src.db.users import AnonymousUser, User
+from src.routers.auth import router as auth_router
+from src.security.auth import decode_jwt, get_current_user
+from src.security.session_context import AMR_CLAIM, SORG_CLAIM
+from src.services.auth.mfa import encrypt_secret, generate_totp_secret
+
+
+@pytest.fixture
+def app(db):
+    app = FastAPI()
+    app.include_router(auth_router, prefix="/api/v1/auth")
+    app.dependency_overrides[get_db_session] = lambda: db
+    app.dependency_overrides[get_current_user] = lambda: AnonymousUser()
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def client(app):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture
+def login_user(db):
+    user = User(
+        id=4110,
+        username="provuser",
+        first_name="Prov",
+        last_name="User",
+        email="prov@test.com",
+        password="hashed_password",
+        user_uuid="user_prov",
+        email_verified=True,
+        creation_date=str(datetime.now()),
+        update_date=str(datetime.now()),
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _login_patches():
+    """The environmental stubs shared by both tests — everything except the
+    token factories, which we deliberately leave real."""
+    return [
+        patch("src.routers.auth.check_login_rate_limit", return_value=(True, None)),
+        patch("src.routers.auth.check_account_locked", return_value=(False, None)),
+        patch("src.routers.auth.reset_failed_attempts"),
+        patch("src.routers.auth.get_client_ip", return_value="127.0.0.1"),
+        patch("src.routers.auth.update_login_info"),
+        patch("src.routers.auth.record_audit_event"),
+        patch("src.routers.auth.set_auth_cookies"),
+        patch("src.routers.auth.get_deployment_mode", return_value="oss"),
+    ]
+
+
+class TestLoginProvenance:
+    async def test_login_binds_session_to_org_slug(self, client, login_user, org):
+        stubs = _login_patches() + [
+            patch("src.routers.auth.authenticate_user", new_callable=AsyncMock, return_value=login_user),
+        ]
+        import contextlib
+
+        with contextlib.ExitStack() as stack:
+            for s in stubs:
+                stack.enter_context(s)
+            resp = await client.post(
+                "/api/v1/auth/login",
+                data={"username": login_user.email, "password": "secret", "org_slug": org.slug},
+            )
+
+        assert resp.status_code == 200
+        token = resp.json()["tokens"]["access_token"]
+        claims = decode_jwt(token)
+        assert claims[AMR_CLAIM] == "password"
+        assert claims[SORG_CLAIM] == org.id
+
+    async def test_login_without_org_slug_has_no_sorg(self, client, login_user):
+        stubs = _login_patches() + [
+            patch("src.routers.auth.authenticate_user", new_callable=AsyncMock, return_value=login_user),
+        ]
+        import contextlib
+
+        with contextlib.ExitStack() as stack:
+            for s in stubs:
+                stack.enter_context(s)
+            resp = await client.post(
+                "/api/v1/auth/login",
+                data={"username": login_user.email, "password": "secret"},
+            )
+
+        assert resp.status_code == 200
+        claims = decode_jwt(resp.json()["tokens"]["access_token"])
+        assert claims[AMR_CLAIM] == "password"
+        assert SORG_CLAIM not in claims
+
+    async def test_login_with_2fa_returns_challenge_not_session(self, client, db, login_user):
+        # Enrolled second factor → login must hand back an mfa_token, no session.
+        now = str(datetime.now())
+        db.add(
+            UserMFA(
+                user_id=login_user.id,
+                secret_encrypted=encrypt_secret(generate_totp_secret()),
+                confirmed_at=now,
+                creation_date=now,
+                update_date=now,
+            )
+        )
+        await db.commit()
+
+        stubs = _login_patches() + [
+            patch("src.routers.auth.authenticate_user", new_callable=AsyncMock, return_value=login_user),
+        ]
+        import contextlib
+
+        with contextlib.ExitStack() as stack:
+            for s in stubs:
+                stack.enter_context(s)
+            resp = await client.post(
+                "/api/v1/auth/login",
+                data={"username": login_user.email, "password": "secret"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["mfa_required"] is True
+        assert body["mfa_token"]
+        assert "tokens" not in body

--- a/apps/api/src/tests/routers/test_mfa_router.py
+++ b/apps/api/src/tests/routers/test_mfa_router.py
@@ -1,0 +1,623 @@
+"""Endpoint tests for src/routers/mfa.py.
+
+Service-level primitives (TOTP verification, backup-code burning, org-policy
+arithmetic) are already pinned by src/tests/security/test_mfa*.py. These drive
+the nine MFA HTTP endpoints end-to-end: the auth gate, the password/second-factor
+re-authentication checks, and the admin org-policy guards including the
+auth-method / session-sharing self-lockout protections.
+"""
+
+import time
+from datetime import datetime
+
+import pyotp
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.core.events.database import get_db_session
+from src.db.organization_config import OrganizationConfig
+from src.db.user_mfa import UserMFA, UserMFABackupCode
+from src.db.users import APITokenUser
+from src.routers.mfa import router as mfa_router
+from src.security.auth import get_authenticated_user
+from src.security.session_context import (
+    AUTH_METHOD_PASSWORD,
+    SessionProvenance,
+    set_session_provenance,
+)
+from src.services.auth.mfa import (
+    TOTP_PERIOD_SECONDS,
+    encrypt_secret,
+    generate_totp_secret,
+    hash_backup_code,
+)
+from src.services.auth.session import create_mfa_pending_token
+
+
+def _code_for(secret: str, step_offset: int = 0) -> str:
+    step = int(time.time()) // TOTP_PERIOD_SECONDS + step_offset
+    return pyotp.TOTP(secret, interval=TOTP_PERIOD_SECONDS).at(step * TOTP_PERIOD_SECONDS)
+
+
+async def _enroll(db, user_id, secret, *, confirmed=True, last_step=None):
+    now = str(datetime.now())
+    db.add(
+        UserMFA(
+            user_id=user_id,
+            secret_encrypted=encrypt_secret(secret),
+            confirmed_at=now if confirmed else None,
+            last_used_timestep=last_step,
+            creation_date=now,
+            update_date=now,
+        )
+    )
+    await db.commit()
+
+
+async def _add_backup_code(db, user_id, code):
+    db.add(
+        UserMFABackupCode(
+            user_id=user_id,
+            code_hash=hash_backup_code(code),
+            creation_date=str(datetime.now()),
+        )
+    )
+    await db.commit()
+
+
+async def _add_org_config(db, org_id, security=None):
+    config = {"config_version": "2.0"}
+    if security is not None:
+        config["admin_toggles"] = {"security": security}
+    db.add(
+        OrganizationConfig(
+            org_id=org_id,
+            config=config,
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+    )
+    await db.commit()
+
+
+@pytest.fixture(autouse=True)
+def _allow_rate_limit():
+    """Keep the per-account/IP throttle from touching Redis and flaking."""
+    from unittest.mock import patch
+
+    with patch(
+        "src.routers.mfa.check_rate_limit",
+        return_value=(True, 0, None),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_provenance():
+    set_session_provenance(None)
+    yield
+    set_session_provenance(None)
+
+
+@pytest.fixture
+def app(db, regular_user):
+    app = FastAPI()
+    app.include_router(mfa_router, prefix="/api/v1/auth")
+    app.dependency_overrides[get_db_session] = lambda: db
+    app.dependency_overrides[get_authenticated_user] = lambda: regular_user
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def client(app):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+def _act_as(app, user):
+    app.dependency_overrides[get_authenticated_user] = lambda: user
+
+
+class TestStatus:
+    async def test_not_enrolled(self, client, regular_user):
+        response = await client.get("/api/v1/auth/mfa/status")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["enabled"] is False
+        assert body["backup_codes_remaining"] == 0
+        assert body["has_password"] is True
+
+    async def test_enrolled_reports_backup_codes(self, client, db, regular_user):
+        await _enroll(db, regular_user.id, generate_totp_secret())
+        await _add_backup_code(db, regular_user.id, "ABCDE-FGHJK")
+        response = await client.get("/api/v1/auth/mfa/status")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["enabled"] is True
+        assert body["backup_codes_remaining"] == 1
+
+
+class TestSetup:
+    async def test_happy_path_returns_provisioning_uri(self, client, regular_user):
+        from unittest.mock import patch
+
+        with patch("src.routers.mfa.security_verify_password", return_value=True):
+            response = await client.post(
+                "/api/v1/auth/mfa/setup", json={"password": "pw"}
+            )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["secret"]
+        assert body["provisioning_uri"].startswith("otpauth://totp/")
+
+    async def test_password_gate_rejects_missing_password(self, client, regular_user):
+        # regular_user has a local password, so setup demands re-authentication.
+        response = await client.post("/api/v1/auth/mfa/setup", json={})
+        assert response.status_code == 401
+        assert response.json()["detail"]["code"] == "INVALID_PASSWORD"
+
+    async def test_already_enabled_conflicts(self, client, db, regular_user):
+        from unittest.mock import patch
+
+        await _enroll(db, regular_user.id, generate_totp_secret())
+        with patch("src.routers.mfa.security_verify_password", return_value=True):
+            response = await client.post(
+                "/api/v1/auth/mfa/setup", json={"password": "pw"}
+            )
+        assert response.status_code == 409
+        assert response.json()["detail"]["code"] == "MFA_ALREADY_ENABLED"
+
+    async def test_restart_overwrites_unconfirmed_enrollment(self, client, db, regular_user):
+        from unittest.mock import patch
+
+        await _enroll(db, regular_user.id, generate_totp_secret(), confirmed=False)
+        with patch("src.routers.mfa.security_verify_password", return_value=True):
+            response = await client.post(
+                "/api/v1/auth/mfa/setup", json={"password": "pw"}
+            )
+        assert response.status_code == 200
+        assert response.json()["secret"]
+
+
+class TestConfirm:
+    async def test_valid_code_activates_and_returns_backup_codes(self, client, db, regular_user):
+        secret = generate_totp_secret()
+        await _enroll(db, regular_user.id, secret, confirmed=False)
+        response = await client.post(
+            "/api/v1/auth/mfa/confirm", json={"code": _code_for(secret)}
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["enabled"] is True
+        assert len(body["backup_codes"]) == 10
+
+    async def test_invalid_code_rejected(self, client, db, regular_user):
+        secret = generate_totp_secret()
+        await _enroll(db, regular_user.id, secret, confirmed=False)
+        response = await client.post(
+            "/api/v1/auth/mfa/confirm", json={"code": "000000"}
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"]["code"] == "INVALID_CODE"
+
+    async def test_no_enrollment_in_progress(self, client, regular_user):
+        response = await client.post(
+            "/api/v1/auth/mfa/confirm", json={"code": "000000"}
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"]["code"] == "NO_ENROLLMENT"
+
+
+class TestDisable:
+    async def test_valid_totp_disables(self, client, db, regular_user):
+        from unittest.mock import patch
+
+        secret = generate_totp_secret()
+        await _enroll(db, regular_user.id, secret)
+        with patch("src.routers.mfa.security_verify_password", return_value=True):
+            response = await client.post(
+                "/api/v1/auth/mfa/disable",
+                json={"password": "pw", "code": _code_for(secret)},
+            )
+        assert response.status_code == 200
+        assert response.json()["enabled"] is False
+
+    async def test_backup_code_disables(self, client, db, regular_user):
+        from unittest.mock import patch
+
+        await _enroll(db, regular_user.id, generate_totp_secret())
+        await _add_backup_code(db, regular_user.id, "ABCDE-FGHJK")
+        with patch("src.routers.mfa.security_verify_password", return_value=True):
+            response = await client.post(
+                "/api/v1/auth/mfa/disable",
+                json={"password": "pw", "code": "ABCDE-FGHJK"},
+            )
+        assert response.status_code == 200
+        assert response.json()["enabled"] is False
+
+    async def test_wrong_code_rejected(self, client, db, regular_user):
+        from unittest.mock import patch
+
+        await _enroll(db, regular_user.id, generate_totp_secret())
+        with patch("src.routers.mfa.security_verify_password", return_value=True):
+            response = await client.post(
+                "/api/v1/auth/mfa/disable",
+                json={"password": "pw", "code": "000000"},
+            )
+        assert response.status_code == 400
+        assert response.json()["detail"]["code"] == "INVALID_CODE"
+
+    async def test_not_enabled_rejected(self, client, db, regular_user):
+        from unittest.mock import patch
+
+        with patch("src.routers.mfa.security_verify_password", return_value=True):
+            response = await client.post(
+                "/api/v1/auth/mfa/disable",
+                json={"password": "pw", "code": "000000"},
+            )
+        assert response.status_code == 400
+        assert response.json()["detail"]["code"] == "MFA_NOT_ENABLED"
+
+    async def test_api_token_forbidden(self, app, client, db, regular_user):
+        # A machine credential must never be able to strip a human's factor.
+        await _enroll(db, regular_user.id, generate_totp_secret())
+        _act_as(app, APITokenUser(id=99, org_id=1))
+        response = await client.post(
+            "/api/v1/auth/mfa/disable", json={"code": "000000"}
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"]["code"] == "API_TOKEN_NOT_ALLOWED"
+
+
+class TestRegenerateBackupCodes:
+    async def test_valid_code_returns_fresh_batch(self, client, db, regular_user):
+        secret = generate_totp_secret()
+        await _enroll(db, regular_user.id, secret)
+        response = await client.post(
+            "/api/v1/auth/mfa/backup-codes/regenerate", json={"code": _code_for(secret)}
+        )
+        assert response.status_code == 200
+        assert len(response.json()["backup_codes"]) == 10
+
+    async def test_invalid_code_rejected(self, client, db, regular_user):
+        await _enroll(db, regular_user.id, generate_totp_secret())
+        response = await client.post(
+            "/api/v1/auth/mfa/backup-codes/regenerate", json={"code": "000000"}
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"]["code"] == "INVALID_CODE"
+
+    async def test_not_enabled_rejected(self, client, regular_user):
+        response = await client.post(
+            "/api/v1/auth/mfa/backup-codes/regenerate", json={"code": "000000"}
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"]["code"] == "MFA_NOT_ENABLED"
+
+
+class TestLoginMFA:
+    """/login/mfa takes only the DB dependency (no auth gate) — the pending token
+    is the credential. These patch the cookie/expiry helpers that reach for the
+    hosting config, exactly as test_auth_router does for set_auth_cookies."""
+
+    @staticmethod
+    def _patches():
+        from unittest.mock import patch
+
+        return (
+            patch("src.routers.mfa.set_auth_cookies"),
+            patch("src.routers.mfa.get_token_expiry_ms", return_value=12345),
+        )
+
+    async def _get_user_row(self, db, user_id):
+        from sqlmodel import select
+
+        from src.db.users import User
+
+        return (
+            await db.execute(select(User).where(User.id == user_id))
+        ).scalars().first()
+
+    async def test_valid_totp_mints_session(self, app, db, regular_user):
+        # No auth override needed; remove it so the DB-only dep set is honest.
+        app.dependency_overrides.pop(get_authenticated_user, None)
+        user = await self._get_user_row(db, regular_user.id)
+        secret = generate_totp_secret()
+        await _enroll(db, user.id, secret)
+        token = create_mfa_pending_token(user.email, AUTH_METHOD_PASSWORD, 1)
+
+        c1, c2 = self._patches()
+        with c1, c2:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as c:
+                response = await c.post(
+                    "/api/v1/auth/login/mfa",
+                    json={"mfa_token": token, "code": _code_for(secret)},
+                )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["tokens"]["access_token"]
+        assert body["user"]["email"] == user.email
+
+    async def test_backup_code_mints_session(self, app, db, regular_user):
+        app.dependency_overrides.pop(get_authenticated_user, None)
+        user = await self._get_user_row(db, regular_user.id)
+        await _enroll(db, user.id, generate_totp_secret())
+        await _add_backup_code(db, user.id, "ABCDE-FGHJK")
+        token = create_mfa_pending_token(user.email, AUTH_METHOD_PASSWORD, 1)
+
+        c1, c2 = self._patches()
+        with c1, c2:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as c:
+                response = await c.post(
+                    "/api/v1/auth/login/mfa",
+                    json={"mfa_token": token, "code": "ABCDE-FGHJK", "is_backup_code": True},
+                )
+        assert response.status_code == 200
+        assert response.json()["tokens"]["access_token"]
+
+    async def test_invalid_code_401(self, app, db, regular_user):
+        app.dependency_overrides.pop(get_authenticated_user, None)
+        user = await self._get_user_row(db, regular_user.id)
+        await _enroll(db, user.id, generate_totp_secret())
+        token = create_mfa_pending_token(user.email, AUTH_METHOD_PASSWORD, 1)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            response = await c.post(
+                "/api/v1/auth/login/mfa",
+                json={"mfa_token": token, "code": "000000"},
+            )
+        assert response.status_code == 401
+        assert response.json()["detail"]["code"] == "INVALID_CODE"
+
+    async def test_expired_or_invalid_pending_token_401(self, app, db, regular_user):
+        app.dependency_overrides.pop(get_authenticated_user, None)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as c:
+            response = await c.post(
+                "/api/v1/auth/login/mfa",
+                json={"mfa_token": "not-a-valid-token", "code": "000000"},
+            )
+        assert response.status_code == 401
+        assert response.json()["detail"]["code"] == "MFA_SESSION_EXPIRED"
+
+    async def test_factor_removed_mid_flow_falls_through_to_session(self, app, db, regular_user):
+        # The factor was disabled between the password step and the code step:
+        # the user is not stranded at a challenge they can no longer satisfy.
+        app.dependency_overrides.pop(get_authenticated_user, None)
+        user = await self._get_user_row(db, regular_user.id)
+        token = create_mfa_pending_token(user.email, AUTH_METHOD_PASSWORD, 1)
+
+        c1, c2 = self._patches()
+        with c1, c2:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as c:
+                response = await c.post(
+                    "/api/v1/auth/login/mfa",
+                    json={"mfa_token": token, "code": "000000"},
+                )
+        assert response.status_code == 200
+        assert response.json()["tokens"]["access_token"]
+
+
+class TestOrgCompliance:
+    async def test_compliance_state_no_policy(self, client, db, org, regular_user):
+        response = await client.get(f"/api/v1/auth/mfa/org-policy/{org.id}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["required"] is False
+        assert body["satisfied"] is True
+
+    async def test_compliance_list_requires_admin(self, client, db, org, regular_user):
+        response = await client.get(f"/api/v1/auth/mfa/org-compliance/{org.id}")
+        assert response.status_code == 403
+        assert response.json()["detail"]["code"] == "NOT_ORG_ADMIN"
+
+    async def test_compliance_list_for_admin(self, app, client, db, org, admin_user):
+        _act_as(app, admin_user)
+        response = await client.get(f"/api/v1/auth/mfa/org-compliance/{org.id}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total"] >= 1
+        assert any(m["user_id"] == admin_user.id for m in body["members"])
+
+
+class TestSetOrgPolicy:
+    async def test_not_org_admin_forbidden(self, client, db, org, regular_user):
+        response = await client.put(
+            f"/api/v1/auth/mfa/org-policy/{org.id}", json={"require_2fa": True}
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"]["code"] == "NOT_ORG_ADMIN"
+
+    async def test_admin_must_enroll_before_requiring(self, app, client, db, org, admin_user):
+        _act_as(app, admin_user)
+        await _add_org_config(db, org.id)
+        response = await client.put(
+            f"/api/v1/auth/mfa/org-policy/{org.id}", json={"require_2fa": True}
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"]["code"] == "ADMIN_MFA_REQUIRED_FIRST"
+
+    async def test_admin_with_mfa_can_enable(self, app, client, db, org, admin_user):
+        _act_as(app, admin_user)
+        await _add_org_config(db, org.id)
+        await _enroll(db, admin_user.id, generate_totp_secret())
+        response = await client.put(
+            f"/api/v1/auth/mfa/org-policy/{org.id}",
+            json={"require_2fa": True, "require_2fa_grace_days": 7},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["require_2fa"] is True
+        assert body["require_2fa_grace_days"] == 7
+
+    async def test_config_row_missing_404(self, app, client, db, org, admin_user):
+        _act_as(app, admin_user)
+        response = await client.put(
+            f"/api/v1/auth/mfa/org-policy/{org.id}", json={"require_2fa": False}
+        )
+        assert response.status_code == 404
+
+    async def test_auth_method_self_lockout(self, app, client, db, org, admin_user):
+        _act_as(app, admin_user)
+        await _add_org_config(db, org.id)
+        # Signed in with password; restricting to google-only would refuse this
+        # very session — the guard blocks the save.
+        set_session_provenance(SessionProvenance(amr=AUTH_METHOD_PASSWORD, org_id=org.id))
+        response = await client.put(
+            f"/api/v1/auth/mfa/org-policy/{org.id}",
+            json={"require_2fa": False, "allowed_auth_methods": ["google"]},
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"]["code"] == "AUTH_METHOD_SELF_LOCKOUT"
+
+    async def test_session_sharing_self_lockout(self, app, client, db, org, admin_user):
+        _act_as(app, admin_user)
+        await _add_org_config(db, org.id)
+        # Session was minted for a different org, so turning off central sharing
+        # would refuse it.
+        set_session_provenance(SessionProvenance(amr=AUTH_METHOD_PASSWORD, org_id=999))
+        response = await client.put(
+            f"/api/v1/auth/mfa/org-policy/{org.id}",
+            json={"require_2fa": False, "allow_central_session_sharing": False},
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"]["code"] == "SESSION_SHARING_SELF_LOCKOUT"
+
+    async def test_auth_method_and_sharing_saved_when_session_is_compliant(
+        self, app, client, db, org, admin_user
+    ):
+        _act_as(app, admin_user)
+        await _add_org_config(db, org.id)
+        # Signed in with password from this org: restricting to password and
+        # turning off central sharing does not lock the current session out.
+        set_session_provenance(SessionProvenance(amr=AUTH_METHOD_PASSWORD, org_id=org.id))
+        response = await client.put(
+            f"/api/v1/auth/mfa/org-policy/{org.id}",
+            json={
+                "require_2fa": False,
+                "allowed_auth_methods": ["password"],
+                "allow_central_session_sharing": False,
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["allowed_auth_methods"] == ["password"]
+        assert body["allow_central_session_sharing"] is False
+
+
+class TestCoverageGaps:
+    """Branches not hit by the main happy/error paths above."""
+
+    async def test_confirm_when_already_enabled_conflicts(self, client, db, regular_user):
+        secret = generate_totp_secret()
+        await _enroll(db, regular_user.id, secret, confirmed=True)
+        resp = await client.post("/api/v1/auth/mfa/confirm", json={"code": _code_for(secret)})
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["code"] == "MFA_ALREADY_ENABLED"
+
+    async def test_setup_skips_password_for_passwordless_account(self, client, db, regular_user):
+        # A Google/SSO account has no local password — the re-auth check is skipped
+        # rather than making enrollment unreachable.
+        from sqlmodel import select as _select
+
+        from src.db.users import User as _User
+
+        user = (await db.execute(_select(_User).where(_User.id == regular_user.id))).scalars().first()
+        user.password = ""
+        db.add(user)
+        await db.commit()
+
+        resp = await client.post("/api/v1/auth/mfa/setup", json={})
+        assert resp.status_code == 200
+        assert "provisioning_uri" in resp.json()
+
+    async def test_confirm_is_rate_limited(self, app, db, regular_user):
+        from unittest.mock import patch
+
+        secret = generate_totp_secret()
+        await _enroll(db, regular_user.id, secret, confirmed=False)
+        with patch("src.routers.mfa.check_rate_limit", return_value=(False, 99, 42)):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.post("/api/v1/auth/mfa/confirm", json={"code": "000000"})
+        assert resp.status_code == 429
+        assert resp.json()["detail"]["code"] == "RATE_LIMITED"
+
+    async def test_compliance_counts_enrolled_members(self, app, client, db, org, admin_user):
+        _act_as(app, admin_user)
+        await _enroll(db, admin_user.id, generate_totp_secret(), confirmed=True)
+        resp = await client.get(f"/api/v1/auth/mfa/org-compliance/{org.id}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["enabled"] >= 1
+        assert any(m["user_id"] == admin_user.id and m["mfa_enabled"] for m in body["members"])
+
+
+class TestOrgResetMember:
+    """Admin recovery tool: clear a member's factor so they can re-enroll."""
+
+    async def test_admin_resets_member_factor(self, app, client, db, org, admin_user, regular_user):
+        _act_as(app, admin_user)
+        await _enroll(db, regular_user.id, generate_totp_secret(), confirmed=True)
+
+        resp = await client.post(f"/api/v1/auth/mfa/org-reset/{org.id}/{regular_user.id}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["reset"] is True
+        assert body["had_factor"] is True
+
+        # Factor is gone — the member can now re-enroll.
+        from src.services.auth.mfa import get_user_mfa
+
+        assert await get_user_mfa(db, regular_user.id) is None
+
+    async def test_non_admin_forbidden(self, app, client, db, org, admin_user, regular_user):
+        # regular_user (a plain member) may not reset anyone.
+        _act_as(app, regular_user)
+        resp = await client.post(f"/api/v1/auth/mfa/org-reset/{org.id}/{admin_user.id}")
+        assert resp.status_code == 403
+        assert resp.json()["detail"]["code"] == "NOT_ORG_ADMIN"
+
+    async def test_cannot_reset_self(self, app, client, org, admin_user):
+        _act_as(app, admin_user)
+        resp = await client.post(f"/api/v1/auth/mfa/org-reset/{org.id}/{admin_user.id}")
+        assert resp.status_code == 400
+        assert resp.json()["detail"]["code"] == "CANNOT_RESET_SELF"
+
+    async def test_target_must_be_member(self, app, client, org, admin_user):
+        _act_as(app, admin_user)
+        resp = await client.post(f"/api/v1/auth/mfa/org-reset/{org.id}/99999999")
+        assert resp.status_code == 404
+        assert resp.json()["detail"]["code"] == "NOT_A_MEMBER"
+
+    async def test_reset_member_without_factor_is_noop_ok(self, app, client, org, admin_user, regular_user):
+        _act_as(app, admin_user)
+        # regular_user has no factor enrolled — reset still succeeds, had_factor False.
+        resp = await client.post(f"/api/v1/auth/mfa/org-reset/{org.id}/{regular_user.id}")
+        assert resp.status_code == 200
+        assert resp.json()["had_factor"] is False
+
+    async def test_cannot_reset_a_superadmin(self, app, client, db, org, admin_user, regular_user):
+        from sqlmodel import select as _select
+
+        from src.db.users import User as _User
+
+        target = (await db.execute(_select(_User).where(_User.id == regular_user.id))).scalars().first()
+        target.is_superadmin = True
+        db.add(target)
+        await db.commit()
+
+        _act_as(app, admin_user)
+        resp = await client.post(f"/api/v1/auth/mfa/org-reset/{org.id}/{regular_user.id}")
+        assert resp.status_code == 403
+        assert resp.json()["detail"]["code"] == "TARGET_IS_SUPERADMIN"

--- a/apps/api/src/tests/routers/test_rag_chat_ownership.py
+++ b/apps/api/src/tests/routers/test_rag_chat_ownership.py
@@ -135,3 +135,17 @@ class TestRagChatOwnership:
 
         assert resp.media_type == "text/event-stream"
         belongs.assert_not_called()
+
+
+@pytest.fixture(autouse=True)
+def _skip_org_mfa_policy():
+    """No-op the org two-factor policy for this module.
+
+    These tests drive the router with a hand-rolled session whose `execute`
+    returns a fixed, ordered list of results. The policy check issues its own
+    queries, which would consume entries from that list and desynchronise every
+    subsequent lookup. The policy itself is covered directly in
+    src/tests/security/test_mfa_org_policy.py.
+    """
+    with patch.object(rag_router, "enforce_org_mfa", new=AsyncMock(return_value=None)):
+        yield

--- a/apps/api/src/tests/security/test_auth_policy.py
+++ b/apps/api/src/tests/security/test_auth_policy.py
@@ -1,0 +1,220 @@
+"""Tests for the org auth-method / session-sharing policy.
+
+The gate decides, per request, whether *this session* (how it authenticated and
+which org it was minted for) may access the org. Provenance is normally published
+on a contextvar by ``get_current_user``; these tests set it directly so the
+policy logic can be exercised without a full HTTP round-trip.
+"""
+
+from datetime import datetime
+
+import pytest
+from sqlmodel import select
+
+from src.db.organization_config import OrganizationConfig
+from src.db.users import User
+from src.security.session_context import (
+    SessionProvenance,
+    set_session_provenance,
+)
+from src.services.orgs.auth_policy import (
+    METHOD_NOT_ALLOWED_CODE,
+    SESSION_NOT_BOUND_CODE,
+    enforce_org_auth_policy,
+    evaluate_org_auth,
+    get_org_auth_policy,
+)
+
+
+async def _set_auth_policy(db, org_id, **security):
+    row = (
+        await db.execute(select(OrganizationConfig).where(OrganizationConfig.org_id == org_id))
+    ).scalars().first()
+    config = {"config_version": "2.0", "admin_toggles": {"security": security}}
+    if row is None:
+        row = OrganizationConfig(
+            org_id=org_id,
+            config=config,
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+    else:
+        row.config = config
+    db.add(row)
+    await db.commit()
+
+
+def _prov(amr=None, org_id=None):
+    set_session_provenance(SessionProvenance(amr=amr, org_id=org_id))
+
+
+@pytest.fixture(autouse=True)
+def _clear_provenance():
+    set_session_provenance(None)
+    yield
+    set_session_provenance(None)
+
+
+@pytest.mark.asyncio
+class TestDefaultsAreNoOp:
+    async def test_no_config_allows_any_session(self, db, org, regular_user):
+        _prov(amr=None, org_id=None)  # legacy session
+        # No policy row at all → nothing enforced.
+        await enforce_org_auth_policy(db, regular_user.id, org.id)
+
+    async def test_all_methods_and_sharing_on_is_no_op(self, db, org, regular_user):
+        await _set_auth_policy(
+            db, org.id,
+            allowed_auth_methods=["password", "magic_login", "google", "sso"],
+            allow_central_session_sharing=True,
+        )
+        _prov(amr=None, org_id=None)
+        await enforce_org_auth_policy(db, regular_user.id, org.id)
+
+    async def test_empty_allow_list_is_treated_as_unrestricted(self, db, org, regular_user):
+        # A mis-save must never lock every method out.
+        await _set_auth_policy(db, org.id, allowed_auth_methods=[])
+        policy = await get_org_auth_policy(db, org.id)
+        assert policy.method_restricted is False
+        _prov(amr="password", org_id=None)
+        await enforce_org_auth_policy(db, regular_user.id, org.id)
+
+
+@pytest.mark.asyncio
+class TestMethodGate:
+    async def test_disallowed_method_is_refused(self, db, org, regular_user):
+        from fastapi import HTTPException
+
+        await _set_auth_policy(db, org.id, allowed_auth_methods=["sso"])
+        _prov(amr="password", org_id=org.id)
+
+        with pytest.raises(HTTPException) as exc:
+            await enforce_org_auth_policy(db, regular_user.id, org.id)
+        assert exc.value.detail["code"] == METHOD_NOT_ALLOWED_CODE
+        assert exc.value.detail["allowed_methods"] == ["sso"]
+
+    async def test_allowed_method_passes(self, db, org, regular_user):
+        await _set_auth_policy(db, org.id, allowed_auth_methods=["sso", "password"])
+        _prov(amr="password", org_id=org.id)
+        await enforce_org_auth_policy(db, regular_user.id, org.id)
+
+    async def test_legacy_session_blocked_under_restriction(self, db, org, regular_user):
+        from fastapi import HTTPException
+
+        # A pre-feature session carries no amr; a restrictive org must force it to
+        # re-authenticate with a known method rather than let it through blind.
+        await _set_auth_policy(db, org.id, allowed_auth_methods=["password"])
+        _prov(amr=None, org_id=None)
+        with pytest.raises(HTTPException) as exc:
+            await enforce_org_auth_policy(db, regular_user.id, org.id)
+        assert exc.value.detail["code"] == METHOD_NOT_ALLOWED_CODE
+
+    async def test_api_token_is_exempt(self, db, org, regular_user):
+        # Machine credentials carry their own org boundary; the human method
+        # policy must not apply to them.
+        await _set_auth_policy(db, org.id, allowed_auth_methods=["sso"])
+        _prov(amr="api_token", org_id=org.id)
+        await enforce_org_auth_policy(db, regular_user.id, org.id)
+
+
+@pytest.mark.asyncio
+class TestSharingGate:
+    async def test_foreign_session_refused_when_sharing_off(self, db, org, regular_user):
+        from fastapi import HTTPException
+
+        await _set_auth_policy(db, org.id, allow_central_session_sharing=False)
+        _prov(amr="password", org_id=None)  # central/apex session
+        with pytest.raises(HTTPException) as exc:
+            await enforce_org_auth_policy(db, regular_user.id, org.id)
+        assert exc.value.detail["code"] == SESSION_NOT_BOUND_CODE
+
+    async def test_other_org_session_refused_when_sharing_off(self, db, org, regular_user):
+        from fastapi import HTTPException
+
+        await _set_auth_policy(db, org.id, allow_central_session_sharing=False)
+        _prov(amr="password", org_id=org.id + 999)
+        with pytest.raises(HTTPException) as exc:
+            await enforce_org_auth_policy(db, regular_user.id, org.id)
+        assert exc.value.detail["code"] == SESSION_NOT_BOUND_CODE
+
+    async def test_matching_org_session_passes(self, db, org, regular_user):
+        await _set_auth_policy(db, org.id, allow_central_session_sharing=False)
+        _prov(amr="password", org_id=org.id)
+        await enforce_org_auth_policy(db, regular_user.id, org.id)
+
+    async def test_sharing_on_lets_central_session_through(self, db, org, regular_user):
+        await _set_auth_policy(db, org.id, allow_central_session_sharing=True)
+        _prov(amr="password", org_id=None)
+        await enforce_org_auth_policy(db, regular_user.id, org.id)
+
+
+@pytest.mark.asyncio
+class TestSuperadminAndResilience:
+    async def test_superadmin_is_never_blocked(self, db, org, regular_user):
+        await _set_auth_policy(
+            db, org.id,
+            allowed_auth_methods=["sso"],
+            allow_central_session_sharing=False,
+        )
+        user = (
+            await db.execute(select(User).where(User.id == regular_user.id))
+        ).scalars().first()
+        user.is_superadmin = True
+        db.add(user)
+        await db.commit()
+
+        _prov(amr="password", org_id=None)
+        # Would fail both gates, but a platform admin must not be locked out of a
+        # tenant by that tenant's own policy.
+        await enforce_org_auth_policy(db, regular_user.id, org.id)
+
+    async def test_decision_is_memoized_per_session(self, db, org, regular_user):
+        await _set_auth_policy(db, org.id, allowed_auth_methods=["sso"])
+        _prov(amr="password", org_id=org.id)
+
+        first = await evaluate_org_auth(db, regular_user.id, org.id)
+        assert first is not None
+        assert (regular_user.id, org.id) in db._auth_policy_cache
+
+
+@pytest.mark.asyncio
+class TestGateWiring:
+    """The policy must actually fire from the shared org gate, not just in
+    isolation — that is the seam every request funnels through."""
+
+    async def test_require_org_membership_enforces_method_policy(self, db, org, regular_user):
+        from fastapi import HTTPException
+        from src.security.org_auth import require_org_membership
+
+        await _set_auth_policy(db, org.id, allowed_auth_methods=["sso"])
+        _prov(amr="password", org_id=org.id)
+
+        with pytest.raises(HTTPException) as exc:
+            await require_org_membership(regular_user.id, org.id, db)
+        assert exc.value.detail["code"] == METHOD_NOT_ALLOWED_CODE
+
+    async def test_require_org_membership_passes_allowed_method(self, db, org, regular_user):
+        from src.security.org_auth import require_org_membership
+
+        await _set_auth_policy(db, org.id, allowed_auth_methods=["password"])
+        _prov(amr="password", org_id=org.id)
+        await require_org_membership(regular_user.id, org.id, db)
+
+
+@pytest.mark.asyncio
+class TestMalformedConfig:
+    async def test_non_dict_security_falls_back_to_defaults(self, db, org):
+        # A security blob of the wrong shape (a list) must not raise or lock the
+        # org — get_org_auth_policy swallows it and returns the permissive default.
+        row = OrganizationConfig(
+            org_id=org.id,
+            config={"config_version": "2.0", "admin_toggles": {"security": ["bogus"]}},
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(row)
+        await db.commit()
+
+        policy = await get_org_auth_policy(db, org.id)
+        assert policy.method_restricted is False
+        assert policy.allow_central_session_sharing is True

--- a/apps/api/src/tests/security/test_get_current_user_provenance.py
+++ b/apps/api/src/tests/security/test_get_current_user_provenance.py
@@ -1,0 +1,81 @@
+"""get_current_user publishes session provenance on every auth path.
+
+These call get_current_user directly (rather than relying on a whole request
+flow) so each provenance branch — JWT session, org API token, superadmin API
+token — is covered deterministically, independent of suite ordering.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from sqlmodel import select
+
+from src.db.users import User
+from src.security.auth import JWT_COOKIE_NAME, get_current_user
+from src.security.session_context import (
+    AUTH_METHOD_API_TOKEN,
+    get_session_provenance,
+    set_session_provenance,
+)
+from src.services.auth.session import mint_session_tokens
+
+
+@pytest.fixture(autouse=True)
+def _clear():
+    set_session_provenance(None)
+    yield
+    set_session_provenance(None)
+
+
+def _request(*, auth: str = "", cookies: dict | None = None) -> Mock:
+    req = Mock()
+    req.headers = {"Authorization": auth}
+    req.cookies = cookies or {}
+    req.state = SimpleNamespace()
+    return req
+
+
+@pytest.mark.asyncio
+class TestProvenancePublished:
+    async def test_jwt_session_publishes_amr_and_sorg(self, db, regular_user):
+        user = (
+            await db.execute(select(User).where(User.id == regular_user.id))
+        ).scalars().first()
+        tokens = mint_session_tokens(user.email, amr="password", org_id=55)
+        req = _request(cookies={JWT_COOKIE_NAME: tokens.access_token})
+
+        with patch("src.security.auth._record_activity_from_request"):
+            result = await get_current_user(req, db)
+
+        assert result.email == user.email
+        prov = get_session_provenance()
+        assert prov is not None
+        assert prov.amr == "password"
+        assert prov.org_id == 55
+
+    async def test_org_api_token_publishes_api_token_and_org(self, db):
+        token_user = SimpleNamespace(id=0, org_id=77, created_by_user_id=3)
+        req = _request(auth="Bearer lh_faketoken")
+
+        with patch("src.security.auth.validate_api_token", return_value=token_user), patch(
+            "src.security.auth._verify_api_token_org_boundary"
+        ):
+            result = await get_current_user(req, db)
+
+        assert result is token_user
+        prov = get_session_provenance()
+        assert prov.amr == AUTH_METHOD_API_TOKEN
+        assert prov.org_id == 77
+
+    async def test_superadmin_api_token_publishes_api_token_no_org(self, db):
+        sa_user = SimpleNamespace(id=0, is_superadmin=True)
+        req = _request(auth="Bearer lh_sa_faketoken")
+
+        with patch("src.security.auth.validate_superadmin_api_token", return_value=sa_user):
+            result = await get_current_user(req, db)
+
+        assert result is sa_user
+        prov = get_session_provenance()
+        assert prov.amr == AUTH_METHOD_API_TOKEN
+        assert prov.org_id is None

--- a/apps/api/src/tests/security/test_magic_login.py
+++ b/apps/api/src/tests/security/test_magic_login.py
@@ -1,0 +1,185 @@
+"""User-facing passwordless magic-login token: shape, single-use, purpose."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.db.users import UserRead
+from src.security.auth import create_access_token, decode_jwt
+from src.services.auth import magic_login as ml
+from src.services.auth.magic_login import (
+    MAGIC_LOGIN_PURPOSE,
+    consume_magic_login_token,
+    issue_magic_login_token,
+    resolve_org,
+    send_magic_login_email,
+)
+from src.services.auth.session import mint_session_tokens
+
+
+class _FakeRedis:
+    """Minimal SETNX-capable stand-in for the single-use marker store."""
+
+    def __init__(self):
+        self.store = {}
+
+    def set(self, key, value, nx=False, ex=None):
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        return True
+
+
+@pytest.fixture
+def fake_redis():
+    r = _FakeRedis()
+    with patch.object(ml, "_redis", return_value=r):
+        yield r
+
+
+class TestIssue:
+    def test_token_shape(self):
+        token = issue_magic_login_token("a@b.co", org_id=5)
+        payload = decode_jwt(token)
+        assert payload["purpose"] == MAGIC_LOGIN_PURPOSE
+        assert payload["sub"] == "a@b.co"
+        assert payload["org_id"] == 5
+        assert payload.get("jti")
+
+    def test_token_without_org(self):
+        payload = decode_jwt(issue_magic_login_token("a@b.co", org_id=None))
+        assert "org_id" not in payload
+
+
+class TestConsume:
+    def test_valid_token_returns_email_and_org(self, fake_redis):
+        token = issue_magic_login_token("a@b.co", org_id=9)
+        assert consume_magic_login_token(token) == ("a@b.co", 9)
+
+    def test_single_use(self, fake_redis):
+        token = issue_magic_login_token("a@b.co", org_id=None)
+        assert consume_magic_login_token(token) == ("a@b.co", None)
+        with pytest.raises(HTTPException) as exc:
+            consume_magic_login_token(token)
+        assert exc.value.status_code == 410
+        assert exc.value.detail["code"] == "MAGIC_LINK_USED"
+
+    def test_wrong_purpose_rejected(self, fake_redis):
+        # A real session token must never be spendable as a login link.
+        session = mint_session_tokens("a@b.co", amr="password", org_id=1)
+        with pytest.raises(HTTPException) as exc:
+            consume_magic_login_token(session.access_token)
+        assert exc.value.status_code == 410
+        assert exc.value.detail["code"] == "MAGIC_LINK_INVALID"
+
+    def test_garbage_token_rejected(self, fake_redis):
+        # decode_jwt returns None (not a raise) for an unparseable token, so this
+        # lands on the wrong-purpose branch.
+        with pytest.raises(HTTPException) as exc:
+            consume_magic_login_token("not-a-jwt")
+        assert exc.value.status_code == 410
+        assert exc.value.detail["code"] == "MAGIC_LINK_INVALID"
+
+    def test_fails_closed_without_redis(self):
+        # If the single-use store is unavailable the link must be refused, not
+        # allowed to replay.
+        token = issue_magic_login_token("a@b.co", org_id=None)
+        with patch.object(ml, "_redis", return_value=None):
+            with pytest.raises(HTTPException) as exc:
+                consume_magic_login_token(token)
+        assert exc.value.status_code == 410
+        assert exc.value.detail["code"] == "MAGIC_LINK_USED"
+
+    def test_fails_closed_when_redis_errors(self):
+        # A Redis that is reachable but throws on SET must also fail closed.
+        token = issue_magic_login_token("a@b.co", org_id=None)
+        boom = Mock()
+        boom.set.side_effect = RuntimeError("connection reset")
+        with patch.object(ml, "_redis", return_value=boom):
+            with pytest.raises(HTTPException) as exc:
+                consume_magic_login_token(token)
+        assert exc.value.status_code == 410
+        assert exc.value.detail["code"] == "MAGIC_LINK_USED"
+
+    def test_undecodable_token_raises_401(self, fake_redis):
+        # decode_jwt raising (rather than returning None) lands on the 401 path.
+        with patch.object(ml, "decode_jwt", side_effect=ValueError("bad")):
+            with pytest.raises(HTTPException) as exc:
+                consume_magic_login_token("whatever")
+        assert exc.value.status_code == 401
+        assert exc.value.detail["code"] == "MAGIC_LINK_INVALID"
+
+    def test_token_without_subject_raises_401(self, fake_redis):
+        token = create_access_token(
+            data={"sub": "", "purpose": MAGIC_LOGIN_PURPOSE, "jti": "abc"}
+        )
+        with pytest.raises(HTTPException) as exc:
+            consume_magic_login_token(token)
+        assert exc.value.status_code == 401
+        assert exc.value.detail["code"] == "MAGIC_LINK_INVALID"
+
+    def test_non_integer_org_id_falls_back_to_none(self, fake_redis):
+        token = create_access_token(
+            data={
+                "sub": "a@b.co",
+                "purpose": MAGIC_LOGIN_PURPOSE,
+                "jti": "xyz",
+                "org_id": "not-a-number",
+            }
+        )
+        assert consume_magic_login_token(token) == ("a@b.co", None)
+
+
+@pytest.mark.asyncio
+class TestResolveOrg:
+    async def test_none_slug_returns_none(self, db):
+        assert await resolve_org(None, db) is None
+
+    async def test_unknown_slug_returns_none(self, db, org):
+        assert await resolve_org("does-not-exist", db) is None
+
+    async def test_matching_slug_returns_org(self, db, org):
+        resolved = await resolve_org(org.slug, db)
+        assert resolved is not None
+        assert resolved.id == org.id
+
+
+def _fake_user_read() -> UserRead:
+    return UserRead(
+        id=1,
+        username="learner",
+        first_name="Learn",
+        last_name="Er",
+        email="learner@example.com",
+        user_uuid="user_learner",
+    )
+
+
+class TestSendMagicLoginEmail:
+    def test_builds_consume_url_and_delegates_to_send_email(self):
+        # The clickable link must point at the frontend consume page with the
+        # (url-encoded) token, and must be handed to the shared mailer.
+        with patch.object(ml, "send_email", return_value=True) as send_mock:
+            result = send_magic_login_email(
+                _fake_user_read(),
+                "learner@example.com",
+                "https://academy.example.com/",
+                "raw.jwt.token",
+            )
+        assert result is True
+        send_mock.assert_called_once()
+        body = send_mock.call_args.kwargs["body"]
+        assert "https://academy.example.com/auth/magic?token=raw.jwt.token" in body
+        assert send_mock.call_args.kwargs["to"] == "learner@example.com"
+
+    def test_token_is_url_encoded_in_link(self):
+        with patch.object(ml, "send_email", return_value=True) as send_mock:
+            send_magic_login_email(
+                _fake_user_read(),
+                "learner@example.com",
+                "https://academy.example.com",
+                "a b/c+d",
+            )
+        body = send_mock.call_args.kwargs["body"]
+        assert "/auth/magic?token=a%20b%2Fc%2Bd" in body

--- a/apps/api/src/tests/security/test_mfa.py
+++ b/apps/api/src/tests/security/test_mfa.py
@@ -1,0 +1,281 @@
+"""Unit tests for the TOTP second-factor primitives.
+
+These cover the parts where a subtle bug is silent and security-relevant:
+secret encryption round-tripping, the drift window, and replay rejection.
+"""
+
+import time
+from datetime import datetime
+
+import pyotp
+import pytest
+from sqlmodel import select
+
+from src.db.user_mfa import UserMFA, UserMFABackupCode
+from src.services.auth.mfa import (
+    TOTP_PERIOD_SECONDS,
+    build_provisioning_uri,
+    claim_totp_timestep,
+    consume_backup_code,
+    count_unused_backup_codes,
+    decrypt_secret,
+    encrypt_secret,
+    generate_backup_codes,
+    generate_totp_secret,
+    hash_backup_code,
+    replace_backup_codes,
+    verify_and_consume_totp,
+    verify_totp_code,
+)
+
+
+def _code_for(secret: str, step_offset: int = 0) -> str:
+    step = int(time.time()) // TOTP_PERIOD_SECONDS + step_offset
+    return pyotp.TOTP(secret, interval=TOTP_PERIOD_SECONDS).at(step * TOTP_PERIOD_SECONDS)
+
+
+class TestSecretEncryption:
+    def test_roundtrip(self):
+        secret = generate_totp_secret()
+        assert decrypt_secret(encrypt_secret(secret)) == secret
+
+    def test_ciphertext_is_not_plaintext(self):
+        secret = generate_totp_secret()
+        assert secret not in encrypt_secret(secret)
+
+    def test_encryption_is_non_deterministic(self):
+        # Fernet embeds a random IV, so two encryptions of the same secret must
+        # not be byte-identical — otherwise equal ciphertexts would leak that
+        # two users share a secret.
+        secret = generate_totp_secret()
+        assert encrypt_secret(secret) != encrypt_secret(secret)
+
+    def test_undecryptable_returns_none_rather_than_raising(self):
+        # Simulates a rotated key. Callers must be able to distinguish "broken"
+        # from "not enrolled"; a raise here would surface as a 500 instead.
+        assert decrypt_secret("not-a-valid-fernet-token") is None
+
+
+class TestProvisioningURI:
+    def test_contains_issuer_and_account(self):
+        uri = build_provisioning_uri(generate_totp_secret(), "learner@example.com")
+        assert uri.startswith("otpauth://totp/")
+        assert "issuer=LearnHouse" in uri
+        assert "learner%40example.com" in uri
+
+
+class TestTOTPVerification:
+    def test_accepts_current_code(self):
+        secret = generate_totp_secret()
+        is_valid, step = verify_totp_code(secret, _code_for(secret), None)
+        assert is_valid is True
+        assert step is not None
+
+    def test_accepts_one_step_of_drift_either_side(self):
+        secret = generate_totp_secret()
+        for offset in (-1, 1):
+            is_valid, _ = verify_totp_code(secret, _code_for(secret, offset), None)
+            assert is_valid is True, f"offset {offset} should be inside the drift window"
+
+    def test_rejects_two_steps_of_drift(self):
+        secret = generate_totp_secret()
+        for offset in (-2, 2):
+            is_valid, _ = verify_totp_code(secret, _code_for(secret, offset), None)
+            assert is_valid is False, f"offset {offset} should be outside the drift window"
+
+    def test_rejects_wrong_secret(self):
+        is_valid, _ = verify_totp_code(
+            generate_totp_secret(), _code_for(generate_totp_secret()), None
+        )
+        assert is_valid is False
+
+    @pytest.mark.parametrize("bad", ["", "12345", "1234567", "abcdef", "12 34 56 78", None])
+    def test_rejects_malformed_input(self, bad):
+        assert verify_totp_code(generate_totp_secret(), bad, None)[0] is False
+
+    def test_strips_spaces_and_dashes(self):
+        secret = generate_totp_secret()
+        code = _code_for(secret)
+        spaced = f"{code[:3]} {code[3:]}"
+        assert verify_totp_code(secret, spaced, None)[0] is True
+
+    def test_rejects_replay_of_the_same_timestep(self):
+        secret = generate_totp_secret()
+        code = _code_for(secret)
+
+        is_valid, step = verify_totp_code(secret, code, None)
+        assert is_valid is True
+
+        # Same code, now that the timestep has been recorded as spent.
+        replayed, _ = verify_totp_code(secret, code, step)
+        assert replayed is False
+
+    def test_rejects_older_timestep_after_a_newer_one_was_used(self):
+        secret = generate_totp_secret()
+        current_step = int(time.time()) // TOTP_PERIOD_SECONDS
+
+        # Previous step's code is normally inside the drift window, but must be
+        # refused once the current step has already been consumed.
+        is_valid, _ = verify_totp_code(secret, _code_for(secret, -1), current_step)
+        assert is_valid is False
+
+
+class TestBackupCodes:
+    def test_generates_distinct_formatted_codes(self):
+        codes = generate_backup_codes()
+        assert len(codes) == 10
+        assert len(set(codes)) == 10
+        for code in codes:
+            assert len(code) == 11 and code[5] == "-"
+
+    def test_excludes_visually_ambiguous_characters(self):
+        joined = "".join(generate_backup_codes(50)).replace("-", "")
+        for ambiguous in "01OIL":
+            assert ambiguous not in joined
+
+    def test_hash_is_insensitive_to_formatting_and_case(self):
+        canonical = hash_backup_code("ABCDE-FGHJK")
+        assert hash_backup_code("abcde-fghjk") == canonical
+        assert hash_backup_code("ABCDEFGHJK") == canonical
+        assert hash_backup_code("  abcde fghjk  ") == canonical
+
+    def test_distinct_codes_hash_differently(self):
+        assert hash_backup_code("ABCDE-FGHJK") != hash_backup_code("ABCDE-FGHJM")
+
+    def test_hash_is_not_reversible_to_plaintext(self):
+        assert "ABCDE" not in hash_backup_code("ABCDE-FGHJK")
+
+
+async def _enroll_confirmed(db, user_id, last_step=None):
+    now = str(datetime.now())
+    db.add(
+        UserMFA(
+            user_id=user_id,
+            secret_encrypted="ciphertext",
+            confirmed_at=now,
+            last_used_timestep=last_step,
+            creation_date=now,
+            update_date=now,
+        )
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+class TestTimestepClaim:
+    """A code is single-use because the timestep is claimed by an atomic,
+    conditional UPDATE — not read, checked, then written. These pin that a
+    second claim of the same (or an older) step loses, which is what stops two
+    concurrent logins from both minting a session off one intercepted code.
+    """
+
+    async def test_first_claim_wins_replay_loses(self, db, regular_user):
+        await _enroll_confirmed(db, regular_user.id)
+        step = int(time.time()) // TOTP_PERIOD_SECONDS
+
+        assert await claim_totp_timestep(db, regular_user.id, step) is True
+        # Same step again — already burned.
+        assert await claim_totp_timestep(db, regular_user.id, step) is False
+
+    async def test_older_step_cannot_be_claimed_after_a_newer_one(self, db, regular_user):
+        await _enroll_confirmed(db, regular_user.id)
+        step = int(time.time()) // TOTP_PERIOD_SECONDS
+
+        assert await claim_totp_timestep(db, regular_user.id, step) is True
+        assert await claim_totp_timestep(db, regular_user.id, step - 1) is False
+        # A genuinely newer step is still claimable.
+        assert await claim_totp_timestep(db, regular_user.id, step + 1) is True
+
+    async def test_verify_and_consume_burns_the_code(self, db, regular_user):
+        secret = generate_totp_secret()
+        await _enroll_confirmed(db, regular_user.id)
+        # Point the stored secret at a known value so we can mint a live code.
+        mfa = (await db.execute(select(UserMFA).where(UserMFA.user_id == regular_user.id))).scalars().first()
+        mfa.secret_encrypted = encrypt_secret(secret)
+        await db.commit()
+
+        code = pyotp.TOTP(secret, interval=TOTP_PERIOD_SECONDS).now()
+
+        assert await verify_and_consume_totp(db, regular_user.id, secret, code, None) is True
+        # Replaying the exact same code within its window must now fail.
+        row = (await db.execute(select(UserMFA).where(UserMFA.user_id == regular_user.id))).scalars().first()
+        assert await verify_and_consume_totp(db, regular_user.id, secret, code, row.last_used_timestep) is False
+
+    # NB: true parallel racing is not exercised here — the shared test session is
+    # a single connection (SQLAlchemy forbids concurrent ops on one AsyncSession,
+    # and separate connections to in-memory SQLite would see different DBs). The
+    # single-use guarantee is enforced by the conditional UPDATE at the DB layer;
+    # the sequential tests above pin the contract that guarantee provides.
+
+
+@pytest.mark.asyncio
+class TestBackupCodeConsumption:
+    """Backup codes must be burned exactly once. Consumption is a single
+    conditional UPDATE (``WHERE used_at IS NULL``) so a racing second request
+    against the same code matches zero rows instead of re-reading it as unused.
+    """
+
+    async def _add_code(self, db, user_id, code):
+        db.add(
+            UserMFABackupCode(
+                user_id=user_id,
+                code_hash=hash_backup_code(code),
+                creation_date=str(datetime.now()),
+            )
+        )
+        await db.commit()
+
+    async def test_code_is_consumed_once(self, db, regular_user):
+        await self._add_code(db, regular_user.id, "ABCDE-FGHJK")
+        assert await consume_backup_code(db, regular_user.id, "ABCDE-FGHJK") is True
+        assert await consume_backup_code(db, regular_user.id, "ABCDE-FGHJK") is False
+
+    async def test_unknown_code_is_rejected(self, db, regular_user):
+        assert await consume_backup_code(db, regular_user.id, "ZZZZZ-ZZZZZ") is False
+
+
+@pytest.mark.asyncio
+class TestDisableRemovesBackupCodes:
+    async def test_disable_deletes_factor_and_codes(self, db, regular_user):
+        from src.services.auth.mfa import disable_mfa, get_user_mfa
+
+        await _enroll_confirmed(db, regular_user.id)
+        # Give the account backup codes so disable exercises the delete loop.
+        await replace_backup_codes(db, regular_user.id)
+        assert await count_unused_backup_codes(db, regular_user.id) == 10
+
+        await disable_mfa(db, regular_user.id)
+        assert await get_user_mfa(db, regular_user.id) is None
+        assert await count_unused_backup_codes(db, regular_user.id) == 0
+
+
+@pytest.mark.asyncio
+class TestRegenerateDeletesPriorCodes:
+    async def test_second_generation_replaces_first(self, db, regular_user):
+        await _enroll_confirmed(db, regular_user.id)
+        first = await replace_backup_codes(db, regular_user.id)
+        # Second call must delete the prior batch (the delete loop) before adding.
+        second = await replace_backup_codes(db, regular_user.id)
+        assert set(first).isdisjoint(second)
+        assert await count_unused_backup_codes(db, regular_user.id) == 10
+
+
+@pytest.mark.asyncio
+class TestIssueSessionChallenge:
+    async def test_mfa_active_user_gets_challenge_with_provenance(self, db, regular_user):
+        from src.db.users import User
+        from src.services.auth.session import (
+            decode_mfa_pending_provenance,
+            issue_session_or_challenge,
+        )
+
+        await _enroll_confirmed(db, regular_user.id)
+        user = (
+            await db.execute(select(User).where(User.id == regular_user.id))
+        ).scalars().first()
+
+        result = await issue_session_or_challenge(db, user, amr="password", org_id=7)
+        assert result.mfa_required is True
+        assert result.access_token is None
+        # Provenance must ride the pending token so the /login/mfa step can stamp it.
+        assert decode_mfa_pending_provenance(result.mfa_token) == ("password", 7)

--- a/apps/api/src/tests/security/test_mfa_org_policy.py
+++ b/apps/api/src/tests/security/test_mfa_org_policy.py
@@ -1,0 +1,461 @@
+"""Tests for the org-wide "require 2FA" policy evaluation.
+
+The deadline arithmetic is the part worth pinning down: it decides whether a
+real user is locked out of their organisation today or in three weeks.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlmodel import select
+
+from src.db.organization_config import OrganizationConfig
+from src.db.user_mfa import UserMFA
+from src.db.user_organizations import UserOrganization
+from src.db.users import User
+from src.services.orgs.mfa_policy import evaluate_mfa_compliance, get_org_mfa_policy
+
+
+async def _set_policy(db, org_id, **security):
+    row = (
+        await db.execute(
+            select(OrganizationConfig).where(OrganizationConfig.org_id == org_id)
+        )
+    ).scalars().first()
+    config = {"config_version": "2.0", "admin_toggles": {"security": security}}
+    if row is None:
+        row = OrganizationConfig(
+            org_id=org_id,
+            config=config,
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+    else:
+        row.config = config
+    db.add(row)
+    await db.commit()
+
+
+async def _get_user(db, user_id) -> User:
+    return (await db.execute(select(User).where(User.id == user_id))).scalars().first()
+
+
+async def _backdate_membership(db, user_id, org_id, days):
+    membership = (
+        await db.execute(
+            select(UserOrganization).where(
+                UserOrganization.user_id == user_id,
+                UserOrganization.org_id == org_id,
+            )
+        )
+    ).scalars().first()
+    membership.creation_date = str(datetime.now() - timedelta(days=days))
+    db.add(membership)
+    await db.commit()
+
+
+async def _enroll(db, user_id, confirmed=True):
+    db.add(
+        UserMFA(
+            user_id=user_id,
+            secret_encrypted="ciphertext",
+            confirmed_at=str(datetime.now()) if confirmed else None,
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+class TestPolicyOff:
+    async def test_no_config_means_no_requirement(self, db, org, regular_user):
+        user = await _get_user(db, regular_user.id)
+        state = await evaluate_mfa_compliance(db, user, org.id)
+        assert state.required is False
+        assert state.satisfied is True
+        assert state.blocking is False
+
+    async def test_explicitly_disabled(self, db, org, regular_user):
+        await _set_policy(db, org.id, require_2fa=False)
+        user = await _get_user(db, regular_user.id)
+        state = await evaluate_mfa_compliance(db, user, org.id)
+        assert state.required is False
+        assert state.blocking is False
+
+    async def test_malformed_config_fails_closed_to_no_policy(self, db, org, regular_user):
+        await _set_policy(db, org.id, require_2fa=True, require_2fa_grace_days="not-a-number")
+        user = await _get_user(db, regular_user.id)
+        state = await evaluate_mfa_compliance(db, user, org.id)
+        # Must not enforce with nonsense numbers — an admin fixes the config
+        # rather than the whole org being blocked by a typo.
+        assert state.required is False
+
+
+@pytest.mark.asyncio
+class TestPolicyOn:
+    async def test_enrolled_user_satisfies_immediately(self, db, org, regular_user):
+        await _set_policy(
+            db, org.id, require_2fa=True, require_2fa_enabled_at=datetime.now().isoformat()
+        )
+        await _enroll(db, regular_user.id)
+        user = await _get_user(db, regular_user.id)
+
+        state = await evaluate_mfa_compliance(db, user, org.id)
+        assert state.required is True
+        assert state.satisfied is True
+        assert state.blocking is False
+
+    async def test_unconfirmed_enrollment_does_not_satisfy(self, db, org, regular_user):
+        await _set_policy(
+            db, org.id, require_2fa=True, require_2fa_enabled_at=datetime.now().isoformat()
+        )
+        await _enroll(db, regular_user.id, confirmed=False)
+        user = await _get_user(db, regular_user.id)
+
+        state = await evaluate_mfa_compliance(db, user, org.id)
+        assert state.satisfied is False
+
+    async def test_zero_grace_blocks_right_away(self, db, org, regular_user):
+        await _set_policy(
+            db,
+            org.id,
+            require_2fa=True,
+            require_2fa_grace_days=0,
+            require_2fa_enabled_at=datetime.now().isoformat(),
+        )
+        user = await _get_user(db, regular_user.id)
+
+        state = await evaluate_mfa_compliance(db, user, org.id)
+        assert state.satisfied is False
+        assert state.blocking is True
+        assert state.days_remaining == 0
+
+    async def test_grace_period_leaves_user_working(self, db, org, regular_user):
+        await _set_policy(
+            db,
+            org.id,
+            require_2fa=True,
+            require_2fa_grace_days=30,
+            require_2fa_enabled_at=datetime.now().isoformat(),
+        )
+        user = await _get_user(db, regular_user.id)
+
+        state = await evaluate_mfa_compliance(db, user, org.id)
+        assert state.satisfied is False
+        assert state.blocking is False
+        assert 28 <= state.days_remaining <= 30
+
+    async def test_expired_grace_blocks(self, db, org, regular_user):
+        await _set_policy(
+            db,
+            org.id,
+            require_2fa=True,
+            require_2fa_grace_days=7,
+            require_2fa_enabled_at=(datetime.now() - timedelta(days=30)).isoformat(),
+        )
+        # The membership must be backdated too: the fixture joins the user
+        # today, and the late-joiner rule would (correctly) hand them a fresh
+        # grace window that outlives the policy anchor.
+        await _backdate_membership(db, regular_user.id, org.id, days=60)
+        user = await _get_user(db, regular_user.id)
+
+        state = await evaluate_mfa_compliance(db, user, org.id)
+        assert state.blocking is True
+        assert state.days_remaining == 0
+
+
+@pytest.mark.asyncio
+class TestLateJoinerGetsFullGrace:
+    """The max(policy_anchor, join_date) rule.
+
+    Without it, anyone joining after the policy was switched on inherits an
+    already-expired deadline and is blocked on their first login.
+    """
+
+    async def test_user_joining_after_policy_still_gets_full_grace(
+        self, db, org, regular_user
+    ):
+        await _set_policy(
+            db,
+            org.id,
+            require_2fa=True,
+            require_2fa_grace_days=14,
+            # Policy switched on a year ago...
+            require_2fa_enabled_at=(datetime.now() - timedelta(days=365)).isoformat(),
+        )
+        # ...but this member joined today.
+        membership = (
+            await db.execute(
+                select(UserOrganization).where(
+                    UserOrganization.user_id == regular_user.id,
+                    UserOrganization.org_id == org.id,
+                )
+            )
+        ).scalars().first()
+        membership.creation_date = str(datetime.now())
+        db.add(membership)
+        await db.commit()
+
+        user = await _get_user(db, regular_user.id)
+        state = await evaluate_mfa_compliance(db, user, org.id)
+
+        assert state.blocking is False, "a brand-new member must not be blocked on day one"
+        assert 12 <= state.days_remaining <= 14
+
+    async def test_long_standing_member_uses_policy_anchor(self, db, org, regular_user):
+        await _set_policy(
+            db,
+            org.id,
+            require_2fa=True,
+            require_2fa_grace_days=7,
+            require_2fa_enabled_at=(datetime.now() - timedelta(days=10)).isoformat(),
+        )
+        membership = (
+            await db.execute(
+                select(UserOrganization).where(
+                    UserOrganization.user_id == regular_user.id,
+                    UserOrganization.org_id == org.id,
+                )
+            )
+        ).scalars().first()
+        membership.creation_date = str(datetime.now() - timedelta(days=400))
+        db.add(membership)
+        await db.commit()
+
+        user = await _get_user(db, regular_user.id)
+        state = await evaluate_mfa_compliance(db, user, org.id)
+        assert state.blocking is True
+
+
+@pytest.mark.asyncio
+class TestExternalAuthExemption:
+    async def test_google_user_is_exempt_by_default(self, db, org, regular_user):
+        await _set_policy(
+            db,
+            org.id,
+            require_2fa=True,
+            require_2fa_enabled_at=datetime.now().isoformat(),
+        )
+        user = await _get_user(db, regular_user.id)
+        user.signup_method = "google"
+        db.add(user)
+        await db.commit()
+
+        state = await evaluate_mfa_compliance(db, user, org.id)
+        assert state.satisfied is True
+        assert state.exempt_reason == "external_auth"
+
+    async def test_exemption_can_be_switched_off(self, db, org, regular_user):
+        await _set_policy(
+            db,
+            org.id,
+            require_2fa=True,
+            exempt_external_auth=False,
+            require_2fa_enabled_at=datetime.now().isoformat(),
+        )
+        user = await _get_user(db, regular_user.id)
+        user.signup_method = "google"
+        db.add(user)
+        await db.commit()
+
+        state = await evaluate_mfa_compliance(db, user, org.id)
+        assert state.satisfied is False
+
+    async def test_password_user_is_never_exempt(self, db, org, regular_user):
+        await _set_policy(
+            db,
+            org.id,
+            require_2fa=True,
+            require_2fa_enabled_at=datetime.now().isoformat(),
+        )
+        user = await _get_user(db, regular_user.id)
+        user.signup_method = "password"
+        db.add(user)
+        await db.commit()
+
+        state = await evaluate_mfa_compliance(db, user, org.id)
+        assert state.satisfied is False
+
+
+@pytest.mark.asyncio
+class TestPolicyReading:
+    async def test_defaults_when_org_has_no_config_row(self, db, org):
+        policy = await get_org_mfa_policy(db, org.id)
+        assert policy.require_2fa is False
+        assert policy.grace_days == 0
+        assert policy.exempt_external_auth is True
+
+    async def test_negative_grace_is_clamped(self, db, org):
+        await _set_policy(db, org.id, require_2fa=True, require_2fa_grace_days=-5)
+        policy = await get_org_mfa_policy(db, org.id)
+        assert policy.grace_days == 0
+
+
+@pytest.mark.asyncio
+class TestEnforcement:
+    """The policy is only real if a blocked user is actually refused."""
+
+    async def _make_blocking(self, db, org_id, user_id):
+        await _set_policy(
+            db,
+            org_id,
+            require_2fa=True,
+            require_2fa_grace_days=7,
+            require_2fa_enabled_at=(datetime.now() - timedelta(days=30)).isoformat(),
+        )
+        await _backdate_membership(db, user_id, org_id, days=60)
+
+    async def test_blocked_member_is_refused(self, db, org, regular_user):
+        from fastapi import HTTPException
+        from src.security.org_auth import require_org_membership
+
+        await self._make_blocking(db, org.id, regular_user.id)
+
+        with pytest.raises(HTTPException) as exc:
+            await require_org_membership(regular_user.id, org.id, db)
+
+        assert exc.value.status_code == 403
+        assert exc.value.detail["code"] == "MFA_REQUIRED_BY_ORG"
+        # The deadline is handed back so the UI can say when access was lost.
+        assert exc.value.detail["deadline"] is not None
+
+    async def test_enrolled_member_passes(self, db, org, regular_user):
+        from src.security.org_auth import require_org_membership
+
+        await self._make_blocking(db, org.id, regular_user.id)
+        await _enroll(db, regular_user.id)
+
+        # Must not raise.
+        await require_org_membership(regular_user.id, org.id, db)
+
+    async def test_member_inside_grace_passes(self, db, org, regular_user):
+        from src.security.org_auth import require_org_membership
+
+        await _set_policy(
+            db,
+            org.id,
+            require_2fa=True,
+            require_2fa_grace_days=30,
+            require_2fa_enabled_at=datetime.now().isoformat(),
+        )
+        await require_org_membership(regular_user.id, org.id, db)
+
+    async def test_superadmin_is_never_blocked(self, db, org, regular_user):
+        from src.security.org_auth import require_org_membership
+
+        await self._make_blocking(db, org.id, regular_user.id)
+        user = await _get_user(db, regular_user.id)
+        user.is_superadmin = True
+        db.add(user)
+        await db.commit()
+
+        # A platform admin locked out of a tenant by that tenant's own policy
+        # would have no way back in.
+        await require_org_membership(regular_user.id, org.id, db)
+
+    async def test_policy_off_is_a_no_op(self, db, org, regular_user):
+        from src.security.org_auth import require_org_membership
+
+        await require_org_membership(regular_user.id, org.id, db)
+
+    async def test_decision_is_memoized_per_session(self, db, org, regular_user):
+        from src.services.orgs.mfa_policy import is_org_mfa_blocking
+
+        await self._make_blocking(db, org.id, regular_user.id)
+
+        first = await is_org_mfa_blocking(db, regular_user.id, org.id)
+        assert first is not None
+        # Second call must come from the per-session cache, not re-query.
+        assert (regular_user.id, org.id) in db._mfa_policy_cache
+        assert await is_org_mfa_blocking(db, regular_user.id, org.id) is first
+
+
+@pytest.mark.asyncio
+class TestPlaygroundEnforcement:
+    """Playgrounds run their own org-role gate rather than going through
+    ``require_org_*``. These pin that the policy is nonetheless enforced there —
+    the module was a bypass around the org-wide requirement — while a
+    non-member is never swept up by an org they do not belong to.
+    """
+
+    async def _make_blocking(self, db, org_id, user_id):
+        await _set_policy(
+            db,
+            org_id,
+            require_2fa=True,
+            require_2fa_grace_days=7,
+            require_2fa_enabled_at=(datetime.now() - timedelta(days=30)).isoformat(),
+        )
+        await _backdate_membership(db, user_id, org_id, days=60)
+
+    async def test_blocked_member_cannot_resolve_playground_rights(self, db, org, regular_user):
+        from fastapi import HTTPException
+        from src.services.playgrounds.playgrounds import _get_user_rights
+
+        await self._make_blocking(db, org.id, regular_user.id)
+
+        with pytest.raises(HTTPException) as exc:
+            await _get_user_rights(regular_user.id, org.id, db)
+        assert exc.value.detail["code"] == "MFA_REQUIRED_BY_ORG"
+
+    async def test_blocked_member_read_gate_refuses(self, db, org, regular_user):
+        from fastapi import HTTPException
+        from src.services.playgrounds.playgrounds import _enforce_member_mfa
+
+        await self._make_blocking(db, org.id, regular_user.id)
+
+        with pytest.raises(HTTPException) as exc:
+            await _enforce_member_mfa(regular_user.id, org.id, db)
+        assert exc.value.detail["code"] == "MFA_REQUIRED_BY_ORG"
+
+    async def test_enrolled_member_resolves_rights(self, db, org, regular_user):
+        from src.services.playgrounds.playgrounds import _get_user_rights
+
+        await self._make_blocking(db, org.id, regular_user.id)
+        await _enroll(db, regular_user.id)
+
+        # Must not raise — an enrolled member is compliant.
+        await _get_user_rights(regular_user.id, org.id, db)
+
+    async def test_non_member_is_not_subject_to_policy(self, db, org, regular_user):
+        from src.services.playgrounds.playgrounds import _enforce_member_mfa
+
+        await self._make_blocking(db, org.id, regular_user.id)
+        # Drop the membership: a non-member viewing this org's public playgrounds
+        # must not inherit its 2FA requirement.
+        membership = (
+            await db.execute(
+                select(UserOrganization).where(
+                    UserOrganization.user_id == regular_user.id,
+                    UserOrganization.org_id == org.id,
+                )
+            )
+        ).scalars().first()
+        await db.delete(membership)
+        await db.commit()
+
+        # Must not raise.
+        await _enforce_member_mfa(regular_user.id, org.id, db)
+
+
+class TestParseDt:
+    """The date-shape fallback in _parse_dt decides real lockout deadlines, so
+    the non-ISO and unparseable branches are pinned explicitly."""
+
+    def test_none_and_empty(self):
+        from src.services.orgs.mfa_policy import _parse_dt
+
+        assert _parse_dt(None) is None
+        assert _parse_dt("") is None
+
+    def test_iso(self):
+        from src.services.orgs.mfa_policy import _parse_dt
+
+        assert _parse_dt("2024-01-01T09:30:00") is not None
+
+    def test_unparseable_returns_none(self):
+        from src.services.orgs.mfa_policy import _parse_dt
+
+        # Exercises the fromisoformat failure -> strptime fallbacks -> warning.
+        assert _parse_dt("definitely-not-a-date") is None

--- a/apps/api/src/tests/security/test_remediation_magic_link.py
+++ b/apps/api/src/tests/security/test_remediation_magic_link.py
@@ -59,11 +59,18 @@ async def test_magic_link_single_use_blocks_replay(legit_payload):
         "src.services.admin.admin._validate_magic_link_redirect",
         return_value="/dashboard",
     ), patch(
-        "src.services.admin.admin.create_access_token",
+        # Session minting moved behind issue_session_or_challenge, which is the
+        # single gate every sign-in path now goes through.
+        "src.services.auth.session.create_access_token",
         return_value="new-access",
     ), patch(
-        "src.services.admin.admin.create_refresh_token",
+        "src.services.auth.session.create_refresh_token",
         return_value="new-refresh",
+    ), patch(
+        # This test drives the service with a Mock session, so the MFA lookup
+        # would otherwise return a truthy Mock and read as "user has 2FA".
+        "src.services.auth.session.is_mfa_active",
+        return_value=False,
     ), patch(
         "redis.Redis.from_url",
         return_value=redis_client,
@@ -71,13 +78,14 @@ async def test_magic_link_single_use_blocks_replay(legit_payload):
         "config.config.get_learnhouse_config",
         return_value=fake_cfg,
     ):
-        _, access, refresh, redirect_to = await consume_magic_link_token(
+        _, access, refresh, redirect_to, mfa_token = await consume_magic_link_token(
             token="legit-jwt",
             db_session=db_mock,
         )
         assert access == "new-access"
         assert refresh == "new-refresh"
         assert redirect_to == "/dashboard"
+        assert mfa_token is None
 
         with pytest.raises(HTTPException) as exc:
             await consume_magic_link_token(
@@ -111,11 +119,14 @@ async def test_magic_link_falls_through_when_redis_unavailable(legit_payload):
         "src.services.admin.admin._validate_magic_link_redirect",
         return_value=None,
     ), patch(
-        "src.services.admin.admin.create_access_token",
+        "src.services.auth.session.create_access_token",
         return_value="new-access",
     ), patch(
-        "src.services.admin.admin.create_refresh_token",
+        "src.services.auth.session.create_refresh_token",
         return_value="new-refresh",
+    ), patch(
+        "src.services.auth.session.is_mfa_active",
+        return_value=False,
     ), patch(
         "redis.Redis.from_url",
         side_effect=RuntimeError("redis down"),

--- a/apps/api/src/tests/security/test_session_provenance.py
+++ b/apps/api/src/tests/security/test_session_provenance.py
@@ -1,0 +1,50 @@
+"""Session provenance (``amr`` / ``sorg``) is stamped at mint and survives the
+paths that could silently strip it (MFA completion, refresh)."""
+
+
+from src.security.auth import decode_jwt
+from src.security.session_context import AMR_CLAIM, SORG_CLAIM, session_claims
+from src.services.auth.session import (
+    create_mfa_pending_token,
+    decode_mfa_pending_provenance,
+    decode_mfa_pending_token,
+    mint_session_tokens,
+)
+
+
+class TestSessionClaims:
+    def test_omits_absent_claims(self):
+        assert session_claims(None, None) == {}
+        assert session_claims("password", None) == {AMR_CLAIM: "password"}
+        assert session_claims(None, 7) == {SORG_CLAIM: 7}
+
+    def test_mint_embeds_amr_and_org(self):
+        result = mint_session_tokens("a@b.co", amr="password", org_id=42)
+        access = decode_jwt(result.access_token)
+        refresh = decode_jwt(result.refresh_token)
+        assert access[AMR_CLAIM] == "password" and access[SORG_CLAIM] == 42
+        # Refresh must carry it too, or rotation would launder the claims away.
+        assert refresh[AMR_CLAIM] == "password" and refresh[SORG_CLAIM] == 42
+        assert access["purpose"] == "session"
+
+    def test_mint_without_provenance_is_backward_compatible(self):
+        access = decode_jwt(mint_session_tokens("a@b.co").access_token)
+        assert AMR_CLAIM not in access and SORG_CLAIM not in access
+        assert access["purpose"] == "session"
+
+
+class TestPendingTokenProvenance:
+    def test_pending_token_carries_provenance(self):
+        token = create_mfa_pending_token("a@b.co", amr="sso", org_id=3)
+        assert decode_mfa_pending_token(token) == "a@b.co"
+        assert decode_mfa_pending_provenance(token) == ("sso", 3)
+
+    def test_pending_token_without_provenance(self):
+        token = create_mfa_pending_token("a@b.co")
+        assert decode_mfa_pending_provenance(token) == (None, None)
+
+    def test_pending_provenance_ignores_non_pending_token(self):
+        # A session token is not a pending token; decode_mfa_pending_token gates
+        # that. Provenance decode is only ever called after that check.
+        session = mint_session_tokens("a@b.co", amr="password", org_id=1)
+        assert decode_mfa_pending_token(session.access_token) is None

--- a/apps/api/src/tests/services/test_org_users_service.py
+++ b/apps/api/src/tests/services/test_org_users_service.py
@@ -1263,3 +1263,16 @@ class TestOrgUsersService:
             )
 
         assert result == {"detail": "0 user(s) removed from org"}
+
+
+@pytest.fixture(autouse=True)
+def _skip_org_mfa_policy():
+    """No-op the org two-factor policy for this module.
+
+    These tests use a fake session that returns a fixed, ordered list of
+    results. The policy check issues its own queries, which would consume
+    entries from that list and desynchronise every subsequent lookup. The
+    policy itself is covered in src/tests/security/test_mfa_org_policy.py.
+    """
+    with patch("src.services.orgs.users.enforce_org_mfa", new=AsyncMock(return_value=None)):
+        yield

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -953,6 +953,7 @@ dependencies = [
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-ai-slim", extra = ["anthropic", "google", "mistral", "openai"] },
     { name = "pyjwt", extra = ["crypto"] },
+    { name = "pyotp" },
     { name = "pypdf" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -998,6 +999,7 @@ requires-dist = [
     { name = "pydantic", extras = ["email"], specifier = "==2.13.4" },
     { name = "pydantic-ai-slim", extras = ["openai", "anthropic", "google", "mistral"], specifier = "==2.15.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
+    { name = "pyotp", specifier = "==2.9.0" },
     { name = "pypdf", specifier = "==6.14.2" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-asyncio", specifier = "==1.4.0" },
@@ -1665,6 +1667,15 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pyotp"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/b2/1d5994ba2acde054a443bd5e2d384175449c7d2b6d1a0614dbca3a63abfc/pyotp-2.9.0.tar.gz", hash = "sha256:346b6642e0dbdde3b4ff5a930b664ca82abfa116356ed48cc42c7d6590d36f63", size = 17763, upload-time = "2023-07-27T23:41:03.295Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/c0/c33c8792c3e50193ef55adb95c1c3c2786fe281123291c2dbf0eaab95a6f/pyotp-2.9.0-py3-none-any.whl", hash = "sha256:81c2e5865b8ac55e825b0358e496e1d9387c811e85bb40e71a3b29b288963612", size = 13376, upload-time = "2023-07-27T23:41:01.685Z" },
 ]
 
 [[package]]

--- a/apps/web/app/api/auth/[...path]/route.ts
+++ b/apps/web/app/api/auth/[...path]/route.ts
@@ -16,7 +16,9 @@ const BACKEND_URL = (getConfig('NEXT_PUBLIC_LEARNHOUSE_BACKEND_URL') || 'http://
 // Paths that return tokens in response body (relative to /api/v1/auth/)
 // `verify-email` auto-signs-in the user on successful email verification, so
 // it returns tokens just like login/signup and its cookies must be mirrored.
-const TOKEN_RESPONSE_PATHS = ['login', 'refresh', 'oauth', 'signup', 'verify-email']
+// `magic-link` covers /magic-link/verify, which mints a session (or an mfa_token)
+// from a passwordless login link.
+const TOKEN_RESPONSE_PATHS = ['login', 'refresh', 'oauth', 'signup', 'verify-email', 'magic-link']
 
 function shouldExtractTokens(path: string): boolean {
   return TOKEN_RESPONSE_PATHS.some(p => path.startsWith(p))

--- a/apps/web/app/auth/login/login.tsx
+++ b/apps/web/app/auth/login/login.tsx
@@ -5,7 +5,7 @@ import FormLayout, {
 import * as Form from '@radix-ui/react-form'
 import { useFormik } from 'formik'
 import React, { useState, useEffect } from 'react'
-import { AlertTriangle, Info, Lock, Mail, Shield, X, Clock } from 'lucide-react'
+import { AlertTriangle, Info, Lock, Mail, Shield, X, Clock, Send, CheckCircle2 } from 'lucide-react'
 import { checkSSOEnabled, redirectToSSOLogin } from '@services/auth/sso'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
@@ -24,7 +24,7 @@ interface LoginClientProps {
 
 const LoginClient = (props: LoginClientProps) => {
   const { t } = useTranslation()
-  const { signIn } = useAuth()
+  const { signIn, completeMfaLogin, requestMagicLink } = useAuth()
   const { track } = useLHAnalytics('public')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [ssoEnabled, setSsoEnabled] = useState(false)
@@ -53,15 +53,140 @@ const LoginClient = (props: LoginClientProps) => {
   const [showErrorModal, setShowErrorModal] = useState(false)
   const [retryAfter, setRetryAfter] = useState<number | null>(null)
 
+  // Second-factor challenge. When mfaToken is set the credentials form is
+  // replaced in place by the code step — same route, so the ?next redirect and
+  // the org context survive without being threaded through a navigation.
+  const [mfaToken, setMfaToken] = useState<string | null>(null)
+  const [mfaCode, setMfaCode] = useState('')
+  const [useBackupCode, setUseBackupCode] = useState(false)
+  const [mfaError, setMfaError] = useState('')
+  const [mfaSubmitting, setMfaSubmitting] = useState(false)
+
+  // Passwordless "email me a login link" affordance. Toggled in place next to
+  // the credentials form; on success it flips to a "check your email"
+  // confirmation. Kept entirely separate from the password/2FA state above.
+  const [magicMode, setMagicMode] = useState(false)
+  const [magicEmail, setMagicEmail] = useState('')
+  const [magicSubmitting, setMagicSubmitting] = useState(false)
+  const [magicSent, setMagicSent] = useState(false)
+  const [magicError, setMagicError] = useState('')
+
+  const openMagicMode = () => {
+    // Seed from whatever they already typed in the password form.
+    setMagicEmail(formik.values.email)
+    setMagicError('')
+    setMagicSent(false)
+    setMagicMode(true)
+  }
+
+  const handleMagicLinkRequest = async (e?: React.FormEvent) => {
+    e?.preventDefault()
+    const email = magicEmail.trim()
+    if (!email || magicSubmitting) return
+    if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(email)) {
+      setMagicError(t('validation.invalid_email'))
+      return
+    }
+
+    setMagicSubmitting(true)
+    setMagicError('')
+
+    const res = await requestMagicLink(email, props.org?.slug)
+    setMagicSubmitting(false)
+
+    if (res.rateLimited) {
+      setMagicError(res.detail)
+      return
+    }
+    // The backend answers generically whether or not the account exists, so a
+    // non-rate-limited response always advances to the confirmation state.
+    setMagicSent(true)
+  }
+
+  // An admin magic link for a 2FA-enabled user lands here with a pending token
+  // in the query string instead of a session (see /admin/{org}/auth/magic-consume).
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const token = params.get('mfa_token')
+    if (token) setMfaToken(token)
+  }, [])
+
   // Honor a post-login redirect via ?next / ?redirect, sanitized to an
   // internal same-origin path (no open-redirect), defaulting to /home.
   // Forward it through the cross-domain /redirect_from_auth handoff.
   const buildCallbackUrl = () => {
     const params = new URLSearchParams(window.location.search)
-    const raw = params.get('next') ?? params.get('redirect')
+    // `redirect_to` is what the magic-link consume endpoint forwards when it
+    // bounces a 2FA-enabled user here instead of signing them straight in.
+    const raw = params.get('next') ?? params.get('redirect') ?? params.get('redirect_to')
     const dest = raw && /^\/(?!\/)/.test(raw) ? raw : '/home'
     return `${window.location.origin}/redirect_from_auth?next=${encodeURIComponent(dest)}`
   }
+
+  const handleMfaSubmit = async (e?: React.FormEvent) => {
+    e?.preventDefault()
+    if (!mfaToken || mfaSubmitting) return
+
+    const code = mfaCode.trim()
+    if (!code) return
+
+    setMfaSubmitting(true)
+    setMfaError('')
+
+    const callbackUrl = buildCallbackUrl()
+    const res = await completeMfaLogin(mfaToken, code, {
+      isBackupCode: useBackupCode,
+      callbackUrl,
+      redirect: false,
+    })
+
+    if (res.ok) {
+      track(AnalyticsEvent.LoginSucceeded, { method: 'credentials_mfa' })
+      window.location.href = callbackUrl
+      return
+    }
+
+    let code_ = null
+    let message = t('auth.mfa_invalid_code', {
+      defaultValue: "That code isn't right. Check your device's clock is set automatically, then try the next code.",
+    })
+    try {
+      const parsed = JSON.parse(res.error || '{}')
+      code_ = parsed.code ?? null
+      if (parsed.message) message = parsed.message
+    } catch {
+      // keep the default message
+    }
+
+    track(AnalyticsEvent.LoginFailed, { method: 'credentials_mfa', error_type: code_ })
+
+    if (code_ === 'MFA_SESSION_EXPIRED') {
+      // The pending token died. Returning to the password step is the only way
+      // forward — keeping the code field up would let them retry forever
+      // against a token that can never be accepted.
+      setMfaToken(null)
+      setMfaCode('')
+      setUseBackupCode(false)
+      setErrorType('MFA_SESSION_EXPIRED')
+      setError(message)
+      setShowErrorModal(true)
+      turnstileRef.current?.reset()
+    } else {
+      setMfaError(message)
+      setMfaCode('')
+    }
+
+    setMfaSubmitting(false)
+  }
+
+  // Auto-submit once six digits are in — every authenticator app produces
+  // exactly six, so making the user reach for a button is pure friction.
+  // Backup codes are excluded: they are variable-shaped and pasted.
+  useEffect(() => {
+    if (mfaToken && !useBackupCode && !mfaSubmitting && mfaCode.length === 6) {
+      handleMfaSubmit()
+    }
+  }, [mfaCode, useBackupCode, mfaSubmitting, mfaToken]) // eslint-disable-line
 
   const handleGoogleSignIn = () => {
     track(AnalyticsEvent.LoginGoogleClicked)
@@ -208,6 +333,9 @@ const LoginClient = (props: LoginClientProps) => {
           redirect: false,
           email: values.email,
           password: values.password,
+          // Bind the session to this org when the login page is org-scoped, so
+          // the org's session/auth-method policy can enforce against it.
+          orgSlug: props.org?.slug,
           callbackUrl
         });
       } catch {
@@ -220,6 +348,20 @@ const LoginClient = (props: LoginClientProps) => {
         setSubmitting(false)
         setIsSubmitting(false)
         turnstileRef.current?.reset()
+        return
+      }
+
+      // Password accepted, second factor outstanding. Must be checked before
+      // the res.error branch below: this result carries error === null, so it
+      // would otherwise fall through to the success path and redirect an
+      // unauthenticated user.
+      if (res && res.mfa_required && res.mfa_token) {
+        track(AnalyticsEvent.LoginSubmitted, { has_sso_enabled: ssoEnabled, mfa_required: true })
+        setMfaToken(res.mfa_token)
+        setMfaCode('')
+        setMfaError('')
+        setIsSubmitting(false)
+        setSubmitting(false)
         return
       }
 
@@ -349,6 +491,216 @@ const LoginClient = (props: LoginClientProps) => {
 
         <div className="flex-1 flex items-center justify-center px-6 md:px-12 lg:px-20">
           <div className="w-full max-w-[420px] py-10">
+            {mfaToken ? (
+              <>
+                {/* Second-factor challenge */}
+                <h1 className="text-[28px] md:text-[32px] font-black text-black tracking-tight leading-tight">
+                  {t('auth.mfa_title', { defaultValue: 'Two-step verification' })}
+                </h1>
+                <p className="mt-2 text-black/45 text-[15px] font-medium">
+                  {useBackupCode
+                    ? t('auth.mfa_subtitle_backup', { defaultValue: 'Enter one of the backup codes you saved.' })
+                    : t('auth.mfa_subtitle', { defaultValue: 'Enter the 6-digit code from your authenticator app.' })}
+                </p>
+
+                <form onSubmit={handleMfaSubmit} className="mt-8">
+                  <label className="block text-[13px] font-semibold text-black/70 mb-1.5">
+                    {useBackupCode
+                      ? t('auth.mfa_backup_code', { defaultValue: 'Backup code' })
+                      : t('auth.mfa_code', { defaultValue: 'Verification code' })}
+                  </label>
+                  <input
+                    type="text"
+                    value={mfaCode}
+                    onChange={(e) => {
+                      setMfaCode(
+                        useBackupCode
+                          ? e.target.value.toUpperCase()
+                          : e.target.value.replace(/\D/g, '').slice(0, 6)
+                      )
+                      if (mfaError) setMfaError('')
+                    }}
+                    autoFocus
+                    autoComplete="one-time-code"
+                    inputMode={useBackupCode ? 'text' : 'numeric'}
+                    placeholder={useBackupCode ? 'XXXXX-XXXXX' : '000000'}
+                    disabled={mfaSubmitting}
+                    className={`box-border w-full bg-neutral-50 text-black rounded-lg px-4 border inline-flex h-[44px] appearance-none items-center focus:outline-none focus:ring-2 focus:ring-black/5 transition-all placeholder:text-black/25 disabled:opacity-50 ${
+                      useBackupCode
+                        ? 'text-sm tracking-normal'
+                        : 'text-lg tracking-[0.4em] font-semibold'
+                    } ${mfaError ? 'border-red-300 focus:border-red-400' : 'border-neutral-200 focus:border-neutral-400'}`}
+                  />
+
+                  {mfaError && (
+                    <p className="mt-2 text-red-600 text-xs flex items-start gap-1.5">
+                      <Info size={12} className="shrink-0 mt-0.5" />
+                      <span>{mfaError}</span>
+                    </p>
+                  )}
+
+                  <button
+                    type="submit"
+                    disabled={mfaSubmitting || !mfaCode.trim()}
+                    className="box-border w-full inline-flex h-[44px] rounded-lg items-center justify-center bg-black hover:bg-black/85 text-white px-[15px] font-bold text-[14px] leading-none mt-4 transition-all disabled:opacity-50"
+                  >
+                    {mfaSubmitting ? (
+                      <span className="flex items-center space-x-2">
+                        <span className="w-4 h-4 border-t-2 border-white rounded-full animate-spin" />
+                        <span>{t('common.loading')}</span>
+                      </span>
+                    ) : (
+                      t('auth.mfa_verify', { defaultValue: 'Verify' })
+                    )}
+                  </button>
+                </form>
+
+                <div className="mt-6 space-y-2 text-center">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setUseBackupCode(!useBackupCode)
+                      setMfaCode('')
+                      setMfaError('')
+                    }}
+                    disabled={mfaSubmitting}
+                    className="text-sm text-black font-semibold hover:underline disabled:opacity-50"
+                  >
+                    {useBackupCode
+                      ? t('auth.mfa_use_authenticator', { defaultValue: 'Use your authenticator app instead' })
+                      : t('auth.mfa_use_backup', { defaultValue: 'Use a backup code instead' })}
+                  </button>
+                  <p>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setMfaToken(null)
+                        setMfaCode('')
+                        setMfaError('')
+                        setUseBackupCode(false)
+                        turnstileRef.current?.reset()
+                      }}
+                      disabled={mfaSubmitting}
+                      className="text-sm text-black/35 hover:text-black/60 disabled:opacity-50"
+                    >
+                      {t('auth.mfa_back_to_login', { defaultValue: 'Back to sign in' })}
+                    </button>
+                  </p>
+                </div>
+              </>
+            ) : magicMode ? (
+              <>
+                {/* Passwordless "email me a link" step */}
+                <h1 className="text-[28px] md:text-[32px] font-black text-black tracking-tight leading-tight">
+                  {t('auth.magic_title', { defaultValue: 'Sign in with a link' })}
+                </h1>
+                {magicSent ? (
+                  <>
+                    <div className="mt-8 flex flex-col items-center text-center">
+                      <div className="p-3 rounded-2xl bg-green-50 text-green-600">
+                        <CheckCircle2 size={28} />
+                      </div>
+                      <h2 className="mt-4 text-lg font-bold text-black">
+                        {t('auth.magic_sent_title', { defaultValue: 'Check your email' })}
+                      </h2>
+                      <p className="mt-2 text-black/45 text-[15px] font-medium max-w-sm">
+                        {t('auth.magic_sent_body', {
+                          defaultValue:
+                            'If an account exists for {{email}}, we just sent it a secure link to sign in. It expires shortly, so use it soon.',
+                          email: magicEmail.trim(),
+                        })}
+                      </p>
+                    </div>
+                    <div className="mt-8 text-center">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setMagicMode(false)
+                          setMagicSent(false)
+                          setMagicError('')
+                        }}
+                        className="text-sm text-black/35 hover:text-black/60"
+                      >
+                        {t('auth.magic_back_to_login', { defaultValue: 'Back to sign in' })}
+                      </button>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <p className="mt-2 text-black/45 text-[15px] font-medium">
+                      {t('auth.magic_subtitle', {
+                        defaultValue:
+                          'Enter your email and we’ll send you a link that signs you in — no password needed.',
+                      })}
+                    </p>
+                    <form onSubmit={handleMagicLinkRequest} className="mt-8">
+                      <label className="block text-[13px] font-semibold text-black/70 mb-1.5">
+                        {t('auth.email')}
+                      </label>
+                      <input
+                        type="email"
+                        value={magicEmail}
+                        onChange={(e) => {
+                          setMagicEmail(e.target.value)
+                          if (magicError) setMagicError('')
+                        }}
+                        autoFocus
+                        autoComplete="email"
+                        placeholder="you@example.com"
+                        disabled={magicSubmitting}
+                        className={`box-border w-full bg-neutral-50 text-black rounded-lg px-4 border inline-flex h-[44px] appearance-none items-center focus:outline-none focus:ring-2 focus:ring-black/5 transition-all placeholder:text-black/25 text-sm disabled:opacity-50 ${
+                          magicError
+                            ? 'border-red-300 focus:border-red-400'
+                            : 'border-neutral-200 focus:border-neutral-400'
+                        }`}
+                      />
+
+                      {magicError && (
+                        <p className="mt-2 text-red-600 text-xs flex items-start gap-1.5">
+                          <Info size={12} className="shrink-0 mt-0.5" />
+                          <span>{magicError}</span>
+                        </p>
+                      )}
+
+                      <button
+                        type="submit"
+                        disabled={magicSubmitting || !magicEmail.trim()}
+                        className="box-border w-full inline-flex h-[44px] rounded-lg items-center justify-center bg-black hover:bg-black/85 text-white px-[15px] font-bold text-[14px] leading-none mt-4 transition-all disabled:opacity-50"
+                      >
+                        {magicSubmitting ? (
+                          <span className="flex items-center space-x-2">
+                            <span className="w-4 h-4 border-t-2 border-white rounded-full animate-spin" />
+                            <span>{t('common.loading')}</span>
+                          </span>
+                        ) : (
+                          <span className="flex items-center gap-2">
+                            <Send size={15} />
+                            {t('auth.magic_send', { defaultValue: 'Email me a login link' })}
+                          </span>
+                        )}
+                      </button>
+                    </form>
+
+                    <div className="mt-6 text-center">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setMagicMode(false)
+                          setMagicError('')
+                        }}
+                        disabled={magicSubmitting}
+                        className="text-sm text-black/35 hover:text-black/60 disabled:opacity-50"
+                      >
+                        {t('auth.magic_use_password', {
+                          defaultValue: 'Sign in with a password instead',
+                        })}
+                      </button>
+                    </div>
+                  </>
+                )}
+              </>
+            ) : (
+              <>
             {/* Header */}
             <h1 className="text-[28px] md:text-[32px] font-black text-black tracking-tight leading-tight">{t('auth.welcome_back')}</h1>
             <p className="mt-2 text-black/45 text-[15px] font-medium">{t('auth.enter_credentials')}</p>
@@ -458,6 +810,16 @@ const LoginClient = (props: LoginClientProps) => {
                     <span>{ssoLoading ? t('common.loading') : t('auth.sign_in_with_sso')}</span>
                   </button>
                 )}
+
+                <button
+                  type="button"
+                  onClick={openMagicMode}
+                  disabled={isSubmitting}
+                  className="flex justify-center items-center w-full bg-white hover:bg-neutral-50 text-black space-x-3 font-medium p-3 rounded-lg border border-neutral-200 transition-all text-sm disabled:opacity-50"
+                >
+                  <Mail size={16} />
+                  <span>{t('auth.magic_send', { defaultValue: 'Email me a login link' })}</span>
+                </button>
               </div>
 
               {/* Sign Up Link */}
@@ -468,6 +830,8 @@ const LoginClient = (props: LoginClientProps) => {
                 </Link>
               </p>
             </div>
+              </>
+            )}
           </div>
         </div>
     </AuthLayout>

--- a/apps/web/app/auth/magic/page.tsx
+++ b/apps/web/app/auth/magic/page.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import React, { useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
+import { Loader2, AlertTriangle } from 'lucide-react'
+import { useAuth } from '@components/Contexts/AuthContext'
+
+/**
+ * Consumes a passwordless login link: reads ?token from the URL and hands it to
+ * completeMagicLink(). Mirrors the loading/redirect pattern of the Google OAuth
+ * callback page.
+ *
+ *   - 2FA account  → bounce to /login?mfa_token=… (the login page picks it up),
+ *   - success      → forward through the same /redirect_from_auth handoff every
+ *                    other flow uses,
+ *   - expired/used → friendly "request a new one" state linking back to /login.
+ *
+ * The token is read from window.location (not useSearchParams) to stay off the
+ * Suspense/CSR-bailout path, matching how the login page reads ?mfa_token.
+ */
+export default function MagicLinkConsumePage() {
+  const { completeMagicLink } = useAuth()
+  const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading')
+  const [error, setError] = useState<string | null>(null)
+  const ranRef = useRef(false)
+
+  // Honor a sanitized ?next / ?redirect through the cross-domain handoff — same
+  // rule the login page applies (internal same-origin path only, default /home).
+  const buildCallbackUrl = () => {
+    const params = new URLSearchParams(window.location.search)
+    const raw = params.get('next') ?? params.get('redirect') ?? params.get('redirect_to')
+    const dest = raw && /^\/(?!\/)/.test(raw) ? raw : '/home'
+    return `${window.location.origin}/redirect_from_auth?next=${encodeURIComponent(dest)}`
+  }
+
+  useEffect(() => {
+    // Single-use link: never run the verify twice (React strict-mode double-mount).
+    if (ranRef.current) return
+    ranRef.current = true
+
+    const run = async () => {
+      const params = new URLSearchParams(window.location.search)
+      const token = params.get('token')
+
+      if (!token) {
+        setError('This link is missing its token. Request a new one to sign in.')
+        setStatus('error')
+        return
+      }
+
+      const callbackUrl = buildCallbackUrl()
+      const res = await completeMagicLink(token, { callbackUrl, redirect: false })
+
+      // 2FA account — the login page already knows how to finish from an mfa_token.
+      if (res.mfa_required && res.mfa_token) {
+        const raw =
+          params.get('next') ?? params.get('redirect') ?? params.get('redirect_to')
+        const loginUrl = new URL('/login', window.location.origin)
+        loginUrl.searchParams.set('mfa_token', res.mfa_token)
+        if (raw && /^\/(?!\/)/.test(raw)) loginUrl.searchParams.set('next', raw)
+        window.location.href = loginUrl.toString()
+        return
+      }
+
+      if (res.ok) {
+        setStatus('success')
+        window.location.href = callbackUrl
+        return
+      }
+
+      let message = 'This link has expired or was already used. Request a new one to sign in.'
+      try {
+        const parsed = JSON.parse(res.error || '{}')
+        if (parsed.message) message = parsed.message
+      } catch {
+        // keep the default message
+      }
+      setError(message)
+      setStatus('error')
+    }
+
+    run()
+  }, [completeMagicLink])
+
+  if (status === 'error') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-center max-w-md mx-auto p-6">
+          <div className="flex justify-center mb-4">
+            <div className="p-3 bg-amber-100 rounded-full">
+              <AlertTriangle className="w-12 h-12 text-amber-600" />
+            </div>
+          </div>
+          <h1 className="text-xl font-semibold text-gray-800 mb-2">
+            This link isn’t valid anymore
+          </h1>
+          <p className="text-gray-600 mb-6">{error}</p>
+          <div className="space-y-3">
+            <Link
+              href="/login"
+              className="block w-full py-2 px-4 bg-black text-white rounded-md hover:bg-gray-800 transition-colors"
+            >
+              Request a new link
+            </Link>
+            <Link
+              href="/"
+              className="block w-full py-2 px-4 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200 transition-colors"
+            >
+              Go Home
+            </Link>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <div className="flex justify-center mb-4">
+            <Loader2 className="w-12 h-12 text-green-600 animate-spin" />
+          </div>
+          <h1 className="text-xl font-semibold text-gray-800 mb-2">Success!</h1>
+          <p className="text-gray-500">Redirecting you now...</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="text-center">
+        <div className="flex justify-center mb-4">
+          <Loader2 className="w-12 h-12 text-gray-600 animate-spin" />
+        </div>
+        <h1 className="text-xl font-semibold text-gray-800 mb-2">Signing you in...</h1>
+        <p className="text-gray-500">Please wait while we verify your link.</p>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/layout.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/layout.tsx
@@ -6,6 +6,7 @@ import { SessionGate } from '@components/Contexts/LHSessionContext'
 import { OrgMenu } from '@components/Objects/Menus/OrgMenu'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { OrgJoinBanner, OrgJoinBannerProvider } from '@components/Objects/Banners/OrgJoinBanner'
+import { OrgMFAPolicyGate } from '@components/Objects/Banners/OrgMFAPolicyGate'
 import { PodcastPlayerProvider } from '@components/Contexts/PodcastPlayerContext'
 import dynamic from 'next/dynamic'
 const PodcastPlayer = dynamic(() => import('@components/Objects/Podcasts/PodcastPlayer'), { ssr: false })
@@ -115,6 +116,8 @@ function LayoutContent({ children, orgslug }: { children: ReactNode; orgslug: st
       <PageViewTracker />
       {!chromeless && <OrgJoinBanner />}
       {!chromeless && <OrgMenu orgslug={orgslug} />}
+      {/* Org-wide 2FA policy: renders nothing unless this user is non-compliant. */}
+      {!chromeless && <OrgMFAPolicyGate />}
       <div className="flex-1 relative" style={{ zIndex: 'var(--z-content)' }}>
         {children}
       </div>

--- a/apps/web/app/orgs/[orgslug]/dash/org/settings/[subpage]/page.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/org/settings/[subpage]/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { Breadcrumbs } from '@components/Objects/Breadcrumbs/Breadcrumbs'
 import { getUriWithOrg } from '@services/config/config'
-import { TextIcon, LucideIcon, LayoutDashboardIcon, CodeIcon, Palette, School, BarChart3, Menu as MenuIcon, AlertTriangle } from 'lucide-react'
+import { TextIcon, LucideIcon, LayoutDashboardIcon, CodeIcon, Palette, School, BarChart3, Menu as MenuIcon, AlertTriangle, ShieldCheck } from 'lucide-react'
 import React, { useEffect, use } from 'react';
 import { useRouter } from 'next/navigation'
 import { motion } from 'motion/react'
@@ -13,6 +13,7 @@ import OrgEditOther from '@components/Dashboard/Pages/Org/OrgEditOther/OrgEditOt
 import OrgEditAI from '@components/Dashboard/Pages/Org/OrgEditAI/OrgEditAI'
 import OrgEditUsage from '@components/Dashboard/Pages/Org/OrgEditUsage/OrgEditUsage'
 import OrgEditMenu from '@components/Dashboard/Pages/Org/OrgEditMenu/OrgEditMenu'
+import OrgEditSecurity from '@components/Dashboard/Pages/Org/OrgEditSecurity/OrgEditSecurity'
 import OrgEditDangerZone from '@components/Dashboard/Pages/Org/OrgEditDangerZone/OrgEditDangerZone'
 import { useTranslation } from 'react-i18next'
 import { PlanLevel } from '@services/plans/plans'
@@ -49,6 +50,7 @@ const getSettingTabs = (t: any): TabConfig[] => [
   { id: 'landing', label: t('dashboard.organization.settings.tabs.landing'), icon: LayoutDashboardIcon },
   { id: 'ai', label: t('dashboard.organization.settings.tabs.ai') || 'AI', customIcon: '/learnhouse_ai_simple_colored.png', requiredPlan: 'standard' },
   { id: 'usage', label: t('dashboard.organization.settings.tabs.usage') || 'Usage', icon: BarChart3 },
+  { id: 'security', label: t('dashboard.organization.settings.tabs.security', { defaultValue: 'Security' }), icon: ShieldCheck },
   { id: 'other', label: t('dashboard.organization.settings.tabs.other'), icon: CodeIcon },
   { id: 'danger', label: t('dashboard.organization.settings.tabs.danger') || 'Danger Zone', icon: AlertTriangle },
 ]
@@ -86,6 +88,9 @@ function OrgPage(props: { params: Promise<OrgParams> }) {
     } else if (params.subpage == 'usage') {
       setH1Label(t('dashboard.organization.settings.pages.usage.title') || 'Usage')
       setH2Label(t('dashboard.organization.settings.pages.usage.subtitle') || 'Monitor your organization\'s resource usage and plan limits')
+    } else if (params.subpage == 'security') {
+      setH1Label(t('dashboard.organization.settings.pages.security.title', { defaultValue: 'Security' }))
+      setH2Label(t('dashboard.organization.settings.pages.security.subtitle', { defaultValue: 'Require two-factor authentication for members of this organization' }))
     } else if (params.subpage == 'other') {
       setH1Label(t('dashboard.organization.settings.pages.other.title'))
       setH2Label(t('dashboard.organization.settings.pages.other.subtitle'))
@@ -150,6 +155,7 @@ function OrgPage(props: { params: Promise<OrgParams> }) {
         {params.subpage == 'landing' ? <OrgEditLanding /> : ''}
         {params.subpage == 'ai' ? <OrgEditAI /> : ''}
         {params.subpage == 'usage' ? <OrgEditUsage /> : ''}
+        {params.subpage == 'security' ? <OrgEditSecurity /> : ''}
         {params.subpage == 'other' ? <OrgEditOther /> : ''}
         {params.subpage == 'danger' ? <OrgEditDangerZone /> : ''}
       </motion.div>

--- a/apps/web/components/Contexts/AuthContext.tsx
+++ b/apps/web/components/Contexts/AuthContext.tsx
@@ -69,11 +69,27 @@ export interface SignInResult {
   error: string | null
   url: string | null
   status: number
+  // Set when the password was correct but the account carries a second factor.
+  // `ok` stays false — nothing is authenticated yet — and the caller must hand
+  // `mfa_token` back to completeMfaLogin() along with a code.
+  mfa_required?: boolean
+  mfa_token?: string
 }
 
 export interface SignOutOptions {
   callbackUrl?: string
   redirect?: boolean
+}
+
+// Result of a passwordless (magic link) request. The backend ALWAYS answers 200
+// with a generic `detail` so it never reveals whether the account exists — the
+// UI treats any non-rate-limited answer as "check your email". `rateLimited`
+// carries the 429 case so the caller can show a distinct retry message.
+export interface MagicLinkRequestResult {
+  ok: boolean
+  detail: string
+  rateLimited?: boolean
+  retryAfter?: number
 }
 
 // Session cache for performance (similar to NextAuth's 10s cache)
@@ -99,6 +115,20 @@ interface AuthContextValue {
   refreshSession: (_force?: boolean) => Promise<string | null>
   signIn: (_provider: string, _options?: SignInOptions) => Promise<SignInResult | void>
   signOut: (_options?: SignOutOptions) => Promise<void>
+  completeMfaLogin: (
+    _mfaToken: string,
+    _code: string,
+    _options?: { isBackupCode?: boolean; callbackUrl?: string; redirect?: boolean }
+  ) => Promise<SignInResult>
+  // Passwordless (magic link) login. `requestMagicLink` sends the email; it never
+  // throws on the generic 200. `completeMagicLink` consumes the token from the
+  // link and either establishes a session or (for 2FA accounts) returns an
+  // mfa_token the login page can pick up — mirroring completeMfaLogin.
+  requestMagicLink: (_email: string, _orgSlug?: string) => Promise<MagicLinkRequestResult>
+  completeMagicLink: (
+    _token: string,
+    _options?: { callbackUrl?: string; redirect?: boolean }
+  ) => Promise<SignInResult>
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)
@@ -567,6 +597,219 @@ export function SessionProvider({
     }
   }, [refetchInterval, status, refreshSession, hasSessionMarker])
 
+  // Establish a client-side session from a token-bearing auth response.
+  // Shared by password login and by second-factor completion so the two cannot
+  // drift apart — a session established one way must be identical to the other.
+  const establishSession = useCallback(
+    async (data: any, callbackUrl: string, redirect: boolean): Promise<SignInResult> => {
+      const newSession: Session = {
+        user: data.user,
+        roles: [],
+        tokens: {
+          access_token: data.tokens.access_token,
+          refresh_token: data.tokens.refresh_token,
+          expiry: data.tokens.expiry,
+        },
+      }
+
+      setSession(newSession)
+      setAccessToken(data.tokens.access_token)
+      setTokenExpiry(data.tokens.expiry || null)
+      setStatus('authenticated')
+      sessionCacheRef.current = { data: newSession, timestamp: Date.now() }
+
+      // Fetch full session with roles
+      const fullSession = await fetchUserSession(data.tokens.access_token, data.tokens.expiry)
+      if (fullSession) {
+        fullSession.tokens = newSession.tokens
+        setSession(fullSession)
+        sessionCacheRef.current = { data: fullSession, timestamp: Date.now() }
+      }
+
+      // Notify other tabs
+      broadcastChannelRef.current?.postMessage({ type: 'LOGIN' })
+
+      if (redirect) {
+        window.location.href = safeRedirectUrl(callbackUrl)
+      }
+
+      return { ok: true, error: null, url: callbackUrl, status: 200 }
+    },
+    [fetchUserSession]
+  )
+
+  // Complete a login that stopped at the second-factor challenge.
+  const completeMfaLogin = useCallback(
+    async (
+      mfaToken: string,
+      code: string,
+      options: { isBackupCode?: boolean; callbackUrl?: string; redirect?: boolean } = {}
+    ): Promise<SignInResult> => {
+      const { isBackupCode = false, callbackUrl = '/', redirect = true } = options
+
+      try {
+        const response = await fetch('/api/auth/login/mfa', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            mfa_token: mfaToken,
+            code,
+            is_backup_code: isBackupCode,
+          }),
+          credentials: 'include',
+        })
+
+        const data = await response.json()
+
+        if (!response.ok) {
+          const errorData = data.detail || data
+          return {
+            ok: false,
+            error: JSON.stringify({
+              code: errorData?.code || 'UNKNOWN_ERROR',
+              message: errorData?.message || 'Verification failed',
+              retry_after: errorData?.retry_after,
+            }),
+            url: null,
+            status: response.status,
+          }
+        }
+
+        if (!data.tokens?.access_token) {
+          return {
+            ok: false,
+            error: JSON.stringify({ code: 'INVALID_RESPONSE', message: 'Invalid server response' }),
+            url: null,
+            status: 500,
+          }
+        }
+
+        return await establishSession(data, callbackUrl, redirect)
+      } catch (error) {
+        console.error('MFA verification error:', error)
+        return {
+          ok: false,
+          error: JSON.stringify({ code: 'NETWORK_ERROR', message: 'Could not reach the server' }),
+          url: null,
+          status: 0,
+        }
+      }
+    },
+    [establishSession]
+  )
+
+  // Request a passwordless login link. The backend ALWAYS returns 200 with a
+  // generic detail (never revealing whether the account exists), except for a
+  // 429 rate-limit — so this never throws on the happy path.
+  const requestMagicLink = useCallback(
+    async (email: string, orgSlug?: string): Promise<MagicLinkRequestResult> => {
+      try {
+        const response = await fetch('/api/auth/magic-link/request', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, ...(orgSlug ? { org_slug: orgSlug } : {}) }),
+          credentials: 'include',
+        })
+
+        const data = await response.json().catch(() => ({}))
+
+        if (response.status === 429) {
+          const errorData = data.detail || data
+          return {
+            ok: false,
+            rateLimited: true,
+            detail:
+              errorData?.message ||
+              'Too many requests. Please wait a moment before trying again.',
+            retryAfter: errorData?.retry_after,
+          }
+        }
+
+        return {
+          ok: response.ok,
+          detail:
+            typeof data.detail === 'string'
+              ? data.detail
+              : 'If that account exists, a login link is on its way.',
+        }
+      } catch (error) {
+        console.error('Magic link request error:', error)
+        return { ok: false, detail: 'Could not reach the server. Please try again.' }
+      }
+    },
+    []
+  )
+
+  // Complete a passwordless login from the token embedded in the emailed link.
+  // Mirrors completeMfaLogin: on a 2FA account it hands back an mfa_token instead
+  // of a session; otherwise it runs the same establishSession path as every other
+  // flow. Cookies are set by the /api/auth proxy on the verify response.
+  const completeMagicLink = useCallback(
+    async (
+      token: string,
+      options: { callbackUrl?: string; redirect?: boolean } = {}
+    ): Promise<SignInResult> => {
+      const { callbackUrl = '/', redirect = true } = options
+
+      try {
+        const response = await fetch('/api/auth/magic-link/verify', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token }),
+          credentials: 'include',
+        })
+
+        const data = await response.json()
+
+        if (!response.ok) {
+          const errorData = data.detail || data
+          return {
+            ok: false,
+            error: JSON.stringify({
+              code: errorData?.code || 'UNKNOWN_ERROR',
+              message: errorData?.message || 'This link is no longer valid.',
+            }),
+            url: null,
+            status: response.status,
+          }
+        }
+
+        // Account carries a second factor — no session yet. Hand the pending
+        // token to the caller (the /auth/magic page forwards it to /login).
+        if (data.mfa_required && data.mfa_token) {
+          return {
+            ok: false,
+            error: null,
+            url: null,
+            status: response.status,
+            mfa_required: true,
+            mfa_token: data.mfa_token,
+          }
+        }
+
+        if (!data.tokens?.access_token) {
+          return {
+            ok: false,
+            error: JSON.stringify({ code: 'INVALID_RESPONSE', message: 'Invalid server response' }),
+            url: null,
+            status: 500,
+          }
+        }
+
+        return await establishSession(data, callbackUrl, redirect)
+      } catch (error) {
+        console.error('Magic link verification error:', error)
+        return {
+          ok: false,
+          error: JSON.stringify({ code: 'NETWORK_ERROR', message: 'Could not reach the server' }),
+          url: null,
+          status: 0,
+        }
+      }
+    },
+    [establishSession]
+  )
+
   // Sign in function
   const handleSignIn = useCallback(
     async (provider: string, options: SignInOptions = {}): Promise<SignInResult | void> => {
@@ -641,6 +884,10 @@ export function SessionProvider({
             body: new URLSearchParams({
               username: options.email || '',
               password: options.password || '',
+              // Bind the session to the org whose login page this came from, so
+              // org-scoped session policies can enforce against it. Omitted on the
+              // org-less apex login.
+              ...(options.orgSlug ? { org_slug: options.orgSlug } : {}),
             }),
             credentials: 'include',
           })
@@ -663,6 +910,20 @@ export function SessionProvider({
             }
           }
 
+          // Password was correct but the account has a second factor. No
+          // session exists yet — hand the pending token to the caller, which
+          // collects a code and calls completeMfaLogin().
+          if (data.mfa_required && data.mfa_token) {
+            return {
+              ok: false,
+              error: null,
+              url: null,
+              status: response.status,
+              mfa_required: true,
+              mfa_token: data.mfa_token,
+            }
+          }
+
           // Validate response structure
           if (!data.tokens?.access_token) {
             return {
@@ -673,45 +934,7 @@ export function SessionProvider({
             }
           }
 
-          // Login successful
-          const newSession: Session = {
-            user: data.user,
-            roles: [],
-            tokens: {
-              access_token: data.tokens.access_token,
-              refresh_token: data.tokens.refresh_token,
-              expiry: data.tokens.expiry,
-            },
-          }
-
-          setSession(newSession)
-          setAccessToken(data.tokens.access_token)
-          setTokenExpiry(data.tokens.expiry || null)
-          setStatus('authenticated')
-          sessionCacheRef.current = {
-            data: newSession,
-            timestamp: Date.now(),
-          }
-
-          // Fetch full session with roles
-          const fullSession = await fetchUserSession(data.tokens.access_token, data.tokens.expiry)
-          if (fullSession) {
-            fullSession.tokens = newSession.tokens
-            setSession(fullSession)
-            sessionCacheRef.current = {
-              data: fullSession,
-              timestamp: Date.now(),
-            }
-          }
-
-          // Notify other tabs
-          broadcastChannelRef.current?.postMessage({ type: 'LOGIN' })
-
-          if (redirect) {
-            window.location.href = safeRedirectUrl(callbackUrl)
-          }
-
-          return { ok: true, error: null, url: callbackUrl, status: 200 }
+          return await establishSession(data, callbackUrl, redirect)
         }
 
         if (provider === 'google') {
@@ -790,7 +1013,7 @@ export function SessionProvider({
         }
       }
     },
-    [fetchUserSession]
+    [fetchUserSession, establishSession]
   )
 
   // Sign out function
@@ -899,6 +1122,9 @@ export function SessionProvider({
     refreshSession,
     signIn: handleSignIn,
     signOut: handleSignOut,
+    completeMfaLogin,
+    requestMagicLink,
+    completeMagicLink,
   }
 
   return (
@@ -1088,6 +1314,9 @@ export function useAuth() {
     accessToken: context.accessToken,
     signIn: context.signIn,
     signOut: context.signOut,
+    completeMfaLogin: context.completeMfaLogin,
+    requestMagicLink: context.requestMagicLink,
+    completeMagicLink: context.completeMagicLink,
     refreshSession: context.refreshSession,
     // Convenience method to get valid access token (refreshes if needed)
     getAccessToken: async (): Promise<string | null> => {

--- a/apps/web/components/Dashboard/Pages/Org/OrgEditSecurity/OrgEditSecurity.tsx
+++ b/apps/web/components/Dashboard/Pages/Org/OrgEditSecurity/OrgEditSecurity.tsx
@@ -1,0 +1,1292 @@
+'use client'
+import React from 'react'
+import Link from 'next/link'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'react-hot-toast'
+import { useQueryClient } from '@tanstack/react-query'
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  Clock,
+  ExternalLink,
+  Info,
+  Loader2,
+  RefreshCw,
+  ShieldAlert,
+  ShieldCheck,
+  ShieldOff,
+  Users,
+} from 'lucide-react'
+import { useOrg } from '@components/Contexts/OrgContext'
+import { useLHSession } from '@components/Contexts/LHSessionContext'
+import useAdminStatus from '@components/Hooks/useAdminStatus'
+import { getAPIUrl, getUriWithOrg } from '@services/config/config'
+import {
+  RequestBodyWithAuthHeader,
+  getResponseMetadata,
+  revalidateTags,
+} from '@services/utils/ts/requests'
+import { getErrorMessage } from '@services/utils/ts/errorMessage'
+import { queryKeys } from '@/lib/query/keys'
+import { Switch } from '@components/ui/switch'
+import { Checkbox } from '@components/ui/checkbox'
+import { Button } from '@components/ui/button'
+import { Label } from '@components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@components/ui/select'
+import Modal from '@components/Objects/StyledElements/Modal/Modal'
+
+// ---------------------------------------------------------------------------
+// Types — mirror of the backend payloads (src/routers/mfa.py)
+// ---------------------------------------------------------------------------
+
+type ComplianceMember = {
+  user_id: number
+  email: string | null
+  username: string | null
+  first_name: string | null
+  last_name: string | null
+  signup_method: string | null
+  mfa_enabled: boolean
+  confirmed_at: string | null
+}
+
+type ComplianceResponse = {
+  total: number
+  enabled: number
+  members: ComplianceMember[]
+}
+
+type OrgSecurityPolicy = {
+  require_2fa: boolean
+  require_2fa_grace_days: number
+  require_2fa_enabled_at: string | null
+  exempt_external_auth: boolean
+  // Which sign-in methods this org accepts. The full set = unrestricted.
+  allowed_auth_methods: string[]
+  // When off, a central learnhouse.io session can't carry members into this org.
+  allow_central_session_sharing: boolean
+}
+
+// The CALLING user's own compliance state — context only, not the policy.
+type SelfComplianceState = {
+  required: boolean
+  satisfied: boolean
+  deadline: string | null
+  days_remaining: number | null
+  blocking: boolean
+  exempt_reason: string | null
+}
+
+// Kept in sync with EXTERNAL_AUTH_METHODS in
+// apps/api/src/services/orgs/mfa_policy.py. An unrecognised signup_method is
+// deliberately treated as a local password account, i.e. subject to the policy.
+const EXTERNAL_AUTH_METHODS = [
+  'google',
+  'sso',
+  'saml',
+  'oidc',
+  'workos',
+  'keycloak',
+  'okta',
+  'auth0',
+]
+
+const GRACE_OPTIONS = [0, 7, 14, 30]
+
+// The complete set of sign-in methods. Selecting all of them = unrestricted,
+// which is also what an absent policy falls back to. Kept in sync with the
+// backend's allowed_auth_methods contract.
+const ALL_AUTH_METHODS = ['password', 'magic_login', 'google', 'sso'] as const
+
+const AUTH_METHOD_OPTIONS: {
+  key: string
+  labelKey: string
+  labelDefault: string
+  hintKey: string
+  hintDefault: string
+}[] = [
+  {
+    key: 'password',
+    labelKey: 'dashboard.organization.security.method_password',
+    labelDefault: 'Email + password',
+    hintKey: 'dashboard.organization.security.method_password_hint',
+    hintDefault: 'Sign in with an email address and password.',
+  },
+  {
+    key: 'magic_login',
+    labelKey: 'dashboard.organization.security.method_magic_login',
+    labelDefault: 'Magic login link',
+    hintKey: 'dashboard.organization.security.method_magic_login_hint',
+    hintDefault: 'Sign in through a one-time link sent by email.',
+  },
+  {
+    key: 'google',
+    labelKey: 'dashboard.organization.security.method_google',
+    labelDefault: 'Google',
+    hintKey: 'dashboard.organization.security.method_google_hint',
+    hintDefault: 'Sign in with a Google account.',
+  },
+  {
+    key: 'sso',
+    labelKey: 'dashboard.organization.security.method_sso',
+    labelDefault: 'SSO',
+    hintKey: 'dashboard.organization.security.method_sso_hint',
+    hintDefault: 'Sign in through your configured single sign-on provider.',
+  },
+]
+
+const DEFAULT_POLICY: OrgSecurityPolicy = {
+  require_2fa: false,
+  require_2fa_grace_days: 0,
+  require_2fa_enabled_at: null,
+  exempt_external_auth: true,
+  allowed_auth_methods: [...ALL_AUTH_METHODS],
+  allow_central_session_sharing: true,
+}
+
+// Two string sets are equal regardless of order/dupes.
+const sameMethodSet = (a: string[], b: string[]): boolean => {
+  const sa = new Set(a)
+  const sb = new Set(b)
+  if (sa.size !== sb.size) return false
+  for (const v of sa) if (!sb.has(v)) return false
+  return true
+}
+
+const isExternalAuth = (signup_method: string | null): boolean =>
+  EXTERNAL_AUTH_METHODS.includes((signup_method || '').toLowerCase())
+
+const memberName = (m: ComplianceMember): string => {
+  const full = [m.first_name, m.last_name].filter(Boolean).join(' ').trim()
+  return full || m.username || m.email || `#${m.user_id}`
+}
+
+const formatDate = (value: string | null | undefined): string => {
+  if (!value) return ''
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return String(value)
+  return d.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+const addDays = (days: number): Date => {
+  const d = new Date()
+  d.setDate(d.getDate() + days)
+  return d
+}
+
+// ---------------------------------------------------------------------------
+
+const OrgEditSecurity: React.FC = () => {
+  const { t } = useTranslation()
+  const session = useLHSession() as any
+  const access_token = session?.data?.tokens?.access_token
+  const currentUserId = session?.data?.user?.id
+  const org = useOrg() as any
+  const orgId = org?.id
+  const orgslug = org?.slug
+  const queryClient = useQueryClient()
+  const { canManageOrg } = useAdminStatus()
+
+  // Saved policy — seeded from the org config the page already loads, then kept
+  // authoritative from the PUT response.
+  const savedPolicy: OrgSecurityPolicy = React.useMemo(() => {
+    const security = org?.config?.config?.admin_toggles?.security
+    if (!security) return DEFAULT_POLICY
+    return {
+      require_2fa: !!security.require_2fa,
+      require_2fa_grace_days: Math.max(0, Number(security.require_2fa_grace_days) || 0),
+      require_2fa_enabled_at: security.require_2fa_enabled_at ?? null,
+      exempt_external_auth: security.exempt_external_auth !== false,
+      // Absent → unrestricted (all methods) + central sharing on.
+      allowed_auth_methods: Array.isArray(security.allowed_auth_methods)
+        ? security.allowed_auth_methods
+        : [...ALL_AUTH_METHODS],
+      allow_central_session_sharing: security.allow_central_session_sharing !== false,
+    }
+  }, [org])
+
+  const [policy, setPolicy] = React.useState<OrgSecurityPolicy>(savedPolicy)
+  const [draftRequire, setDraftRequire] = React.useState(savedPolicy.require_2fa)
+  const [draftGrace, setDraftGrace] = React.useState(savedPolicy.require_2fa_grace_days)
+  const [draftExempt, setDraftExempt] = React.useState(savedPolicy.exempt_external_auth)
+  const [draftMethods, setDraftMethods] = React.useState<string[]>(savedPolicy.allowed_auth_methods)
+  const [draftSharing, setDraftSharing] = React.useState(savedPolicy.allow_central_session_sharing)
+
+  // Re-seed once the org config lands (it arrives asynchronously via OrgContext).
+  const seededRef = React.useRef(false)
+  React.useEffect(() => {
+    if (seededRef.current) return
+    if (!org?.config?.config) return
+    seededRef.current = true
+    setPolicy(savedPolicy)
+    setDraftRequire(savedPolicy.require_2fa)
+    setDraftGrace(savedPolicy.require_2fa_grace_days)
+    setDraftExempt(savedPolicy.exempt_external_auth)
+    setDraftMethods(savedPolicy.allowed_auth_methods)
+    setDraftSharing(savedPolicy.allow_central_session_sharing)
+  }, [org, savedPolicy])
+
+  const [compliance, setCompliance] = React.useState<ComplianceResponse | null>(null)
+  const [selfState, setSelfState] = React.useState<SelfComplianceState | null>(null)
+  const [loading, setLoading] = React.useState(true)
+  const [loadError, setLoadError] = React.useState<string | null>(null)
+  const [forbidden, setForbidden] = React.useState(false)
+
+  const [saving, setSaving] = React.useState(false)
+  const [saveError, setSaveError] = React.useState<string | null>(null)
+  // Set when the backend refuses because the admin has no second factor of
+  // their own — drives the "enable it on your account first" call to action.
+  const [needsOwnMfa, setNeedsOwnMfa] = React.useState(false)
+  const [confirmOpen, setConfirmOpen] = React.useState(false)
+  const [showAllMembers, setShowAllMembers] = React.useState(false)
+
+  // Same call shape as the account-level two-factor section: getAPIUrl() +
+  // RequestBodyWithAuthHeader + getResponseMetadata. Deliberately NOT apiFetch —
+  // its errorHandling() turns a 401 into a global "session expired" event, and
+  // we want to read the structured `detail.code` on 403 ourselves.
+  const mfaFetch = React.useCallback(
+    async (path: string, method: 'GET' | 'PUT' | 'POST', body?: any) => {
+      const result = await fetch(
+        `${getAPIUrl()}auth/mfa${path}`,
+        RequestBodyWithAuthHeader(method, body ?? null, null, access_token)
+      )
+      return getResponseMetadata(result)
+    },
+    [access_token]
+  )
+
+  // Admin recovery state: clear a member's factor so they can re-enroll (lost
+  // device, no backup codes). Handler defined after loadData (below).
+  const [confirmResetId, setConfirmResetId] = React.useState<number | null>(null)
+  const [resettingId, setResettingId] = React.useState<number | null>(null)
+  const [resetError, setResetError] = React.useState<string | null>(null)
+
+  const loadData = React.useCallback(async () => {
+    if (!access_token || !orgId) return
+    setLoading(true)
+    setLoadError(null)
+    try {
+      const [complianceRes, selfRes] = await Promise.all([
+        mfaFetch(`/org-compliance/${orgId}`, 'GET'),
+        mfaFetch(`/org-policy/${orgId}`, 'GET'),
+      ])
+
+      if (complianceRes.success) {
+        setCompliance(complianceRes.data as ComplianceResponse)
+        setForbidden(false)
+      } else {
+        if (complianceRes.status === 403) setForbidden(true)
+        setLoadError(
+          getErrorMessage(
+            complianceRes.data?.detail,
+            t('dashboard.organization.security.load_error', {
+              defaultValue: 'Could not load your organization’s two-factor status.',
+            })
+          )
+        )
+      }
+
+      // The caller's own state is context, not the policy — a failure here must
+      // not blank the page.
+      if (selfRes.success) setSelfState(selfRes.data as SelfComplianceState)
+    } catch {
+      setLoadError(
+        t('dashboard.organization.security.load_error', {
+          defaultValue: 'Could not load your organization’s two-factor status.',
+        })
+      )
+    } finally {
+      setLoading(false)
+    }
+  }, [access_token, orgId, mfaFetch, t])
+
+  React.useEffect(() => {
+    loadData()
+  }, [loadData])
+
+  // Two-click confirm on the row; never resets your own factor here (the backend
+  // rejects self-reset — use the code-gated disable flow instead).
+  const handleResetMember = React.useCallback(
+    async (userId: number) => {
+      if (confirmResetId !== userId) {
+        setConfirmResetId(userId)
+        setResetError(null)
+        return
+      }
+      setResettingId(userId)
+      setResetError(null)
+      try {
+        const res = await mfaFetch(`/org-reset/${orgId}/${userId}`, 'POST')
+        if (!res.success) {
+          setResetError(
+            getErrorMessage(res.data?.detail, t('dashboard.organization.security.reset_error', {
+              defaultValue: 'Could not reset this member’s two-factor.',
+            }))
+          )
+        } else {
+          await loadData()
+        }
+      } catch {
+        setResetError(
+          t('dashboard.organization.security.reset_error', {
+            defaultValue: 'Could not reset this member’s two-factor.',
+          })
+        )
+      } finally {
+        setResettingId(null)
+        setConfirmResetId(null)
+      }
+    },
+    [confirmResetId, mfaFetch, orgId, loadData, t]
+  )
+
+  // --- derived numbers -----------------------------------------------------
+
+  const members = React.useMemo(() => compliance?.members ?? [], [compliance])
+  const total = compliance?.total ?? 0
+  const enabled = compliance?.enabled ?? 0
+  const percent = total > 0 ? Math.round((enabled / total) * 100) : 0
+
+  const notEnrolled = React.useMemo(
+    () => members.filter((m) => !m.mfa_enabled),
+    [members]
+  )
+  const exemptMembers = React.useMemo(
+    () => (draftExempt ? notEnrolled.filter((m) => isExternalAuth(m.signup_method)) : []),
+    [notEnrolled, draftExempt]
+  )
+  // The number the admin actually cares about.
+  const blockedMembers = React.useMemo(
+    () => notEnrolled.filter((m) => !(draftExempt && isExternalAuth(m.signup_method))),
+    [notEnrolled, draftExempt]
+  )
+
+  // Does the calling admin have two-factor on their own account? The backend
+  // refuses to switch the policy on otherwise, so we warn before they try.
+  const adminHasOwnMfa = React.useMemo(() => {
+    if (!currentUserId || members.length === 0) return null
+    const me = members.find((m) => String(m.user_id) === String(currentUserId))
+    return me ? me.mfa_enabled : null
+  }, [members, currentUserId])
+
+  const isDirty =
+    draftRequire !== policy.require_2fa ||
+    draftGrace !== policy.require_2fa_grace_days ||
+    draftExempt !== policy.exempt_external_auth ||
+    !sameMethodSet(draftMethods, policy.allowed_auth_methods) ||
+    draftSharing !== policy.allow_central_session_sharing
+
+  const toggleMethod = (key: string, checked: boolean) => {
+    setSaveError(null)
+    setNeedsOwnMfa(false)
+    setDraftMethods((prev) =>
+      checked ? Array.from(new Set([...prev, key])) : prev.filter((m) => m !== key)
+    )
+  }
+
+  const isTurningOn = draftRequire && !policy.require_2fa
+
+  const accountSecurityHref = getUriWithOrg(orgslug || '', '/account/security')
+
+  // --- save ----------------------------------------------------------------
+
+  const persist = React.useCallback(async () => {
+    if (!orgId) return
+    setSaving(true)
+    setSaveError(null)
+    setNeedsOwnMfa(false)
+    const loadingToast = toast.loading(
+      t('dashboard.organization.security.saving', { defaultValue: 'Saving security policy…' })
+    )
+    try {
+      const res = await mfaFetch(`/org-policy/${orgId}`, 'PUT', {
+        require_2fa: draftRequire,
+        require_2fa_grace_days: draftGrace,
+        exempt_external_auth: draftExempt,
+        allowed_auth_methods: draftMethods,
+        allow_central_session_sharing: draftSharing,
+      })
+
+      if (!res.success) {
+        const code = res.data?.detail?.code
+        const message = getErrorMessage(
+          res.data?.detail,
+          t('dashboard.organization.security.save_error', {
+            defaultValue: 'Could not save the security policy.',
+          })
+        )
+        if (code === 'ADMIN_MFA_REQUIRED_FIRST') setNeedsOwnMfa(true)
+        setSaveError(message)
+        toast.error(message, { id: loadingToast })
+        return
+      }
+
+      const raw = res.data as Partial<OrgSecurityPolicy>
+      // Normalize against the contract: an omitted methods list / sharing flag
+      // means unrestricted + sharing on.
+      const next: OrgSecurityPolicy = {
+        require_2fa: !!raw.require_2fa,
+        require_2fa_grace_days: Math.max(0, Number(raw.require_2fa_grace_days) || 0),
+        require_2fa_enabled_at: raw.require_2fa_enabled_at ?? null,
+        exempt_external_auth: raw.exempt_external_auth !== false,
+        allowed_auth_methods: Array.isArray(raw.allowed_auth_methods)
+          ? raw.allowed_auth_methods
+          : [...ALL_AUTH_METHODS],
+        allow_central_session_sharing: raw.allow_central_session_sharing !== false,
+      }
+      setPolicy(next)
+      setDraftRequire(next.require_2fa)
+      setDraftGrace(next.require_2fa_grace_days)
+      setDraftExempt(next.exempt_external_auth)
+      setDraftMethods(next.allowed_auth_methods)
+      setDraftSharing(next.allow_central_session_sharing)
+      setConfirmOpen(false)
+
+      if (orgslug) await revalidateTags(['organizations'], orgslug)
+      if (orgslug) queryClient.invalidateQueries({ queryKey: queryKeys.org.detail(orgslug) })
+      toast.success(
+        t('dashboard.organization.security.save_success', {
+          defaultValue: 'Security policy updated',
+        }),
+        { id: loadingToast }
+      )
+      loadData()
+    } catch {
+      const message = t('dashboard.organization.security.save_error', {
+        defaultValue: 'Could not save the security policy.',
+      })
+      setSaveError(message)
+      toast.error(message, { id: loadingToast })
+    } finally {
+      setSaving(false)
+    }
+  }, [orgId, orgslug, draftRequire, draftGrace, draftExempt, draftMethods, draftSharing, mfaFetch, t, queryClient, loadData])
+
+  const handleSaveClick = () => {
+    // Turning the requirement ON is never one click — it can lock staff out.
+    if (isTurningOn) {
+      setConfirmOpen(true)
+      return
+    }
+    persist()
+  }
+
+  // --- states --------------------------------------------------------------
+
+  if (!orgId) return null
+
+  if (loading) {
+    return (
+      <div className="sm:mx-10 mx-0 space-y-4">
+        <div className="bg-white rounded-xl nice-shadow p-6 animate-pulse space-y-4">
+          <div className="h-4 w-48 bg-gray-200 rounded" />
+          <div className="h-2 w-full bg-gray-100 rounded-full" />
+          <div className="h-3 w-64 bg-gray-100 rounded" />
+        </div>
+        <div className="bg-white rounded-xl nice-shadow p-6 animate-pulse space-y-3">
+          {[0, 1, 2, 3].map((i) => (
+            <div key={i} className="h-10 bg-gray-50 rounded-lg" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <div className="sm:mx-10 mx-0">
+        <div className="bg-white rounded-xl nice-shadow p-6 flex items-start gap-3">
+          <ShieldOff className="w-5 h-5 text-gray-400 shrink-0 mt-0.5" />
+          <div>
+            <h2 className="font-semibold text-gray-800">
+              {t('dashboard.organization.security.not_admin_title', {
+                defaultValue: 'You don’t have access to this setting',
+              })}
+            </h2>
+            <p className="text-sm text-gray-500 mt-1">
+              {t('dashboard.organization.security.not_admin_body', {
+                defaultValue:
+                  'Only organization admins can view or change the two-factor requirement.',
+              })}
+            </p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (loadError && !compliance) {
+    return (
+      <div className="sm:mx-10 mx-0">
+        <div className="bg-white rounded-xl nice-shadow p-6 flex items-start gap-3">
+          <AlertTriangle className="w-5 h-5 text-red-500 shrink-0 mt-0.5" />
+          <div className="grow">
+            <h2 className="font-semibold text-gray-800">
+              {t('dashboard.organization.security.load_error_title', {
+                defaultValue: 'Something went wrong',
+              })}
+            </h2>
+            <p className="text-sm text-gray-500 mt-1">{loadError}</p>
+            <Button
+              type="button"
+              onClick={loadData}
+              className="mt-4 bg-black text-white hover:bg-black/90"
+            >
+              <RefreshCw className="w-4 h-4 mr-2" />
+              {t('dashboard.organization.security.retry', { defaultValue: 'Retry' })}
+            </Button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const readOnly = canManageOrg !== true
+  const controlsDisabled = saving || readOnly
+
+  return (
+    <div className="sm:mx-10 mx-0 space-y-4 pb-10">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <div className="p-2 rounded-lg bg-gray-100 text-gray-700">
+          <ShieldCheck className="w-5 h-5" />
+        </div>
+        <div>
+          <h1 className="font-bold text-lg text-gray-800">
+            {t('dashboard.organization.security.title', { defaultValue: 'Security' })}
+          </h1>
+          <p className="text-sm text-gray-500">
+            {t('dashboard.organization.security.subtitle', {
+              defaultValue:
+                'Require two-factor authentication for everyone in this organization.',
+            })}
+          </p>
+        </div>
+      </div>
+
+      {readOnly && (
+        <div className="flex items-center gap-3 px-4 py-3 rounded-xl bg-amber-50 border border-amber-200/80">
+          <ShieldAlert className="w-4 h-4 text-amber-600 shrink-0" />
+          <p className="text-sm text-amber-800">
+            {t('dashboard.organization.security.read_only', {
+              defaultValue:
+                'You can review this page, but only an organization admin can change the policy.',
+            })}
+          </p>
+        </div>
+      )}
+
+      {/* ------------------------------------------------------------------ */}
+      {/* 1. Compliance summary — deliberately ABOVE the toggle. Switching the */}
+      {/*    policy on without reading this is how an org locks out its staff. */}
+      {/* ------------------------------------------------------------------ */}
+      <div className="bg-white rounded-xl nice-shadow p-5 space-y-4">
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <div>
+            <h2 className="font-bold text-gray-800">
+              {t('dashboard.organization.security.compliance_title', {
+                defaultValue: 'Two-factor coverage',
+              })}
+            </h2>
+            <p className="text-sm text-gray-500 mt-0.5">
+              {t('dashboard.organization.security.compliance_count', {
+                defaultValue: '{{enabled}} of {{total}} members have two-factor enabled',
+                enabled,
+                total,
+              })}
+            </p>
+          </div>
+          <div className="text-right">
+            <div className="text-2xl font-bold tracking-tight text-gray-800">{percent}%</div>
+            <button
+              type="button"
+              onClick={loadData}
+              disabled={loading}
+              className="text-xs text-gray-400 hover:text-gray-600 inline-flex items-center gap-1 disabled:opacity-40"
+            >
+              <RefreshCw className="w-3 h-3" />
+              {t('dashboard.organization.security.refresh', { defaultValue: 'Refresh' })}
+            </button>
+          </div>
+        </div>
+
+        {/* Progress indicator */}
+        <div
+          className="h-2 w-full bg-gray-100 rounded-full overflow-hidden"
+          role="progressbar"
+          aria-valuenow={percent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <div
+            className={`h-full rounded-full transition-all ${
+              percent === 100 ? 'bg-green-500' : percent >= 50 ? 'bg-amber-500' : 'bg-red-500'
+            }`}
+            style={{ width: `${percent}%` }}
+          />
+        </div>
+
+        {/* The three numbers that matter */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <StatTile
+            tone="green"
+            icon={<CheckCircle2 className="w-4 h-4" />}
+            value={enabled}
+            label={t('dashboard.organization.security.stat_enrolled', {
+              defaultValue: 'Enrolled',
+            })}
+          />
+          <StatTile
+            tone="blue"
+            icon={<ExternalLink className="w-4 h-4" />}
+            value={exemptMembers.length}
+            label={t('dashboard.organization.security.stat_exempt', {
+              defaultValue: 'Exempt (external sign-in)',
+            })}
+          />
+          <StatTile
+            tone={blockedMembers.length > 0 ? 'red' : 'gray'}
+            icon={<ShieldOff className="w-4 h-4" />}
+            value={blockedMembers.length}
+            label={t('dashboard.organization.security.stat_blocked', {
+              defaultValue: 'Would be blocked',
+            })}
+          />
+        </div>
+
+        {blockedMembers.length > 0 && (
+          <p className="text-xs text-gray-500 leading-relaxed">
+            {t('dashboard.organization.security.blocked_hint', {
+              defaultValue:
+                'Review this list before switching the requirement on — these are the people who lose access to this organization if they don’t enroll in time.',
+            })}
+          </p>
+        )}
+
+        {loadError && compliance && (
+          <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200/80 rounded-lg px-3 py-2">
+            {loadError}
+          </p>
+        )}
+      </div>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* 2. Member list                                                      */}
+      {/* ------------------------------------------------------------------ */}
+      <div className="bg-white rounded-xl nice-shadow overflow-hidden">
+        <div className="flex items-center gap-2 px-5 py-3 border-b border-gray-100">
+          <Users className="w-4 h-4 text-gray-400" />
+          <h2 className="font-bold text-gray-800">
+            {t('dashboard.organization.security.members_title', { defaultValue: 'Members' })}
+          </h2>
+          <span className="text-xs text-gray-400">
+            {t('dashboard.organization.security.members_sorted', {
+              defaultValue: 'not enrolled first',
+            })}
+          </span>
+        </div>
+
+        {resetError && (
+          <div className="px-5 py-2.5 text-xs text-red-600 bg-red-50 border-b border-red-100">
+            {resetError}
+          </div>
+        )}
+
+        {members.length === 0 ? (
+          <div className="px-5 py-10 text-center">
+            <Users className="w-6 h-6 text-gray-300 mx-auto" />
+            <p className="text-sm text-gray-500 mt-2">
+              {t('dashboard.organization.security.members_empty', {
+                defaultValue: 'No members in this organization yet.',
+              })}
+            </p>
+          </div>
+        ) : (
+          <>
+            <ul className="divide-y divide-gray-50">
+              {(showAllMembers ? members : members.slice(0, 8)).map((m) => {
+                const exempt = !m.mfa_enabled && draftExempt && isExternalAuth(m.signup_method)
+                return (
+                  <li
+                    key={m.user_id}
+                    className="flex items-center justify-between gap-4 px-5 py-3"
+                  >
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium text-gray-800 truncate">
+                        {memberName(m)}
+                        {String(m.user_id) === String(currentUserId) && (
+                          <span className="ml-2 text-[11px] font-medium text-gray-400">
+                            {t('dashboard.organization.security.you', { defaultValue: 'you' })}
+                          </span>
+                        )}
+                      </div>
+                      <div className="text-xs text-gray-400 truncate">{m.email}</div>
+                    </div>
+                    <div className="shrink-0 flex items-center gap-2">
+                      {m.mfa_enabled ? (
+                        <Badge tone="green" icon={<CheckCircle2 className="w-3 h-3" />}>
+                          {t('dashboard.organization.security.badge_enrolled', {
+                            defaultValue: 'Enrolled',
+                          })}
+                        </Badge>
+                      ) : exempt ? (
+                        <Badge tone="blue" icon={<ExternalLink className="w-3 h-3" />}>
+                          {t('dashboard.organization.security.badge_exempt', {
+                            defaultValue: 'Exempt — {{method}}',
+                            method: m.signup_method || 'external',
+                          })}
+                        </Badge>
+                      ) : (
+                        <Badge tone="red" icon={<ShieldOff className="w-3 h-3" />}>
+                          {t('dashboard.organization.security.badge_not_enrolled', {
+                            defaultValue: 'Not enrolled',
+                          })}
+                        </Badge>
+                      )}
+                      {m.mfa_enabled && String(m.user_id) !== String(currentUserId) && (
+                        <button
+                          type="button"
+                          disabled={resettingId === m.user_id}
+                          onClick={() => handleResetMember(m.user_id)}
+                          onBlur={() => confirmResetId === m.user_id && setConfirmResetId(null)}
+                          className={`text-[11px] font-medium px-2 py-1 rounded-md transition-colors disabled:opacity-50 ${
+                            confirmResetId === m.user_id
+                              ? 'bg-red-100 text-red-700 hover:bg-red-200'
+                              : 'text-gray-400 hover:text-red-600 hover:bg-red-50'
+                          }`}
+                          title={t('dashboard.organization.security.reset_hint', {
+                            defaultValue: 'Clear this member’s two-factor so they can set it up again',
+                          })}
+                        >
+                          {resettingId === m.user_id
+                            ? t('dashboard.organization.security.resetting', { defaultValue: 'Resetting…' })
+                            : confirmResetId === m.user_id
+                              ? t('dashboard.organization.security.reset_confirm', { defaultValue: 'Confirm reset?' })
+                              : t('dashboard.organization.security.reset_2fa', { defaultValue: 'Reset 2FA' })}
+                        </button>
+                      )}
+                    </div>
+                  </li>
+                )
+              })}
+            </ul>
+            {members.length > 8 && (
+              <button
+                type="button"
+                onClick={() => setShowAllMembers((v) => !v)}
+                className="w-full px-5 py-2.5 text-xs font-medium text-gray-500 hover:text-gray-700 hover:bg-gray-50 inline-flex items-center justify-center gap-1 border-t border-gray-50"
+              >
+                {showAllMembers ? (
+                  <>
+                    <ChevronUp className="w-3.5 h-3.5" />
+                    {t('dashboard.organization.security.show_less', {
+                      defaultValue: 'Show less',
+                    })}
+                  </>
+                ) : (
+                  <>
+                    <ChevronDown className="w-3.5 h-3.5" />
+                    {t('dashboard.organization.security.show_all', {
+                      defaultValue: 'Show all {{count}} members',
+                      count: members.length,
+                    })}
+                  </>
+                )}
+              </button>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* 3. The policy itself                                                */}
+      {/* ------------------------------------------------------------------ */}
+      <div className="bg-white rounded-xl nice-shadow p-5 space-y-5">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <h2 className="font-bold text-gray-800">
+              {t('dashboard.organization.security.policy_title', {
+                defaultValue: 'Require two-factor authentication',
+              })}
+            </h2>
+            <p className="text-sm text-gray-500 mt-0.5 max-w-2xl leading-relaxed">
+              {t('dashboard.organization.security.policy_description', {
+                defaultValue:
+                  'Members without a second factor are blocked from this organization once their grace period ends. They keep their account and any other organization they belong to, and regain access the moment they enroll.',
+              })}
+            </p>
+          </div>
+          <Switch
+            checked={draftRequire}
+            onCheckedChange={(checked) => {
+              setDraftRequire(checked)
+              setSaveError(null)
+              setNeedsOwnMfa(false)
+            }}
+            disabled={controlsDisabled}
+            className="shrink-0 mt-1"
+            aria-label={t('dashboard.organization.security.policy_title', {
+              defaultValue: 'Require two-factor authentication',
+            })}
+          />
+        </div>
+
+        {/* Active-policy context */}
+        {policy.require_2fa && (
+          <div className="rounded-lg bg-gray-50 border border-gray-100 px-4 py-3 space-y-1">
+            <div className="flex items-center gap-2 text-sm text-gray-700">
+              <Clock className="w-4 h-4 text-gray-400 shrink-0" />
+              <span>
+                {policy.require_2fa_enabled_at
+                  ? t('dashboard.organization.security.active_since', {
+                      defaultValue: 'Policy active since {{date}}',
+                      date: formatDate(policy.require_2fa_enabled_at),
+                    })
+                  : t('dashboard.organization.security.active_no_date', {
+                      defaultValue: 'Policy is active',
+                    })}
+              </span>
+            </div>
+            <p className="text-xs text-gray-500 leading-relaxed pl-6">
+              {t('dashboard.organization.security.no_restart_note', {
+                defaultValue:
+                  'Saving changes to an already-active policy does not restart anyone’s countdown — existing deadlines stay anchored to the date above. The countdown only resets if you turn the requirement off and back on.',
+              })}
+            </p>
+          </div>
+        )}
+
+        {/* Grace period */}
+        <div className="max-w-sm">
+          <Label htmlFor="grace-period">
+            {t('dashboard.organization.security.grace_label', {
+              defaultValue: 'Grace period',
+            })}
+          </Label>
+          <Select
+            value={String(draftGrace)}
+            onValueChange={(value) => setDraftGrace(Number(value))}
+            disabled={controlsDisabled || !draftRequire}
+          >
+            <SelectTrigger id="grace-period">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {GRACE_OPTIONS.map((days) => (
+                <SelectItem key={days} value={String(days)}>
+                  {days === 0
+                    ? t('dashboard.organization.security.grace_immediately', {
+                        defaultValue: 'Immediately',
+                      })
+                    : t('dashboard.organization.security.grace_days', {
+                        defaultValue: '{{count}} days',
+                        count: days,
+                      })}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-gray-500 mt-1.5 leading-relaxed">
+            {draftGrace === 0
+              ? t('dashboard.organization.security.grace_hint_immediate', {
+                  defaultValue:
+                    'Members without two-factor are blocked as soon as the policy is saved.',
+                })
+              : t('dashboard.organization.security.grace_hint_days', {
+                  defaultValue:
+                    'Members get {{count}} days to enroll before they are blocked. New members get the same window from the day they join.',
+                  count: draftGrace,
+                })}
+          </p>
+        </div>
+
+        {/* External-auth exemption */}
+        <div className="flex items-start gap-3">
+          <Checkbox
+            id="exempt-external-auth"
+            checked={draftExempt}
+            onCheckedChange={(checked) => setDraftExempt(checked === true)}
+            disabled={controlsDisabled}
+            className="mt-0.5"
+          />
+          <div className="space-y-0.5">
+            <Label htmlFor="exempt-external-auth" className="cursor-pointer">
+              {t('dashboard.organization.security.exempt_label', {
+                defaultValue: 'Exempt users who sign in via Google or SSO',
+              })}
+            </Label>
+            <p className="text-xs text-gray-500 leading-relaxed max-w-xl">
+              {t('dashboard.organization.security.exempt_hint', {
+                defaultValue:
+                  'Their identity provider already handles multi-factor, so asking them for a second factor here adds nothing.',
+              })}
+            </p>
+          </div>
+        </div>
+
+        {/* ---------------------------------------------------------------- */}
+        {/* Allowed sign-in methods + central session sharing.               */}
+        {/* Part of the SAME policy save below.                              */}
+        {/* ---------------------------------------------------------------- */}
+        <div className="pt-1 border-t border-gray-100 space-y-4">
+          <div>
+            <h3 className="font-bold text-gray-800">
+              {t('dashboard.organization.security.methods_title', {
+                defaultValue: 'Allowed sign-in methods',
+              })}
+            </h3>
+            <p className="text-sm text-gray-500 mt-0.5 max-w-2xl leading-relaxed">
+              {t('dashboard.organization.security.methods_description', {
+                defaultValue:
+                  'Choose how members are allowed to sign in to this organization. Leave every method checked to keep sign-in unrestricted.',
+              })}
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {AUTH_METHOD_OPTIONS.map((m) => {
+              const checked = draftMethods.includes(m.key)
+              return (
+                <div key={m.key} className="flex items-start gap-3">
+                  <Checkbox
+                    id={`auth-method-${m.key}`}
+                    checked={checked}
+                    onCheckedChange={(value) => toggleMethod(m.key, value === true)}
+                    disabled={controlsDisabled}
+                    className="mt-0.5"
+                  />
+                  <div className="space-y-0.5">
+                    <Label htmlFor={`auth-method-${m.key}`} className="cursor-pointer">
+                      {t(m.labelKey, { defaultValue: m.labelDefault })}
+                    </Label>
+                    <p className="text-xs text-gray-500 leading-relaxed">
+                      {t(m.hintKey, { defaultValue: m.hintDefault })}
+                    </p>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+
+          {draftMethods.length === 0 && (
+            <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200/80 rounded-lg px-3 py-2">
+              {t('dashboard.organization.security.methods_empty_warning', {
+                defaultValue:
+                  'With no method selected, no one could sign in to this organization. Pick at least one.',
+              })}
+            </p>
+          )}
+
+          {/* Central session sharing */}
+          <div className="flex items-start justify-between gap-4 pt-1">
+            <div className="min-w-0">
+              <Label htmlFor="central-session-sharing" className="cursor-pointer">
+                {t('dashboard.organization.security.session_sharing_label', {
+                  defaultValue: 'Allow sharing sessions with learnhouse.io',
+                })}
+              </Label>
+              <p className="text-xs text-gray-500 mt-0.5 leading-relaxed max-w-xl">
+                {t('dashboard.organization.security.session_sharing_hint', {
+                  defaultValue:
+                    'When off, signing in at learnhouse.io won’t let members into this org — they must sign in again from this org’s login page using an allowed method.',
+                })}
+              </p>
+            </div>
+            <Switch
+              id="central-session-sharing"
+              checked={draftSharing}
+              onCheckedChange={(checked) => {
+                setDraftSharing(checked)
+                setSaveError(null)
+                setNeedsOwnMfa(false)
+              }}
+              disabled={controlsDisabled}
+              className="shrink-0 mt-1"
+              aria-label={t('dashboard.organization.security.session_sharing_label', {
+                defaultValue: 'Allow sharing sessions with learnhouse.io',
+              })}
+            />
+          </div>
+        </div>
+
+        {/* Self-lockout warning: the backend refuses the change anyway. */}
+        {draftRequire && adminHasOwnMfa === false && !needsOwnMfa && (
+          <AdminMfaCallout href={accountSecurityHref} />
+        )}
+
+        {/* The backend's ADMIN_MFA_REQUIRED_FIRST refusal. */}
+        {needsOwnMfa && <AdminMfaCallout href={accountSecurityHref} message={saveError} />}
+
+        {saveError && !needsOwnMfa && (
+          <div className="flex items-start gap-2 rounded-lg bg-red-50 border border-red-200/80 px-4 py-3">
+            <AlertTriangle className="w-4 h-4 text-red-500 shrink-0 mt-0.5" />
+            <p className="text-sm text-red-700">{saveError}</p>
+          </div>
+        )}
+
+        {/* Your own compliance state — context for the admin. */}
+        {selfState?.required && !selfState.satisfied && (
+          <div className="flex items-start gap-2 rounded-lg bg-amber-50 border border-amber-200/80 px-4 py-3">
+            <Info className="w-4 h-4 text-amber-600 shrink-0 mt-0.5" />
+            <p className="text-sm text-amber-800">
+              {selfState.blocking
+                ? t('dashboard.organization.security.self_blocking', {
+                    defaultValue:
+                      'Your own deadline has passed. Enroll now to keep access to this organization.',
+                  })
+                : t('dashboard.organization.security.self_days_left', {
+                    defaultValue:
+                      'You have {{count}} days left to enroll in two-factor yourself.',
+                    count: selfState.days_remaining ?? 0,
+                  })}
+            </p>
+          </div>
+        )}
+
+        <div className="flex flex-row-reverse items-center gap-3 pt-1">
+          <Button
+            type="button"
+            onClick={handleSaveClick}
+            disabled={controlsDisabled || !isDirty}
+            className="bg-black text-white hover:bg-black/90"
+          >
+            {saving && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+            {saving
+              ? t('dashboard.organization.security.saving_short', { defaultValue: 'Saving…' })
+              : t('dashboard.organization.security.save', { defaultValue: 'Save changes' })}
+          </Button>
+          {isDirty && !saving && (
+            <button
+              type="button"
+              onClick={() => {
+                setDraftRequire(policy.require_2fa)
+                setDraftGrace(policy.require_2fa_grace_days)
+                setDraftExempt(policy.exempt_external_auth)
+                setDraftMethods(policy.allowed_auth_methods)
+                setDraftSharing(policy.allow_central_session_sharing)
+                setSaveError(null)
+                setNeedsOwnMfa(false)
+              }}
+              className="text-sm text-gray-500 hover:text-gray-700"
+            >
+              {t('dashboard.organization.security.cancel', { defaultValue: 'Cancel' })}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Confirmation step for off -> on. Never a one-click accident.        */}
+      {/* ------------------------------------------------------------------ */}
+      <Modal
+        isDialogOpen={confirmOpen}
+        onOpenChange={(open) => {
+          if (!saving) setConfirmOpen(open)
+        }}
+        minWidth="sm"
+        customWidth="sm:max-w-[640px]"
+        dialogTitle={t('dashboard.organization.security.confirm_title', {
+          defaultValue: 'Require two-factor for everyone?',
+        })}
+        dialogContent={
+          <div className="space-y-4 tracking-tight">
+            <div className="flex items-start gap-3 rounded-xl bg-red-50 border border-red-200/80 px-4 py-3">
+              <AlertTriangle className="w-5 h-5 text-red-600 shrink-0 mt-0.5" />
+              <div className="text-sm text-red-800 leading-relaxed">
+                {blockedMembers.length === 0 ? (
+                  t('dashboard.organization.security.confirm_none', {
+                    defaultValue:
+                      'Everyone in this organization either has two-factor enabled or is exempt. No one loses access.',
+                  })
+                ) : draftGrace === 0 ? (
+                  <span>
+                    {t('dashboard.organization.security.confirm_immediate', {
+                      defaultValue:
+                        '{{count}} of {{total}} members will lose access to this organization immediately, as soon as you save.',
+                      count: blockedMembers.length,
+                      total,
+                    })}
+                  </span>
+                ) : (
+                  <span>
+                    {t('dashboard.organization.security.confirm_deadline', {
+                      defaultValue:
+                        '{{count}} of {{total}} members will lose access to this organization on {{date}} unless they enable two-factor before then.',
+                      count: blockedMembers.length,
+                      total,
+                      date: formatDate(addDays(draftGrace).toISOString()),
+                    })}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            {blockedMembers.length > 0 && (
+              <div className="rounded-xl border border-gray-100 overflow-hidden">
+                <div className="px-4 py-2 bg-gray-50 text-xs font-medium text-gray-500">
+                  {t('dashboard.organization.security.confirm_list_title', {
+                    defaultValue: 'Who is affected',
+                  })}
+                </div>
+                <ul className="max-h-48 overflow-y-auto divide-y divide-gray-50">
+                  {blockedMembers.map((m) => (
+                    <li key={m.user_id} className="px-4 py-2">
+                      <div className="text-sm text-gray-800 truncate">{memberName(m)}</div>
+                      <div className="text-xs text-gray-400 truncate">{m.email}</div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {exemptMembers.length > 0 && (
+              <p className="text-xs text-gray-500 leading-relaxed">
+                {t('dashboard.organization.security.confirm_exempt_note', {
+                  defaultValue:
+                    '{{count}} members are exempt because they sign in through an external identity provider.',
+                  count: exemptMembers.length,
+                })}
+              </p>
+            )}
+
+            <p className="text-xs text-gray-500 leading-relaxed">
+              {t('dashboard.organization.security.confirm_reversible', {
+                defaultValue:
+                  'This is reversible: turning the requirement off restores access immediately.',
+              })}
+            </p>
+
+            <div className="flex flex-row-reverse gap-3 pt-1">
+              <Button
+                type="button"
+                onClick={persist}
+                disabled={saving}
+                className="bg-red-600 text-white hover:bg-red-700"
+              >
+                {saving && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+                {t('dashboard.organization.security.confirm_button', {
+                  defaultValue: 'Yes, require two-factor',
+                })}
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                disabled={saving}
+                onClick={() => setConfirmOpen(false)}
+              >
+                {t('dashboard.organization.security.cancel', { defaultValue: 'Cancel' })}
+              </Button>
+            </div>
+          </div>
+        }
+      />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Small presentational helpers
+// ---------------------------------------------------------------------------
+
+const TILE_TONES: Record<string, string> = {
+  green: 'bg-green-50 text-green-700 border-green-100',
+  blue: 'bg-blue-50 text-blue-700 border-blue-100',
+  red: 'bg-red-50 text-red-700 border-red-100',
+  gray: 'bg-gray-50 text-gray-600 border-gray-100',
+}
+
+function StatTile({
+  tone,
+  icon,
+  value,
+  label,
+}: {
+  tone: 'green' | 'blue' | 'red' | 'gray'
+  icon: React.ReactNode
+  value: number
+  label: string
+}) {
+  return (
+    <div className={`rounded-xl border px-4 py-3 ${TILE_TONES[tone]}`}>
+      <div className="flex items-center gap-2">
+        {icon}
+        <span className="text-xl font-bold tracking-tight">{value}</span>
+      </div>
+      <div className="text-xs mt-0.5 opacity-80">{label}</div>
+    </div>
+  )
+}
+
+const BADGE_TONES: Record<string, string> = {
+  green: 'bg-green-50 text-green-700',
+  blue: 'bg-blue-50 text-blue-700',
+  red: 'bg-red-50 text-red-700',
+}
+
+function Badge({
+  tone,
+  icon,
+  children,
+}: {
+  tone: 'green' | 'blue' | 'red'
+  icon: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium ${BADGE_TONES[tone]}`}
+    >
+      {icon}
+      {children}
+    </span>
+  )
+}
+
+// The one error that needs a way out, not just a message: the admin must enable
+// two-factor on their OWN account before they can require it org-wide.
+function AdminMfaCallout({ href, message }: { href: string; message?: string | null }) {
+  const { t } = useTranslation()
+  return (
+    <div className="flex items-start gap-3 rounded-lg bg-amber-50 border border-amber-200/80 px-4 py-3">
+      <ShieldAlert className="w-4 h-4 text-amber-600 shrink-0 mt-0.5" />
+      <div className="space-y-2">
+        <p className="text-sm text-amber-900">
+          {message ||
+            t('dashboard.organization.security.admin_mfa_first', {
+              defaultValue:
+                'Enable two-factor on your own account before requiring it for the organization.',
+            })}
+        </p>
+        <p className="text-xs text-amber-800/80 leading-relaxed">
+          {t('dashboard.organization.security.admin_mfa_first_why', {
+            defaultValue:
+              'Otherwise the policy would lock you out of your own organization the moment it saves — and no admin would be left to turn it back off.',
+          })}
+        </p>
+        <Link
+          href={href}
+          className="inline-flex items-center gap-1.5 text-sm font-medium text-amber-900 underline underline-offset-2 hover:text-amber-950"
+        >
+          {t('dashboard.organization.security.admin_mfa_first_cta', {
+            defaultValue: 'Set up two-factor on your account',
+          })}
+          <ExternalLink className="w-3.5 h-3.5" />
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+export default OrgEditSecurity

--- a/apps/web/components/Objects/Account/subpages/AccountSecurity.tsx
+++ b/apps/web/components/Objects/Account/subpages/AccountSecurity.tsx
@@ -3,14 +3,30 @@ import { useLHSession } from '@components/Contexts/LHSessionContext'
 import { updatePassword } from '@services/settings/password'
 import { Formik, Form } from 'formik'
 import React from 'react'
-import { AlertTriangle, Monitor, LogOut } from 'lucide-react'
+import {
+  AlertTriangle,
+  Monitor,
+  LogOut,
+  ShieldCheck,
+  ShieldOff,
+  ShieldAlert,
+  KeyRound,
+  Copy,
+  Check,
+  Download,
+  RefreshCw,
+  Loader2,
+  Smartphone,
+} from 'lucide-react'
 import { getErrorMessage } from '@services/utils/ts/errorMessage'
 import { Input } from "@components/ui/input"
 import { Button } from "@components/ui/button"
 import { Label } from "@components/ui/label"
+import { Checkbox } from "@components/ui/checkbox"
 import { toast } from 'react-hot-toast'
 import { signOut } from '@components/Contexts/AuthContext'
-import { getUriWithoutOrg } from '@services/config/config'
+import { getUriWithoutOrg, getAPIUrl } from '@services/config/config'
+import { RequestBodyWithAuthHeader, getResponseMetadata } from '@services/utils/ts/requests'
 import * as Yup from 'yup'
 import { useTranslation } from 'react-i18next'
 import AccountDangerZone from '@components/Objects/Account/subpages/AccountDangerZone'
@@ -21,6 +37,1015 @@ const validationSchema = Yup.object().shape({
     .required('validation.required')
     .min(8, 'validation.password_min_length'),
 })
+
+// ---------------------------------------------------------------------------
+// Two-factor authentication (TOTP)
+// ---------------------------------------------------------------------------
+
+type MfaStatus = {
+  enabled: boolean
+  confirmed_at: string | null
+  backup_codes_remaining: number
+  // Accounts created through SSO/OAuth have no password, so the backend does
+  // not require (and rejects) one on setup/disable. Drives whether we render
+  // the password step at all.
+  has_password: boolean
+}
+
+// The enrolment wizard runs INSIDE the section (no route change):
+//   password → scan → verify → codes
+// `password` is skipped entirely when the account has no password.
+type EnrollStep = 'password' | 'scan' | 'verify' | 'codes'
+
+const BACKUP_CODES_LOW_THRESHOLD = 3
+
+function TwoFactorAuthSection() {
+  const { t } = useTranslation()
+  const session = useLHSession() as any
+  const access_token = session?.data?.tokens?.access_token
+
+  const [status, setStatus] = React.useState<MfaStatus | null>(null)
+  const [statusLoading, setStatusLoading] = React.useState(true)
+  const [statusError, setStatusError] = React.useState<string | null>(null)
+
+  // Enrolment wizard
+  const [step, setStep] = React.useState<EnrollStep | null>(null)
+  const [password, setPassword] = React.useState('')
+  const [secret, setSecret] = React.useState('')
+  const [provisioningUri, setProvisioningUri] = React.useState('')
+  const [qrDataUrl, setQrDataUrl] = React.useState<string | null>(null)
+  const [qrFailed, setQrFailed] = React.useState(false)
+  const [code, setCode] = React.useState('')
+  const [backupCodes, setBackupCodes] = React.useState<string[]>([])
+  const [codesAcknowledged, setCodesAcknowledged] = React.useState(false)
+
+  // Managing an already-enabled factor
+  const [panel, setPanel] = React.useState<'disable' | 'regenerate' | null>(null)
+
+  // A single in-flight flag guards EVERY mutating call in this section, which
+  // is what makes double-submits impossible (Enter key + click, double click…).
+  const [busy, setBusy] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const [retryAfter, setRetryAfter] = React.useState(0)
+  const [copied, setCopied] = React.useState<'secret' | 'codes' | null>(null)
+
+  // 429 cooldown: tick down so the button stays disabled and the user can see
+  // exactly how long they have to wait.
+  React.useEffect(() => {
+    if (retryAfter <= 0) return
+    const id = setTimeout(() => setRetryAfter((s) => Math.max(0, s - 1)), 1000)
+    return () => clearTimeout(id)
+  }, [retryAfter])
+
+  React.useEffect(() => {
+    if (!copied) return
+    const id = setTimeout(() => setCopied(null), 2000)
+    return () => clearTimeout(id)
+  }, [copied])
+
+  // Same call shape the change-password form uses (getAPIUrl() +
+  // RequestBodyWithAuthHeader + getResponseMetadata). Deliberately NOT apiFetch:
+  // its errorHandling() turns a 401 into a global "session expired" event, and
+  // /mfa/setup answers a wrong password with a 401 — which would sign the user
+  // out mid-enrolment.
+  const mfaFetch = React.useCallback(
+    async (path: string, method: 'GET' | 'POST', body?: any) => {
+      const result = await fetch(
+        `${getAPIUrl()}auth/mfa${path}`,
+        RequestBodyWithAuthHeader(method, body ?? null, null, access_token)
+      )
+      return getResponseMetadata(result)
+    },
+    [access_token]
+  )
+
+  // Surface the backend `detail.message` verbatim — those strings are already
+  // written for end users — and turn a 429 into a visible cooldown.
+  const readError = React.useCallback(
+    (res: { data: any; status: number }, fallback: string): string => {
+      const detail = res?.data?.detail
+      if (res?.status === 429) {
+        const seconds = Number(detail?.retry_after)
+        if (Number.isFinite(seconds) && seconds > 0) setRetryAfter(Math.ceil(seconds))
+        return getErrorMessage(
+          detail,
+          t('user.settings.security.mfa.rate_limited', {
+            defaultValue: 'Too many attempts. Please wait a moment and try again.',
+          })
+        )
+      }
+      return getErrorMessage(detail, fallback)
+    },
+    [t]
+  )
+
+  const loadStatus = React.useCallback(async () => {
+    if (!access_token) return
+    try {
+      const res = await mfaFetch('/status', 'GET')
+      if (res.success) {
+        setStatus(res.data as MfaStatus)
+        setStatusError(null)
+      } else {
+        setStatusError(
+          getErrorMessage(
+            res.data?.detail,
+            t('user.settings.security.mfa.status_error', {
+              defaultValue: 'Could not load your two-factor settings.',
+            })
+          )
+        )
+      }
+    } catch {
+      setStatusError(
+        t('user.settings.security.mfa.status_error', {
+          defaultValue: 'Could not load your two-factor settings.',
+        })
+      )
+    } finally {
+      setStatusLoading(false)
+    }
+  }, [access_token, mfaFetch, t])
+
+  React.useEffect(() => {
+    loadStatus()
+  }, [loadStatus])
+
+  // Render the QR locally (the `qrcode` package) instead of an image service —
+  // the secret must never leave the page, and the CSP blocks third-party images
+  // anyway. Imported lazily so it stays out of the settings page bundle.
+  React.useEffect(() => {
+    if (step !== 'scan' || !provisioningUri) return
+    let cancelled = false
+    setQrFailed(false)
+    import('qrcode')
+      .then(async (mod) => {
+        const QRCode: typeof import('qrcode') = (mod as any).default ?? mod
+        const url = await QRCode.toDataURL(provisioningUri, {
+          width: 200,
+          margin: 1,
+          errorCorrectionLevel: 'M',
+        })
+        if (!cancelled) setQrDataUrl(url)
+      })
+      .catch(() => {
+        if (!cancelled) setQrFailed(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [step, provisioningUri])
+
+  const resetFlow = React.useCallback(() => {
+    setStep(null)
+    setPanel(null)
+    setPassword('')
+    setSecret('')
+    setProvisioningUri('')
+    setQrDataUrl(null)
+    setQrFailed(false)
+    setCode('')
+    setBackupCodes([])
+    setCodesAcknowledged(false)
+    setError(null)
+    setRetryAfter(0)
+  }, [])
+
+  const copyToClipboard = async (text: string, what: 'secret' | 'codes') => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(what)
+    } catch {
+      toast.error(
+        t('user.settings.security.mfa.copy_failed', {
+          defaultValue: 'Could not copy. Please select the text and copy it manually.',
+        })
+      )
+    }
+  }
+
+  const downloadBackupCodes = () => {
+    const header = t('user.settings.security.mfa.codes_file_header', {
+      defaultValue: 'LearnHouse two-factor backup codes. Each code can be used once.',
+    })
+    const blob = new Blob([`${header}\n\n${backupCodes.join('\n')}\n`], {
+      type: 'text/plain;charset=utf-8',
+    })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = 'learnhouse-backup-codes.txt'
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+    URL.revokeObjectURL(url)
+  }
+
+  // --- requests -----------------------------------------------------------
+
+  const runSetup = async (withPassword?: string) => {
+    if (busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await mfaFetch('/setup', 'POST', withPassword ? { password: withPassword } : {})
+      if (res.success) {
+        setSecret(res.data?.secret ?? '')
+        setProvisioningUri(res.data?.provisioning_uri ?? '')
+        setPassword('')
+        setStep('scan')
+      } else if (res.status === 409) {
+        // Already enabled somewhere else (another tab) — resync rather than lie.
+        toast.error(
+          readError(
+            res,
+            t('user.settings.security.mfa.already_enabled', {
+              defaultValue: 'Two-factor authentication is already enabled on this account.',
+            })
+          )
+        )
+        resetFlow()
+        await loadStatus()
+      } else {
+        setError(
+          readError(
+            res,
+            t('user.settings.security.mfa.setup_failed', {
+              defaultValue: 'Could not start two-factor setup. Please try again.',
+            })
+          )
+        )
+      }
+    } catch {
+      setError(
+        t('user.settings.security.mfa.setup_failed', {
+          defaultValue: 'Could not start two-factor setup. Please try again.',
+        })
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const startEnrollment = () => {
+    setError(null)
+    setRetryAfter(0)
+    setCode('')
+    setPassword('')
+    if (status?.has_password) {
+      setStep('password')
+    } else {
+      // No password on the account (SSO) — go straight to the QR.
+      setStep('scan')
+      runSetup()
+    }
+  }
+
+  const confirmEnrollment = async () => {
+    if (busy || code.length !== 6 || retryAfter > 0) return
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await mfaFetch('/confirm', 'POST', { code })
+      if (res.success) {
+        setBackupCodes(Array.isArray(res.data?.backup_codes) ? res.data.backup_codes : [])
+        setCodesAcknowledged(false)
+        setCode('')
+        setSecret('')
+        setProvisioningUri('')
+        setQrDataUrl(null)
+        setStep('codes')
+        toast.success(
+          t('user.settings.security.mfa.enabled_toast', {
+            defaultValue: 'Two-factor authentication is now enabled.',
+          })
+        )
+      } else {
+        setError(
+          readError(
+            res,
+            t('user.settings.security.mfa.invalid_code', {
+              defaultValue: 'That code is not valid. Please try again.',
+            })
+          )
+        )
+      }
+    } catch {
+      setError(
+        t('user.settings.security.mfa.invalid_code', {
+          defaultValue: 'That code is not valid. Please try again.',
+        })
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const regenerateCodes = async () => {
+    if (busy || code.length !== 6 || retryAfter > 0) return
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await mfaFetch('/backup-codes/regenerate', 'POST', { code })
+      if (res.success) {
+        setBackupCodes(Array.isArray(res.data?.backup_codes) ? res.data.backup_codes : [])
+        setCodesAcknowledged(false)
+        setCode('')
+        setPanel(null)
+        setStep('codes')
+      } else {
+        setError(
+          readError(
+            res,
+            t('user.settings.security.mfa.invalid_code', {
+              defaultValue: 'That code is not valid. Please try again.',
+            })
+          )
+        )
+      }
+    } catch {
+      setError(
+        t('user.settings.security.mfa.regenerate_failed', {
+          defaultValue: 'Could not regenerate your backup codes. Please try again.',
+        })
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const disableMfa = async () => {
+    if (busy || code.length !== 6 || retryAfter > 0) return
+    if (status?.has_password && !password) return
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await mfaFetch(
+        '/disable',
+        'POST',
+        status?.has_password ? { password, code } : { code }
+      )
+      if (res.success) {
+        toast.success(
+          t('user.settings.security.mfa.disabled_toast', {
+            defaultValue: 'Two-factor authentication has been turned off.',
+          })
+        )
+        resetFlow()
+        await loadStatus()
+      } else {
+        setError(
+          readError(
+            res,
+            t('user.settings.security.mfa.disable_failed', {
+              defaultValue: 'Could not turn off two-factor authentication. Please try again.',
+            })
+          )
+        )
+      }
+    } catch {
+      setError(
+        t('user.settings.security.mfa.disable_failed', {
+          defaultValue: 'Could not turn off two-factor authentication. Please try again.',
+        })
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const finishCodes = async () => {
+    if (!codesAcknowledged || busy) return
+    setBusy(true)
+    try {
+      resetFlow()
+      await loadStatus()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  // --- pieces -------------------------------------------------------------
+
+  const errorBlock = error ? (
+    <div className="flex items-start gap-2 text-red-600 bg-red-50 p-3 rounded-md">
+      <AlertTriangle size={16} className="mt-0.5 shrink-0" />
+      <span className="text-sm">
+        {error}
+        {retryAfter > 0 && (
+          <>
+            {' '}
+            {t('user.settings.security.mfa.retry_in', {
+              defaultValue: 'You can try again in {{seconds}}s.',
+              seconds: retryAfter,
+            })}
+          </>
+        )}
+      </span>
+    </div>
+  ) : null
+
+  const codeField = (id: string, onEnter: () => void) => (
+    <div>
+      <Label htmlFor={id}>
+        {t('user.settings.security.mfa.code_label', { defaultValue: 'Authentication code' })}
+      </Label>
+      <Input
+        id={id}
+        name={id}
+        type="text"
+        inputMode="numeric"
+        autoComplete="one-time-code"
+        maxLength={6}
+        placeholder="000000"
+        value={code}
+        onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            onEnter()
+          }
+        }}
+        disabled={busy}
+        className="mt-1 max-w-[12rem] font-mono tracking-[0.4em] text-center"
+      />
+      <p className="text-xs text-gray-500 mt-1.5">
+        {t('user.settings.security.mfa.code_hint', {
+          defaultValue: 'Enter the 6-digit code currently shown in your authenticator app.',
+        })}
+      </p>
+    </div>
+  )
+
+  const sectionHeader = (
+    <div className="flex flex-col bg-gray-50 -space-y-1 px-5 py-3 mx-3 my-3 rounded-md">
+      <h1 className="font-bold text-xl text-gray-800 flex items-center gap-2">
+        <ShieldCheck size={18} className="text-gray-500" />
+        {t('user.settings.security.mfa.title', {
+          defaultValue: 'Two-factor authentication',
+        })}
+      </h1>
+      <h2 className="text-gray-500 text-md pl-7">
+        {t('user.settings.security.mfa.subtitle', {
+          defaultValue:
+            'Ask for a one-time code from your authenticator app whenever you sign in.',
+        })}
+      </h2>
+    </div>
+  )
+
+  // --- render -------------------------------------------------------------
+
+  let body: React.ReactNode
+
+  if (statusLoading) {
+    body = (
+      <div className="flex items-center gap-2 rounded-lg border border-gray-200 p-4 text-sm text-gray-500">
+        <Loader2 size={16} className="animate-spin" />
+        {t('common.loading', { defaultValue: 'Loading...' })}
+      </div>
+    )
+  } else if (statusError) {
+    body = (
+      <div className="flex items-center justify-between gap-4 rounded-lg border border-gray-200 p-4">
+        <div className="flex items-start gap-2 text-red-600 min-w-0">
+          <AlertTriangle size={16} className="mt-0.5 shrink-0" />
+          <span className="text-sm">{statusError}</span>
+        </div>
+        <Button
+          variant="outline"
+          className="shrink-0"
+          onClick={() => {
+            setStatusLoading(true)
+            setStatusError(null)
+            loadStatus()
+          }}
+        >
+          {t('user.settings.security.mfa.retry', { defaultValue: 'Retry' })}
+        </Button>
+      </div>
+    )
+  } else if (step === 'codes') {
+    // Step 4 — the ONLY time these codes are ever visible.
+    body = (
+      <div className="rounded-lg border border-gray-200 p-4 space-y-4">
+        <div className="flex items-start gap-2 text-amber-700 bg-amber-50 p-3 rounded-md">
+          <AlertTriangle size={16} className="mt-0.5 shrink-0" />
+          <div className="text-sm">
+            <p className="font-semibold">
+              {t('user.settings.security.mfa.codes_once_title', {
+                defaultValue: 'This is the only time these codes will be shown.',
+              })}
+            </p>
+            <p className="mt-0.5">
+              {t('user.settings.security.mfa.codes_once_body', {
+                defaultValue:
+                  'Save them somewhere safe now. Each code can be used once to sign in if you lose access to your authenticator app. Once you leave this screen they cannot be retrieved — you would have to generate new ones.',
+              })}
+            </p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+          {backupCodes.map((c) => (
+            <div
+              key={c}
+              className="font-mono text-sm text-gray-800 bg-gray-50 border border-gray-200 rounded-md px-3 py-2 text-center select-all"
+            >
+              {c}
+            </div>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            className="gap-1.5"
+            onClick={() => copyToClipboard(backupCodes.join('\n'), 'codes')}
+          >
+            {copied === 'codes' ? <Check size={14} /> : <Copy size={14} />}
+            {copied === 'codes'
+              ? t('user.settings.security.mfa.copied', { defaultValue: 'Copied' })
+              : t('user.settings.security.mfa.copy_all', { defaultValue: 'Copy all' })}
+          </Button>
+          <Button type="button" variant="outline" className="gap-1.5" onClick={downloadBackupCodes}>
+            <Download size={14} />
+            {t('user.settings.security.mfa.download', { defaultValue: 'Download .txt' })}
+          </Button>
+        </div>
+
+        <div className="flex items-start gap-2.5 pt-1">
+          <Checkbox
+            id="mfa-codes-saved"
+            checked={codesAcknowledged}
+            onCheckedChange={(checked) => setCodesAcknowledged(checked === true)}
+            className="mt-0.5"
+          />
+          <Label htmlFor="mfa-codes-saved" className="text-sm text-gray-700 leading-snug">
+            {t('user.settings.security.mfa.codes_ack', {
+              defaultValue: 'I have saved these codes somewhere safe.',
+            })}
+          </Label>
+        </div>
+
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            onClick={finishCodes}
+            disabled={!codesAcknowledged || busy}
+            className="bg-black text-white hover:bg-black/90"
+          >
+            {busy && <Loader2 size={14} className="animate-spin" />}
+            {t('user.settings.security.mfa.done', { defaultValue: 'Done' })}
+          </Button>
+        </div>
+      </div>
+    )
+  } else if (step === 'password') {
+    // Step 1 — confirm the password before we hand out a secret.
+    body = (
+      <div className="rounded-lg border border-gray-200 p-4 space-y-4">
+        <div className="flex items-center gap-2">
+          <KeyRound size={16} className="text-gray-400" />
+          <p className="text-sm font-medium text-gray-800">
+            {t('user.settings.security.mfa.step_password_title', {
+              defaultValue: 'Confirm your password',
+            })}
+          </p>
+        </div>
+        <p className="text-sm text-gray-500">
+          {t('user.settings.security.mfa.step_password_body', {
+            defaultValue: 'For your security, enter your current password to continue.',
+          })}
+        </p>
+        <div>
+          <Label htmlFor="mfa-password">
+            {t('user.settings.password.current_password', { defaultValue: 'Current Password' })}
+          </Label>
+          <Input
+            id="mfa-password"
+            name="mfa-password"
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                if (password) runSetup(password)
+              }
+            }}
+            disabled={busy}
+            className="mt-1 max-w-md"
+          />
+        </div>
+        {errorBlock}
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" onClick={resetFlow} disabled={busy}>
+            {t('common.cancel', { defaultValue: 'Cancel' })}
+          </Button>
+          <Button
+            type="button"
+            onClick={() => runSetup(password)}
+            disabled={busy || !password}
+            className="bg-black text-white hover:bg-black/90"
+          >
+            {busy && <Loader2 size={14} className="animate-spin" />}
+            {t('user.settings.security.mfa.continue', { defaultValue: 'Continue' })}
+          </Button>
+        </div>
+      </div>
+    )
+  } else if (step === 'scan') {
+    // Step 2 — QR + the raw secret for desktop authenticators.
+    body = (
+      <div className="rounded-lg border border-gray-200 p-4 space-y-4">
+        <div className="flex items-center gap-2">
+          <Smartphone size={16} className="text-gray-400" />
+          <p className="text-sm font-medium text-gray-800">
+            {t('user.settings.security.mfa.step_scan_title', {
+              defaultValue: 'Scan this with your authenticator app',
+            })}
+          </p>
+        </div>
+        <p className="text-sm text-gray-500">
+          {t('user.settings.security.mfa.step_scan_body', {
+            defaultValue:
+              'Open an authenticator app (1Password, Google Authenticator, Authy, …) and scan the code below.',
+          })}
+        </p>
+
+        <div className="flex flex-col sm:flex-row sm:items-center gap-5">
+          <div className="flex items-center justify-center bg-white border border-gray-200 rounded-lg p-3 w-[224px] h-[224px] shrink-0">
+            {qrDataUrl ? (
+              /* eslint-disable-next-line @next/next/no-img-element */
+              <img
+                src={qrDataUrl}
+                width={200}
+                height={200}
+                alt={t('user.settings.security.mfa.qr_alt', {
+                  defaultValue: 'Two-factor setup QR code',
+                })}
+              />
+            ) : qrFailed ? (
+              <p className="text-xs text-gray-500 text-center px-3">
+                {t('user.settings.security.mfa.qr_failed', {
+                  defaultValue: 'The QR code could not be drawn. Use the setup key instead.',
+                })}
+              </p>
+            ) : (
+              <Loader2 size={20} className="animate-spin text-gray-400" />
+            )}
+          </div>
+
+          <div className="min-w-0 flex-1 space-y-2">
+            <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+              {t('user.settings.security.mfa.secret_label', {
+                defaultValue: 'Or enter this setup key manually',
+              })}
+            </p>
+            <div className="flex items-center gap-2">
+              <code className="font-mono text-sm text-gray-800 bg-gray-50 border border-gray-200 rounded-md px-3 py-2 break-all select-all min-w-0 flex-1">
+                {secret || '…'}
+              </code>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="shrink-0"
+                disabled={!secret}
+                onClick={() => copyToClipboard(secret, 'secret')}
+                aria-label={t('user.settings.security.mfa.copy_secret', {
+                  defaultValue: 'Copy setup key',
+                })}
+              >
+                {copied === 'secret' ? <Check size={14} /> : <Copy size={14} />}
+              </Button>
+            </div>
+            <p className="text-xs text-gray-500">
+              {t('user.settings.security.mfa.secret_hint', {
+                defaultValue: 'Useful for desktop authenticator apps that cannot scan a QR code.',
+              })}
+            </p>
+          </div>
+        </div>
+
+        {errorBlock}
+
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" onClick={resetFlow} disabled={busy}>
+            {t('common.cancel', { defaultValue: 'Cancel' })}
+          </Button>
+          <Button
+            type="button"
+            onClick={() => {
+              setError(null)
+              setStep('verify')
+            }}
+            disabled={busy || !secret}
+            className="bg-black text-white hover:bg-black/90"
+          >
+            {busy && <Loader2 size={14} className="animate-spin" />}
+            {t('user.settings.security.mfa.continue', { defaultValue: 'Continue' })}
+          </Button>
+        </div>
+      </div>
+    )
+  } else if (step === 'verify') {
+    // Step 3 — prove the app is set up before we switch 2FA on.
+    body = (
+      <div className="rounded-lg border border-gray-200 p-4 space-y-4">
+        <div className="flex items-center gap-2">
+          <ShieldCheck size={16} className="text-gray-400" />
+          <p className="text-sm font-medium text-gray-800">
+            {t('user.settings.security.mfa.step_verify_title', {
+              defaultValue: 'Confirm the code from your app',
+            })}
+          </p>
+        </div>
+        {codeField('mfa-confirm-code', confirmEnrollment)}
+        {errorBlock}
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              setError(null)
+              setCode('')
+              setStep('scan')
+            }}
+            disabled={busy}
+          >
+            {t('user.settings.security.mfa.back', { defaultValue: 'Back' })}
+          </Button>
+          <Button
+            type="button"
+            onClick={confirmEnrollment}
+            disabled={busy || code.length !== 6 || retryAfter > 0}
+            className="bg-black text-white hover:bg-black/90"
+          >
+            {busy && <Loader2 size={14} className="animate-spin" />}
+            {retryAfter > 0
+              ? t('user.settings.security.mfa.wait_seconds', {
+                  defaultValue: 'Wait {{seconds}}s',
+                  seconds: retryAfter,
+                })
+              : t('user.settings.security.mfa.verify_and_enable', {
+                  defaultValue: 'Verify and enable',
+                })}
+          </Button>
+        </div>
+      </div>
+    )
+  } else if (status?.enabled) {
+    const remaining = status.backup_codes_remaining ?? 0
+    const lowOnCodes = remaining <= BACKUP_CODES_LOW_THRESHOLD
+    body = (
+      <div className="rounded-lg border border-gray-200 p-4 space-y-4">
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="flex items-center justify-center w-9 h-9 rounded-lg bg-green-50 text-green-600 shrink-0">
+              <ShieldCheck size={18} />
+            </div>
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-gray-800">
+                {t('user.settings.security.mfa.enabled', { defaultValue: 'Enabled' })}
+              </p>
+              <p className="text-xs text-gray-500">
+                {status.confirmed_at
+                  ? t('user.settings.security.mfa.enabled_since', {
+                      defaultValue: 'Since {{date}}',
+                      date: new Date(status.confirmed_at).toLocaleDateString(undefined, {
+                        year: 'numeric',
+                        month: 'short',
+                        day: 'numeric',
+                      }),
+                    })
+                  : t('user.settings.security.mfa.enabled_hint', {
+                      defaultValue: 'A code from your authenticator app is required to sign in.',
+                    })}
+              </p>
+            </div>
+          </div>
+          <div className="flex gap-2 shrink-0">
+            <Button
+              type="button"
+              variant="outline"
+              className="gap-1.5"
+              disabled={busy}
+              onClick={() => {
+                setError(null)
+                setCode('')
+                setRetryAfter(0)
+                setPanel(panel === 'regenerate' ? null : 'regenerate')
+              }}
+            >
+              <RefreshCw size={14} />
+              {t('user.settings.security.mfa.regenerate', {
+                defaultValue: 'Regenerate backup codes',
+              })}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="gap-1.5 text-red-600 border-red-200 hover:bg-red-50 hover:text-red-700"
+              disabled={busy}
+              onClick={() => {
+                setError(null)
+                setCode('')
+                setPassword('')
+                setRetryAfter(0)
+                setPanel(panel === 'disable' ? null : 'disable')
+              }}
+            >
+              <ShieldOff size={14} />
+              {t('user.settings.security.mfa.disable', { defaultValue: 'Disable' })}
+            </Button>
+          </div>
+        </div>
+
+        <div
+          className={
+            lowOnCodes
+              ? 'flex items-center gap-2 text-amber-700 bg-amber-50 p-3 rounded-md'
+              : 'flex items-center gap-2 text-gray-600 bg-gray-50 p-3 rounded-md'
+          }
+        >
+          {lowOnCodes ? <ShieldAlert size={16} /> : <KeyRound size={16} className="text-gray-400" />}
+          <span className="text-sm">
+            {/* Interpolated as `remaining`, not `count`: `count` would put
+                i18next into plural mode and look for suffixed keys. */}
+            {t('user.settings.security.mfa.codes_remaining', {
+              defaultValue: '{{remaining}} backup codes remaining',
+              remaining,
+            })}
+            {lowOnCodes && (
+              <>
+                {' — '}
+                {t('user.settings.security.mfa.codes_low', {
+                  defaultValue: 'generate a new set so you do not get locked out.',
+                })}
+              </>
+            )}
+          </span>
+        </div>
+
+        {panel === 'regenerate' && (
+          <div className="border-t border-gray-100 pt-4 space-y-4">
+            <p className="text-sm text-gray-500">
+              {t('user.settings.security.mfa.regenerate_body', {
+                defaultValue:
+                  'Generating a new set immediately invalidates all of your existing backup codes.',
+              })}
+            </p>
+            {codeField('mfa-regenerate-code', regenerateCodes)}
+            {errorBlock}
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setPanel(null)
+                  setCode('')
+                  setError(null)
+                }}
+                disabled={busy}
+              >
+                {t('common.cancel', { defaultValue: 'Cancel' })}
+              </Button>
+              <Button
+                type="button"
+                onClick={regenerateCodes}
+                disabled={busy || code.length !== 6 || retryAfter > 0}
+                className="bg-black text-white hover:bg-black/90"
+              >
+                {busy && <Loader2 size={14} className="animate-spin" />}
+                {retryAfter > 0
+                  ? t('user.settings.security.mfa.wait_seconds', {
+                      defaultValue: 'Wait {{seconds}}s',
+                      seconds: retryAfter,
+                    })
+                  : t('user.settings.security.mfa.regenerate_confirm', {
+                      defaultValue: 'Generate new codes',
+                    })}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {panel === 'disable' && (
+          <div className="border-t border-gray-100 pt-4 space-y-4">
+            <div className="flex items-start gap-2 text-amber-700 bg-amber-50 p-3 rounded-md">
+              <AlertTriangle size={16} className="mt-0.5 shrink-0" />
+              <span className="text-sm">
+                {t('user.settings.security.mfa.disable_warning', {
+                  defaultValue:
+                    'Turning this off removes the second step from sign-in and deletes your backup codes.',
+                })}
+              </span>
+            </div>
+            {status.has_password && (
+              <div>
+                <Label htmlFor="mfa-disable-password">
+                  {t('user.settings.password.current_password', {
+                    defaultValue: 'Current Password',
+                  })}
+                </Label>
+                <Input
+                  id="mfa-disable-password"
+                  name="mfa-disable-password"
+                  type="password"
+                  autoComplete="current-password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  disabled={busy}
+                  className="mt-1 max-w-md"
+                />
+              </div>
+            )}
+            {codeField('mfa-disable-code', disableMfa)}
+            {errorBlock}
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setPanel(null)
+                  setCode('')
+                  setPassword('')
+                  setError(null)
+                }}
+                disabled={busy}
+              >
+                {t('common.cancel', { defaultValue: 'Cancel' })}
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={disableMfa}
+                disabled={
+                  busy ||
+                  code.length !== 6 ||
+                  retryAfter > 0 ||
+                  (status.has_password && !password)
+                }
+              >
+                {busy && <Loader2 size={14} className="animate-spin" />}
+                {retryAfter > 0
+                  ? t('user.settings.security.mfa.wait_seconds', {
+                      defaultValue: 'Wait {{seconds}}s',
+                      seconds: retryAfter,
+                    })
+                  : t('user.settings.security.mfa.disable_confirm', {
+                      defaultValue: 'Turn off two-factor',
+                    })}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    )
+  } else {
+    // Disabled, nothing in flight.
+    body = (
+      <div className="flex items-center justify-between gap-4 rounded-lg border border-gray-200 p-4 flex-wrap">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="flex items-center justify-center w-9 h-9 rounded-lg bg-gray-100 text-gray-400 shrink-0">
+            <ShieldOff size={18} />
+          </div>
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-gray-800">
+              {t('user.settings.security.mfa.not_enabled', { defaultValue: 'Not enabled' })}
+            </p>
+            <p className="text-xs text-gray-500">
+              {t('user.settings.security.mfa.not_enabled_hint', {
+                defaultValue:
+                  'Protect your account by also requiring a one-time code from your authenticator app when you sign in.',
+              })}
+            </p>
+          </div>
+        </div>
+        <Button
+          type="button"
+          onClick={startEnrollment}
+          disabled={busy}
+          className="bg-black text-white hover:bg-black/90 shrink-0"
+        >
+          {busy && <Loader2 size={14} className="animate-spin" />}
+          {t('user.settings.security.mfa.enable', { defaultValue: 'Enable' })}
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {sectionHeader}
+      <div className="mx-5 mb-6">{body}</div>
+    </>
+  )
+}
 
 function AccountSecurity() {
   const session = useLHSession() as any
@@ -193,6 +1218,9 @@ function AccountSecurity() {
             )}
           </Formik>
         </div>
+
+        {/* Two-factor authentication (TOTP) */}
+        <TwoFactorAuthSection />
       </div>
     </div>
 

--- a/apps/web/components/Objects/Banners/OrgMFAPolicyGate.tsx
+++ b/apps/web/components/Objects/Banners/OrgMFAPolicyGate.tsx
@@ -1,0 +1,395 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { usePathname } from 'next/navigation'
+import { useTranslation } from 'react-i18next'
+import { ShieldAlert, ShieldCheck, X, LogOut, ArrowRight, LogIn } from 'lucide-react'
+import { useOrgMembership } from '@components/Contexts/OrgContext'
+import { useLHSession } from '@components/Contexts/LHSessionContext'
+import { signOut } from '@components/Contexts/AuthContext'
+import { getAPIUrl, getUriWithOrg, getUriWithoutOrg } from '@services/config/config'
+import { RequestBodyWithAuthHeader } from '@services/utils/ts/requests'
+
+/**
+ * End-user surface for the org-wide "two-factor is mandatory" policy.
+ *
+ * Renders NOTHING in the overwhelmingly common case (policy off, or the user is
+ * already compliant/exempt). To keep that case cheap it:
+ *   - never runs on the server and never blocks first paint (it returns null
+ *     until the query resolves),
+ *   - fetches the compliance state once per org per session (staleTime/gcTime
+ *     Infinity, no refetch on mount/focus/reconnect),
+ *   - fails OPEN — a network/API error renders nothing rather than locking
+ *     someone out of an org over a failed request.
+ *
+ * Two states are user-visible:
+ *   - inside the grace window  → dismissible countdown banner,
+ *   - deadline passed          → full-page blocking interstitial.
+ *
+ * The interstitial deliberately does NOT trap the user: it is mounted below the
+ * org navigation in the stacking order (so the profile menu and its sign-out
+ * stay clickable), it is never rendered on the /account/* routes that contain
+ * the security page which unblocks them, and it carries its own explicit
+ * "Set up two-factor" and "Sign out" actions.
+ */
+
+export interface MFAComplianceState {
+  required: boolean
+  satisfied: boolean
+  deadline: string | null
+  days_remaining: number | null
+  blocking: boolean
+  exempt_reason: string | null
+}
+
+// The new org-scoped auth policy can refuse this request outright. When it does,
+// the org-policy endpoint answers 403 with one of these codes — we surface a
+// scoped "sign in to this org" call-to-action rather than failing fully open.
+export interface OrgAuthPolicyBlock {
+  code: 'AUTH_METHOD_NOT_ALLOWED' | 'SESSION_NOT_BOUND_TO_ORG'
+  message: string
+  allowed_methods?: string[]
+}
+
+// The compliance query result, optionally carrying an auth-policy block.
+export type OrgPolicyState = MFAComplianceState & { authBlock?: OrgAuthPolicyBlock }
+
+const COMPLIANT: MFAComplianceState = {
+  required: false,
+  satisfied: true,
+  deadline: null,
+  days_remaining: null,
+  blocking: false,
+  exempt_reason: null,
+}
+
+async function getOrgMFACompliance(
+  org_id: number,
+  access_token?: string
+): Promise<OrgPolicyState> {
+  const result = await fetch(
+    `${getAPIUrl()}auth/mfa/org-policy/${org_id}`,
+    RequestBodyWithAuthHeader('GET', null, null, access_token)
+  )
+  // Fail open on purpose: this endpoint only drives an advisory banner/blocker,
+  // and `errorHandling()` would additionally force a sign-out on a spurious 401.
+  if (!result.ok) {
+    // A 403 from the new auth-method / session-binding policy is NOT a spurious
+    // error — it's the org telling us this session can't be here. Surface it as a
+    // scoped re-sign-in prompt (still failing open for every other error).
+    if (result.status === 403) {
+      try {
+        const body = await result.json()
+        const detail = body?.detail
+        if (
+          detail?.code === 'AUTH_METHOD_NOT_ALLOWED' ||
+          detail?.code === 'SESSION_NOT_BOUND_TO_ORG'
+        ) {
+          return {
+            ...COMPLIANT,
+            authBlock: {
+              code: detail.code,
+              message:
+                typeof detail.message === 'string' && detail.message
+                  ? detail.message
+                  : 'You need to sign in to this organization to continue.',
+              allowed_methods: Array.isArray(detail.allowed_methods)
+                ? detail.allowed_methods
+                : undefined,
+            },
+          }
+        }
+      } catch {
+        /* unparseable 403 — fall through to fail-open */
+      }
+    }
+    return COMPLIANT
+  }
+  return (await result.json()) as OrgPolicyState
+}
+
+/** Cached per org, for the lifetime of the session. */
+function useOrgMFACompliance(org_id?: number) {
+  const session = useLHSession() as any
+  const access_token = session?.data?.tokens?.access_token
+
+  return useQuery<OrgPolicyState>({
+    queryKey: ['mfa', 'org-policy', org_id],
+    queryFn: () => getOrgMFACompliance(org_id as number, access_token),
+    enabled: session?.status === 'authenticated' && !!org_id && !!access_token,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    retry: false,
+  })
+}
+
+const dismissKey = (org_id: number) => `lh_mfa_policy_banner_dismissed_${org_id}`
+
+function CountdownBanner({
+  orgName,
+  orgslug,
+  org_id,
+  days,
+  overdue = false,
+}: {
+  orgName: string
+  orgslug: string
+  org_id: number
+  days: number | null
+  /** Deadline already passed — the reminder can no longer be dismissed. */
+  overdue?: boolean
+}) {
+  const { t } = useTranslation()
+  // sessionStorage is only read after mount so the server/client markup match,
+  // and using sessionStorage (not localStorage) means the reminder comes back
+  // on the next session — nobody can permanently silence it.
+  const [dismissed, setDismissed] = useState(true)
+
+  useEffect(() => {
+    if (overdue) {
+      setDismissed(false)
+      return
+    }
+    try {
+      setDismissed(window.sessionStorage.getItem(dismissKey(org_id)) === '1')
+    } catch {
+      setDismissed(false)
+    }
+  }, [org_id, overdue])
+
+  const dismiss = () => {
+    setDismissed(true)
+    try {
+      window.sessionStorage.setItem(dismissKey(org_id), '1')
+    } catch {
+      // Private mode / storage disabled — the banner simply reappears.
+    }
+  }
+
+  if (dismissed) return null
+
+  const message = overdue
+    ? t('mfa.policy.banner_message_overdue', {
+        defaultValue:
+          '{{org}} requires two-factor authentication and the deadline has passed. Enable it below to regain access.',
+        org: orgName,
+      })
+    : days === null || days <= 0
+      ? t('mfa.policy.banner_message_today', {
+          defaultValue:
+            '{{org}} requires two-factor authentication. You need to set it up today.',
+          org: orgName,
+        })
+      : days === 1
+        ? t('mfa.policy.banner_message_one_day', {
+            defaultValue:
+              '{{org}} requires two-factor authentication. You have 1 day left to set it up.',
+            org: orgName,
+          })
+        : t('mfa.policy.banner_message', {
+            defaultValue:
+              '{{org}} requires two-factor authentication. You have {{days}} days left to set it up.',
+            org: orgName,
+            days,
+          })
+
+  return (
+    <div className="w-full bg-gradient-to-r from-amber-500 to-orange-500 text-white">
+      <div className="w-full max-w-(--breakpoint-2xl) mx-auto px-4 sm:px-6 lg:px-8 py-2.5 flex items-center gap-3">
+        <ShieldAlert size={20} className="flex-shrink-0" />
+        <p className="text-sm font-medium flex-1">{message}</p>
+        <a
+          href={getUriWithOrg(orgslug, '/account/security')}
+          className="flex items-center gap-1 text-sm font-bold bg-white/20 hover:bg-white/30 transition-colors rounded-lg px-3 py-1.5 whitespace-nowrap"
+        >
+          {t('mfa.policy.set_up_now', { defaultValue: 'Set up now' })}
+          <ArrowRight size={14} />
+        </a>
+        {!overdue && (
+          <button
+            type="button"
+            onClick={dismiss}
+            aria-label={t('common.dismiss', { defaultValue: 'Dismiss' })}
+            className="flex-shrink-0 opacity-70 hover:opacity-100 transition-opacity"
+          >
+            <X size={18} />
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function BlockingInterstitial({
+  orgName,
+  orgslug,
+}: {
+  orgName: string
+  orgslug: string
+}) {
+  const { t } = useTranslation()
+  const session = useLHSession() as any
+  const email = session?.data?.user?.email
+
+  return (
+    <section
+      aria-labelledby="mfa-policy-block-title"
+      className="fixed inset-0 bg-slate-50/95 backdrop-blur-md flex items-start justify-center overflow-y-auto px-4 pt-[100px] pb-12"
+      // Below --z-nav (50) on purpose: the org navigation — and the profile
+      // menu's sign-out inside it — must stay reachable above this overlay.
+      style={{ zIndex: 'var(--z-interactive)' }}
+    >
+      <div className="w-full max-w-lg bg-white rounded-2xl nice-shadow outline outline-1 outline-neutral-200/40 p-8 flex flex-col items-center text-center space-y-5">
+        <div className="bg-amber-100 p-3 rounded-2xl">
+          <ShieldAlert className="text-amber-700" size={34} />
+        </div>
+
+        <div className="space-y-2">
+          <h1
+            id="mfa-policy-block-title"
+            className="text-2xl font-bold text-gray-900"
+          >
+            {t('mfa.policy.blocked_title', {
+              defaultValue: 'Two-factor authentication is required',
+            })}
+          </h1>
+          <p className="text-gray-600 text-sm max-w-prose">
+            {t('mfa.policy.blocked_description', {
+              defaultValue:
+                'The deadline set by {{org}} for enabling two-factor authentication has passed. To keep using {{org}}, add a second factor to your account — it only takes a minute.',
+              org: orgName,
+            })}
+          </p>
+          <p className="text-gray-400 text-xs max-w-prose">
+            {t('mfa.policy.blocked_scope_note', {
+              defaultValue:
+                'This only affects {{org}}. Your other organizations are unaffected.',
+              org: orgName,
+            })}
+          </p>
+        </div>
+
+        <a
+          href={getUriWithOrg(orgslug, '/account/security')}
+          className="w-full flex items-center justify-center gap-2 bg-gray-900 hover:bg-gray-800 text-white font-semibold text-sm rounded-xl px-5 py-3 transition-colors"
+        >
+          <ShieldCheck size={18} />
+          {t('mfa.policy.set_up_2fa', {
+            defaultValue: 'Set up two-factor authentication',
+          })}
+        </a>
+
+        <div className="w-full pt-1 border-t border-gray-100 flex flex-col items-center gap-1.5 text-xs text-gray-400">
+          {email && (
+            <span>
+              {t('mfa.policy.signed_in_as', {
+                defaultValue: 'Signed in as {{email}}',
+                email,
+              })}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() =>
+              signOut({ redirect: true, callbackUrl: getUriWithoutOrg('/') })
+            }
+            className="flex items-center gap-1.5 font-semibold text-gray-500 hover:text-gray-900 transition-colors"
+          >
+            <LogOut size={13} />
+            {t('common.sign_out', { defaultValue: 'Sign out' })}
+          </button>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+// This org's policy refused the current session (wrong auth method, or a central
+// learnhouse.io session that isn't bound to this org). Send the user to THIS
+// org's own login page — never a global logout, since they may belong to other
+// orgs that are perfectly happy with their session.
+function OrgAuthMethodBanner({
+  message,
+  orgslug,
+}: {
+  message: string
+  orgslug: string
+}) {
+  const { t } = useTranslation()
+  return (
+    <div className="w-full bg-gradient-to-r from-indigo-500 to-violet-500 text-white">
+      <div className="w-full max-w-(--breakpoint-2xl) mx-auto px-4 sm:px-6 lg:px-8 py-2.5 flex items-center gap-3">
+        <ShieldAlert size={20} className="flex-shrink-0" />
+        <p className="text-sm font-medium flex-1">{message}</p>
+        <a
+          href={getUriWithOrg(orgslug, '/login')}
+          className="flex items-center gap-1 text-sm font-bold bg-white/20 hover:bg-white/30 transition-colors rounded-lg px-3 py-1.5 whitespace-nowrap"
+        >
+          <LogIn size={14} />
+          {t('mfa.policy.sign_in_to_org', {
+            defaultValue: 'Sign in to this organization',
+          })}
+        </a>
+      </div>
+    </div>
+  )
+}
+
+export function OrgMFAPolicyGate() {
+  const { org, orgslug } = useOrgMembership()
+  const pathname = usePathname()
+  const { data } = useOrgMFACompliance(org?.id)
+
+  if (!data) return null
+
+  const orgName = org?.name || orgslug
+
+  // The org's auth policy refused this session — prompt a scoped re-sign-in.
+  // Shown everywhere EXCEPT the org's own login route (where they fix it).
+  if (data.authBlock) {
+    const segments = (pathname || '').split('/').filter(Boolean)
+    const onLoginRoute = segments.includes('login')
+    if (onLoginRoute) return null
+    return <OrgAuthMethodBanner message={data.authBlock.message} orgslug={orgslug} />
+  }
+
+  // Nothing to show: policy off, or the user is compliant/exempt.
+  if (!data.required || data.satisfied) return null
+
+  if (!data.blocking) {
+    return (
+      <CountdownBanner
+        orgName={orgName}
+        orgslug={orgslug}
+        org_id={org.id}
+        days={data.days_remaining}
+      />
+    )
+  }
+
+  // NEVER block the routes the user needs to unblock themselves. The account
+  // area holds the security page where two-factor is enrolled; blocking it
+  // would leave them with no way out but signing out.
+  const segments = (pathname || '').split('/').filter(Boolean)
+  const isEscapeRoute = ['account', 'login', 'logout', 'signup'].some((s) =>
+    segments.includes(s)
+  )
+  if (isEscapeRoute) {
+    return (
+      <CountdownBanner
+        orgName={orgName}
+        orgslug={orgslug}
+        org_id={org.id}
+        days={0}
+        overdue
+      />
+    )
+  }
+
+  return <BlockingInterstitial orgName={orgName} orgslug={orgslug} />
+}
+
+export default OrgMFAPolicyGate


### PR DESCRIPTION
Account-security suite. All opt-in and backward-compatible — default config keeps today's behavior.

- **Two-factor auth (TOTP)** — enrollment, backup codes, login challenge.
- **Org "require 2FA" policy** — with grace period.
- **Passwordless magic-link login** — plus a per-org toggle to offer it.
- **Per-org allowed auth methods** — restrict to password / magic link / Google / SSO.
- **Session isolation** — optional switch so a central learnhouse.io session can't reach an org without re-authenticating.
- **Admin "reset a member's 2FA"** — lost-device recovery.

### Deploy
- Run `alembic upgrade head` (adds `usermfa` + `usermfabackupcode`; single linear head).
- Requires Redis (magic-link fails closed without it) and an email transport (magic-link / verification emails).
- Recommended: set `LEARNHOUSE_MFA_ENCRYPTION_KEY` (else it derives from the JWT secret — rotating the JWT secret later would then lock out enrolled 2FA users).

Patch coverage 100%. Everything else (allowed methods, session-sharing, reset) is a per-org setting in Org → Settings → Security.
