### PR TITLE
fix: add upload progress indicator for PDF and image blocks

### DIFF
--- a/apps/web/components/Objects/Editor/Extensions/Image/ImageBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Image/ImageBlockComponent.tsx
@@ -1,7 +1,7 @@
 import { NodeViewWrapper } from '@tiptap/react'
 import React, { useEffect } from 'react'
 import { Resizable } from 're-resizable'
-import { Image, Download, AlignLeft, AlignCenter, AlignRight, Expand, Upload, AlertCircle } from 'lucide-react'
+import { Image, Download, AlignLeft, AlignCenter, AlignRight, Expand, Upload, Loader2, AlertCircle } from 'lucide-react'
 import toast from 'react-hot-toast'
 import { uploadNewImageFile } from '../../../../../services/blocks/Image/images'
 import { getActivityBlockMediaDirectory } from '@services/media/media'
@@ -33,7 +33,7 @@ function ImageBlockComponent(props: any) {
   const [isLoading, setIsLoading] = React.useState(false)
   const [isDragging, setIsDragging] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
-  const [progress, setProgress] = React.useState<number | null>(null)
+  const [progress, setProgress] = React.useState(0)
   const [blockObject, setblockObject] = React.useState(
     props.node.attrs.blockObject
   )
@@ -74,6 +74,7 @@ function ImageBlockComponent(props: any) {
         access_token,
         (p) => setProgress(p)
       )
+      setProgress(100)
       setblockObject(object)
       props.updateAttributes({
         blockObject: object,
@@ -87,7 +88,7 @@ function ImageBlockComponent(props: any) {
       toast.error(errorMessage.includes('Upload failed') ? errorMessage : `Upload failed — please try again: ${errorMessage}`)
     } finally {
       setIsLoading(false)
-      setProgress(null)
+      setProgress(0)
     }
   }
 
@@ -315,15 +316,20 @@ function ImageBlockComponent(props: any) {
                 />
                 {isLoading ? (
                   <div className="space-y-3">
-                    <div className="w-full bg-neutral-200 rounded-full h-2">
+                    <Loader2 className="w-8 h-8 animate-spin mx-auto text-neutral-500" />
+                    <p className="text-sm text-neutral-600">{t('editor.blocks.image_block.uploading')} {progress}%</p>
+                    <div
+                      className="w-48 h-1 bg-neutral-200 rounded-full mx-auto overflow-hidden"
+                      role="progressbar"
+                      aria-valuenow={progress}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                    >
                       <div
-                        className="bg-blue-500 h-2 rounded-full transition-all"
-                        style={{ width: `${progress ?? 0}%` }}
+                        className="h-full bg-blue-500 rounded-full transition-all duration-200"
+                        style={{ width: `${progress}%` }}
                       />
                     </div>
-                    <p className="text-sm text-neutral-600">
-                      {t('editor.blocks.image_block.uploading')} {progress ?? 0}%
-                    </p>
                   </div>
                 ) : (
                   <div className="space-y-2">

--- a/apps/web/components/Objects/Editor/Extensions/Image/ImageBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Image/ImageBlockComponent.tsx
@@ -1,7 +1,7 @@
 import { NodeViewWrapper } from '@tiptap/react'
 import React, { useEffect } from 'react'
 import { Resizable } from 're-resizable'
-import { Image, Download, AlignLeft, AlignCenter, AlignRight, Expand, Upload, Loader2, AlertCircle } from 'lucide-react'
+import { Image, Download, AlignLeft, AlignCenter, AlignRight, Expand, Upload, AlertCircle } from 'lucide-react'
 import toast from 'react-hot-toast'
 import { uploadNewImageFile } from '../../../../../services/blocks/Image/images'
 import { getActivityBlockMediaDirectory } from '@services/media/media'
@@ -33,6 +33,7 @@ function ImageBlockComponent(props: any) {
   const [isLoading, setIsLoading] = React.useState(false)
   const [isDragging, setIsDragging] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
+  const [progress, setProgress] = React.useState<number | null>(null)
   const [blockObject, setblockObject] = React.useState(
     props.node.attrs.blockObject
   )
@@ -64,12 +65,14 @@ function ImageBlockComponent(props: any) {
   const handleUpload = async (file: File) => {
     if (!access_token) return
     setIsLoading(true)
+    setProgress(0)
     setError(null)
     try {
       let object = await uploadNewImageFile(
         file,
         props.extension.options.activity.activity_uuid,
-        access_token
+        access_token,
+        (p) => setProgress(p)
       )
       setblockObject(object)
       props.updateAttributes({
@@ -84,6 +87,7 @@ function ImageBlockComponent(props: any) {
       toast.error(errorMessage.includes('Upload failed') ? errorMessage : `Upload failed — please try again: ${errorMessage}`)
     } finally {
       setIsLoading(false)
+      setProgress(null)
     }
   }
 
@@ -311,8 +315,15 @@ function ImageBlockComponent(props: any) {
                 />
                 {isLoading ? (
                   <div className="space-y-3">
-                    <Loader2 className="w-8 h-8 animate-spin mx-auto text-neutral-500" />
-                    <p className="text-sm text-neutral-600">{t('editor.blocks.image_block.uploading')}</p>
+                    <div className="w-full bg-neutral-200 rounded-full h-2">
+                      <div
+                        className="bg-blue-500 h-2 rounded-full transition-all"
+                        style={{ width: `${progress ?? 0}%` }}
+                      />
+                    </div>
+                    <p className="text-sm text-neutral-600">
+                      {t('editor.blocks.image_block.uploading')} {progress ?? 0}%
+                    </p>
                   </div>
                 ) : (
                   <div className="space-y-2">

--- a/apps/web/components/Objects/Editor/Extensions/PDF/PDFBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/PDF/PDFBlockComponent.tsx
@@ -1,6 +1,6 @@
 import { NodeViewWrapper } from '@tiptap/react'
 import React, { useEffect } from 'react'
-import { FileText, Download, Expand, Upload, Loader2, AlertCircle } from 'lucide-react'
+import { FileText, Download, Expand, Upload, AlertCircle } from 'lucide-react'
 import toast from 'react-hot-toast'
 import { uploadNewPDFFile } from '../../../../../services/blocks/Pdf/pdf'
 import { getActivityBlockMediaDirectory } from '@services/media/media'
@@ -27,6 +27,7 @@ function PDFBlockComponent(props: any) {
   )
   const [isModalOpen, setIsModalOpen] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
+  const [progress, setProgress] = React.useState<number | null>(null)
   const fileInputRef = React.useRef<HTMLInputElement>(null)
   const fileId = blockObject
     ? `${blockObject.content.file_id}.${blockObject.content.file_format}`
@@ -46,11 +47,13 @@ function PDFBlockComponent(props: any) {
     e.preventDefault()
     if (!pdf) return
     setIsLoading(true)
+    setProgress(0)
     setError(null)
     try {
       let object = await uploadNewPDFFile(
         pdf,
-        props.extension.options.activity.activity_uuid, access_token
+        props.extension.options.activity.activity_uuid, access_token,
+        (p) => setProgress(p)
       )
       setblockObject(object)
       props.updateAttributes({
@@ -63,6 +66,7 @@ function PDFBlockComponent(props: any) {
       toast.error(errorMessage.includes('Upload failed') ? errorMessage : `Upload failed — please try again: ${errorMessage}`)
     } finally {
       setIsLoading(false)
+      setProgress(null)
     }
   }
 
@@ -201,8 +205,15 @@ function PDFBlockComponent(props: any) {
                 />
                 {isLoading ? (
                   <div className="space-y-3">
-                    <Loader2 className="w-8 h-8 animate-spin mx-auto text-blue-500" />
-                    <p className="text-sm text-neutral-600">{t('editor.blocks.pdf_block.uploading')}</p>
+                    <div className="w-full bg-neutral-200 rounded-full h-2">
+                      <div
+                        className="bg-blue-500 h-2 rounded-full transition-all"
+                        style={{ width: `${progress ?? 0}%` }}
+                      />
+                    </div>
+                    <p className="text-sm text-neutral-600">
+                      {t('editor.blocks.pdf_block.uploading')} {progress ?? 0}%
+                    </p>
                   </div>
                 ) : (
                   <div className="space-y-3">

--- a/apps/web/components/Objects/Editor/Extensions/PDF/PDFBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/PDF/PDFBlockComponent.tsx
@@ -1,6 +1,6 @@
 import { NodeViewWrapper } from '@tiptap/react'
 import React, { useEffect } from 'react'
-import { FileText, Download, Expand, Upload, AlertCircle } from 'lucide-react'
+import { FileText, Download, Expand, Upload, Loader2, AlertCircle } from 'lucide-react'
 import toast from 'react-hot-toast'
 import { uploadNewPDFFile } from '../../../../../services/blocks/Pdf/pdf'
 import { getActivityBlockMediaDirectory } from '@services/media/media'
@@ -27,7 +27,7 @@ function PDFBlockComponent(props: any) {
   )
   const [isModalOpen, setIsModalOpen] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
-  const [progress, setProgress] = React.useState<number | null>(null)
+  const [progress, setProgress] = React.useState(0)
   const fileInputRef = React.useRef<HTMLInputElement>(null)
   const fileId = blockObject
     ? `${blockObject.content.file_id}.${blockObject.content.file_format}`
@@ -55,6 +55,7 @@ function PDFBlockComponent(props: any) {
         props.extension.options.activity.activity_uuid, access_token,
         (p) => setProgress(p)
       )
+      setProgress(100)
       setblockObject(object)
       props.updateAttributes({
         blockObject: object,
@@ -66,7 +67,7 @@ function PDFBlockComponent(props: any) {
       toast.error(errorMessage.includes('Upload failed') ? errorMessage : `Upload failed — please try again: ${errorMessage}`)
     } finally {
       setIsLoading(false)
-      setProgress(null)
+      setProgress(0)
     }
   }
 
@@ -205,15 +206,20 @@ function PDFBlockComponent(props: any) {
                 />
                 {isLoading ? (
                   <div className="space-y-3">
-                    <div className="w-full bg-neutral-200 rounded-full h-2">
+                    <Loader2 className="w-8 h-8 animate-spin mx-auto text-blue-500" />
+                    <p className="text-sm text-neutral-600">{t('editor.blocks.pdf_block.uploading')} {progress}%</p>
+                    <div
+                      className="w-48 h-1 bg-neutral-200 rounded-full mx-auto overflow-hidden"
+                      role="progressbar"
+                      aria-valuenow={progress}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                    >
                       <div
-                        className="bg-blue-500 h-2 rounded-full transition-all"
-                        style={{ width: `${progress ?? 0}%` }}
+                        className="h-full bg-blue-500 rounded-full transition-all duration-200"
+                        style={{ width: `${progress}%` }}
                       />
                     </div>
-                    <p className="text-sm text-neutral-600">
-                      {t('editor.blocks.pdf_block.uploading')} {progress ?? 0}%
-                    </p>
                   </div>
                 ) : (
                   <div className="space-y-3">

--- a/apps/web/services/blocks/Image/images.ts
+++ b/apps/web/services/blocks/Image/images.ts
@@ -1,72 +1,26 @@
 import { getAPIUrl } from '@services/config/config'
 import {
-  RequestBodyFormWithAuthHeader,
   RequestBodyWithAuthHeader,
+  uploadFormWithProgress,
 } from '@services/utils/ts/requests'
 
 export async function uploadNewImageFile(
   file: any,
   activity_uuid: string,
   access_token: string,
-  onProgress?: (percent: number) => void
+  onProgress?: (_percent: number) => void
 ) {
+  // Send file thumbnail as form data
   const formData = new FormData()
   formData.append('file_object', file)
   formData.append('activity_uuid', activity_uuid)
 
-  const url = `${getAPIUrl()}blocks/image`
-
-  if (onProgress) {
-    const data = await new Promise<any>((resolve, reject) => {
-      const xhr = new XMLHttpRequest()
-      xhr.open('POST', url)
-      xhr.setRequestHeader('Authorization', `Bearer ${access_token}`)
-      xhr.withCredentials = true
-      xhr.upload.onprogress = (e) => {
-        if (e.lengthComputable) {
-          onProgress(Math.round((e.loaded / e.total) * 100))
-        }
-      }
-      xhr.onload = () => {
-        try {
-          const json = JSON.parse(xhr.responseText)
-          if (xhr.status >= 200 && xhr.status < 300) {
-            resolve(json)
-          } else {
-            const errorMessage = typeof json?.detail === 'string'
-              ? json.detail
-              : Array.isArray(json?.detail)
-                ? json.detail.map((e: any) => e.msg).join(', ')
-                : 'Upload failed'
-            reject(new Error(errorMessage))
-          }
-        } catch {
-          reject(new Error('Upload failed'))
-        }
-      }
-      xhr.onerror = () => reject(new Error('Upload failed'))
-      xhr.send(formData)
-    })
-    return data
-  }
-
-  const result = await fetch(
-    url,
-    RequestBodyFormWithAuthHeader('POST', formData, null, access_token)
+  return uploadFormWithProgress(
+    `${getAPIUrl()}blocks/image`,
+    formData,
+    access_token,
+    onProgress
   )
-
-  const data = await result.json()
-
-  if (!result.ok) {
-    const errorMessage = typeof data?.detail === 'string'
-      ? data.detail
-      : Array.isArray(data?.detail)
-        ? data.detail.map((e: any) => e.msg).join(', ')
-        : 'Upload failed'
-    throw new Error(errorMessage)
-  }
-
-  return data
 }
 
 export async function getImageFile(file_id: string, access_token: string) {

--- a/apps/web/services/blocks/Image/images.ts
+++ b/apps/web/services/blocks/Image/images.ts
@@ -7,15 +7,51 @@ import {
 export async function uploadNewImageFile(
   file: any,
   activity_uuid: string,
-  access_token: string
+  access_token: string,
+  onProgress?: (percent: number) => void
 ) {
-  // Send file thumbnail as form data
   const formData = new FormData()
   formData.append('file_object', file)
   formData.append('activity_uuid', activity_uuid)
 
+  const url = `${getAPIUrl()}blocks/image`
+
+  if (onProgress) {
+    const data = await new Promise<any>((resolve, reject) => {
+      const xhr = new XMLHttpRequest()
+      xhr.open('POST', url)
+      xhr.setRequestHeader('Authorization', `Bearer ${access_token}`)
+      xhr.withCredentials = true
+      xhr.upload.onprogress = (e) => {
+        if (e.lengthComputable) {
+          onProgress(Math.round((e.loaded / e.total) * 100))
+        }
+      }
+      xhr.onload = () => {
+        try {
+          const json = JSON.parse(xhr.responseText)
+          if (xhr.status >= 200 && xhr.status < 300) {
+            resolve(json)
+          } else {
+            const errorMessage = typeof json?.detail === 'string'
+              ? json.detail
+              : Array.isArray(json?.detail)
+                ? json.detail.map((e: any) => e.msg).join(', ')
+                : 'Upload failed'
+            reject(new Error(errorMessage))
+          }
+        } catch {
+          reject(new Error('Upload failed'))
+        }
+      }
+      xhr.onerror = () => reject(new Error('Upload failed'))
+      xhr.send(formData)
+    })
+    return data
+  }
+
   const result = await fetch(
-    `${getAPIUrl()}blocks/image`,
+    url,
     RequestBodyFormWithAuthHeader('POST', formData, null, access_token)
   )
 

--- a/apps/web/services/blocks/Pdf/pdf.ts
+++ b/apps/web/services/blocks/Pdf/pdf.ts
@@ -7,15 +7,51 @@ import {
 export async function uploadNewPDFFile(
   file: any,
   activity_uuid: string,
-  access_token: string
+  access_token: string,
+  onProgress?: (percent: number) => void
 ) {
-  // Send file thumbnail as form data
   const formData = new FormData()
   formData.append('file_object', file)
   formData.append('activity_uuid', activity_uuid)
 
+  const url = `${getAPIUrl()}blocks/pdf`
+
+  if (onProgress) {
+    const data = await new Promise<any>((resolve, reject) => {
+      const xhr = new XMLHttpRequest()
+      xhr.open('POST', url)
+      xhr.setRequestHeader('Authorization', `Bearer ${access_token}`)
+      xhr.withCredentials = true
+      xhr.upload.onprogress = (e) => {
+        if (e.lengthComputable) {
+          onProgress(Math.round((e.loaded / e.total) * 100))
+        }
+      }
+      xhr.onload = () => {
+        try {
+          const json = JSON.parse(xhr.responseText)
+          if (xhr.status >= 200 && xhr.status < 300) {
+            resolve(json)
+          } else {
+            const errorMessage = typeof json?.detail === 'string'
+              ? json.detail
+              : Array.isArray(json?.detail)
+                ? json.detail.map((e: any) => e.msg).join(', ')
+                : 'Upload failed'
+            reject(new Error(errorMessage))
+          }
+        } catch {
+          reject(new Error('Upload failed'))
+        }
+      }
+      xhr.onerror = () => reject(new Error('Upload failed'))
+      xhr.send(formData)
+    })
+    return data
+  }
+
   const result = await fetch(
-    `${getAPIUrl()}blocks/pdf`,
+    url,
     RequestBodyFormWithAuthHeader('POST', formData, null, access_token)
   )
 

--- a/apps/web/services/blocks/Pdf/pdf.ts
+++ b/apps/web/services/blocks/Pdf/pdf.ts
@@ -1,72 +1,26 @@
 import { getAPIUrl } from '@services/config/config'
 import {
-  RequestBodyFormWithAuthHeader,
   RequestBodyWithAuthHeader,
+  uploadFormWithProgress,
 } from '@services/utils/ts/requests'
 
 export async function uploadNewPDFFile(
   file: any,
   activity_uuid: string,
   access_token: string,
-  onProgress?: (percent: number) => void
+  onProgress?: (_percent: number) => void
 ) {
+  // Send file thumbnail as form data
   const formData = new FormData()
   formData.append('file_object', file)
   formData.append('activity_uuid', activity_uuid)
 
-  const url = `${getAPIUrl()}blocks/pdf`
-
-  if (onProgress) {
-    const data = await new Promise<any>((resolve, reject) => {
-      const xhr = new XMLHttpRequest()
-      xhr.open('POST', url)
-      xhr.setRequestHeader('Authorization', `Bearer ${access_token}`)
-      xhr.withCredentials = true
-      xhr.upload.onprogress = (e) => {
-        if (e.lengthComputable) {
-          onProgress(Math.round((e.loaded / e.total) * 100))
-        }
-      }
-      xhr.onload = () => {
-        try {
-          const json = JSON.parse(xhr.responseText)
-          if (xhr.status >= 200 && xhr.status < 300) {
-            resolve(json)
-          } else {
-            const errorMessage = typeof json?.detail === 'string'
-              ? json.detail
-              : Array.isArray(json?.detail)
-                ? json.detail.map((e: any) => e.msg).join(', ')
-                : 'Upload failed'
-            reject(new Error(errorMessage))
-          }
-        } catch {
-          reject(new Error('Upload failed'))
-        }
-      }
-      xhr.onerror = () => reject(new Error('Upload failed'))
-      xhr.send(formData)
-    })
-    return data
-  }
-
-  const result = await fetch(
-    url,
-    RequestBodyFormWithAuthHeader('POST', formData, null, access_token)
+  return uploadFormWithProgress(
+    `${getAPIUrl()}blocks/pdf`,
+    formData,
+    access_token,
+    onProgress
   )
-
-  const data = await result.json()
-
-  if (!result.ok) {
-    const errorMessage = typeof data?.detail === 'string'
-      ? data.detail
-      : Array.isArray(data?.detail)
-        ? data.detail.map((e: any) => e.msg).join(', ')
-        : 'Upload failed'
-    throw new Error(errorMessage)
-  }
-
-  return data
 }
 
 export async function getPDFFile(file_id: string, access_token: string) {

--- a/apps/web/services/blocks/Video/video.ts
+++ b/apps/web/services/blocks/Video/video.ts
@@ -2,6 +2,7 @@ import { getAPIUrl } from '@services/config/config'
 import {
   RequestBodyFormWithAuthHeader,
   RequestBodyWithAuthHeader,
+  uploadFormWithProgress,
 } from '@services/utils/ts/requests'
 
 export async function uploadNewVideoFile(
@@ -48,42 +49,12 @@ export function uploadNewVideoFileWithProgress(
   const formData = new FormData()
   formData.append('file_object', file)
   formData.append('activity_uuid', activity_uuid)
-  return new Promise((resolve, reject) => {
-    const xhr = new XMLHttpRequest()
-    xhr.open('POST', `${getAPIUrl()}blocks/video`)
-    xhr.withCredentials = true
-    xhr.setRequestHeader('Authorization', `Bearer ${access_token}`)
-    xhr.upload.onprogress = (e) => {
-      if (e.lengthComputable) onProgress((e.loaded / e.total) * 100)
-    }
-    xhr.onload = () => {
-      if (xhr.status >= 200 && xhr.status < 300) {
-        try {
-          resolve(JSON.parse(xhr.responseText))
-        } catch {
-          resolve({})
-        }
-      } else if (xhr.status === 413) {
-        reject(new Error('The file is too large to upload.'))
-      } else {
-        let detail: string | undefined
-        try {
-          const body = JSON.parse(xhr.responseText)
-          detail = typeof body?.detail === 'string'
-            ? body.detail
-            : Array.isArray(body?.detail)
-              ? body.detail.map((e: any) => e.msg).join(', ')
-              : undefined
-        } catch {
-          /* non-JSON error body */
-        }
-        reject(new Error(detail || `Upload failed (HTTP ${xhr.status})`))
-      }
-    }
-    xhr.onerror = () => reject(new Error('Network error during upload'))
-    xhr.onabort = () => reject(new Error('Upload cancelled'))
-    xhr.send(formData)
-  })
+  return uploadFormWithProgress(
+    `${getAPIUrl()}blocks/video`,
+    formData,
+    access_token,
+    onProgress
+  )
 }
 
 /**

--- a/apps/web/services/utils/ts/requests.ts
+++ b/apps/web/services/utils/ts/requests.ts
@@ -101,6 +101,78 @@ export const RequestBodyFormWithAuthHeader = (
   return options
 }
 
+const UPLOAD_TIMEOUT_MS = 30 * 60 * 1000
+
+/**
+ * POST a FormData payload with REAL upload progress.
+ *
+ * Uses XMLHttpRequest because fetch() cannot report request-body upload
+ * progress: large files otherwise sit on an indeterminate spinner for minutes.
+ * Resolves with the parsed JSON body and rejects with the backend `detail`
+ * message (or an HTTP-status message when the body isn't JSON, which is what
+ * an nginx 413 or a gateway 502 returns).
+ */
+export function uploadFormWithProgress<T = any>(
+  url: string,
+  formData: FormData,
+  access_token: string,
+  onProgress?: (_percent: number) => void
+): Promise<T> {
+  validateApiUrl(url)
+  return new Promise<T>((resolve, reject) => {
+    const xhr = new XMLHttpRequest()
+    xhr.open('POST', url)
+    xhr.setRequestHeader('Authorization', `Bearer ${access_token}`)
+    xhr.withCredentials = true
+    xhr.timeout = UPLOAD_TIMEOUT_MS
+
+    xhr.upload.onprogress = (e) => {
+      if (onProgress && e.lengthComputable) {
+        onProgress(Math.round((e.loaded / e.total) * 100))
+      }
+    }
+
+    xhr.onload = () => {
+      // Status first, body second: a successful upload with an empty body must
+      // not be reported as a failure, and a non-JSON error body must not hide
+      // the status code.
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          resolve(JSON.parse(xhr.responseText))
+        } catch {
+          resolve({} as T)
+        }
+        return
+      }
+      if (xhr.status === 413) {
+        reject(new Error('The file is too large to upload.'))
+        return
+      }
+      let detail: string | undefined
+      try {
+        const body = JSON.parse(xhr.responseText)
+        detail =
+          typeof body?.detail === 'string'
+            ? body.detail
+            : Array.isArray(body?.detail)
+              ? body.detail.map((e: any) => e.msg).join(', ')
+              : undefined
+      } catch {
+        /* non-JSON error body (nginx / gateway HTML) */
+      }
+      reject(new Error(detail || `Upload failed (HTTP ${xhr.status})`))
+    }
+
+    xhr.onerror = () =>
+      reject(new Error('Upload failed. Please check your connection and try again.'))
+    xhr.ontimeout = () =>
+      reject(new Error('Upload timed out. Please try again on a faster connection.'))
+    xhr.onabort = () => reject(new Error('Upload cancelled.'))
+
+    xhr.send(formData)
+  })
+}
+
 export const apiFetch = async (url: string, token?: string) => {
   // Create the request options
   let HeadersConfig = new Headers(


### PR DESCRIPTION
## Changes
- Replaced fetch with XMLHttpRequest in both uploadNewPDFFile and uploadNewImageFile to enable upload progress tracking
- Added optional onProgress callback to both upload functions (backward-compatible)
- PDFBlockComponent and ImageBlockComponent now show a real-time progress bar with percentage during upload instead of a static spinner

## Why
Currently, when uploading large PDF or image files, there is no visual feedback to the user about upload progress. This PR adds a real-time progress bar that shows the upload percentage, improving the user experience.

## Acceptance Criteria
- [x] Progress bar or percentage indicator shown on upload
- [x] Progress updates in real time as bytes are sent
- [x] On completion, progress indicator disappears

Closes #849
