### PR TITLE
fix: normalize walk_directory paths to POSIX separators on Windows

### DIFF
--- a/apps/api/src/services/courses/transfer/storage_utils.py
+++ b/apps/api/src/services/courses/transfer/storage_utils.py
@@ -340,7 +340,7 @@ def walk_directory(base_path: str):
 
         # Yield subdirectories
         for dir_rel in sorted(all_dirs):
-            dir_path = os.path.join(base_path, dir_rel)
+            dir_path = f"{base_path}/{dir_rel}"
             files = sorted(dir_files.get(dir_rel, set()))
             # Find immediate subdirs
             subdirs = sorted([
@@ -353,7 +353,7 @@ def walk_directory(base_path: str):
         # Walk local filesystem
         if os.path.exists(base_path):
             for root, dirs, files in os.walk(base_path):
-                yield root, dirs, files
+                yield root.replace(os.sep, "/"), dirs, files
 
 
 def upload_to_s3(file_path: str, content: bytes) -> bool:

--- a/apps/api/src/services/courses/transfer/storage_utils.py
+++ b/apps/api/src/services/courses/transfer/storage_utils.py
@@ -332,15 +332,20 @@ def walk_directory(base_path: str):
                 dir_files[dir_rel_path] = set()
             dir_files[dir_rel_path].add(filename)
 
+        # Every root we yield is a storage key prefix, so it stays '/'-joined
+        # regardless of the host os.sep, and a caller-supplied trailing '/'
+        # must not turn into a doubled separator further down.
+        posix_base = base_path.replace(os.sep, '/').rstrip('/')
+
         # Yield root first
         root_files = dir_files.get('', set())
         root_subdirs = sorted([d for d in all_dirs if '/' not in d and d])
         if root_files or root_subdirs:
-            yield base_path, root_subdirs, sorted(root_files)
+            yield posix_base, root_subdirs, sorted(root_files)
 
         # Yield subdirectories
         for dir_rel in sorted(all_dirs):
-            dir_path = f"{base_path}/{dir_rel}"
+            dir_path = f"{posix_base}/{dir_rel}"
             files = sorted(dir_files.get(dir_rel, set()))
             # Find immediate subdirs
             subdirs = sorted([

--- a/apps/api/src/tests/services/test_storage_utils_service.py
+++ b/apps/api/src/tests/services/test_storage_utils_service.py
@@ -338,9 +338,9 @@ class TestDirectoryHelpers:
             walked = list(storage_utils.walk_directory(str(base_dir)))
 
         assert walked == [
-            (str(base_dir), ["nested"], ["root.txt"]),
-            (str(nested_dir), ["deeper"], ["child.md"]),
-            (str(deeper_dir), [], ["deep.pdf"]),
+            (str(base_dir).replace("\\", "/"), ["nested"], ["root.txt"]),
+            (str(nested_dir).replace("\\", "/"), ["deeper"], ["child.md"]),
+            (str(deeper_dir).replace("\\", "/"), [], ["deep.pdf"]),
         ]
         assert all("\\" not in root for root, _, _ in walked)
 

--- a/apps/api/src/tests/services/test_storage_utils_service.py
+++ b/apps/api/src/tests/services/test_storage_utils_service.py
@@ -380,6 +380,29 @@ class TestDirectoryHelpers:
         ]
         assert all("\\" not in root for root, _, _ in walked)
 
+        # A trailing slash on the base path must not double up in the roots we
+        # yield — the S3 keys built from them would stop resolving.
+        with patch.object(
+            storage_utils,
+            "get_content_delivery_type",
+            return_value="s3api",
+        ), patch.object(
+            storage_utils,
+            "get_storage_client",
+            return_value=s3_client,
+        ), patch.object(
+            storage_utils,
+            "get_s3_bucket_name",
+            return_value="bucket",
+        ):
+            walked = list(storage_utils.walk_directory("content/transfer/"))
+
+        assert walked == [
+            ("content/transfer", ["nested"], ["root.txt", "side.txt"]),
+            ("content/transfer/nested", ["deeper"], ["child.md"]),
+            ("content/transfer/nested/deeper", [], ["deep.pdf"]),
+        ]
+
         s3_client.get_paginator.side_effect = _client_error("500", "list_objects_v2")
         with patch.object(
             storage_utils,


### PR DESCRIPTION
Fixes #814. Normalizes walk_directory to always yield POSIX / separators regardless of OS.