### PR TITLE
Enforce org sign-in method policy at login, not after

### DIFF
--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -564,7 +564,16 @@ async def login(
             },
         )
 
-    # Step 5: Reset failed attempts and update login info
+    # Step 5: Enforce the org's allowed sign-in methods. Only meaningful when the
+    # login page named an org (the apex login belongs to no single org, and is
+    # caught by the per-request gate instead). Runs after the password check so
+    # the refusal can never be used to probe which orgs exist.
+    from src.services.orgs.auth_policy import enforce_login_auth_method
+
+    session_org_id = await _resolve_org_id_from_slug(org_slug, db_session)
+    await enforce_login_auth_method(db_session, session_org_id, AUTH_METHOD_PASSWORD)
+
+    # Step 6: Reset failed attempts and update login info
     await reset_failed_attempts(user, db_session)
     client_ip = get_client_ip(request)
     await update_login_info(user, client_ip, db_session)
@@ -579,11 +588,10 @@ async def login(
         metadata={"method": "password"},
     )
 
-    # Step 6: Issue a session — unless the account carries a second factor, in
+    # Step 7: Issue a session — unless the account carries a second factor, in
     # which case this returns a short-lived pending token instead and the caller
     # must complete /auth/login/mfa. No cookies and no user object are returned
     # on that branch: nothing is authenticated until the code is verified.
-    session_org_id = await _resolve_org_id_from_slug(org_slug, db_session)
     issue = await issue_session_or_challenge(
         db_session, user, amr=AUTH_METHOD_PASSWORD, org_id=session_org_id
     )
@@ -675,6 +683,12 @@ async def third_party_login(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Invalid org_id",
             )
