### PR TITLE
Cancel superseded runs and narrow the infra dispatch

### DIFF
--- a/.github/workflows/api-lint.yaml
+++ b/.github/workflows/api-lint.yaml
@@ -10,6 +10,13 @@ on:
       - "apps/api/**"
 permissions:
   contents: read
+
+# Only the newest commit on a PR needs a result. Runs on dev are never
+# cancelled — those are the ones whose result we keep.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ruff:
     runs-on: ubuntu-latest

--- a/.github/workflows/api-tests.yaml
+++ b/.github/workflows/api-tests.yaml
@@ -10,6 +10,12 @@ on:
   pull_request:
     paths:
       - "apps/api/**"
+
+# See api-lint.yaml — one live run per PR, dev runs always finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -25,6 +31,11 @@ jobs:
         uses: astral-sh/setup-uv@v9.0.0
         with:
           version: latest
+          # Resolving and downloading the API's wheels from scratch on every
+          # run is pure repetition — the lockfile is what decides the answer,
+          # so key the cache on it.
+          enable-cache: true
+          cache-dependency-glob: "apps/api/uv.lock"
 
       - name: Install ffmpeg
         # Required by the video faststart / HLS transcode tests (they skip

--- a/.github/workflows/build-community.yaml
+++ b/.github/workflows/build-community.yaml
@@ -1,20 +1,45 @@
 name: Build Community Images
 
+# The image only ever contains apps/web, apps/collab and apps/api (see
+# Dockerfile). A README edit or a CLI-only change cannot alter the image, so it
+# does not need one. Deliberately a deny-list rather than an allow-list:
+# anything new at the repo root still triggers a build. The list is spelled out
+# twice because GitHub Actions does not support YAML anchors — keep both copies
+# in sync.
 on:
   push:
     branches:
       - prod
       - dev
       - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'apps/cli/**'
+      - 'apps/e2e/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'LICENSE'
   pull_request:
     branches:
       - prod
       - dev
       - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'apps/cli/**'
+      - 'apps/e2e/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'LICENSE'
 
 permissions:
   contents: read
   packages: write
+
+# See api-lint.yaml — one live run per PR, dev runs always finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -11,6 +11,12 @@ on:
     paths:
       - 'apps/cli/**'
 
+# The integration job boots real Docker and is allowed 45 minutes, so a
+# superseded run is worth cancelling the moment a newer commit lands.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 defaults:
   run:
     working-directory: apps/cli
@@ -25,6 +31,14 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      # setup-bun restores the toolchain, not the packages.
+      - name: Cache bun install cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-cli-${{ runner.os }}-${{ hashFiles('apps/cli/bun.lock') }}
+          restore-keys: bun-cli-${{ runner.os }}-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -42,6 +56,14 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      # setup-bun restores the toolchain, not the packages.
+      - name: Cache bun install cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-cli-${{ runner.os }}-${{ hashFiles('apps/cli/bun.lock') }}
+          restore-keys: bun-cli-${{ runner.os }}-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/notify-infra.yaml
+++ b/.github/workflows/notify-infra.yaml
@@ -8,20 +8,41 @@ on:
     tags:
       - '[0-9]*'
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    # A draft only dispatches once it is marked ready (see the job condition).
+    types: [opened, synchronize, reopened, ready_for_review, closed]
 
 permissions: {}
+
+# Only the newest dispatch per ref is useful; supersede the rest.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   notify:
     name: Dispatch to Infrastructure Repo
     runs-on: ubuntu-latest
-    # Skip for pull requests opened from forks: GitHub does not expose
-    # secrets (INFRA_REPO_PAT) to fork PRs, so the dispatch can only ever
-    # fail there. Still runs for pushes and same-repo (internal) PRs.
+    # Dispatch only where the receiving side can act on it:
+    #
+    #   forks   — GitHub does not expose secrets (INFRA_REPO_PAT) to fork PRs,
+    #             so the dispatch can only ever fail there.
+    #   drafts  — dispatched on `ready_for_review` instead.
+    #   bots    — automated dependency PRs are covered by the checks in this
+    #             repo; build-community.yaml still builds the image for them.
+    #
+    # `closed` always dispatches, so teardown is never skipped.
     if: >-
       github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        (
+          github.event.action == 'closed' ||
+          (
+            !github.event.pull_request.draft &&
+            !endsWith(github.event.pull_request.user.login, '[bot]')
+          )
+        )
+      )
     steps:
       - name: Send repository dispatch
         uses: peter-evans/repository-dispatch@v4

--- a/.github/workflows/web-lint.yaml
+++ b/.github/workflows/web-lint.yaml
@@ -10,6 +10,12 @@ on:
       - "apps/web/**"
 permissions:
   contents: read
+
+# See api-lint.yaml — one live run per PR, dev runs always finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   next-lint:
     runs-on: ubuntu-latest
@@ -20,6 +26,14 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      # setup-bun restores the toolchain, not the packages. Without this the
+      # web install re-downloads its whole tree on every lint run.
+      - name: Cache bun install cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-web-${{ runner.os }}-${{ hashFiles('apps/web/bun.lock') }}
+          restore-keys: bun-web-${{ runner.os }}-
       - name: Install dependencies
         run: bun install --frozen-lockfile
         working-directory: ./apps/web


### PR DESCRIPTION
Narrowed to changes that don't touch CI coverage. Nothing here changes what gets tested or what it catches.

- Concurrency groups on the PR-triggered workflows (api-lint, api-tests, web-lint, cli-tests, build-community, notify-infra). A superseded PR run gets cancelled instead of finishing against a commit that's no longer the branch head. Pushes to dev are never cancelled.
- notify-infra.yaml: skip draft PRs and automated dependency PRs, since the receiving side can't act on those anyway. Added `ready_for_review` to the trigger so a draft dispatches once it's marked ready. `closed` still always fires, and fork PRs were already skipped.
- build-community.yaml: added `paths-ignore` for paths the image can't contain (markdown, docs/, apps/cli/, apps/e2e/, issue templates, LICENSE). The Dockerfile only pulls from apps/web, apps/collab, and apps/api.
- Cache keys: uv on apps/api/uv.lock, bun on the bun.lock files.

Dropped from the earlier version, since some of you reviewed that one: the arm64 skip on PR builds, the reduced e2e schedule, the branch filter on cli-tests' push trigger, and the renovate.json changes. All reverted, so the build matrix, e2e schedule, cli-tests triggers, and renovate.json match what's on dev.

actionlint passes clean.