### PR TITLE
fix(assignments): grade/certificate reconciliation, submission-file token IDOR, autosave data loss, and more

### DIFF
--- a/apps/api/src/db/courses/assignments.py
+++ b/apps/api/src/db/courses/assignments.py
@@ -161,7 +161,12 @@ class AssignmentTaskBase(SQLModel):
     # legacy assignments set different values which, when summed, yielded a
     # weighted average. New tasks and the UI always use 100, so the
     # compute_assignment_grade math produces a simple average across tasks.
-    max_grade_value: int = 100
+    # Must be non-negative: a negative max would subtract from the assignment
+    # total, and compute_assignment_grade clamps a non-positive total to a
+    # vacuous pass, so a single negative task could cancel real points and hand
+    # out the certificate. (DB CHECK constraint is a follow-up; the API rejects
+    # it here.)
+    max_grade_value: int = Field(default=100, ge=0)
 
 
 class AssignmentTaskCreate(AssignmentTaskBase):
@@ -187,7 +192,7 @@ class AssignmentTaskUpdate(SQLModel):
     hint: Optional[str] = None
     assignment_type: Optional[AssignmentTaskTypeEnum] = None
     contents: Optional[Dict] = Field(default=None, sa_column=Column(JSON))
-    max_grade_value: Optional[int] = None
+    max_grade_value: Optional[int] = Field(default=None, ge=0)
 
 
 class AssignmentTask(AssignmentTaskBase, table=True):

--- a/apps/api/src/security/submission_file_access.py
+++ b/apps/api/src/security/submission_file_access.py
@@ -16,7 +16,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from src.db.courses.assignments import AssignmentTask, AssignmentTaskSubmission
 from src.db.courses.courses import Course
-from src.db.users import AnonymousUser
+from src.db.users import AnonymousUser, APITokenUser
 
 # Keys under which a FILE_SUBMISSION task_submission stores the uploaded
 # filename. The web client saves it as ``fileUUID`` (the on-disk name returned