+
+        # An org that has turned Google off must not be joinable — or reachable —
+        # through the Google button. Same door-level refusal as password login.
+        from src.services.orgs.auth_policy import enforce_login_auth_method
+
+        await enforce_login_auth_method(db_session, org_id, AUTH_METHOD_GOOGLE)
 
         join_mechanism = await get_org_join_mechanism(
             request, org_id, current_user, db_session
@@ -900,7 +914,7 @@ async def magic_link_request(
         resolve_org,
         send_magic_login_email,
     )
-    from src.services.orgs.auth_policy import get_org_auth_policy
+    from src.services.orgs.auth_policy import is_login_method_allowed
     from src.security.session_context import AUTH_METHOD_MAGIC_LOGIN
     from src.services.email.utils import get_base_url_from_request
 
@@ -916,10 +930,10 @@ async def magic_link_request(
     org = await resolve_org(body.org_slug, db_session)
     # If the request is scoped to an org that does not offer magic-link login,
     # do not send one — the link would only be refused at the org gate anyway.
-    if org is not None:
-        policy = await get_org_auth_policy(db_session, org.id)
-        if policy.method_restricted and AUTH_METHOD_MAGIC_LOGIN not in set(policy.allowed_auth_methods):
-            return generic
+    if org is not None and not await is_login_method_allowed(
+        db_session, org.id, AUTH_METHOD_MAGIC_LOGIN
+    ):
+        return generic
 
     user = (
         await db_session.execute(select(User).where(User.email == str(body.email)))
@@ -963,8 +977,12 @@ async def magic_link_verify(
 ):
     from src.services.auth.magic_login import consume_magic_login_token
     from src.security.session_context import AUTH_METHOD_MAGIC_LOGIN
+    from src.services.orgs.auth_policy import enforce_login_auth_method
 
     email, org_id = consume_magic_login_token(body.token)
+
+    # A link issued before the org turned magic login off must not still work.
+    await enforce_login_auth_method(db_session, org_id, AUTH_METHOD_MAGIC_LOGIN)
 
     user = (
         await db_session.execute(select(User).where(User.email == email))

--- a/apps/api/src/routers/mfa.py
+++ b/apps/api/src/routers/mfa.py
@@ -38,6 +38,7 @@ from src.services.auth.session import (
     decode_mfa_pending_provenance,
     mint_session_tokens,
 )
+from src.services.orgs.auth_policy import auth_policy_exception, evaluate_org_auth
 from src.services.orgs.mfa_policy import evaluate_mfa_compliance, get_org_mfa_policy
 from src.services.security.rate_limiting import check_rate_limit, get_client_ip
 from src.security.org_auth import is_org_admin
@@ -459,11 +460,16 @@ async def api_login_mfa(
 
 
 class OrgMFAPolicyUpdate(BaseModel):
-    require_2fa: bool
-    require_2fa_grace_days: int = 0
-    exempt_external_auth: bool = True
-    # Auth-method / session-sharing policy. Optional so an older client that only
-    # sends the 2FA fields leaves these untouched.
+    """Partial update — every field is optional and an omitted one is left as-is.
+
+    The dashboard splits this policy across two tabs (two-factor / sign-in
+    methods); each must be able to save its own fields without resetting the
+    other tab's to their defaults.
+    """
+
+    require_2fa: Optional[bool] = None
+    require_2fa_grace_days: Optional[int] = None
+    exempt_external_auth: Optional[bool] = None
     allowed_auth_methods: Optional[list[str]] = None
     allow_central_session_sharing: Optional[bool] = None
 
@@ -483,6 +489,17 @@ async def api_org_mfa_compliance(
     current_user=Depends(get_authenticated_user),
 ):
     user = await _require_human_user(current_user, db_session)
+
+    # The org's auth-method / session-sharing policy is enforced per request all
+    # over the API, but this endpoint is the one the dashboard polls to decide
+    # what to tell the user. Evaluating it here is what turns a scattering of
+    # 403s into the single "sign in to this org again" screen — without it the
+    # restriction is enforced but never explained, which reads as "the setting
+    # does nothing unless two-factor is also on".
+    block = await evaluate_org_auth(db_session, user.id, org_id)
+    if block is not None:
+        raise auth_policy_exception(block)
+
     state = await evaluate_mfa_compliance(db_session, user, org_id)
     return state.to_dict()
 
@@ -541,16 +558,19 @@ async def api_set_org_mfa_policy(
 
     was_enabled = bool(security.get("require_2fa", False))
 
-    security["require_2fa"] = form.require_2fa
-    security["require_2fa_grace_days"] = max(0, form.require_2fa_grace_days)
-    security["exempt_external_auth"] = form.exempt_external_auth
-    # Only re-anchor when switching off→on. Re-saving an already-active policy
-    # (e.g. to tweak the grace length) must not silently restart everyone's
-    # countdown.
-    if form.require_2fa and not was_enabled:
-        security["require_2fa_enabled_at"] = datetime.now().isoformat()
-    elif not form.require_2fa:
-        security["require_2fa_enabled_at"] = None
+    if form.require_2fa_grace_days is not None:
+        security["require_2fa_grace_days"] = max(0, form.require_2fa_grace_days)
+    if form.exempt_external_auth is not None:
+        security["exempt_external_auth"] = form.exempt_external_auth
+    if form.require_2fa is not None:
+        security["require_2fa"] = form.require_2fa
+        # Only re-anchor when switching off→on. Re-saving an already-active policy
+        # (e.g. to tweak the grace length) must not silently restart everyone's
+        # countdown.
+        if form.require_2fa and not was_enabled:
+            security["require_2fa_enabled_at"] = datetime.now().isoformat()
+        elif not form.require_2fa:
+            security["require_2fa_enabled_at"] = None
 
     # Auth-method / session-sharing policy, with self-lockout guards so an admin
     # cannot save a policy that would refuse their own current session.

--- a/apps/api/src/routers/users.py
+++ b/apps/api/src/routers/users.py
@@ -162,6 +162,18 @@ async def api_get_authorization_status(
     )
 
 
+async def _enforce_password_signup_allowed(db_session: AsyncSession, org_id: int) -> None:
+    """Refuse a password signup into an org that doesn't accept password sign-in.
+
+    Same gate the login endpoint applies, one step earlier: without it the org's
+    own signup page would happily mint accounts that its policy then refuses.
+    """
+    from src.security.session_context import AUTH_METHOD_PASSWORD
+    from src.services.orgs.auth_policy import enforce_login_auth_method
+
+    await enforce_login_auth_method(db_session, org_id, AUTH_METHOD_PASSWORD)
+
+
 @router.post(
     "/{org_id}",
     response_model=UserRead,
@@ -184,6 +196,9 @@ async def api_create_user_with_orgid(
     """
     Create User with Org ID
     """
+    # An org that has turned email+password off must not hand out password
+    # accounts for itself — they could never be used to sign in to it.
+    await _enforce_password_signup_allowed(db_session, org_id)
 
     # TODO(fix) : This is temporary, logic should be moved to service
     if (
@@ -221,6 +236,8 @@ async def api_create_user_with_orgid_and_invite(
     """
     Create User with Org ID and invite code
     """
+    await _enforce_password_signup_allowed(db_session, org_id)
+
     # Throttle invite-code guessing per IP+org. ``detail`` is a plain string
     # so the frontend's generic error path renders it as-is.
     is_allowed, retry_after = check_invite_acceptance_rate_limit(request, org_id)

--- a/apps/api/src/services/orgs/auth_policy.py
+++ b/apps/api/src/services/orgs/auth_policy.py
@@ -186,6 +186,58 @@ def auth_policy_exception(block: Dict[str, Any]) -> HTTPException:
     )
 
 
+async def is_login_method_allowed(
+    db_session: AsyncSession, org_id: Optional[int], method: str
+) -> bool:
+    """Whether ``method`` may be used to sign in *to* ``org_id``.
+
+    ``org_id`` is None for the org-less apex login, which no single org's policy
+    governs — that session is caught later by the per-request gate instead.
+    """
+    if org_id is None:
+        return True
+    try:
+        policy = await get_org_auth_policy(db_session, org_id)
+    except Exception:
+        # Same fail-open contract as evaluate_org_auth: a policy read that blows
+        # up must not become an outage on the login path.
+        logger.exception("Auth-method policy read failed for org %s; allowing login", org_id)
+        return True
+    if not policy.method_restricted:
+        return True
+    return method in set(policy.allowed_auth_methods)
+
+
+async def enforce_login_auth_method(
+    db_session: AsyncSession, org_id: Optional[int], method: str
+) -> None:
+    """Refuse an org-scoped sign-in whose method the org does not accept.
+
+    :func:`enforce_org_auth_policy` is what actually protects the org's data, but
+    it only runs *after* a session exists. Letting a disallowed sign-in succeed
+    and then refusing every page afterwards is indistinguishable from a broken
+    product, so when the sign-in names an org we refuse it at the door — which is
+    also what the login page renders.
+    """
+    if await is_login_method_allowed(db_session, org_id, method):
+        return
+
+    policy = await get_org_auth_policy(db_session, org_id)  # type: ignore[arg-type]
+    allowed = sorted(set(policy.allowed_auth_methods))
+    labels = ", ".join(_method_label(m) for m in allowed)
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail={
+            "code": METHOD_NOT_ALLOWED_CODE,
+            "message": (
+                f"This organization doesn't allow signing in with {_method_label(method)}. "
+                f"Use {labels or 'an approved method'} instead."
+            ),
+            "allowed_methods": allowed,
+        },
+    )
+
+
 async def enforce_org_auth_policy(
     db_session: AsyncSession, user_id: int, org_id: int
 ) -> None:

--- a/apps/api/src/tests/routers/test_login_provenance.py
+++ b/apps/api/src/tests/routers/test_login_provenance.py
@@ -13,6 +13,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from src.core.events.database import get_db_session
+from src.db.organization_config import OrganizationConfig
 from src.db.user_mfa import UserMFA
 from src.db.users import AnonymousUser, User
 from src.routers.auth import router as auth_router
@@ -55,6 +56,21 @@ def login_user(db):
     db.commit()
     db.refresh(user)
     return user
+
+
+async def _set_allowed_methods(db, org_id, methods):
+    db.add(
+        OrganizationConfig(
+            org_id=org_id,
+            config={
+                "config_version": "2.0",
+                "admin_toggles": {"security": {"allowed_auth_methods": methods}},
+            },
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+    )
+    await db.commit()
 
 
 def _login_patches():
@@ -111,6 +127,65 @@ class TestLoginProvenance:
         claims = decode_jwt(resp.json()["tokens"]["access_token"])
         assert claims[AMR_CLAIM] == "password"
         assert SORG_CLAIM not in claims
+
+    async def test_login_refused_when_org_disallows_password(self, client, db, login_user, org):
+        await _set_allowed_methods(db, org.id, ["google", "sso"])
+
+        stubs = _login_patches() + [
+            patch("src.routers.auth.authenticate_user", new_callable=AsyncMock, return_value=login_user),
+        ]
+        import contextlib
+
+        with contextlib.ExitStack() as stack:
+            for s in stubs:
+                stack.enter_context(s)
+            resp = await client.post(
+                "/api/v1/auth/login",
+                data={"username": login_user.email, "password": "secret", "org_slug": org.slug},
+            )
+
+        assert resp.status_code == 403
+        detail = resp.json()["detail"]
+        assert detail["code"] == "AUTH_METHOD_NOT_ALLOWED"
+        assert detail["allowed_methods"] == ["google", "sso"]
+
+    async def test_org_policy_does_not_block_the_apex_login(self, client, db, login_user, org):
+        # Same restricted org, but a login that names no org is not that org's to
+        # refuse — the per-request gate handles it once they reach the org.
+        await _set_allowed_methods(db, org.id, ["google"])
+
+        stubs = _login_patches() + [
+            patch("src.routers.auth.authenticate_user", new_callable=AsyncMock, return_value=login_user),
+        ]
+        import contextlib
+
+        with contextlib.ExitStack() as stack:
+            for s in stubs:
+                stack.enter_context(s)
+            resp = await client.post(
+                "/api/v1/auth/login",
+                data={"username": login_user.email, "password": "secret"},
+            )
+
+        assert resp.status_code == 200
+
+    async def test_login_allowed_when_password_is_on_the_list(self, client, db, login_user, org):
+        await _set_allowed_methods(db, org.id, ["password", "google"])
+
+        stubs = _login_patches() + [
+            patch("src.routers.auth.authenticate_user", new_callable=AsyncMock, return_value=login_user),
+        ]
+        import contextlib
+
+        with contextlib.ExitStack() as stack:
+            for s in stubs:
+                stack.enter_context(s)
+            resp = await client.post(
+                "/api/v1/auth/login",
+                data={"username": login_user.email, "password": "secret", "org_slug": org.slug},
+            )
+
+        assert resp.status_code == 200
 
     async def test_login_with_2fa_returns_challenge_not_session(self, client, db, login_user):
         # Enrolled second factor → login must hand back an mfa_token, no session.

--- a/apps/web/app/auth/login/login.tsx
+++ b/apps/web/app/auth/login/login.tsx
@@ -17,6 +17,7 @@ import { resendVerificationEmail } from '@services/auth/auth'
 import AuthLayout from '@components/Auth/AuthLayout'
 import TurnstileWidget, { useTurnstileRequired, verifyTurnstileToken, type TurnstileWidgetHandle } from '@components/Auth/TurnstileWidget'
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
+import { getAllowedAuthMethods } from '@services/auth/authMethods'
 
 interface LoginClientProps {
   org: any
@@ -35,6 +36,19 @@ const LoginClient = (props: LoginClientProps) => {
   const router = useRouter();
   const session = useLHSession() as any;
   const isAuthenticated = session?.status === 'authenticated'
+
+  // The org's allowed sign-in methods. Offering a method the org has turned off
+  // only leads to a 403 from the backend, so it isn't offered at all.
+  const allowedMethods = React.useMemo(
+    () => getAllowedAuthMethods(props.org),
+    [props.org]
+  )
+  const passwordAllowed = allowedMethods.has('password')
+  const magicLoginAllowed = allowedMethods.has('magic_login')
+  const googleAllowed = allowedMethods.has('google')
+  const ssoAllowed = allowedMethods.has('sso')
+  // SSO counts only once it is actually configured for the org (ssoEnabled).
+  const hasAlternativeMethods = googleAllowed || magicLoginAllowed || (ssoAllowed && ssoEnabled)
 
   // A signed-in user has nothing to do on /login → bounce to the hub. The proxy
   // does this best-effort, but pages must self-handle it too (mirrors signup.tsx).
@@ -210,6 +224,11 @@ const LoginClient = (props: LoginClientProps) => {
   // Check if SSO is enabled for this organization (requires enterprise plan)
   useEffect(() => {
     const checkSSO = async () => {
+      // The org can switch SSO off as a sign-in method regardless of its plan.
+      if (!ssoAllowed) {
+        setSsoEnabled(false)
+        return
+      }
       // SSO is only available for enterprise plan (requires EE or SaaS/enterprise)
       const orgConfig = props.org?.config?.config
       const plan = orgConfig?.plan ?? orgConfig?.cloud?.plan
@@ -230,7 +249,7 @@ const LoginClient = (props: LoginClientProps) => {
       }
     }
     checkSSO()
-  }, [props.org?.slug, props.org?.config?.config?.plan, props.org?.config?.config?.cloud?.plan]) // eslint-disable-line
+  }, [props.org?.slug, props.org?.config?.config?.plan, props.org?.config?.config?.cloud?.plan, ssoAllowed]) // eslint-disable-line
 
   const handleSSOLogin = async () => {
     track(AnalyticsEvent.LoginSsoClicked)
@@ -703,9 +722,16 @@ const LoginClient = (props: LoginClientProps) => {
               <>
             {/* Header */}
             <h1 className="text-[28px] md:text-[32px] font-black text-black tracking-tight leading-tight">{t('auth.welcome_back')}</h1>
-            <p className="mt-2 text-black/45 text-[15px] font-medium">{t('auth.enter_credentials')}</p>
+            <p className="mt-2 text-black/45 text-[15px] font-medium">
+              {passwordAllowed
+                ? t('auth.enter_credentials')
+                : t('auth.choose_sign_in_method', {
+                    defaultValue: 'Choose how you’d like to sign in.',
+                  })}
+            </p>
 
             <div className="mt-8">
+              {passwordAllowed && (
               <FormLayout onSubmit={formik.handleSubmit}>
                 <FormField name="email">
                   <div className="flex items-center space-x-2 mb-1.5">
@@ -778,19 +804,23 @@ const LoginClient = (props: LoginClientProps) => {
                   </button>
                 </Form.Submit>
               </FormLayout>
+              )}
 
-              {/* Divider */}
-              <div className="relative my-6">
-                <div className="absolute inset-0 flex items-center">
-                  <div className="w-full border-t border-neutral-200" />
+              {/* Divider — only earns its place between two sets of options. */}
+              {passwordAllowed && hasAlternativeMethods && (
+                <div className="relative my-6">
+                  <div className="absolute inset-0 flex items-center">
+                    <div className="w-full border-t border-neutral-200" />
+                  </div>
+                  <div className="relative flex justify-center text-sm">
+                    <span className="px-3 text-black/30 bg-white text-xs font-medium">{t('common.or')}</span>
+                  </div>
                 </div>
-                <div className="relative flex justify-center text-sm">
-                  <span className="px-3 text-black/30 bg-white text-xs font-medium">{t('common.or')}</span>
-                </div>
-              </div>
+              )}
 
               {/* Social & SSO Buttons */}
               <div className="space-y-2.5">
+                {googleAllowed && (
                 <button
                   onClick={handleGoogleSignIn}
                   disabled={isSubmitting}
@@ -799,6 +829,7 @@ const LoginClient = (props: LoginClientProps) => {
                   <img src="https://fonts.gstatic.com/s/i/productlogos/googleg/v6/24px.svg" alt="" className="w-4 h-4" />
                   <span>{t('auth.sign_in_with_google')}</span>
                 </button>
+                )}
 
                 {ssoEnabled && (
                   <button
@@ -811,6 +842,7 @@ const LoginClient = (props: LoginClientProps) => {
                   </button>
                 )}
 
+                {magicLoginAllowed && (
                 <button
                   type="button"
                   onClick={openMagicMode}
@@ -820,7 +852,22 @@ const LoginClient = (props: LoginClientProps) => {
                   <Mail size={16} />
                   <span>{t('auth.magic_send', { defaultValue: 'Email me a login link' })}</span>
                 </button>
+                )}
               </div>
+
+              {/* Every method is off, or the only allowed one (SSO) is not set
+                  up yet. Say so instead of rendering an empty page. */}
+              {!passwordAllowed && !hasAlternativeMethods && (
+                <div className="rounded-lg border border-neutral-200 bg-neutral-50 px-4 py-3 flex items-start gap-3">
+                  <Info size={16} className="shrink-0 mt-0.5 text-black/40" />
+                  <p className="text-sm text-black/60">
+                    {t('auth.no_sign_in_method_available', {
+                      defaultValue:
+                        'This organization has restricted how members sign in, and none of the allowed methods are available here. Contact an administrator.',
+                    })}
+                  </p>
+                </div>
+              )}
 
               {/* Sign Up Link */}
               <p className="text-center text-sm text-black/35 mt-6">

--- a/apps/web/app/auth/signup/OpenSignup.tsx
+++ b/apps/web/app/auth/signup/OpenSignup.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from 'react-i18next'
 import { PasswordStrengthIndicator, validatePasswordStrength } from '@components/Auth/PasswordStrengthIndicator'
 import TurnstileWidget, { useTurnstileRequired, type TurnstileWidgetHandle } from '@components/Auth/TurnstileWidget'
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
+import { getAllowedAuthMethods } from '@services/auth/authMethods'
 
 const validate = (values: any, t: any) => {
   const errors: any = {}
@@ -66,6 +67,15 @@ function OpenSignUpComponent({ org: propOrg }: OpenSignUpComponentProps = {}) {
   const [resendState, setResendState] = React.useState<'idle' | 'sending' | 'sent' | 'error'>('idle')
   const turnstileRef = React.useRef<TurnstileWidgetHandle>(null)
   const turnstileRequired = useTurnstileRequired()
+
+  // The org's allowed sign-in methods also govern how an account may be
+  // created: minting a password account for an org that refuses password
+  // sign-in produces an account that can never be used. The backend refuses
+  // both, so offering them here would only surface a 403.
+  const allowedMethods = React.useMemo(() => getAllowedAuthMethods(org), [org])
+  const passwordAllowed = allowedMethods.has('password')
+  const googleAllowed = allowedMethods.has('google')
+
   const formik = useFormik({
     initialValues: {
       org_slug: org?.slug,
@@ -213,6 +223,7 @@ function OpenSignUpComponent({ org: propOrg }: OpenSignUpComponentProps = {}) {
           </div>
         )}
 
+        {passwordAllowed && (
         <FormLayout onSubmit={formik.handleSubmit}>
           <FormField name="email">
             <div className="flex items-center space-x-2 mb-1.5">
@@ -362,18 +373,22 @@ function OpenSignUpComponent({ org: propOrg }: OpenSignUpComponentProps = {}) {
             </button>
           </Form.Submit>
         </FormLayout>
+        )}
 
-        {/* Divider */}
-        <div className="relative my-6">
-          <div className="absolute inset-0 flex items-center">
-            <div className="w-full border-t border-neutral-200" />
+        {/* Divider — only earns its place between two sets of options. */}
+        {passwordAllowed && googleAllowed && (
+          <div className="relative my-6">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-neutral-200" />
+            </div>
+            <div className="relative flex justify-center text-sm">
+              <span className="px-3 text-black/30 bg-white text-xs font-medium">{t('common.or')}</span>
+            </div>
           </div>
-          <div className="relative flex justify-center text-sm">
-            <span className="px-3 text-black/30 bg-white text-xs font-medium">{t('common.or')}</span>
-          </div>
-        </div>
+        )}
 
         {/* Google Sign In */}
+        {googleAllowed && (
         <button
           onClick={handleGoogleSignIn}
           disabled={isSubmitting}
@@ -382,6 +397,19 @@ function OpenSignUpComponent({ org: propOrg }: OpenSignUpComponentProps = {}) {
           <img src="https://fonts.gstatic.com/s/i/productlogos/googleg/v6/24px.svg" alt="" className="w-4 h-4" />
           <span>{t('auth.sign_in_with_google')}</span>
         </button>
+        )}
+
+        {!passwordAllowed && !googleAllowed && (
+          <div className="rounded-lg border border-neutral-200 bg-neutral-50 px-4 py-3 flex items-start gap-3">
+            <Info size={16} className="shrink-0 mt-0.5 text-black/40" />
+            <p className="text-sm text-black/60">
+              {t('auth.no_sign_up_method_available', {
+                defaultValue:
+                  'This organization has restricted how members sign in, so accounts can’t be created here. Contact an administrator.',
+              })}
+            </p>
+          </div>
+        )}
 
         {/* Login Link */}
         <p className="text-center text-sm text-black/35 mt-6">

--- a/apps/web/app/orgs/[orgslug]/dash/org/settings/[subpage]/page.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/org/settings/[subpage]/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { Breadcrumbs } from '@components/Objects/Breadcrumbs/Breadcrumbs'
 import { getUriWithOrg } from '@services/config/config'
-import { TextIcon, LucideIcon, LayoutDashboardIcon, CodeIcon, Palette, School, BarChart3, Menu as MenuIcon, AlertTriangle, ShieldCheck } from 'lucide-react'
+import { TextIcon, LucideIcon, LayoutDashboardIcon, CodeIcon, Palette, School, BarChart3, Menu as MenuIcon, AlertTriangle } from 'lucide-react'
 import React, { useEffect, use } from 'react';
 import { useRouter } from 'next/navigation'
 import { motion } from 'motion/react'
@@ -13,11 +13,16 @@ import OrgEditOther from '@components/Dashboard/Pages/Org/OrgEditOther/OrgEditOt
 import OrgEditAI from '@components/Dashboard/Pages/Org/OrgEditAI/OrgEditAI'
 import OrgEditUsage from '@components/Dashboard/Pages/Org/OrgEditUsage/OrgEditUsage'
 import OrgEditMenu from '@components/Dashboard/Pages/Org/OrgEditMenu/OrgEditMenu'
-import OrgEditSecurity from '@components/Dashboard/Pages/Org/OrgEditSecurity/OrgEditSecurity'
 import OrgEditDangerZone from '@components/Dashboard/Pages/Org/OrgEditDangerZone/OrgEditDangerZone'
 import { useTranslation } from 'react-i18next'
 import { PlanLevel } from '@services/plans/plans'
 import { DashTabBar, DashTabItem } from '@components/Dashboard/Shared/DashTabBar/DashTabBar'
+
+// Security now lives with the people it governs, under Users, split across a
+// two-factor tab and a sign-in-methods tab. The old single URL keeps working.
+const MOVED_TO_USERS: Record<string, string> = {
+  security: 'two-factor',
+}
 
 // Sections that moved to the top-level Developers dashboard. Old settings links
 // (/dash/org/settings/{seo,api,domains,automations,sso}) redirect there.
@@ -50,7 +55,6 @@ const getSettingTabs = (t: any): TabConfig[] => [
   { id: 'landing', label: t('dashboard.organization.settings.tabs.landing'), icon: LayoutDashboardIcon },
   { id: 'ai', label: t('dashboard.organization.settings.tabs.ai') || 'AI', customIcon: '/learnhouse_ai_simple_colored.png', requiredPlan: 'standard' },
   { id: 'usage', label: t('dashboard.organization.settings.tabs.usage') || 'Usage', icon: BarChart3 },
-  { id: 'security', label: t('dashboard.organization.settings.tabs.security', { defaultValue: 'Security' }), icon: ShieldCheck },
   { id: 'other', label: t('dashboard.organization.settings.tabs.other'), icon: CodeIcon },
   { id: 'danger', label: t('dashboard.organization.settings.tabs.danger') || 'Danger Zone', icon: AlertTriangle },
 ]
@@ -65,9 +69,11 @@ function OrgPage(props: { params: Promise<OrgParams> }) {
 
   // Redirect legacy developer subpages to the new top-level Developers dashboard.
   const movedTo = MOVED_TO_DEVELOPERS[params.subpage]
+  const movedToUsers = MOVED_TO_USERS[params.subpage]
   useEffect(() => {
     if (movedTo) router.replace(`/dash/developers/${movedTo}`)
-  }, [movedTo, router])
+    else if (movedToUsers) router.replace(`/dash/users/settings/${movedToUsers}`)
+  }, [movedTo, movedToUsers, router])
 
   function handleLabels() {
     if (params.subpage == 'general') {
@@ -88,9 +94,6 @@ function OrgPage(props: { params: Promise<OrgParams> }) {
     } else if (params.subpage == 'usage') {
       setH1Label(t('dashboard.organization.settings.pages.usage.title') || 'Usage')
       setH2Label(t('dashboard.organization.settings.pages.usage.subtitle') || 'Monitor your organization\'s resource usage and plan limits')
-    } else if (params.subpage == 'security') {
-      setH1Label(t('dashboard.organization.settings.pages.security.title', { defaultValue: 'Security' }))
-      setH2Label(t('dashboard.organization.settings.pages.security.subtitle', { defaultValue: 'Require two-factor authentication for members of this organization' }))
     } else if (params.subpage == 'other') {
       setH1Label(t('dashboard.organization.settings.pages.other.title'))
       setH2Label(t('dashboard.organization.settings.pages.other.subtitle'))
@@ -118,8 +121,8 @@ function OrgPage(props: { params: Promise<OrgParams> }) {
     requiresPlan: tab.requiredPlan,
   }))
 
-  // Legacy developer subpages redirect (above) — render nothing while it happens.
-  if (movedTo) return null
+  // Moved subpages redirect (above) — render nothing while it happens.
+  if (movedTo || movedToUsers) return null
 
   return (
     <div className="h-full w-full bg-[#f8f8f8] flex flex-col">
@@ -155,7 +158,6 @@ function OrgPage(props: { params: Promise<OrgParams> }) {
         {params.subpage == 'landing' ? <OrgEditLanding /> : ''}
         {params.subpage == 'ai' ? <OrgEditAI /> : ''}
         {params.subpage == 'usage' ? <OrgEditUsage /> : ''}
-        {params.subpage == 'security' ? <OrgEditSecurity /> : ''}
         {params.subpage == 'other' ? <OrgEditOther /> : ''}
         {params.subpage == 'danger' ? <OrgEditDangerZone /> : ''}
       </motion.div>

--- a/apps/web/app/orgs/[orgslug]/dash/users/settings/[subpage]/page.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/users/settings/[subpage]/page.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, use } from 'react';
 import { motion } from 'motion/react'
 import { getUriWithOrg } from '@services/config/config'
-import { ScanEye, SquareUserRound, UserPlus, Users, Shield } from 'lucide-react'
+import { KeyRound, ScanEye, ShieldCheck, SquareUserRound, UserPlus, Users, Shield } from 'lucide-react'
 import { Breadcrumbs } from '@components/Objects/Breadcrumbs/Breadcrumbs'
 import OrgUsers from '@components/Dashboard/Pages/Users/OrgUsers/OrgUsers'
 import OrgAccess from '@components/Dashboard/Pages/Users/OrgAccess/OrgAccess'
@@ -10,6 +10,8 @@ import OrgUsersAdd from '@components/Dashboard/Pages/Users/OrgUsersAdd/OrgUsersA
 import OrgUserGroups from '@components/Dashboard/Pages/Users/OrgUserGroups/OrgUserGroups'
 import OrgRoles from '@components/Dashboard/Pages/Users/OrgRoles/OrgRoles'
 import OrgAuditLogs from '@components/Dashboard/Pages/Org/OrgAuditLogs/OrgAuditLogs'
+import OrgTwoFactorPolicy from '@components/Dashboard/Pages/Users/Security/OrgTwoFactorPolicy'
+import OrgSignInMethods from '@components/Dashboard/Pages/Users/Security/OrgSignInMethods'
 import { ShieldAlert } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { DashTabBar, DashTabItem } from '@components/Dashboard/Shared/DashTabBar/DashTabBar'
@@ -49,6 +51,18 @@ function UsersSettingsPage(props: { params: Promise<SettingsParams> }) {
     if (params.subpage == 'audit-logs') {
       setH1Label(t('dashboard.users.settings.pages.audit_logs.title'))
       setH2Label(t('dashboard.users.settings.pages.audit_logs.subtitle'))
+    }
+    if (params.subpage == 'two-factor') {
+      setH1Label(t('dashboard.users.settings.pages.two_factor.title', { defaultValue: 'Two-factor' }))
+      setH2Label(t('dashboard.users.settings.pages.two_factor.subtitle', {
+        defaultValue: 'Require two-factor authentication for members of this organization',
+      }))
+    }
+    if (params.subpage == 'sign-in') {
+      setH1Label(t('dashboard.users.settings.pages.sign_in.title', { defaultValue: 'Sign-in' }))
+      setH2Label(t('dashboard.users.settings.pages.sign_in.subtitle', {
+        defaultValue: 'Choose how members are allowed to sign in to this organization',
+      }))
     }
   }
 
@@ -95,6 +109,20 @@ function UsersSettingsPage(props: { params: Promise<SettingsParams> }) {
       active: params.subpage === 'add',
     },
     {
+      key: 'sign-in',
+      label: t('dashboard.users.settings.tabs.sign_in', { defaultValue: 'Sign-in' }),
+      icon: <KeyRound size={16} />,
+      href: getUriWithOrg(params.orgslug, '') + `/dash/users/settings/sign-in`,
+      active: params.subpage === 'sign-in',
+    },
+    {
+      key: 'two-factor',
+      label: t('dashboard.users.settings.tabs.two_factor', { defaultValue: 'Two-factor' }),
+      icon: <ShieldCheck size={16} />,
+      href: getUriWithOrg(params.orgslug, '') + `/dash/users/settings/two-factor`,
+      active: params.subpage === 'two-factor',
+    },
+    {
       key: 'audit-logs',
       label: t('dashboard.users.settings.tabs.audit_logs'),
       icon: <ShieldAlert size={16} />,
@@ -137,6 +165,8 @@ function UsersSettingsPage(props: { params: Promise<SettingsParams> }) {
         {params.subpage == 'usergroups' ? <><div className="h-6"></div><OrgUserGroups /></> : ''}
         {params.subpage == 'roles' ? <><div className="h-6"></div><OrgRoles /></> : ''}
         {params.subpage == 'audit-logs' ? <><div className="h-6"></div><OrgAuditLogs /></> : ''}
+        {params.subpage == 'sign-in' ? <><div className="h-6"></div><OrgSignInMethods /></> : ''}
+        {params.subpage == 'two-factor' ? <><div className="h-6"></div><OrgTwoFactorPolicy /></> : ''}
       </motion.div>
     </div>
   )

--- a/apps/web/components/Dashboard/Pages/Users/Security/OrgSignInMethods.tsx
+++ b/apps/web/components/Dashboard/Pages/Users/Security/OrgSignInMethods.tsx
@@ -1,0 +1,212 @@
+'use client'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { AlertTriangle, KeyRound, Loader2 } from 'lucide-react'
+import useAdminStatus from '@components/Hooks/useAdminStatus'
+import { Switch } from '@components/ui/switch'
+import { Checkbox } from '@components/ui/checkbox'
+import { Button } from '@components/ui/button'
+import { Label } from '@components/ui/label'
+import {
+  ALL_AUTH_METHODS,
+  AUTH_METHOD_OPTIONS,
+  ReadOnlyNotice,
+  sameMethodSet,
+  useOrgSecurityPolicy,
+} from './shared'
+
+/**
+ * Users → Sign-in methods. Owns which methods members may use to reach this org
+ * and whether a session started on the central apex counts here.
+ *
+ * Both settings are enforced twice: at the door (the login endpoints refuse a
+ * disallowed method for this org) and on every request afterwards (the org gate
+ * refuses a session whose method is no longer allowed). Checking every box is
+ * the unrestricted default.
+ */
+const OrgSignInMethods: React.FC = () => {
+  const { t } = useTranslation()
+  const { canManageOrg } = useAdminStatus()
+  const {
+    orgId,
+    policy,
+    seedVersion,
+    savePolicy,
+    saving,
+    saveError,
+    setSaveError,
+    setNeedsOwnMfa,
+  } = useOrgSecurityPolicy()
+
+  const [draftMethods, setDraftMethods] = React.useState<string[]>(policy.allowed_auth_methods)
+  const [draftSharing, setDraftSharing] = React.useState(policy.allow_central_session_sharing)
+
+  React.useEffect(() => {
+    setDraftMethods(policy.allowed_auth_methods)
+    setDraftSharing(policy.allow_central_session_sharing)
+  }, [seedVersion, policy])
+
+  const isDirty =
+    !sameMethodSet(draftMethods, policy.allowed_auth_methods) ||
+    draftSharing !== policy.allow_central_session_sharing
+
+  const toggleMethod = (key: string, checked: boolean) => {
+    setSaveError(null)
+    setNeedsOwnMfa(false)
+    setDraftMethods((prev) =>
+      checked ? Array.from(new Set([...prev, key])) : prev.filter((m) => m !== key)
+    )
+  }
+
+  const restricted =
+    draftMethods.length > 0 && !ALL_AUTH_METHODS.every((m) => draftMethods.includes(m))
+
+  if (!orgId) return null
+
+  const readOnly = canManageOrg !== true
+  const controlsDisabled = saving || readOnly
+
+  return (
+    <div className="sm:mx-10 mx-0 space-y-4 pb-10">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <div className="p-2 rounded-lg bg-gray-100 text-gray-700">
+          <KeyRound className="w-5 h-5" />
+        </div>
+        <div>
+          <h1 className="font-bold text-lg text-gray-800">
+            {t('dashboard.organization.security.methods_title', {
+              defaultValue: 'Allowed sign-in methods',
+            })}
+          </h1>
+          <p className="text-sm text-gray-500">
+            {t('dashboard.organization.security.methods_description', {
+              defaultValue:
+                'Choose how members are allowed to sign in to this organization. Leave every method checked to keep sign-in unrestricted.',
+            })}
+          </p>
+        </div>
+      </div>
+
+      {readOnly && <ReadOnlyNotice />}
+
+      <div className="bg-white rounded-xl nice-shadow p-5 space-y-5">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {AUTH_METHOD_OPTIONS.map((m) => {
+            const checked = draftMethods.includes(m.key)
+            return (
+              <div key={m.key} className="flex items-start gap-3">
+                <Checkbox
+                  id={`auth-method-${m.key}`}
+                  checked={checked}
+                  onCheckedChange={(value) => toggleMethod(m.key, value === true)}
+                  disabled={controlsDisabled}
+                  className="mt-0.5"
+                />
+                <div className="space-y-0.5">
+                  <Label htmlFor={`auth-method-${m.key}`} className="cursor-pointer">
+                    {t(m.labelKey, { defaultValue: m.labelDefault })}
+                  </Label>
+                  <p className="text-xs text-gray-500 leading-relaxed">
+                    {t(m.hintKey, { defaultValue: m.hintDefault })}
+                  </p>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
+        {draftMethods.length === 0 && (
+          <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200/80 rounded-lg px-3 py-2">
+            {t('dashboard.organization.security.methods_empty_warning', {
+              defaultValue:
+                'With no method selected, no one could sign in to this organization. Pick at least one.',
+            })}
+          </p>
+        )}
+
+        {restricted && (
+          <p className="text-xs text-gray-500 leading-relaxed">
+            {t('dashboard.organization.security.methods_effect', {
+              defaultValue:
+                'Unchecked methods disappear from this organization’s login page, and members already signed in with one are asked to sign in again with an allowed method.',
+            })}
+          </p>
+        )}
+
+        {/* Central session sharing */}
+        <div className="flex items-start justify-between gap-4 pt-1 border-t border-gray-100">
+          <div className="min-w-0 pt-4">
+            <Label htmlFor="central-session-sharing" className="cursor-pointer">
+              {t('dashboard.organization.security.session_sharing_label', {
+                defaultValue: 'Allow sharing sessions with learnhouse.io',
+              })}
+            </Label>
+            <p className="text-xs text-gray-500 mt-0.5 leading-relaxed max-w-xl">
+              {t('dashboard.organization.security.session_sharing_hint', {
+                defaultValue:
+                  'When off, signing in at learnhouse.io won’t let members into this org — they must sign in again from this org’s login page using an allowed method.',
+              })}
+            </p>
+          </div>
+          <Switch
+            id="central-session-sharing"
+            checked={draftSharing}
+            onCheckedChange={(checked) => {
+              setDraftSharing(checked)
+              setSaveError(null)
+              setNeedsOwnMfa(false)
+            }}
+            disabled={controlsDisabled}
+            className="shrink-0 mt-5"
+            aria-label={t('dashboard.organization.security.session_sharing_label', {
+              defaultValue: 'Allow sharing sessions with learnhouse.io',
+            })}
+          />
+        </div>
+
+        {saveError && (
+          <div className="flex items-start gap-2 rounded-lg bg-red-50 border border-red-200/80 px-4 py-3">
+            <AlertTriangle className="w-4 h-4 text-red-500 shrink-0 mt-0.5" />
+            <p className="text-sm text-red-700">{saveError}</p>
+          </div>
+        )}
+
+        <div className="flex flex-row-reverse items-center gap-3 pt-1">
+          <Button
+            type="button"
+            onClick={() =>
+              savePolicy({
+                allowed_auth_methods: draftMethods,
+                allow_central_session_sharing: draftSharing,
+              })
+            }
+            disabled={controlsDisabled || !isDirty || draftMethods.length === 0}
+            className="bg-black text-white hover:bg-black/90"
+          >
+            {saving && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+            {saving
+              ? t('dashboard.organization.security.saving_short', { defaultValue: 'Saving…' })
+              : t('dashboard.organization.security.save', { defaultValue: 'Save changes' })}
+          </Button>
+          {isDirty && !saving && (
+            <button
+              type="button"
+              onClick={() => {
+                setDraftMethods(policy.allowed_auth_methods)
+                setDraftSharing(policy.allow_central_session_sharing)
+                setSaveError(null)
+                setNeedsOwnMfa(false)
+              }}
+              className="text-sm text-gray-500 hover:text-gray-700"
+            >
+              {t('dashboard.organization.security.cancel', { defaultValue: 'Cancel' })}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default OrgSignInMethods

--- a/apps/web/components/Dashboard/Pages/Users/Security/OrgTwoFactorPolicy.tsx
+++ b/apps/web/components/Dashboard/Pages/Users/Security/OrgTwoFactorPolicy.tsx
@@ -1,9 +1,6 @@
 'use client'
 import React from 'react'
-import Link from 'next/link'
 import { useTranslation } from 'react-i18next'
-import { toast } from 'react-hot-toast'
-import { useQueryClient } from '@tanstack/react-query'
 import {
   AlertTriangle,
   CheckCircle2,
@@ -14,22 +11,13 @@ import {
   Info,
   Loader2,
   RefreshCw,
-  ShieldAlert,
   ShieldCheck,
   ShieldOff,
   Users,
 } from 'lucide-react'
-import { useOrg } from '@components/Contexts/OrgContext'
-import { useLHSession } from '@components/Contexts/LHSessionContext'
 import useAdminStatus from '@components/Hooks/useAdminStatus'
-import { getAPIUrl, getUriWithOrg } from '@services/config/config'
-import {
-  RequestBodyWithAuthHeader,
-  getResponseMetadata,
-  revalidateTags,
-} from '@services/utils/ts/requests'
+import { getUriWithOrg } from '@services/config/config'
 import { getErrorMessage } from '@services/utils/ts/errorMessage'
-import { queryKeys } from '@/lib/query/keys'
 import { Switch } from '@components/ui/switch'
 import { Checkbox } from '@components/ui/checkbox'
 import { Button } from '@components/ui/button'
@@ -42,230 +30,69 @@ import {
   SelectValue,
 } from '@components/ui/select'
 import Modal from '@components/Objects/StyledElements/Modal/Modal'
+import {
+  AdminMfaCallout,
+  Badge,
+  ComplianceResponse,
+  GRACE_OPTIONS,
+  NotAdminNotice,
+  ReadOnlyNotice,
+  SecuritySkeleton,
+  SelfComplianceState,
+  StatTile,
+  addDays,
+  formatDate,
+  isExternalAuth,
+  memberName,
+  useOrgSecurityPolicy,
+} from './shared'
 
-// ---------------------------------------------------------------------------
-// Types — mirror of the backend payloads (src/routers/mfa.py)
-// ---------------------------------------------------------------------------
-
-type ComplianceMember = {
-  user_id: number
-  email: string | null
-  username: string | null
-  first_name: string | null
-  last_name: string | null
-  signup_method: string | null
-  mfa_enabled: boolean
-  confirmed_at: string | null
-}
-
-type ComplianceResponse = {
-  total: number
-  enabled: number
-  members: ComplianceMember[]
-}
-
-type OrgSecurityPolicy = {
-  require_2fa: boolean
-  require_2fa_grace_days: number
-  require_2fa_enabled_at: string | null
-  exempt_external_auth: boolean
-  // Which sign-in methods this org accepts. The full set = unrestricted.
-  allowed_auth_methods: string[]
-  // When off, a central learnhouse.io session can't carry members into this org.
-  allow_central_session_sharing: boolean
-}
-
-// The CALLING user's own compliance state — context only, not the policy.
-type SelfComplianceState = {
-  required: boolean
-  satisfied: boolean
-  deadline: string | null
-  days_remaining: number | null
-  blocking: boolean
-  exempt_reason: string | null
-}
-
-// Kept in sync with EXTERNAL_AUTH_METHODS in
-// apps/api/src/services/orgs/mfa_policy.py. An unrecognised signup_method is
-// deliberately treated as a local password account, i.e. subject to the policy.
-const EXTERNAL_AUTH_METHODS = [
-  'google',
-  'sso',
-  'saml',
-  'oidc',
-  'workos',
-  'keycloak',
-  'okta',
-  'auth0',
-]
-
-const GRACE_OPTIONS = [0, 7, 14, 30]
-
-// The complete set of sign-in methods. Selecting all of them = unrestricted,
-// which is also what an absent policy falls back to. Kept in sync with the
-// backend's allowed_auth_methods contract.
-const ALL_AUTH_METHODS = ['password', 'magic_login', 'google', 'sso'] as const
-
-const AUTH_METHOD_OPTIONS: {
-  key: string
-  labelKey: string
-  labelDefault: string
-  hintKey: string
-  hintDefault: string
-}[] = [
-  {
-    key: 'password',
-    labelKey: 'dashboard.organization.security.method_password',
-    labelDefault: 'Email + password',
-    hintKey: 'dashboard.organization.security.method_password_hint',
-    hintDefault: 'Sign in with an email address and password.',
-  },
-  {
-    key: 'magic_login',
-    labelKey: 'dashboard.organization.security.method_magic_login',
-    labelDefault: 'Magic login link',
-    hintKey: 'dashboard.organization.security.method_magic_login_hint',
-    hintDefault: 'Sign in through a one-time link sent by email.',
-  },
-  {
-    key: 'google',
-    labelKey: 'dashboard.organization.security.method_google',
-    labelDefault: 'Google',
-    hintKey: 'dashboard.organization.security.method_google_hint',
-    hintDefault: 'Sign in with a Google account.',
-  },
-  {
-    key: 'sso',
-    labelKey: 'dashboard.organization.security.method_sso',
-    labelDefault: 'SSO',
-    hintKey: 'dashboard.organization.security.method_sso_hint',
-    hintDefault: 'Sign in through your configured single sign-on provider.',
-  },
-]
-
-const DEFAULT_POLICY: OrgSecurityPolicy = {
-  require_2fa: false,
-  require_2fa_grace_days: 0,
-  require_2fa_enabled_at: null,
-  exempt_external_auth: true,
-  allowed_auth_methods: [...ALL_AUTH_METHODS],
-  allow_central_session_sharing: true,
-}
-
-// Two string sets are equal regardless of order/dupes.
-const sameMethodSet = (a: string[], b: string[]): boolean => {
-  const sa = new Set(a)
-  const sb = new Set(b)
-  if (sa.size !== sb.size) return false
-  for (const v of sa) if (!sb.has(v)) return false
-  return true
-}
-
-const isExternalAuth = (signup_method: string | null): boolean =>
-  EXTERNAL_AUTH_METHODS.includes((signup_method || '').toLowerCase())
-
-const memberName = (m: ComplianceMember): string => {
-  const full = [m.first_name, m.last_name].filter(Boolean).join(' ').trim()
-  return full || m.username || m.email || `#${m.user_id}`
-}
-
-const formatDate = (value: string | null | undefined): string => {
-  if (!value) return ''
-  const d = new Date(value)
-  if (Number.isNaN(d.getTime())) return String(value)
-  return d.toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  })
-}
-
-const addDays = (days: number): Date => {
-  const d = new Date()
-  d.setDate(d.getDate() + days)
-  return d
-}
-
-// ---------------------------------------------------------------------------
-
-const OrgEditSecurity: React.FC = () => {
+/**
+ * Users → Two-factor. Owns the "require two-factor" half of the org security
+ * policy: the requirement itself, its grace period, the external-auth exemption,
+ * and the member coverage it implies.
+ *
+ * The coverage panel and member list only appear once the requirement is
+ * actually on — with the policy off they are a wall of red badges about a rule
+ * that isn't in force. Before switching it on, the confirmation dialog still
+ * spells out exactly who loses access.
+ */
+const OrgTwoFactorPolicy: React.FC = () => {
   const { t } = useTranslation()
-  const session = useLHSession() as any
-  const access_token = session?.data?.tokens?.access_token
-  const currentUserId = session?.data?.user?.id
-  const org = useOrg() as any
-  const orgId = org?.id
-  const orgslug = org?.slug
-  const queryClient = useQueryClient()
   const { canManageOrg } = useAdminStatus()
+  const {
+    orgId,
+    orgslug,
+    access_token,
+    currentUserId,
+    policy,
+    seedVersion,
+    mfaFetch,
+    savePolicy,
+    saving,
+    saveError,
+    setSaveError,
+    needsOwnMfa,
+    setNeedsOwnMfa,
+  } = useOrgSecurityPolicy()
 
-  // Saved policy — seeded from the org config the page already loads, then kept
-  // authoritative from the PUT response.
-  const savedPolicy: OrgSecurityPolicy = React.useMemo(() => {
-    const security = org?.config?.config?.admin_toggles?.security
-    if (!security) return DEFAULT_POLICY
-    return {
-      require_2fa: !!security.require_2fa,
-      require_2fa_grace_days: Math.max(0, Number(security.require_2fa_grace_days) || 0),
-      require_2fa_enabled_at: security.require_2fa_enabled_at ?? null,
-      exempt_external_auth: security.exempt_external_auth !== false,
-      // Absent → unrestricted (all methods) + central sharing on.
-      allowed_auth_methods: Array.isArray(security.allowed_auth_methods)
-        ? security.allowed_auth_methods
-        : [...ALL_AUTH_METHODS],
-      allow_central_session_sharing: security.allow_central_session_sharing !== false,
-    }
-  }, [org])
+  const [draftRequire, setDraftRequire] = React.useState(policy.require_2fa)
+  const [draftGrace, setDraftGrace] = React.useState(policy.require_2fa_grace_days)
+  const [draftExempt, setDraftExempt] = React.useState(policy.exempt_external_auth)
 
-  const [policy, setPolicy] = React.useState<OrgSecurityPolicy>(savedPolicy)
-  const [draftRequire, setDraftRequire] = React.useState(savedPolicy.require_2fa)
-  const [draftGrace, setDraftGrace] = React.useState(savedPolicy.require_2fa_grace_days)
-  const [draftExempt, setDraftExempt] = React.useState(savedPolicy.exempt_external_auth)
-  const [draftMethods, setDraftMethods] = React.useState<string[]>(savedPolicy.allowed_auth_methods)
-  const [draftSharing, setDraftSharing] = React.useState(savedPolicy.allow_central_session_sharing)
-
-  // Re-seed once the org config lands (it arrives asynchronously via OrgContext).
-  const seededRef = React.useRef(false)
   React.useEffect(() => {
-    if (seededRef.current) return
-    if (!org?.config?.config) return
-    seededRef.current = true
-    setPolicy(savedPolicy)
-    setDraftRequire(savedPolicy.require_2fa)
-    setDraftGrace(savedPolicy.require_2fa_grace_days)
-    setDraftExempt(savedPolicy.exempt_external_auth)
-    setDraftMethods(savedPolicy.allowed_auth_methods)
-    setDraftSharing(savedPolicy.allow_central_session_sharing)
-  }, [org, savedPolicy])
+    setDraftRequire(policy.require_2fa)
+    setDraftGrace(policy.require_2fa_grace_days)
+    setDraftExempt(policy.exempt_external_auth)
+  }, [seedVersion, policy])
 
   const [compliance, setCompliance] = React.useState<ComplianceResponse | null>(null)
   const [selfState, setSelfState] = React.useState<SelfComplianceState | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [loadError, setLoadError] = React.useState<string | null>(null)
   const [forbidden, setForbidden] = React.useState(false)
-
-  const [saving, setSaving] = React.useState(false)
-  const [saveError, setSaveError] = React.useState<string | null>(null)
-  // Set when the backend refuses because the admin has no second factor of
-  // their own — drives the "enable it on your account first" call to action.
-  const [needsOwnMfa, setNeedsOwnMfa] = React.useState(false)
   const [confirmOpen, setConfirmOpen] = React.useState(false)
   const [showAllMembers, setShowAllMembers] = React.useState(false)
-
-  // Same call shape as the account-level two-factor section: getAPIUrl() +
-  // RequestBodyWithAuthHeader + getResponseMetadata. Deliberately NOT apiFetch —
-  // its errorHandling() turns a 401 into a global "session expired" event, and
-  // we want to read the structured `detail.code` on 403 ourselves.
-  const mfaFetch = React.useCallback(
-    async (path: string, method: 'GET' | 'PUT' | 'POST', body?: any) => {
-      const result = await fetch(
-        `${getAPIUrl()}auth/mfa${path}`,
-        RequestBodyWithAuthHeader(method, body ?? null, null, access_token)
-      )
-      return getResponseMetadata(result)
-    },
-    [access_token]
-  )
 
   // Admin recovery state: clear a member's factor so they can re-enroll (lost
   // device, no backup codes). Handler defined after loadData (below).
@@ -384,95 +211,23 @@ const OrgEditSecurity: React.FC = () => {
   const isDirty =
     draftRequire !== policy.require_2fa ||
     draftGrace !== policy.require_2fa_grace_days ||
-    draftExempt !== policy.exempt_external_auth ||
-    !sameMethodSet(draftMethods, policy.allowed_auth_methods) ||
-    draftSharing !== policy.allow_central_session_sharing
-
-  const toggleMethod = (key: string, checked: boolean) => {
-    setSaveError(null)
-    setNeedsOwnMfa(false)
-    setDraftMethods((prev) =>
-      checked ? Array.from(new Set([...prev, key])) : prev.filter((m) => m !== key)
-    )
-  }
+    draftExempt !== policy.exempt_external_auth
 
   const isTurningOn = draftRequire && !policy.require_2fa
 
   const accountSecurityHref = getUriWithOrg(orgslug || '', '/account/security')
 
-  // --- save ----------------------------------------------------------------
-
   const persist = React.useCallback(async () => {
-    if (!orgId) return
-    setSaving(true)
-    setSaveError(null)
-    setNeedsOwnMfa(false)
-    const loadingToast = toast.loading(
-      t('dashboard.organization.security.saving', { defaultValue: 'Saving security policy…' })
-    )
-    try {
-      const res = await mfaFetch(`/org-policy/${orgId}`, 'PUT', {
-        require_2fa: draftRequire,
-        require_2fa_grace_days: draftGrace,
-        exempt_external_auth: draftExempt,
-        allowed_auth_methods: draftMethods,
-        allow_central_session_sharing: draftSharing,
-      })
-
-      if (!res.success) {
-        const code = res.data?.detail?.code
-        const message = getErrorMessage(
-          res.data?.detail,
-          t('dashboard.organization.security.save_error', {
-            defaultValue: 'Could not save the security policy.',
-          })
-        )
-        if (code === 'ADMIN_MFA_REQUIRED_FIRST') setNeedsOwnMfa(true)
-        setSaveError(message)
-        toast.error(message, { id: loadingToast })
-        return
-      }
-
-      const raw = res.data as Partial<OrgSecurityPolicy>
-      // Normalize against the contract: an omitted methods list / sharing flag
-      // means unrestricted + sharing on.
-      const next: OrgSecurityPolicy = {
-        require_2fa: !!raw.require_2fa,
-        require_2fa_grace_days: Math.max(0, Number(raw.require_2fa_grace_days) || 0),
-        require_2fa_enabled_at: raw.require_2fa_enabled_at ?? null,
-        exempt_external_auth: raw.exempt_external_auth !== false,
-        allowed_auth_methods: Array.isArray(raw.allowed_auth_methods)
-          ? raw.allowed_auth_methods
-          : [...ALL_AUTH_METHODS],
-        allow_central_session_sharing: raw.allow_central_session_sharing !== false,
-      }
-      setPolicy(next)
-      setDraftRequire(next.require_2fa)
-      setDraftGrace(next.require_2fa_grace_days)
-      setDraftExempt(next.exempt_external_auth)
-      setDraftMethods(next.allowed_auth_methods)
-      setDraftSharing(next.allow_central_session_sharing)
+    const ok = await savePolicy({
+      require_2fa: draftRequire,
+      require_2fa_grace_days: draftGrace,
+      exempt_external_auth: draftExempt,
+    })
+    if (ok) {
       setConfirmOpen(false)
-
-      if (orgslug) await revalidateTags(['organizations'], orgslug)
-      if (orgslug) queryClient.invalidateQueries({ queryKey: queryKeys.org.detail(orgslug) })
-      toast.success(
-        t('dashboard.organization.security.save_success', {
-          defaultValue: 'Security policy updated',
-        }),
-        { id: loadingToast }
-      )
       loadData()
-    } catch {
-      const message = t('dashboard.organization.security.save_error', {
-        defaultValue: 'Could not save the security policy.',
-      })
-      setSaveError(message)
-      toast.error(message, { id: loadingToast })
-    } finally {
-      setSaving(false)
     }
-  }, [orgId, orgslug, draftRequire, draftGrace, draftExempt, draftMethods, draftSharing, mfaFetch, t, queryClient, loadData])
+  }, [savePolicy, draftRequire, draftGrace, draftExempt, loadData])
 
   const handleSaveClick = () => {
     // Turning the requirement ON is never one click — it can lock staff out.
@@ -486,46 +241,8 @@ const OrgEditSecurity: React.FC = () => {
   // --- states --------------------------------------------------------------
 
   if (!orgId) return null
-
-  if (loading) {
-    return (
-      <div className="sm:mx-10 mx-0 space-y-4">
-        <div className="bg-white rounded-xl nice-shadow p-6 animate-pulse space-y-4">
-          <div className="h-4 w-48 bg-gray-200 rounded" />
-          <div className="h-2 w-full bg-gray-100 rounded-full" />
-          <div className="h-3 w-64 bg-gray-100 rounded" />
-        </div>
-        <div className="bg-white rounded-xl nice-shadow p-6 animate-pulse space-y-3">
-          {[0, 1, 2, 3].map((i) => (
-            <div key={i} className="h-10 bg-gray-50 rounded-lg" />
-          ))}
-        </div>
-      </div>
-    )
-  }
-
-  if (forbidden) {
-    return (
-      <div className="sm:mx-10 mx-0">
-        <div className="bg-white rounded-xl nice-shadow p-6 flex items-start gap-3">
-          <ShieldOff className="w-5 h-5 text-gray-400 shrink-0 mt-0.5" />
-          <div>
-            <h2 className="font-semibold text-gray-800">
-              {t('dashboard.organization.security.not_admin_title', {
-                defaultValue: 'You don’t have access to this setting',
-              })}
-            </h2>
-            <p className="text-sm text-gray-500 mt-1">
-              {t('dashboard.organization.security.not_admin_body', {
-                defaultValue:
-                  'Only organization admins can view or change the two-factor requirement.',
-              })}
-            </p>
-          </div>
-        </div>
-      </div>
-    )
-  }
+  if (loading) return <SecuritySkeleton />
+  if (forbidden) return <NotAdminNotice />
 
   if (loadError && !compliance) {
     return (
@@ -555,6 +272,8 @@ const OrgEditSecurity: React.FC = () => {
 
   const readOnly = canManageOrg !== true
   const controlsDisabled = saving || readOnly
+  // Coverage is only meaningful once the requirement is actually in force.
+  const showCoverage = policy.require_2fa
 
   return (
     <div className="sm:mx-10 mx-0 space-y-4 pb-10">
@@ -565,7 +284,7 @@ const OrgEditSecurity: React.FC = () => {
         </div>
         <div>
           <h1 className="font-bold text-lg text-gray-800">
-            {t('dashboard.organization.security.title', { defaultValue: 'Security' })}
+            {t('dashboard.users.security.two_factor_title', { defaultValue: 'Two-factor' })}
           </h1>
           <p className="text-sm text-gray-500">
             {t('dashboard.organization.security.subtitle', {
@@ -576,22 +295,12 @@ const OrgEditSecurity: React.FC = () => {
         </div>
       </div>
 
-      {readOnly && (
-        <div className="flex items-center gap-3 px-4 py-3 rounded-xl bg-amber-50 border border-amber-200/80">
-          <ShieldAlert className="w-4 h-4 text-amber-600 shrink-0" />
-          <p className="text-sm text-amber-800">
-            {t('dashboard.organization.security.read_only', {
-              defaultValue:
-                'You can review this page, but only an organization admin can change the policy.',
-            })}
-          </p>
-        </div>
-      )}
+      {readOnly && <ReadOnlyNotice />}
 
       {/* ------------------------------------------------------------------ */}
-      {/* 1. Compliance summary — deliberately ABOVE the toggle. Switching the */}
-      {/*    policy on without reading this is how an org locks out its staff. */}
+      {/* 1. Compliance summary — only while the requirement is on.          */}
       {/* ------------------------------------------------------------------ */}
+      {showCoverage && (
       <div className="bg-white rounded-xl nice-shadow p-5 space-y-4">
         <div className="flex items-start justify-between gap-4 flex-wrap">
           <div>
@@ -668,9 +377,9 @@ const OrgEditSecurity: React.FC = () => {
 
         {blockedMembers.length > 0 && (
           <p className="text-xs text-gray-500 leading-relaxed">
-            {t('dashboard.organization.security.blocked_hint', {
+            {t('dashboard.organization.security.blocked_hint_active', {
               defaultValue:
-                'Review this list before switching the requirement on — these are the people who lose access to this organization if they don’t enroll in time.',
+                'These members lose access to this organization when their grace period ends, unless they enroll.',
             })}
           </p>
         )}
@@ -681,10 +390,12 @@ const OrgEditSecurity: React.FC = () => {
           </p>
         )}
       </div>
+      )}
 
       {/* ------------------------------------------------------------------ */}
-      {/* 2. Member list                                                      */}
+      {/* 2. Member list — same condition as the coverage panel above.       */}
       {/* ------------------------------------------------------------------ */}
+      {showCoverage && (
       <div className="bg-white rounded-xl nice-shadow overflow-hidden">
         <div className="flex items-center gap-2 px-5 py-3 border-b border-gray-100">
           <Users className="w-4 h-4 text-gray-400" />
@@ -809,6 +520,7 @@ const OrgEditSecurity: React.FC = () => {
           </>
         )}
       </div>
+      )}
 
       {/* ------------------------------------------------------------------ */}
       {/* 3. The policy itself                                                */}
@@ -936,91 +648,6 @@ const OrgEditSecurity: React.FC = () => {
           </div>
         </div>
 
-        {/* ---------------------------------------------------------------- */}
-        {/* Allowed sign-in methods + central session sharing.               */}
-        {/* Part of the SAME policy save below.                              */}
-        {/* ---------------------------------------------------------------- */}
-        <div className="pt-1 border-t border-gray-100 space-y-4">
-          <div>
-            <h3 className="font-bold text-gray-800">
-              {t('dashboard.organization.security.methods_title', {
-                defaultValue: 'Allowed sign-in methods',
-              })}
-            </h3>
-            <p className="text-sm text-gray-500 mt-0.5 max-w-2xl leading-relaxed">
-              {t('dashboard.organization.security.methods_description', {
-                defaultValue:
-                  'Choose how members are allowed to sign in to this organization. Leave every method checked to keep sign-in unrestricted.',
-              })}
-            </p>
-          </div>
-
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            {AUTH_METHOD_OPTIONS.map((m) => {
-              const checked = draftMethods.includes(m.key)
-              return (
-                <div key={m.key} className="flex items-start gap-3">
-                  <Checkbox
-                    id={`auth-method-${m.key}`}
-                    checked={checked}
-                    onCheckedChange={(value) => toggleMethod(m.key, value === true)}
-                    disabled={controlsDisabled}
-                    className="mt-0.5"
-                  />
-                  <div className="space-y-0.5">
-                    <Label htmlFor={`auth-method-${m.key}`} className="cursor-pointer">
-                      {t(m.labelKey, { defaultValue: m.labelDefault })}
-                    </Label>
-                    <p className="text-xs text-gray-500 leading-relaxed">
-                      {t(m.hintKey, { defaultValue: m.hintDefault })}
-                    </p>
-                  </div>
-                </div>
-              )
-            })}
-          </div>
-
-          {draftMethods.length === 0 && (
-            <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200/80 rounded-lg px-3 py-2">
-              {t('dashboard.organization.security.methods_empty_warning', {
-                defaultValue:
-                  'With no method selected, no one could sign in to this organization. Pick at least one.',
-              })}
-            </p>
-          )}
-
-          {/* Central session sharing */}
-          <div className="flex items-start justify-between gap-4 pt-1">
-            <div className="min-w-0">
-              <Label htmlFor="central-session-sharing" className="cursor-pointer">
-                {t('dashboard.organization.security.session_sharing_label', {
-                  defaultValue: 'Allow sharing sessions with learnhouse.io',
-                })}
-              </Label>
-              <p className="text-xs text-gray-500 mt-0.5 leading-relaxed max-w-xl">
-                {t('dashboard.organization.security.session_sharing_hint', {
-                  defaultValue:
-                    'When off, signing in at learnhouse.io won’t let members into this org — they must sign in again from this org’s login page using an allowed method.',
-                })}
-              </p>
-            </div>
-            <Switch
-              id="central-session-sharing"
-              checked={draftSharing}
-              onCheckedChange={(checked) => {
-                setDraftSharing(checked)
-                setSaveError(null)
-                setNeedsOwnMfa(false)
-              }}
-              disabled={controlsDisabled}
-              className="shrink-0 mt-1"
-              aria-label={t('dashboard.organization.security.session_sharing_label', {
-                defaultValue: 'Allow sharing sessions with learnhouse.io',
-              })}
-            />
-          </div>
-        </div>
-
         {/* Self-lockout warning: the backend refuses the change anyway. */}
         {draftRequire && adminHasOwnMfa === false && !needsOwnMfa && (
           <AdminMfaCallout href={accountSecurityHref} />
@@ -1074,8 +701,6 @@ const OrgEditSecurity: React.FC = () => {
                 setDraftRequire(policy.require_2fa)
                 setDraftGrace(policy.require_2fa_grace_days)
                 setDraftExempt(policy.exempt_external_auth)
-                setDraftMethods(policy.allowed_auth_methods)
-                setDraftSharing(policy.allow_central_session_sharing)
                 setSaveError(null)
                 setNeedsOwnMfa(false)
               }}
@@ -1196,97 +821,4 @@ const OrgEditSecurity: React.FC = () => {
   )
 }
 
-// ---------------------------------------------------------------------------
-// Small presentational helpers
-// ---------------------------------------------------------------------------
-
-const TILE_TONES: Record<string, string> = {
-  green: 'bg-green-50 text-green-700 border-green-100',
-  blue: 'bg-blue-50 text-blue-700 border-blue-100',
-  red: 'bg-red-50 text-red-700 border-red-100',
-  gray: 'bg-gray-50 text-gray-600 border-gray-100',
-}
-
-function StatTile({
-  tone,
-  icon,
-  value,
-  label,
-}: {
-  tone: 'green' | 'blue' | 'red' | 'gray'
-  icon: React.ReactNode
-  value: number
-  label: string
-}) {
-  return (
-    <div className={`rounded-xl border px-4 py-3 ${TILE_TONES[tone]}`}>
-      <div className="flex items-center gap-2">
-        {icon}
-        <span className="text-xl font-bold tracking-tight">{value}</span>
-      </div>
-      <div className="text-xs mt-0.5 opacity-80">{label}</div>
-    </div>
-  )
-}
-
-const BADGE_TONES: Record<string, string> = {
-  green: 'bg-green-50 text-green-700',
-  blue: 'bg-blue-50 text-blue-700',
-  red: 'bg-red-50 text-red-700',
-}
-
-function Badge({
-  tone,
-  icon,
-  children,
-}: {
-  tone: 'green' | 'blue' | 'red'
-  icon: React.ReactNode
-  children: React.ReactNode
-}) {
-  return (
-    <span
-      className={`inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium ${BADGE_TONES[tone]}`}
-    >
-      {icon}
-      {children}
-    </span>
-  )
-}
-
-// The one error that needs a way out, not just a message: the admin must enable
-// two-factor on their OWN account before they can require it org-wide.
-function AdminMfaCallout({ href, message }: { href: string; message?: string | null }) {
-  const { t } = useTranslation()
-  return (
-    <div className="flex items-start gap-3 rounded-lg bg-amber-50 border border-amber-200/80 px-4 py-3">
-      <ShieldAlert className="w-4 h-4 text-amber-600 shrink-0 mt-0.5" />
-      <div className="space-y-2">
-        <p className="text-sm text-amber-900">
-          {message ||
-            t('dashboard.organization.security.admin_mfa_first', {
-              defaultValue:
-                'Enable two-factor on your own account before requiring it for the organization.',
-            })}
-        </p>
-        <p className="text-xs text-amber-800/80 leading-relaxed">
-          {t('dashboard.organization.security.admin_mfa_first_why', {
-            defaultValue:
-              'Otherwise the policy would lock you out of your own organization the moment it saves — and no admin would be left to turn it back off.',
-          })}
-        </p>
-        <Link
-          href={href}
-          className="inline-flex items-center gap-1.5 text-sm font-medium text-amber-900 underline underline-offset-2 hover:text-amber-950"
-        >
-          {t('dashboard.organization.security.admin_mfa_first_cta', {
-            defaultValue: 'Set up two-factor on your account',
-          })}
-          <ExternalLink className="w-3.5 h-3.5" />
-        </Link>
-      </div>
-    </div>
-  )
-}
-
-export default OrgEditSecurity
+export default OrgTwoFactorPolicy

--- a/apps/web/components/Dashboard/Pages/Users/Security/shared.tsx
+++ b/apps/web/components/Dashboard/Pages/Users/Security/shared.tsx
@@ -1,0 +1,468 @@
+'use client'
+import React from 'react'
+import Link from 'next/link'
+import { useTranslation } from 'react-i18next'
+import { ExternalLink, ShieldAlert } from 'lucide-react'
+import { useOrg } from '@components/Contexts/OrgContext'
+import { useLHSession } from '@components/Contexts/LHSessionContext'
+import { toast } from 'react-hot-toast'
+import { useQueryClient } from '@tanstack/react-query'
+import { getAPIUrl } from '@services/config/config'
+import {
+  RequestBodyWithAuthHeader,
+  getResponseMetadata,
+  revalidateTags,
+} from '@services/utils/ts/requests'
+import { getErrorMessage } from '@services/utils/ts/errorMessage'
+import { queryKeys } from '@/lib/query/keys'
+
+/**
+ * Shared state for the two org security tabs (Users → Two-factor / Sign-in
+ * methods). Both edit the same backend policy blob but save independently, so
+ * the save is a PATCH: only the fields a tab owns are sent.
+ *
+ * Mirrors the backend payloads in src/routers/mfa.py.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ComplianceMember = {
+  user_id: number
+  email: string | null
+  username: string | null
+  first_name: string | null
+  last_name: string | null
+  signup_method: string | null
+  mfa_enabled: boolean
+  confirmed_at: string | null
+}
+
+export type ComplianceResponse = {
+  total: number
+  enabled: number
+  members: ComplianceMember[]
+}
+
+export type OrgSecurityPolicy = {
+  require_2fa: boolean
+  require_2fa_grace_days: number
+  require_2fa_enabled_at: string | null
+  exempt_external_auth: boolean
+  // Which sign-in methods this org accepts. The full set = unrestricted.
+  allowed_auth_methods: string[]
+  // When off, a central learnhouse.io session can't carry members into this org.
+  allow_central_session_sharing: boolean
+}
+
+// The CALLING user's own compliance state — context only, not the policy.
+export type SelfComplianceState = {
+  required: boolean
+  satisfied: boolean
+  deadline: string | null
+  days_remaining: number | null
+  blocking: boolean
+  exempt_reason: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+// Kept in sync with EXTERNAL_AUTH_METHODS in
+// apps/api/src/services/orgs/mfa_policy.py. An unrecognised signup_method is
+// deliberately treated as a local password account, i.e. subject to the policy.
+const EXTERNAL_AUTH_METHODS = [
+  'google',
+  'sso',
+  'saml',
+  'oidc',
+  'workos',
+  'keycloak',
+  'okta',
+  'auth0',
+]
+
+export const GRACE_OPTIONS = [0, 7, 14, 30]
+
+// The complete set of sign-in methods. Selecting all of them = unrestricted,
+// which is also what an absent policy falls back to. Kept in sync with the
+// backend's allowed_auth_methods contract.
+export const ALL_AUTH_METHODS = ['password', 'magic_login', 'google', 'sso'] as const
+
+export const AUTH_METHOD_OPTIONS: {
+  key: string
+  labelKey: string
+  labelDefault: string
+  hintKey: string
+  hintDefault: string
+}[] = [
+  {
+    key: 'password',
+    labelKey: 'dashboard.organization.security.method_password',
+    labelDefault: 'Email + password',
+    hintKey: 'dashboard.organization.security.method_password_hint',
+    hintDefault: 'Sign in with an email address and password.',
+  },
+  {
+    key: 'magic_login',
+    labelKey: 'dashboard.organization.security.method_magic_login',
+    labelDefault: 'Magic login link',
+    hintKey: 'dashboard.organization.security.method_magic_login_hint',
+    hintDefault: 'Sign in through a one-time link sent by email.',
+  },
+  {
+    key: 'google',
+    labelKey: 'dashboard.organization.security.method_google',
+    labelDefault: 'Google',
+    hintKey: 'dashboard.organization.security.method_google_hint',
+    hintDefault: 'Sign in with a Google account.',
+  },
+  {
+    key: 'sso',
+    labelKey: 'dashboard.organization.security.method_sso',
+    labelDefault: 'SSO',
+    hintKey: 'dashboard.organization.security.method_sso_hint',
+    hintDefault: 'Sign in through your configured single sign-on provider.',
+  },
+]
+
+export const DEFAULT_POLICY: OrgSecurityPolicy = {
+  require_2fa: false,
+  require_2fa_grace_days: 0,
+  require_2fa_enabled_at: null,
+  exempt_external_auth: true,
+  allowed_auth_methods: [...ALL_AUTH_METHODS],
+  allow_central_session_sharing: true,
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/** Two string sets are equal regardless of order/dupes. */
+export const sameMethodSet = (a: string[], b: string[]): boolean => {
+  const sa = new Set(a)
+  const sb = new Set(b)
+  if (sa.size !== sb.size) return false
+  for (const v of sa) if (!sb.has(v)) return false
+  return true
+}
+
+export const isExternalAuth = (signup_method: string | null): boolean =>
+  EXTERNAL_AUTH_METHODS.includes((signup_method || '').toLowerCase())
+
+export const memberName = (m: ComplianceMember): string => {
+  const full = [m.first_name, m.last_name].filter(Boolean).join(' ').trim()
+  return full || m.username || m.email || `#${m.user_id}`
+}
+
+export const formatDate = (value: string | null | undefined): string => {
+  if (!value) return ''
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return String(value)
+  return d.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+export const addDays = (days: number): Date => {
+  const d = new Date()
+  d.setDate(d.getDate() + days)
+  return d
+}
+
+const normalizePolicy = (raw: any): OrgSecurityPolicy => ({
+  require_2fa: !!raw?.require_2fa,
+  require_2fa_grace_days: Math.max(0, Number(raw?.require_2fa_grace_days) || 0),
+  require_2fa_enabled_at: raw?.require_2fa_enabled_at ?? null,
+  exempt_external_auth: raw?.exempt_external_auth !== false,
+  // Absent → unrestricted (all methods) + central sharing on.
+  allowed_auth_methods: Array.isArray(raw?.allowed_auth_methods)
+    ? raw.allowed_auth_methods
+    : [...ALL_AUTH_METHODS],
+  allow_central_session_sharing: raw?.allow_central_session_sharing !== false,
+})
+
+// ---------------------------------------------------------------------------
+// Policy hook
+// ---------------------------------------------------------------------------
+
+export function useOrgSecurityPolicy() {
+  const { t } = useTranslation()
+  const session = useLHSession() as any
+  const access_token = session?.data?.tokens?.access_token
+  const currentUserId = session?.data?.user?.id
+  const org = useOrg() as any
+  const orgId = org?.id
+  const orgslug = org?.slug
+  const queryClient = useQueryClient()
+
+  // Saved policy — seeded from the org config the page already loads, then kept
+  // authoritative from the PUT response.
+  const savedPolicy: OrgSecurityPolicy = React.useMemo(() => {
+    const security = org?.config?.config?.admin_toggles?.security
+    return security ? normalizePolicy(security) : DEFAULT_POLICY
+  }, [org])
+
+  const [policy, setPolicy] = React.useState<OrgSecurityPolicy>(savedPolicy)
+  const [saving, setSaving] = React.useState(false)
+  const [saveError, setSaveError] = React.useState<string | null>(null)
+  // Set when the backend refuses because the admin has no second factor of
+  // their own — drives the "enable it on your account first" call to action.
+  const [needsOwnMfa, setNeedsOwnMfa] = React.useState(false)
+
+  // Re-seed once the org config lands (it arrives asynchronously via OrgContext).
+  const seededRef = React.useRef(false)
+  const [seedVersion, setSeedVersion] = React.useState(0)
+  React.useEffect(() => {
+    if (seededRef.current) return
+    if (!org?.config?.config) return
+    seededRef.current = true
+    setPolicy(savedPolicy)
+    setSeedVersion((v) => v + 1)
+  }, [org, savedPolicy])
+
+  // Same call shape as the account-level two-factor section: getAPIUrl() +
+  // RequestBodyWithAuthHeader + getResponseMetadata. Deliberately NOT apiFetch —
+  // its errorHandling() turns a 401 into a global "session expired" event, and
+  // we want to read the structured `detail.code` on 403 ourselves.
+  const mfaFetch = React.useCallback(
+    async (path: string, method: 'GET' | 'PUT' | 'POST', body?: any) => {
+      const result = await fetch(
+        `${getAPIUrl()}auth/mfa${path}`,
+        RequestBodyWithAuthHeader(method, body ?? null, null, access_token)
+      )
+      return getResponseMetadata(result)
+    },
+    [access_token]
+  )
+
+  /**
+   * Save only the fields this tab owns. The backend treats every field as
+   * optional and leaves omitted ones untouched, so the other tab's settings
+   * survive.
+   */
+  const savePolicy = React.useCallback(
+    async (patch: Partial<OrgSecurityPolicy>): Promise<boolean> => {
+      if (!orgId) return false
+      setSaving(true)
+      setSaveError(null)
+      setNeedsOwnMfa(false)
+      const loadingToast = toast.loading(
+        t('dashboard.organization.security.saving', { defaultValue: 'Saving security policy…' })
+      )
+      try {
+        const res = await mfaFetch(`/org-policy/${orgId}`, 'PUT', patch)
+
+        if (!res.success) {
+          const code = res.data?.detail?.code
+          const message = getErrorMessage(
+            res.data?.detail,
+            t('dashboard.organization.security.save_error', {
+              defaultValue: 'Could not save the security policy.',
+            })
+          )
+          if (code === 'ADMIN_MFA_REQUIRED_FIRST') setNeedsOwnMfa(true)
+          setSaveError(message)
+          toast.error(message, { id: loadingToast })
+          return false
+        }
+
+        setPolicy(normalizePolicy(res.data))
+
+        if (orgslug) await revalidateTags(['organizations'], orgslug)
+        if (orgslug) queryClient.invalidateQueries({ queryKey: queryKeys.org.detail(orgslug) })
+        toast.success(
+          t('dashboard.organization.security.save_success', {
+            defaultValue: 'Security policy updated',
+          }),
+          { id: loadingToast }
+        )
+        return true
+      } catch {
+        const message = t('dashboard.organization.security.save_error', {
+          defaultValue: 'Could not save the security policy.',
+        })
+        setSaveError(message)
+        toast.error(message, { id: loadingToast })
+        return false
+      } finally {
+        setSaving(false)
+      }
+    },
+    [orgId, orgslug, mfaFetch, t, queryClient]
+  )
+
+  return {
+    orgId,
+    orgslug,
+    access_token,
+    currentUserId,
+    policy,
+    // Bumped when the async org config first lands, so a tab knows to reset its
+    // drafts to the freshly seeded policy.
+    seedVersion,
+    mfaFetch,
+    savePolicy,
+    saving,
+    saveError,
+    setSaveError,
+    needsOwnMfa,
+    setNeedsOwnMfa,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Small presentational helpers
+// ---------------------------------------------------------------------------
+
+const TILE_TONES: Record<string, string> = {
+  green: 'bg-green-50 text-green-700 border-green-100',
+  blue: 'bg-blue-50 text-blue-700 border-blue-100',
+  red: 'bg-red-50 text-red-700 border-red-100',
+  gray: 'bg-gray-50 text-gray-600 border-gray-100',
+}
+
+export function StatTile({
+  tone,
+  icon,
+  value,
+  label,
+}: {
+  tone: 'green' | 'blue' | 'red' | 'gray'
+  icon: React.ReactNode
+  value: number
+  label: string
+}) {
+  return (
+    <div className={`rounded-xl border px-4 py-3 ${TILE_TONES[tone]}`}>
+      <div className="flex items-center gap-2">
+        {icon}
+        <span className="text-xl font-bold tracking-tight">{value}</span>
+      </div>
+      <div className="text-xs mt-0.5 opacity-80">{label}</div>
+    </div>
+  )
+}
+
+const BADGE_TONES: Record<string, string> = {
+  green: 'bg-green-50 text-green-700',
+  blue: 'bg-blue-50 text-blue-700',
+  red: 'bg-red-50 text-red-700',
+}
+
+export function Badge({
+  tone,
+  icon,
+  children,
+}: {
+  tone: 'green' | 'blue' | 'red'
+  icon: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium ${BADGE_TONES[tone]}`}
+    >
+      {icon}
+      {children}
+    </span>
+  )
+}
+
+// The one error that needs a way out, not just a message: the admin must enable
+// two-factor on their OWN account before they can require it org-wide.
+export function AdminMfaCallout({ href, message }: { href: string; message?: string | null }) {
+  const { t } = useTranslation()
+  return (
+    <div className="flex items-start gap-3 rounded-lg bg-amber-50 border border-amber-200/80 px-4 py-3">
+      <ShieldAlert className="w-4 h-4 text-amber-600 shrink-0 mt-0.5" />
+      <div className="space-y-2">
+        <p className="text-sm text-amber-900">
+          {message ||
+            t('dashboard.organization.security.admin_mfa_first', {
+              defaultValue:
+                'Enable two-factor on your own account before requiring it for the organization.',
+            })}
+        </p>
+        <p className="text-xs text-amber-800/80 leading-relaxed">
+          {t('dashboard.organization.security.admin_mfa_first_why', {
+            defaultValue:
+              'Otherwise the policy would lock you out of your own organization the moment it saves — and no admin would be left to turn it back off.',
+          })}
+        </p>
+        <Link
+          href={href}
+          className="inline-flex items-center gap-1.5 text-sm font-medium text-amber-900 underline underline-offset-2 hover:text-amber-950"
+        >
+          {t('dashboard.organization.security.admin_mfa_first_cta', {
+            defaultValue: 'Set up two-factor on your account',
+          })}
+          <ExternalLink className="w-3.5 h-3.5" />
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+// Shared page-level states, so both tabs fail the same way.
+
+export function SecuritySkeleton() {
+  return (
+    <div className="sm:mx-10 mx-0 space-y-4">
+      <div className="bg-white rounded-xl nice-shadow p-6 animate-pulse space-y-4">
+        <div className="h-4 w-48 bg-gray-200 rounded" />
+        <div className="h-2 w-full bg-gray-100 rounded-full" />
+        <div className="h-3 w-64 bg-gray-100 rounded" />
+      </div>
+      <div className="bg-white rounded-xl nice-shadow p-6 animate-pulse space-y-3">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="h-10 bg-gray-50 rounded-lg" />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function NotAdminNotice() {
+  const { t } = useTranslation()
+  return (
+    <div className="sm:mx-10 mx-0">
+      <div className="bg-white rounded-xl nice-shadow p-6 flex items-start gap-3">
+        <ShieldAlert className="w-5 h-5 text-gray-400 shrink-0 mt-0.5" />
+        <div>
+          <h2 className="font-semibold text-gray-800">
+            {t('dashboard.organization.security.not_admin_title', {
+              defaultValue: 'You don’t have access to this setting',
+            })}
+          </h2>
+          <p className="text-sm text-gray-500 mt-1">
+            {t('dashboard.organization.security.not_admin_body', {
+              defaultValue:
+                'Only organization admins can view or change the two-factor requirement.',
+            })}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function ReadOnlyNotice() {
+  const { t } = useTranslation()
+  return (
+    <div className="flex items-center gap-3 px-4 py-3 rounded-xl bg-amber-50 border border-amber-200/80">
+      <ShieldAlert className="w-4 h-4 text-amber-600 shrink-0" />
+      <p className="text-sm text-amber-800">
+        {t('dashboard.organization.security.read_only', {
+          defaultValue:
+            'You can review this page, but only an organization admin can change the policy.',
+        })}
+      </p>
+    </div>
+  )
+}

--- a/apps/web/services/auth/authMethods.ts
+++ b/apps/web/services/auth/authMethods.ts
@@ -1,0 +1,36 @@
+/**
+ * Which sign-in methods an organization accepts.
+ *
+ * Mirrors `allowed_auth_methods` in src/services/orgs/auth_policy.py, including
+ * its two "unrestricted" cases: an absent list and an empty one. The empty case
+ * matters — a mis-saved policy must not render a login page with no way in.
+ *
+ * The backend refuses a disallowed sign-in at /auth/login, /auth/oauth and the
+ * magic-link endpoints; this module only decides what the login page bothers to
+ * render. It is a convenience, never the enforcement.
+ */
+
+export const ALL_AUTH_METHODS = ['password', 'magic_login', 'google', 'sso'] as const
+
+export type AuthMethod = (typeof ALL_AUTH_METHODS)[number]
+
+/**
+ * The methods this org allows, read from the public org config.
+ *
+ * `org` is the payload of GET /orgs/slug/{slug}. On the org-less apex there is
+ * no org, so nothing is restricted.
+ */
+export function getAllowedAuthMethods(org: any): Set<AuthMethod> {
+  const configured = org?.config?.config?.admin_toggles?.security?.allowed_auth_methods
+
+  if (!Array.isArray(configured)) return new Set(ALL_AUTH_METHODS)
+
+  const allowed = ALL_AUTH_METHODS.filter((m) => configured.includes(m))
+
+  // Empty (or entirely unrecognised) list = unrestricted, matching the backend.
+  return allowed.length === 0 ? new Set(ALL_AUTH_METHODS) : new Set(allowed)
+}
+
+export function isAuthMethodAllowed(org: any, method: AuthMethod): boolean {
+  return getAllowedAuthMethods(org).has(method)
+}


### PR DESCRIPTION
Unchecking a sign-in method in org settings (password, magic link, Google, SSO) did nothing visible. The login page still showed every option, and disallowed methods still signed people in. The only symptom was scattered 403s later, because the policy was only enforced per request, after a session already existed. None of the login endpoints checked it up front.

- New `enforce_login_auth_method()` gate on password login, OAuth, magic-link request/verify, and org-scoped signup. Apex (org-less) login is untouched since no single org's policy applies there.
- `GET /auth/mfa/org-policy/{org_id}` now also evaluates the auth-method/session policy, so the frontend's existing "method not allowed" screen actually shows up.
- `PUT /auth/mfa/org-policy/{org_id}` is now a partial update, so the two-factor and sign-in settings tabs stop overwriting each other.
- Login/signup pages hide methods the org disallows and explain when none are left.
- Security settings moved out of org branding into Users, split into two-factor and sign-in tabs (old URL redirects). The 2FA coverage/badge panel only renders when the requirement is on.

Known gap: the SSO callback still isn't refused at the door. The per-request check still catches it, just not at sign-in time like the rest.

3 new endpoint tests, plus 1854 passing in the API routers/security suites. eslint and tsc clean on changed web files. Not tested in a browser. SCORM suite's 33 failures pre-date this branch.