@@ -75,6 +75,15 @@ async def enforce_submission_file_access(
     # Submission files are never public — authentication is always required.
     if isinstance(current_user, AnonymousUser) or getattr(current_user, "id", None) is None:
         raise HTTPException(status_code=401, detail="Authentication required")
+
+    # An API token must never reach the identity checks below: its ``.id`` is the
+    # token's own primary key, not a user id, so the owner query
+    # (``user_id == current_user.id``) and the RBAC subject would both treat it
+    # as a same-numbered learner — letting a token read another user's submission
+    # file, across orgs. There is no token-integration use case for downloading
+    # raw submission files, so deny outright.
+    if isinstance(current_user, APITokenUser):
+        raise HTTPException(status_code=403, detail="Access denied")
 
     # Instructors / authors (course UPDATE right) may view any submission.
     if request is not None:

--- a/apps/api/src/services/ai/assignment_gen.py
+++ b/apps/api/src/services/ai/assignment_gen.py
@@ -254,6 +254,11 @@ async def generate_assignment_plan(
             continue
         generated_tasks.append(gen_task)
 
+    # The prompt asks for exactly num_tasks, but a model can over-produce; cap
+    # the persisted plan so a chatty response can't create more tasks than the
+    # (already clamped) request allowed.
+    generated_tasks = generated_tasks[:num_tasks]
+
     generated = GeneratedAssignmentPlan(
         title=plan.title,
         description=plan.description,

--- a/apps/api/src/services/courses/activities/assignments.py
+++ b/apps/api/src/services/courses/activities/assignments.py
@@ -1579,6 +1579,17 @@ async def update_assignment_task(
     # RBAC check
     await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.UPDATE)
 
+    # A change to how a task is scored (its type, its answer key/definition, or
+    # its max points) invalidates the grades already stored for it. The delete
+    # path re-grades for exactly this reason; an in-place edit is the same
+    # hazard, so detect a scoring-relevant change and re-grade the same way.
+    _SCORING_FIELDS = ("assignment_type", "contents", "max_grade_value")
+    scoring_changed = any(
+        getattr(assignment_task_object, f, None) is not None
+        and getattr(assignment_task_object, f) != getattr(assignment_task, f)
+        for f in _SCORING_FIELDS
+    )
+
     # Update only the fields that were passed in
     for var, value in vars(assignment_task_object).items():
         if value is not None:
@@ -1589,6 +1600,14 @@ async def update_assignment_task(
     db_session.add(assignment_task)
     await db_session.commit()
     await db_session.refresh(assignment_task)
+
+    if scoring_changed:
+        await _regrade_graded_submissions(
+            assignment=assignment,
+            course=course,
+            db_session=db_session,
+            request=request,
+        )
 
     # return assignment task read
     return AssignmentTaskRead.model_validate(assignment_task)
@@ -1651,21 +1670,63 @@ async def delete_assignment_task(
         assignment=assignment,
         course=course,
         db_session=db_session,
+        request=request,
     )
 
     return {"message": "Assignment Task deleted"}
+
+
+async def _reconcile_certificate_after_grade_change(
+    request: Request | None,
+    user_id: int,
+    course: Course,
+    db_session: AsyncSession,
+) -> None:
+    """Bring a learner's certificate back in line with their current grades.
+
+    Recomputing a grade can flip a learner across the passing threshold. If they
+    no longer pass every gating assignment, a held certificate is revoked and the
+    enrollment status demoted; if they now pass and the course is otherwise
+    complete, a certificate is (re)issued. Best-effort: never abort the caller.
+    """
+    if not course.id:
+        return
+    try:
+        passed = await are_course_assignments_passed(user_id, course.id, db_session)
+        if not passed:
+            await revoke_user_certificate(
+                user_id, course.id, db_session, reason="regraded_below_threshold"
+            )
+            await sync_trailrun_status(user_id, course.id, db_session)
+        elif request is not None:
+            # Now passing — re-issue if the course is otherwise complete. Safe to
+            # call when a cert already exists (it no-ops on a duplicate).
+            await check_course_completion_and_create_certificate(
+                request, user_id, course.id, db_session
+            )
+    except Exception:
+        logger.exception(
+            "Failed to reconcile certificate for user %s on course %s after a grade change",
+            user_id,
+            course.id,
+        )
 
 
 async def _regrade_graded_submissions(
     assignment: Assignment,
     course: Course,
     db_session: AsyncSession,
+    request: Request | None = None,
 ) -> None:
     """Recompute stored grades for every GRADED submission of ``assignment``.
 
     Call after the task set changes, so the persisted numerator stops
     disagreeing with the live denominator. Best-effort per learner: one
     learner's failure must not abort the teacher's edit.
+
+    Recomputing can move a learner across the passing threshold, so each
+    regraded learner's certificate is reconciled — revoked if they now fail,
+    reissued if they now pass. Pass ``request`` to enable reissue.
     """
     graded = (await db_session.execute(
         select(AssignmentUserSubmission).where(
@@ -1695,6 +1756,10 @@ async def _regrade_graded_submissions(
                 submission.user_id,
                 assignment.assignment_uuid,
             )
+            continue
+        await _reconcile_certificate_after_grade_change(
+            request, submission.user_id, course, db_session
+        )
 
 
 ## > Assignments Tasks Submissions CRUD
@@ -2382,8 +2447,43 @@ async def delete_assignment_task_submission(
     await check_resource_access(request, db_session, current_user, course.course_uuid, AccessAction.DELETE)
 
     # Delete Assignment Task Submission
+    deleted_user_id = assignment_task_submission.user_id
     await db_session.delete(assignment_task_submission)
     await db_session.commit()
+
+    # Removing one per-task answer changes the learner's aggregate for this
+    # assignment. If their overall submission was already GRADED, its stored
+    # grade (and any certificate that depended on it) is now stale — recompute
+    # and reconcile, the same as when a whole task is deleted.
+    if deleted_user_id is not None:
+        graded_submission = (await db_session.execute(
+            select(AssignmentUserSubmission).where(
+                AssignmentUserSubmission.assignment_id == assignment.id,
+                AssignmentUserSubmission.user_id == deleted_user_id,
+                AssignmentUserSubmission.submission_status
+                == AssignmentUserSubmissionStatus.GRADED,
+            )
+        )).scalars().first()
+        if graded_submission is not None:
+            try:
+                await _apply_grade_and_finalize(
+                    assignment=assignment,
+                    course=course,
+                    user_id=deleted_user_id,
+                    assignment_user_submission=graded_submission,
+                    db_session=db_session,
+                    overall_feedback=None,
+                    auto_graded=True,
+                    dispatch_webhook=False,
+                )
+                await _reconcile_certificate_after_grade_change(
+                    request, deleted_user_id, course, db_session
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to recompute aggregate for user %s after deleting a task submission",
+                    deleted_user_id,
+                )
 
     return {"message": "Assignment Task Submission deleted"}
 

--- a/apps/api/src/services/courses/activities/assignments.py
+++ b/apps/api/src/services/courses/activities/assignments.py
@@ -2499,6 +2499,7 @@ async def create_assignment_submission(
     # race and already created the row (unique (user_id, assignment_id)), recover
     # by adopting the existing row instead of erroring/duplicating.
     db_session.add(assignment_user_submission)
+    won_insert = True
     try:
         await db_session.commit()
     except IntegrityError:  # pragma: no cover - concurrent-submit race recovery
@@ -2507,6 +2508,10 @@ async def create_assignment_submission(
         # branch only fires under a genuine DB-level race, which the aiosqlite test
         # harness can't faithfully simulate (raises MissingGreenlet where prod
         # asyncpg recovers), so it is excluded from coverage.
+        # This request LOST the race: another concurrent submit already created
+        # the row and emitted the ASSIGNMENT_SUBMITTED analytics/webhook events,
+        # so this one must adopt the winner's row WITHOUT re-firing them.
+        won_insert = False
         await db_session.rollback()
         assignment_user_submission = (await db_session.execute(
             select(AssignmentUserSubmission).where(
@@ -2531,41 +2536,43 @@ async def create_assignment_submission(
 
     # Track assignment submission. attempt_number lets downstream consumers
     # (analytics, webhooks) tell a retry resubmit from the original — without
-    # it, retries would silently double-count.
+    # it, retries would silently double-count. Skipped when this request lost
+    # the concurrent-submit race, so a duplicate submit fires the event once.
     submitted_attempt_number = int(assignment_user_submission.attempt_number or 1)
-    await track(
-        event_name=analytics_events.ASSIGNMENT_SUBMITTED,
-        org_id=course.org_id,
-        user_id=submitter.id,
-        properties={
-            "assignment_uuid": assignment_uuid,
-            "course_uuid": course.course_uuid,
-            "attempt_number": submitted_attempt_number,
-        },
-    )
-    # Durable audit row — retries reset the live submission in place, so each
-    # attempt only survives permanently here.
-    await record_audit_event(
-        event_type=UserAuditEventType.ASSIGNMENT_SUBMITTED,
-        user_id=submitter.id,
-        org_id=course.org_id,
-        target_uuid=assignment_uuid,
-        metadata={
-            "course_uuid": course.course_uuid,
-            "course_name": course.name,
-            "attempt_number": submitted_attempt_number,
-        },
-    )
-    await dispatch_webhooks(
-        event_name=analytics_events.ASSIGNMENT_SUBMITTED,
-        org_id=course.org_id,
-        data={
-            "user": {"user_uuid": submitter.user_uuid, "email": submitter.email, "username": submitter.username},
-            "assignment": {"assignment_uuid": assignment_uuid},
-            "course": {"course_uuid": course.course_uuid, "name": course.name},
-            "attempt_number": submitted_attempt_number,
-        },
-    )
+    if won_insert:
+        await track(
+            event_name=analytics_events.ASSIGNMENT_SUBMITTED,
+            org_id=course.org_id,
+            user_id=submitter.id,
+            properties={
+                "assignment_uuid": assignment_uuid,
+                "course_uuid": course.course_uuid,
+                "attempt_number": submitted_attempt_number,
+            },
+        )
+        # Durable audit row — retries reset the live submission in place, so each
+        # attempt only survives permanently here.
+        await record_audit_event(
+            event_type=UserAuditEventType.ASSIGNMENT_SUBMITTED,
+            user_id=submitter.id,
+            org_id=course.org_id,
+            target_uuid=assignment_uuid,
+            metadata={
+                "course_uuid": course.course_uuid,
+                "course_name": course.name,
+                "attempt_number": submitted_attempt_number,
+            },
+        )
+        await dispatch_webhooks(
+            event_name=analytics_events.ASSIGNMENT_SUBMITTED,
+            org_id=course.org_id,
+            data={
+                "user": {"user_uuid": submitter.user_uuid, "email": submitter.email, "username": submitter.username},
+                "assignment": {"assignment_uuid": assignment_uuid},
+                "course": {"course_uuid": course.course_uuid, "name": course.name},
+                "attempt_number": submitted_attempt_number,
+            },
+        )
 
     # User (the learner the submission belongs to)
     statement = select(User).where(User.id == submitter.id)

--- a/apps/api/src/tests/security/test_submission_file_access.py
+++ b/apps/api/src/tests/security/test_submission_file_access.py
@@ -20,7 +20,7 @@ from src.db.courses.assignments import (
     AssignmentTaskTypeEnum,
     GradingTypeEnum,
 )
-from src.db.users import AnonymousUser, PublicUser
+from src.db.users import AnonymousUser, PublicUser, APITokenUser
 from src.security.submission_file_access import (
     is_submission_file,
     enforce_submission_file_access,
@@ -167,5 +167,18 @@ class TestEnforceSubmissionFileAccess:
         with pytest.raises(HTTPException) as exc:
             await enforce_submission_file_access(
                 _parts("course_does_not_exist"), regular_user, db, request=None
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_api_token_is_denied(self, db, org, course, chapter, activity, regular_user):
+        # An API token's id is a token PK, not a user id. If it were used as a
+        # learner identity, a token whose id equals a learner's id could read
+        # that learner's submission file (cross-org). Tokens are denied outright.
+        await _seed(db, org, course, chapter, activity, regular_user, filename=FILE)
+        token = APITokenUser(id=regular_user.id, org_id=org.id, created_by_user_id=1)
+        with pytest.raises(HTTPException) as exc:
+            await enforce_submission_file_access(
+                _parts(course.course_uuid), token, db, request=MagicMock()
             )
         assert exc.value.status_code == 403

--- a/apps/api/src/tests/services/test_ai_assignment_gen_service.py
+++ b/apps/api/src/tests/services/test_ai_assignment_gen_service.py
@@ -122,6 +122,29 @@ async def test_generate_assignment_plan_filters_disallowed_types():
     save.assert_called_once()
 
 
+async def test_generate_assignment_plan_caps_tasks_to_requested_count():
+    # An over-producing model must not create more tasks than requested.
+    def _two():
+        return AIAssignmentPlan(
+            title="A", description="d", grading_type="PERCENTAGE",
+            tasks=[
+                AITask(title="t1", description="d1", assignment_type="SHORT_ANSWER",
+                       short_answer=AIShortAnswerContents(prompt="P", correct_answers=["a"])),
+                AITask(title="t2", description="d2", assignment_type="SHORT_ANSWER",
+                       short_answer=AIShortAnswerContents(prompt="P2", correct_answers=["b"])),
+            ],
+        )
+    with patch.object(ag, "_course_context", new=AsyncMock(return_value="ctx")), \
+         patch.object(ag, "get_chat_session_history", return_value={"aichat_uuid": "s1", "message_history": []}), \
+         patch.object(ag, "generate", new=AsyncMock(return_value=_two())), \
+         patch.object(ag, "save_message_to_history"):
+        plan, _ = await ag.generate_assignment_plan(
+            org_id=1, course_id=2, prompt="p", model_name="m", db_session=AsyncMock(),
+            num_tasks=1, allowed_task_types=["SHORT_ANSWER"],
+        )
+    assert len(plan.tasks) == 1
+
+
 async def test_generate_assignment_plan_clamps_num_tasks():
     captured = {}
 

--- a/apps/api/src/tests/services/test_assignment_lifecycle_reconcile.py
+++ b/apps/api/src/tests/services/test_assignment_lifecycle_reconcile.py
@@ -136,3 +136,58 @@ class TestDeleteTaskSubmissionReconciles:
         await db.refresh(us)
         # The graded aggregate no longer counts the deleted answer.
         assert us.grade == 0
+
+
+class TestReconcileCertificateAfterGradeChange:
+    """The reconcile helper revokes when a regrade drops a learner below the
+    threshold and reissues when it lifts them above."""
+
+    @pytest.mark.asyncio
+    async def test_revokes_when_no_longer_passing(self, mock_request, db, org, course):
+        from src.services.courses.activities import assignments as ag
+        with patch.object(ag, "are_course_assignments_passed", new=AsyncMock(return_value=False)), \
+             patch.object(ag, "revoke_user_certificate", new_callable=AsyncMock) as revoke, \
+             patch.object(ag, "sync_trailrun_status", new_callable=AsyncMock) as sync, \
+             patch.object(ag, "check_course_completion_and_create_certificate", new_callable=AsyncMock) as issue:
+            await ag._reconcile_certificate_after_grade_change(mock_request, 7, course, db)
+        revoke.assert_awaited_once()
+        sync.assert_awaited_once()
+        issue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reissues_when_now_passing(self, mock_request, db, org, course):
+        from src.services.courses.activities import assignments as ag
+        with patch.object(ag, "are_course_assignments_passed", new=AsyncMock(return_value=True)), \
+             patch.object(ag, "revoke_user_certificate", new_callable=AsyncMock) as revoke, \
+             patch.object(ag, "check_course_completion_and_create_certificate", new_callable=AsyncMock) as issue:
+            await ag._reconcile_certificate_after_grade_change(mock_request, 7, course, db)
+        issue.assert_awaited_once()
+        revoke.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_swallows_errors(self, mock_request, db, org, course):
+        # Best-effort: a failure in the eligibility check must not propagate.
+        from src.services.courses.activities import assignments as ag
+        with patch.object(ag, "are_course_assignments_passed",
+                          new=AsyncMock(side_effect=RuntimeError("boom"))):
+            await ag._reconcile_certificate_after_grade_change(mock_request, 7, course, db)
+
+
+class TestRegradeIsBestEffort:
+    @pytest.mark.asyncio
+    async def test_one_learner_failure_does_not_abort_the_rest(
+        self, mock_request, db, org, course, chapter, activity, regular_user
+    ):
+        # A regrade that throws for one submission is logged and skipped, never
+        # aborting the teacher's edit or the remaining learners.
+        from src.services.courses.activities import assignments as ag
+        a, task, us, ts = await _seed_graded(db, org, course, chapter, activity, regular_user)
+        with patch.object(ag, "_apply_grade_and_finalize",
+                          new=AsyncMock(side_effect=RuntimeError("boom"))), \
+             patch.object(ag, "_reconcile_certificate_after_grade_change",
+                          new_callable=AsyncMock) as reconcile:
+            await ag._regrade_graded_submissions(
+                assignment=a, course=course, db_session=db, request=mock_request
+            )
+        # Reconcile is skipped for the failed learner (the `continue` path).
+        reconcile.assert_not_called()

--- a/apps/api/src/tests/services/test_assignment_lifecycle_reconcile.py
+++ b/apps/api/src/tests/services/test_assignment_lifecycle_reconcile.py
@@ -1,0 +1,138 @@
+"""Regrade + certificate reconciliation when a task or task submission changes.
+
+Editing a task's scoring definition, or deleting a per-task submission, changes
+the aggregate grade already stored for a GRADED assignment submission. These
+paths must re-grade (and reconcile certificates), the same way deleting a whole
+task already did.
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.db.courses.assignments import (
+    Assignment,
+    AssignmentTask,
+    AssignmentTaskSubmission,
+    AssignmentTaskTypeEnum,
+    AssignmentUserSubmission,
+    AssignmentUserSubmissionStatus,
+    GradingTypeEnum,
+)
+from src.db.courses.assignments import AssignmentTaskUpdate
+from src.services.courses.activities.assignments import (
+    _apply_grade_and_finalize,
+    delete_assignment_task_submission,
+    update_assignment_task,
+)
+
+_AUTHZ = "src.services.courses.activities.assignments.authorize_assignment_access"
+_RBAC = "src.services.courses.activities.assignments.check_resource_access"
+
+
+async def _seed_graded(db, org, course, chapter, activity, user, *, answer="4", correct="4"):
+    a = Assignment(
+        title="A", description="x", due_date="2030-01-01", published=True,
+        grading_type=GradingTypeEnum.NUMERIC, auto_grading=True,
+        org_id=org.id, course_id=course.id, chapter_id=chapter.id, activity_id=activity.id,
+        assignment_uuid="assignment_recon", creation_date=str(datetime.now()),
+        update_date=str(datetime.now()),
+    )
+    db.add(a)
+    await db.commit()
+    await db.refresh(a)
+    task = AssignmentTask(
+        title="Q", description="d", hint="", reference_file=None,
+        assignment_type=AssignmentTaskTypeEnum.SHORT_ANSWER,
+        contents={"correct_answers": [correct], "match_mode": "exact"},
+        max_grade_value=100, assignment_id=a.id, org_id=org.id, course_id=course.id,
+        chapter_id=chapter.id, activity_id=activity.id,
+        assignment_task_uuid="assignmenttask_recon",
+        creation_date=str(datetime.now()), update_date=str(datetime.now()),
+    )
+    db.add(task)
+    await db.commit()
+    await db.refresh(task)
+    us = AssignmentUserSubmission(
+        user_id=user.id, assignment_id=a.id, grade=0,
+        submission_status=AssignmentUserSubmissionStatus.SUBMITTED, attempt_number=1,
+        assignmentusersubmission_uuid="aus_recon",
+        creation_date=str(datetime.now()), update_date=str(datetime.now()),
+    )
+    db.add(us)
+    ts = AssignmentTaskSubmission(
+        assignment_task_submission_uuid="ats_recon",
+        task_submission={"answer": answer}, grade=0, manually_graded=False,
+        task_submission_grade_feedback="",
+        assignment_type=AssignmentTaskTypeEnum.SHORT_ANSWER,
+        user_id=user.id, activity_id=task.activity_id, course_id=task.course_id,
+        chapter_id=task.chapter_id, assignment_task_id=task.id,
+        creation_date=str(datetime.now()), update_date=str(datetime.now()),
+    )
+    db.add(ts)
+    await db.commit()
+    await db.refresh(us)
+    await db.refresh(task)
+    await db.refresh(ts)
+    # Grade it now (answer matches -> 100).
+    with patch("src.services.courses.activities.assignments.dispatch_webhooks", new_callable=AsyncMock):
+        await _apply_grade_and_finalize(
+            assignment=a, course=course, user_id=user.id,
+            assignment_user_submission=us, db_session=db, auto_graded=True,
+        )
+    await db.refresh(us)
+    return a, task, us, ts
+
+
+class TestUpdateTaskRegrades:
+    @pytest.mark.asyncio
+    async def test_changing_answer_key_regrades_graded_submission(
+        self, mock_request, db, org, course, chapter, activity, regular_user, admin_user
+    ):
+        a, task, us, ts = await _seed_graded(db, org, course, chapter, activity, regular_user)
+        assert us.grade == 100  # answered correctly
+
+        # Move the correct answer so the same student answer is now wrong.
+        with patch(_AUTHZ, new_callable=AsyncMock):
+            await update_assignment_task(
+                mock_request, task.assignment_task_uuid,
+                AssignmentTaskUpdate(contents={"correct_answers": ["5"], "match_mode": "exact"}),
+                admin_user, db,
+            )
+        await db.refresh(us)
+        assert us.grade == 0  # re-graded against the new key
+
+    @pytest.mark.asyncio
+    async def test_non_scoring_edit_does_not_regrade(
+        self, mock_request, db, org, course, chapter, activity, regular_user, admin_user
+    ):
+        a, task, us, ts = await _seed_graded(db, org, course, chapter, activity, regular_user)
+        assert us.grade == 100
+        with patch(_AUTHZ, new_callable=AsyncMock), patch(
+            "src.services.courses.activities.assignments._regrade_graded_submissions",
+            new_callable=AsyncMock,
+        ) as regrade:
+            await update_assignment_task(
+                mock_request, task.assignment_task_uuid,
+                AssignmentTaskUpdate(title="Renamed", description="new"),
+                admin_user, db,
+            )
+        regrade.assert_not_called()
+
+
+class TestDeleteTaskSubmissionReconciles:
+    @pytest.mark.asyncio
+    async def test_deleting_task_submission_recomputes_aggregate(
+        self, mock_request, db, org, course, chapter, activity, regular_user, admin_user
+    ):
+        a, task, us, ts = await _seed_graded(db, org, course, chapter, activity, regular_user)
+        assert us.grade == 100
+
+        with patch(_RBAC, new_callable=AsyncMock):
+            await delete_assignment_task_submission(
+                mock_request, ts.assignment_task_submission_uuid, admin_user, db,
+            )
+        await db.refresh(us)
+        # The graded aggregate no longer counts the deleted answer.
+        assert us.grade == 0

--- a/apps/api/src/tests/services/test_assignments_service.py
+++ b/apps/api/src/tests/services/test_assignments_service.py
@@ -426,6 +426,20 @@ class TestCreateAssignmentTask:
                 await create_assignment_task(mock_request, "nonexistent", obj, admin_user, db)
         assert exc.value.status_code == 404
 
+    def test_negative_max_grade_value_is_rejected(self):
+        # A negative max would subtract from the assignment total and could hand
+        # out a certificate on a vacuous pass; the request models must reject it.
+        from pydantic import ValidationError
+        from src.db.courses.assignments import AssignmentTaskUpdate
+        with pytest.raises(ValidationError):
+            AssignmentTaskCreate(
+                title="T", description="D", hint="",
+                assignment_type=AssignmentTaskTypeEnum.SHORT_ANSWER,
+                contents={}, max_grade_value=-5,
+            )
+        with pytest.raises(ValidationError):
+            AssignmentTaskUpdate(max_grade_value=-1)
+
     async def test_creates_task_successfully(
         self, mock_request, db, assignment, admin_user
     ):

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/Modals/GenerateTasksAIModal.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/Modals/GenerateTasksAIModal.tsx
@@ -252,6 +252,11 @@ function GenerateTasksAIModal({
     setIsSaving(true)
     let saved = 0
     let failed = 0
+    // Tasks that didn't persist this round. On a partial failure we keep only
+    // these in the preview, so pressing Save again retries just the failures
+    // instead of re-posting the ones that already succeeded (which duplicated
+    // them).
+    const remaining: typeof tasks = []
     try {
       for (const task of tasks) {
         const body = {
@@ -265,8 +270,12 @@ function GenerateTasksAIModal({
         }
         // createAssignmentTask returns { success: false } on non-200 (it does not throw).
         const res = await createAssignmentTask(body, assignment_uuid, access_token)
-        if (res?.success === false) failed += 1
-        else saved += 1
+        if (res?.success === false) {
+          failed += 1
+          remaining.push(task)
+        } else {
+          saved += 1
+        }
       }
       // Refresh the task list the editor page renders (react-query key used by
       // AssignmentProvider / Tasks list).
@@ -278,9 +287,13 @@ function GenerateTasksAIModal({
       if (failed > 0) {
         toast.error(`${failed} task${failed === 1 ? '' : 's'} could not be saved.`)
       }
-      // Only close when everything saved; otherwise keep the preview so the
-      // teacher can retry the ones that failed.
-      if (failed === 0) closeModal(false)
+      // Only close when everything saved; otherwise keep ONLY the failed tasks
+      // in the preview so a retry re-posts just those, never the saved ones.
+      if (failed === 0) {
+        closeModal(false)
+      } else {
+        setTasks(remaining)
+      }
     } catch {
       toast.error('Some tasks could not be saved.')
     } finally {

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskCodeObject.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskCodeObject.tsx
@@ -462,10 +462,15 @@ function TaskCodeObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskCod
     if (res.success) {
       setUserSubmissions(res.data)
       setInitialCode(code)
-      // Refresh the batch task-submissions cache so a future re-mount sees the
-      // new submission. Skipped on silent auto-saves (draft; would refetch ~1s).
+      // Keep the shared 60s batch cache in sync with what we just saved, even on
+      // a silent auto-save. Patching the cached entry in place (no refetch)
+      // avoids the stale-hydration bug: a remount that reads the batch would
+      // otherwise get the pre-save submission and overwrite the newer code.
+      queryClient.setQueryData(
+        queryKeys.assignments.taskSubmission(assignment.assignment_object.assignment_uuid),
+        (old: any) => (old ? { ...old, [assignmentTaskUUID]: res.data } : old)
+      )
       if (!opts?.silent) {
-        queryClient.invalidateQueries({ queryKey: queryKeys.assignments.taskSubmission(assignment.assignment_object.assignment_uuid) })
         toast.success(t('dashboard.assignments.editor.toasts.task_saved'))
       }
       return true

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskFileObject.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskFileObject.tsx
@@ -174,9 +174,14 @@ export default function TaskFileObject({ view, user_id, assignmentTaskUUID, onGr
                 // to the call-time snapshot, so a change during the save survives.
                 setInitialUserSubmissions({ ...userSubmissions, assignment_task_submission_uuid: savedUUID });
                 setUserSubmissions(prev => ({ ...prev, assignment_task_submission_uuid: savedUUID }));
-                if (!opts?.silent) {
-                    queryClient.invalidateQueries({ queryKey: queryKeys.assignments.taskSubmission(assignment.assignment_object.assignment_uuid) });
-                }
+                // Keep the shared batch cache current with the saved file UUID,
+                // even on a silent save. Without this the 60s-cached batch still
+                // holds the pre-upload submission, so a remount re-hydrates the
+                // old file UUID and the next save persists the stale one.
+                queryClient.setQueryData(
+                    queryKeys.assignments.taskSubmission(assignment.assignment_object.assignment_uuid),
+                    (old: any) => (old ? { ...old, [assignmentTaskUUID]: res.data ?? old[assignmentTaskUUID] } : old)
+                );
                 return true;
             } else {
                 if (!opts?.silent) toast.error(t('dashboard.assignments.editor.toasts.task_save_error'));

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskFormObject.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskFormObject.tsx
@@ -324,11 +324,17 @@ function TaskFormObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskFor
 
         questions.forEach((question) => {
             question.blanks.forEach((blank) => {
+                // Mirror the server grader: a blank with no configured answer
+                // can't be auto-scored, so it counts toward neither the
+                // numerator nor the denominator. Counting it here inflated the
+                // denominator and made this preview grade lower than the server's.
+                const correct = (blank.correctAnswer ?? '').trim();
+                if (!correct) return;
                 totalBlanks++;
                 const userAnswer = userSubmissions.submissions.find(
                     (submission) => submission.questionUUID === question.questionUUID && submission.blankUUID === blank.blankUUID
                 );
-                if (userAnswer && userAnswer.answer.toLowerCase().trim() === blank.correctAnswer.toLowerCase().trim()) {
+                if (userAnswer && userAnswer.answer.toLowerCase().trim() === correct.toLowerCase()) {
                     correctAnswers++;
                 }
             });

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskQuizObject.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskQuizObject.tsx
@@ -445,8 +445,13 @@ function TaskQuizObject({ view, assignmentTaskUUID, user_id, onGraded }: TaskQui
             // Grade PER QUESTION (mirrors the server's _grade_quiz_task): a
             // question counts only when the student's selected option set exactly
             // matches the answer key. Per-option scoring gave phantom credit for
-            // unanswered questions (unselected wrong options "matched").
-            const gradableQuestions = questions.filter((q) => (q.options?.length ?? 0) > 0);
+            // unanswered questions (unselected wrong options "matched"). A
+            // question with no correct option is skipped by the server too (a
+            // blank submission would "match" an all-false key), so exclude it
+            // here or this preview grade drops below the server's.
+            const gradableQuestions = questions.filter(
+                (q) => (q.options?.length ?? 0) > 0 && q.options.some((o) => !!o.assigned_right_answer)
+            );
             let correctQuestions = 0;
 
             gradableQuestions.forEach((question) => {

--- a/apps/web/components/Objects/Activities/Assignment/useAutoSave.ts
+++ b/apps/web/components/Objects/Activities/Assignment/useAutoSave.ts
@@ -109,6 +109,11 @@ export function useAutoSave({
   const enabledRef = React.useRef(enabled)
   const inFlight = React.useRef(false)
   const mounted = React.useRef(true)
+  // Points at the persist-based flush (defined below). Used by the unmount and
+  // page-exit handlers so they await any in-flight save and THEN write the
+  // latest dirty value, instead of skipping while a save is mid-flight and
+  // losing the newer edit.
+  const flushRef = React.useRef<(() => Promise<boolean>) | null>(null)
   React.useEffect(() => { curRef.current = currentValue })
   React.useEffect(() => { savedRef.current = savedValue })
   React.useEffect(() => { saveRef.current = save })
@@ -250,8 +255,12 @@ export function useAutoSave({
   React.useEffect(() => () => {
     if (retryTimer.current) clearTimeout(retryTimer.current)
     const isBlockedValue = blockedValue.current !== null && blockedValue.current === curRef.current
-    if (!inFlight.current && !isBlockedValue && enabledRef.current && curRef.current !== savedRef.current) {
-      void saveRef.current({ silent: true })
+    if (!isBlockedValue && enabledRef.current && curRef.current !== savedRef.current) {
+      // Route through the persist-based flush: it awaits an in-flight save and
+      // then writes the latest dirty value. Firing the raw save here (as it
+      // used to) skipped whenever a save was already running, dropping the
+      // newer edit. Fire-and-forget — the request is what matters.
+      void flushRef.current?.()
     }
     mounted.current = false
   }, [])
@@ -262,7 +271,10 @@ export function useAutoSave({
   // beforeunload guard (shared with the Editor) warns if the write can't finish.
   React.useEffect(() => {
     if (typeof window === 'undefined') return
-    const flushPending = () => { void runAutoSave() }
+    // Persist-based flush (awaits any in-flight save, then writes the latest
+    // dirty value) rather than runAutoSave, which no-ops while a save is
+    // in flight and would drop an edit made during that request.
+    const flushPending = () => { void flushRef.current?.() }
     const onVisibilityChange = () => {
       if (document.visibilityState === 'hidden') flushPending()
     }
@@ -283,6 +295,9 @@ export function useAutoSave({
 
   const flush = React.useCallback(() => persist(true, false), [persist])
   const saveNow = React.useCallback(() => persist(false, true), [persist])
+
+  // Keep the unmount / page-exit handlers pointed at the current flush.
+  React.useEffect(() => { flushRef.current = flush }, [flush])
 
   return {
     status,


### PR DESCRIPTION
Two audit passes over the assignments feature, one per user role and one across concurrency, lifecycle, grading math, AI generation, and the frontend, checked 17 findings against the code. 15 held up, 2 were false positives. This fixes 11 and documents 4 that need real concurrency work to fix safely.

**Grades and certificates**
- Editing a task's scoring definition (type, answer key, max points) left already-graded submissions on the old rubric. Now re-grades them.
- Deleting a single per-task submission never recomputed the parent graded submission. Now recomputes.
- No re-grade path reconciled certificates, so a learner could keep one after dropping below threshold, or miss one after rising above. Added a reconcile step (revoke/reissue) to every re-grade path.
- `max_grade_value` accepted negatives. A negative task max drags the total down, and the grader treats a non-positive total as a vacuous pass, which could hand out a certificate for nothing. Request models now require >= 0. A DB check constraint is a follow-up (repo currently has two alembic heads).

**Security**
- Submission-file access keyed off `current_user.id` as a learner id, but an API token's `id` is a token primary key. A token whose id happened to match a learner's could read that learner's file, across orgs. Tokens are now denied that endpoint.

**Correctness / integrations**
- AI assignment generation appended every task the model returned, so a chatty model could exceed the requested count. Capped it.
- A submit that lost the concurrent unique-row race still fired submitted analytics/webhooks, double-counting. Events now gate on winning the insert.

**Frontend**
- Autosave dropped the latest answer on unmount or page exit if an earlier save was in flight. Now awaits it, then writes the still-dirty value.
- Code and file autosave left the shared submission cache stale on silent saves; a remount could overwrite a newer answer with the old one. Both now patch the cache in place.
- Quiz and form grade previews counted ungradable questions and blanks the server excludes, so the preview could read lower than the real grade. Aligned to server predicates.
- Retrying a partial AI-task save re-posted already-saved tasks. Preview now keeps only the failures.

Added regression tests for re-grade wiring, negative max grade, token file-access denial, and the AI task cap. Full assignments/grading/certification suites pass. Web changes are tsc/eslint clean. Not browser-verified.

**Known, not fixed here**
- Plan-limit check on assignment create is count-then-insert racy, so a free org could exceed the cap by one under exact concurrency.
- Answer writes can race submission finalization; grading can race a retry reset. Both need the parent-submission row lock the retry path already uses.
- API-token submit-on-behalf skips enrollment, deadline, and answer-freeze checks by design (org boundary still enforced separately). Flagged for a product call, not changed.