### PR TITLE
Connect the Library to the editor, add previews, and flashcard grids

### DIFF
--- a/apps/api/src/routers/ai/courseplanning.py
+++ b/apps/api/src/routers/ai/courseplanning.py
@@ -538,7 +538,8 @@ def validate_prosemirror_content(content: dict) -> tuple[bool, str]:
         "codeBlock", "blockQuiz", "flipcard", "calloutInfo", "calloutWarning",
         "blockEmbed", "blockImage", "blockVideo", "blockPDF", "blockMathEquation",
         "table", "tableRow", "tableCell", "tableHeader", "horizontalRule",
-        "hardBreak", "text", "scenarios", "blockUser", "blockWebPreview", "button", "badge"
+        "hardBreak", "text", "scenarios", "blockUser", "blockWebPreview", "button", "badge",
+        "blockLibrary", "flipcardGrid"
     }
 
     def check_node(node: dict, path: str = "root") -> tuple[bool, str]:

--- a/apps/api/src/routers/media/media.py
+++ b/apps/api/src/routers/media/media.py
@@ -25,16 +25,19 @@ router = APIRouter()
 @router.get(
     "/{media_uuid}/file",
     summary="Serve a media file",
-    description="Streams the media file's bytes after enforcing access (folder-aware). The storage path is never exposed to the client. Supports Range requests.",
+    description="Streams the media file's bytes after enforcing access (folder-aware). The storage path is never exposed to the client. Supports Range requests. Pass `download=true` to force a save-as instead of inline rendering.",
 )
 async def api_serve_media_file(
     request: Request,
     media_uuid: str,
+    download: bool = False,
     current_user=Depends(get_current_user),
     db_session=Depends(get_db_session),
 ):
     media, is_public = await authorize_media_file(request, media_uuid, current_user, db_session)
-    return await serve_media_file(request, media, db_session, is_public=is_public)
+    return await serve_media_file(
+        request, media, db_session, is_public=is_public, download=download
+    )
 
 
 @router.head("/{media_uuid}/file", summary="Media file metadata")
@@ -68,11 +71,14 @@ async def api_create_media_share_link(
 async def api_serve_shared_media(
     request: Request,
     token: str,
+    download: bool = False,
     current_user=Depends(get_current_user),
     db_session=Depends(get_db_session),
 ):
     media, is_public = await authorize_share_token(request, token, current_user, db_session)
-    return await serve_media_file(request, media, db_session, is_public=is_public)
+    return await serve_media_file(
+        request, media, db_session, is_public=is_public, download=download
+    )
 
 
 @router.head("/shared/{token}/file", summary="Shared media file metadata by token")

--- a/apps/api/src/services/ai/courseplanning.py
+++ b/apps/api/src/services/ai/courseplanning.py
@@ -222,6 +222,7 @@ Activities in LearnHouse use a rich content editor with various block types. For
 - codeBlock: Code snippets with syntax highlighting
 - blockQuiz: Interactive quiz questions with multiple choice answers
 - flipcard: Flashcards for memorization (front/back cards)
+- flipcardGrid: Several flashcards laid out side by side (wraps flipcard children)
 - calloutInfo: Important information callouts
 - calloutWarning: Warning/caution notices
 - blockEmbed: YouTube videos and external embeds (IMPORTANT: Use this for any YouTube URLs provided by the user)
@@ -332,6 +333,14 @@ AVAILABLE BLOCK TYPES (use EXACTLY these type names):
      "alignment": "center",
      "size": "medium"
    }}}}
+
+9b. flipcardGrid - several flashcards side by side (use instead of consecutive
+    standalone flipcards when a grid or row is wanted). `columns` is 1-4 and the
+    content array holds only flipcard nodes.
+   {{"type": "flipcardGrid", "attrs": {{"columns": 2}}, "content": [
+     {{"type": "flipcard", "attrs": {{"question": "Term", "answer": "Definition", "color": "blue", "alignment": "center", "size": "medium"}}}},
+     {{"type": "flipcard", "attrs": {{"question": "Term", "answer": "Definition", "color": "blue", "alignment": "center", "size": "medium"}}}}
+   ]}}
 
 10. blockEmbed - YouTube videos and external embeds
     {{"type": "blockEmbed", "attrs": {{

--- a/apps/api/src/services/ai/editor.py
+++ b/apps/api/src/services/ai/editor.py
@@ -81,6 +81,16 @@ def _serialize_tiptap_content_to_text(content: Any) -> str:
                 text_parts.append(f"\n[FLIPCARD]\nQ: {attrs.get('question', '')}\nA: {attrs.get('answer', '')}")
                 return
 
+            # A library block only references an asset; name it so the model has
+            # something to reason about instead of an empty node.
+            if node_type == 'blockLibrary':
+                attrs = node.get('attrs', {})
+                snapshot = attrs.get('snapshot') or {}
+                name = snapshot.get('name') or attrs.get('resourceUuid', '')
+                kind = attrs.get('resourceType', 'resource')
+                text_parts.append(f"\n[LIBRARY {str(kind).upper()}] {name}")
+                return
+
             # Recursively process content
             content = node.get('content', [])
             if isinstance(content, list):

--- a/apps/api/src/services/ai/schemas/editor.py
+++ b/apps/api/src/services/ai/schemas/editor.py
@@ -94,6 +94,12 @@ Flipcard format:
 - size options: "small", "medium", "large"
 - alignment options: "left", "center", "right"
 
+Flipcard grid format (lays several flipcards out side by side):
+{"type":"flipcardGrid","attrs":{"columns":2},"content":[{"type":"flipcard","attrs":{...}},{"type":"flipcard","attrs":{...}}]}
+- columns options: 1, 2, 3, 4
+- content must contain at least one flipcard, and only flipcards
+- use this instead of consecutive standalone flipcards when the user wants a grid or a row
+
 Math equation format:
 {"type":"blockMathEquation","attrs":{"math_equation":"E = mc^2"}}
 - Uses LaTeX syntax for equations

--- a/apps/api/src/services/folders/folders.py
+++ b/apps/api/src/services/folders/folders.py
@@ -99,6 +99,21 @@ def _resource_registry():
     }
 
 
+def _public_resource_dump(resource) -> dict:
+    """Serialize a resolved resource for the client.
+
+    Media rows must go through MediaRead: dumping the table model would ship
+    `file_id` and `storage_key`, and the whole point of the randomized storage
+    key is that the client can never derive a storage path (bytes are only
+    reachable via GET /media/{uuid}/file).
+    """
+    from src.db.media.media import Media, MediaRead
+
+    if isinstance(resource, Media):
+        return MediaRead.model_validate(resource, from_attributes=True).model_dump()
+    return resource.model_dump()
+
+
 async def _resolve_items(
     db_session: AsyncSession,
     content_rows: list[FolderContent],
@@ -132,7 +147,7 @@ async def _resolve_items(
                     resource_uuid=r_uuid,
                     resource_type=resource_type,
                     position=position_map.get(r_uuid, 0),
-                    resource=resource.model_dump(),
+                    resource=_public_resource_dump(resource),
                 )
             )
 
@@ -844,7 +859,7 @@ async def search_library(
                 "resource_uuid": r.resource_uuid,
                 "resource_type": rtype,
                 "position": r.position,
-                "resource": res.model_dump(),
+                "resource": _public_resource_dump(res),
                 "path": await folder_path(r.folder_id),
             })
 

--- a/apps/api/src/services/media/media_serve.py
+++ b/apps/api/src/services/media/media_serve.py
@@ -7,6 +7,7 @@ Handles both filesystem and s3/R2 delivery, with HTTP Range support.
 """
 
 from pathlib import Path
+from urllib.parse import quote
 
 from botocore.exceptions import ClientError
 from fastapi import HTTPException, Request
@@ -57,13 +58,33 @@ async def _resolve_storage_key(db_session: AsyncSession, media: Media) -> str:
     return f"orgs/{org.org_uuid}/media/{media.media_uuid}/{media.file_id}"
 
 
-def _headers(mime: str, is_public: bool) -> dict:
+def _download_filename(media: Media, rel_key: str) -> str:
+    """A human filename for the Content-Disposition header.
+
+    `media.name` is the label the user gave the asset and usually has no
+    extension, so the stored format (or the storage key's suffix) is appended.
+    """
+    stem = (media.name or "").strip() or Path(rel_key).stem or "file"
+    stem = stem.replace("/", "-").replace("\\", "-")
+    suffix = (media.file_format or "").strip().lstrip(".").lower()
+    if not suffix:
+        suffix = Path(rel_key).suffix.lstrip(".").lower()
+    if suffix and not stem.lower().endswith(f".{suffix}"):
+        return f"{stem}.{suffix}"
+    return stem
+
+
+def _headers(mime: str, is_public: bool, filename: str, download: bool) -> dict:
     cache = "public, max-age=86400" if is_public else "private, no-store"
+    # Always send a filename so "save as" proposes something sensible; only the
+    # disposition type changes. RFC 5987 encoding keeps non-ASCII names intact.
+    disposition = "attachment" if download else "inline"
     return {
         "Content-Type": mime,
         "Accept-Ranges": "bytes",
         "Cache-Control": cache,
         "X-Content-Type-Options": "nosniff",
+        "Content-Disposition": f"{disposition}; filename*=UTF-8''{quote(filename, safe='')}",
     }
 
 
@@ -91,15 +112,19 @@ async def serve_media_file(
     *,
     is_public: bool,
     head: bool = False,
+    download: bool = False,
 ) -> Response:
     """Stream (or HEAD) a media file's bytes after the caller has already
-    authorized access. `is_public` only controls caching headers."""
+    authorized access. `is_public` only controls caching headers; `download`
+    switches Content-Disposition to attachment so the browser saves the file
+    instead of rendering it (the `download` attribute on an anchor is ignored
+    cross-origin, and media is served from the API host)."""
     if media.media_type != MediaTypeEnum.UPLOAD:
         raise HTTPException(status_code=404, detail="This media has no file")
 
     rel_key = await _resolve_storage_key(db_session, media)
     mime = media.file_mime or _mime_for(rel_key)
-    headers = _headers(mime, is_public)
+    headers = _headers(mime, is_public, _download_filename(media, rel_key), download)
     range_header = request.headers.get("range")
 
     if get_content_delivery_type() == "s3api":

--- a/apps/api/src/tests/routers/test_media_serve_router.py
+++ b/apps/api/src/tests/routers/test_media_serve_router.py
@@ -56,11 +56,14 @@ def fs_file():
     shutil.rmtree(Path("content") / "orgs" / "org_test", ignore_errors=True)
 
 
-async def _mk_media(db, org, storage_key="", public=True, media_type=MediaTypeEnum.UPLOAD, name="m"):
+async def _mk_media(
+    db, org, storage_key="", public=True, media_type=MediaTypeEnum.UPLOAD, name="m",
+    file_format="pdf",
+):
     m = Media(
         name=name, media_type=media_type, public=public, org_id=org.id,
         media_uuid=f"media_{name}", file_id="testfile.pdf", storage_key=storage_key,
-        file_format="pdf", file_mime="application/pdf",
+        file_format=file_format, file_mime="application/pdf",
         creation_date=str(datetime.now()), update_date=str(datetime.now()),
     )
     db.add(m)
@@ -120,6 +123,16 @@ class TestServeFilesystem:
         disposition = res.headers["content-disposition"]
         assert disposition.startswith("attachment; filename*=UTF-8''")
         assert "rapport%20financier.pdf" in disposition
+
+    async def test_filename_falls_back_to_storage_suffix_and_keeps_one_extension(
+        self, client, db, org, fs_file
+    ):
+        # Legacy rows can have no file_format, so the extension comes from the
+        # storage key; and a name that already carries it must not get it twice.
+        m = await _mk_media(db, org, storage_key=fs_file, name="already.pdf", file_format="")
+        res = await client.get(f"/api/v1/media/{m.media_uuid}/file?download=true")
+        assert res.status_code == 200, res.text
+        assert res.headers["content-disposition"] == "attachment; filename*=UTF-8''already.pdf"
 
     async def test_missing_file_on_disk_404(self, client, db, org):
         m = await _mk_media(db, org, storage_key="orgs/org_test/media/none/missing.pdf", name="fsmiss")

--- a/apps/api/src/tests/routers/test_media_serve_router.py
+++ b/apps/api/src/tests/routers/test_media_serve_router.py
@@ -97,6 +97,30 @@ class TestServeFilesystem:
         assert res.status_code == 200, res.text
         assert res.headers["cache-control"] == "private, no-store"
 
+    async def test_inline_disposition_by_default(self, client, db, org, fs_file):
+        m = await _mk_media(db, org, storage_key=fs_file, name="fsinline")
+        res = await client.get(f"/api/v1/media/{m.media_uuid}/file")
+        assert res.status_code == 200, res.text
+        assert res.headers["content-disposition"].startswith("inline;")
+        assert "fsinline.pdf" in res.headers["content-disposition"]
+
+    async def test_download_forces_attachment(self, client, db, org, fs_file):
+        # The `download` attribute on an anchor is ignored cross-origin, so the
+        # attachment disposition has to come from the API.
+        m = await _mk_media(db, org, storage_key=fs_file, name="fsdl")
+        res = await client.get(f"/api/v1/media/{m.media_uuid}/file?download=true")
+        assert res.status_code == 200, res.text
+        assert res.headers["content-disposition"].startswith("attachment;")
+        assert "fsdl.pdf" in res.headers["content-disposition"]
+
+    async def test_download_filename_is_rfc5987_encoded(self, client, db, org, fs_file):
+        m = await _mk_media(db, org, storage_key=fs_file, name="rapport financier")
+        res = await client.get(f"/api/v1/media/{m.media_uuid}/file?download=true")
+        assert res.status_code == 200, res.text
+        disposition = res.headers["content-disposition"]
+        assert disposition.startswith("attachment; filename*=UTF-8''")
+        assert "rapport%20financier.pdf" in disposition
+
     async def test_missing_file_on_disk_404(self, client, db, org):
         m = await _mk_media(db, org, storage_key="orgs/org_test/media/none/missing.pdf", name="fsmiss")
         res = await client.get(f"/api/v1/media/{m.media_uuid}/file")

--- a/apps/api/src/tests/services/test_folders_service_coverage.py
+++ b/apps/api/src/tests/services/test_folders_service_coverage.py
@@ -107,6 +107,54 @@ class TestFoldersServiceCoverage:
         assert "course_deadbeef" not in uuids  # orphan filtered
         assert "course_private" not in uuids    # private skipped (line 78)
 
+    # --- media rows must be projected through MediaRead, never dumped raw ---
+    @pytest.mark.asyncio
+    async def test_media_storage_fields_never_reach_the_client(
+        self, db, org, mock_request
+    ):
+        """The randomized storage key is only useful if it stays server-side.
+
+        Dumping the Media table model would ship file_id/storage_key in every
+        folder and search payload, letting a client derive a storage path.
+        """
+        from src.db.media.media import Media, MediaTypeEnum
+
+        media = Media(
+            name="Leaky",
+            media_type=MediaTypeEnum.UPLOAD,
+            public=True,
+            org_id=org.id,
+            media_uuid="media_leaky",
+            file_id="secret-file-id",
+            storage_key="orgs/x/media/secret-random-dir/secret.pdf",
+            file_format="pdf",
+            file_mime="application/pdf",
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(media)
+        await db.commit()
+
+        folder = await _mk_folder(db, org, "MediaHolder")
+        await _add_content(db, org, folder.id, "media_leaky")
+
+        rbac, webhooks = _bypass()
+        with rbac, webhooks:
+            fetched = await get_folder(
+                mock_request, folder.folder_uuid, AnonymousLike(), db
+            )
+            found = await search_library(mock_request, str(org.id), "Leaky", AnonymousLike(), db)
+
+        payloads = [i.resource for i in fetched.items if i.resource_type == "media"]
+        payloads += [i["resource"] for i in found["items"] if i["resource_type"] == "media"]
+        assert payloads, "the media item should have been resolved"
+        for payload in payloads:
+            assert "file_id" not in payload
+            assert "storage_key" not in payload
+            # The metadata the UI actually needs is still there.
+            assert payload["file_format"] == "pdf"
+            assert payload["media_uuid"] == "media_leaky"
+
     # --- line 100: breadcrumb cycle-guard break ---
     @pytest.mark.asyncio
     async def test_build_breadcrumbs_cycle_guard_break(self, db, org):

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/library/library-cards.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/library/library-cards.tsx
@@ -8,11 +8,12 @@ import { getUriWithOrg } from '@services/config/config'
 import { removeFolderPrefix } from '@services/folders/folders'
 import CourseThumbnail from '@components/Objects/Thumbnails/CourseThumbnail'
 import { getFolderThumbnailMediaDirectory } from '@services/media/media'
-import { getMediaFileDirectory } from '@services/media/media-resource'
 import { folderTone } from '@components/Dashboard/Library/LibraryToolbar'
 import { shareFolderLink } from '@components/Dashboard/Library/shareFolder'
-import { resourceHref, safeExternalUrl } from '@components/Dashboard/Library/resourceLink'
+import { resourceHref } from '@components/Dashboard/Library/resourceLink'
 import MediaPreview from '@components/Dashboard/Library/MediaPreview'
+import MediaLightbox from '@components/Objects/Media/MediaLightbox'
+import { mediaKind } from '@/lib/media/mediaKind'
 import {
   FolderSimple,
   GraduationCap,
@@ -27,6 +28,7 @@ import {
   MusicNote,
   File as FileIcon,
   ArrowSquareOut,
+  Eye,
   type IconProps,
 } from '@phosphor-icons/react'
 
@@ -42,13 +44,14 @@ const TYPE_TONE: Record<string, string> = {
 }
 
 function mediaIcon(resource: any): React.ComponentType<IconProps> {
-  if (resource?.media_type === 'EMBED') return LinkSimple
-  const f = (resource?.file_format || '').toLowerCase()
-  if (f === 'pdf') return FilePdf
-  if (['mp4', 'webm', 'mov'].includes(f)) return VideoCamera
-  if (['png', 'jpg', 'jpeg', 'gif', 'webp'].includes(f)) return ImageIcon
-  if (['mp3', 'wav', 'ogg', 'm4a'].includes(f)) return MusicNote
-  return FileIcon
+  switch (mediaKind(resource)) {
+    case 'embed': return LinkSimple
+    case 'pdf': return FilePdf
+    case 'video': return VideoCamera
+    case 'image': return ImageIcon
+    case 'audio': return MusicNote
+    default: return FileIcon
+  }
 }
 
 function typeIcon(type: string, resource: any): React.ComponentType<IconProps> {
@@ -106,6 +109,7 @@ export function FolderCard({ folder, orgslug }: { folder: any; orgslug: string }
 export function LibraryItemCard({ item, orgslug }: { item: any; orgslug: string }) {
   const { t } = useTranslation()
   const org = useOrg() as any
+  const [previewOpen, setPreviewOpen] = React.useState(false)
   const type = item.resource_type as ResourceType
   const resource = item.resource || {}
 
@@ -118,20 +122,9 @@ export function LibraryItemCard({ item, orgslug }: { item: any; orgslug: string 
   const tone = TYPE_TONE[type] || 'bg-gray-50 text-gray-400'
   const Icon = typeIcon(type, resource)
 
-  let href: string | null = null
-  let external = false
-  let fileUrl: string | null = null
-  if (type === 'media') {
-    // file_id is no longer exposed; uploaded media is served via the authed
-    // /media/{uuid}/file endpoint keyed only by media_uuid.
-    if (resource.media_type !== 'EMBED') fileUrl = getMediaFileDirectory(org?.org_uuid, resource.media_uuid || item.resource_uuid)
-    if (resource.media_type === 'EMBED' && resource.url) { href = safeExternalUrl(resource.url); external = !!href }
-    else if (fileUrl) { href = fileUrl; external = true }
-  } else {
-    // Podcasts, communities, boards, playgrounds → their own resource page.
-    href = resourceHref(type, resource, orgslug, 'public')
-  }
-  const isUpload = type === 'media' && resource.media_type !== 'EMBED'
+  const mediaUuid = resource.media_uuid || item.resource_uuid
+  // Media previews in-app (see below); everything else links to its own page.
+  const href = type === 'media' ? null : resourceHref(type, resource, orgslug, 'public')
 
   const body = (
     <>
@@ -147,10 +140,10 @@ export function LibraryItemCard({ item, orgslug }: { item: any; orgslug: string 
         <h3 className="text-base font-bold text-gray-900 leading-tight line-clamp-1">{name}</h3>
         <div className="pt-1.5 flex items-center justify-between border-t border-gray-100">
           <span className="text-[10px] font-bold uppercase tracking-wider text-gray-400">{t(`library.tabs.${type}`)}</span>
-          {href && (
+          {(href || type === 'media') && (
             <span className="text-[10px] font-bold uppercase tracking-wider text-gray-400 inline-flex items-center gap-1">
-              {isUpload ? t('media.download') : t('library.open_resource')}
-              {external && <ArrowSquareOut size={11} />}
+              {type === 'media' ? t('library.preview') : t('library.open_resource')}
+              {type === 'media' ? <Eye size={11} /> : <ArrowSquareOut size={11} />}
             </span>
           )}
         </div>
@@ -159,7 +152,22 @@ export function LibraryItemCard({ item, orgslug }: { item: any; orgslug: string 
   )
 
   const BIG = 'group relative flex flex-col bg-white rounded-xl nice-shadow overflow-hidden w-full transition-all hover:bg-gray-50/40'
-  if (href && external) return <a href={href} target="_blank" rel="noopener noreferrer" className={BIG}>{body}</a>
+  // Media opens in-app rather than sending the learner off to the raw file.
+  if (type === 'media') {
+    return (
+      <>
+        <button type="button" onClick={() => setPreviewOpen(true)} className={`${BIG} text-left`}>
+          {body}
+        </button>
+        <MediaLightbox
+          resource={resource}
+          mediaUuid={mediaUuid}
+          isOpen={previewOpen}
+          onOpenChange={setPreviewOpen}
+        />
+      </>
+    )
+  }
   if (href) return <Link href={href} className={BIG}>{body}</Link>
   return <div className={BIG}>{body}</div>
 }

--- a/apps/web/components/Dashboard/Library/LibraryItemCard.tsx
+++ b/apps/web/components/Dashboard/Library/LibraryItemCard.tsx
@@ -5,9 +5,11 @@ import ConfirmationModal from '@components/Objects/StyledElements/ConfirmationMo
 import Modal from '@components/Objects/StyledElements/Modal/Modal'
 import ManageAccessPopover from '@components/Dashboard/Library/ManageAccessPopover'
 import MediaPreview from '@components/Dashboard/Library/MediaPreview'
+import MediaLightbox from '@components/Objects/Media/MediaLightbox'
 import { resourceHref, safeExternalUrl } from '@components/Dashboard/Library/resourceLink'
 import { shareMediaLink } from '@components/Dashboard/Library/shareFolder'
 import { getMediaFileDirectory } from '@services/media/media-resource'
+import { mediaKind } from '@/lib/media/mediaKind'
 import Link from 'next/link'
 import {
   MicrophoneStage,
@@ -23,6 +25,7 @@ import {
   DotsThreeVertical,
   ArrowSquareOut,
   DownloadSimple,
+  Eye,
   Lock,
   FolderMinus,
 } from '@phosphor-icons/react'
@@ -45,13 +48,14 @@ const TYPE_TONE: Record<string, string> = {
 }
 
 function mediaIcon(resource: any) {
-  if (resource?.media_type === 'EMBED') return LinkSimple
-  const f = (resource?.file_format || '').toLowerCase()
-  if (f === 'pdf') return FilePdf
-  if (['mp4', 'webm', 'mov'].includes(f)) return VideoCamera
-  if (['png', 'jpg', 'jpeg', 'gif', 'webp'].includes(f)) return ImageIcon
-  if (['mp3', 'wav', 'ogg', 'm4a'].includes(f)) return MusicNote
-  return FileIcon
+  switch (mediaKind(resource)) {
+    case 'embed': return LinkSimple
+    case 'pdf': return FilePdf
+    case 'video': return VideoCamera
+    case 'image': return ImageIcon
+    case 'audio': return MusicNote
+    default: return FileIcon
+  }
 }
 
 function typeIcon(type: string, resource: any) {
@@ -79,6 +83,7 @@ export default function LibraryItemCard({ item, orgslug, onRemove }: Props) {
   const access_token = session?.data?.tokens?.access_token
   const [isMenuOpen, setIsMenuOpen] = React.useState(false)
   const [accessOpen, setAccessOpen] = React.useState(false)
+  const [previewOpen, setPreviewOpen] = React.useState(false)
 
   const type: string = item.resource_type
   const resource = item.resource || {}
@@ -87,15 +92,21 @@ export default function LibraryItemCard({ item, orgslug, onRemove }: Props) {
   const Icon = typeIcon(type, resource)
   const isUploadMedia = type === 'media' && resource.media_type !== 'EMBED'
 
+  const mediaUuid = resource.media_uuid || item.resource_uuid
   let href: string | null = null          // external (media file / embed url)
   let internalHref: string | null = null  // resource detail page (same-tab)
-  let fileUrl: string | null = null
+  let downloadUrl: string | null = null
   if (type === 'media') {
     // file_id is no longer exposed; uploaded media is served via the authed
     // /media/{uuid}/file endpoint keyed only by media_uuid.
-    if (isUploadMedia) fileUrl = getMediaFileDirectory(org?.org_uuid, resource.media_uuid || item.resource_uuid)
-    if (resource.media_type === 'EMBED' && resource.url) href = safeExternalUrl(resource.url)
-    else if (fileUrl) href = fileUrl
+    if (isUploadMedia) {
+      href = getMediaFileDirectory(org?.org_uuid, mediaUuid)
+      // The `download` attribute is ignored cross-origin, so the attachment
+      // disposition has to come from the API.
+      downloadUrl = getMediaFileDirectory(org?.org_uuid, mediaUuid, undefined, { download: true })
+    } else if (resource.url) {
+      href = safeExternalUrl(resource.url)
+    }
   } else {
     // Podcasts, communities, boards, playgrounds → their dashboard page.
     internalHref = resourceHref(type, resource, orgslug, 'dashboard')
@@ -118,8 +129,8 @@ export default function LibraryItemCard({ item, orgslug, onRemove }: Props) {
           <span className="text-[10px] font-bold uppercase tracking-wider text-gray-400">{typeLabel}</span>
           {(href || internalHref) && (
             <span className="text-[10px] font-bold uppercase tracking-wider text-gray-400 inline-flex items-center gap-1">
-              {isUploadMedia ? t('media.download') : t('library.open_resource')}
-              {isUploadMedia ? <DownloadSimple size={11} /> : <ArrowSquareOut size={11} />}
+              {type === 'media' ? t('library.preview') : t('library.open_resource')}
+              {type === 'media' ? <Eye size={11} /> : <ArrowSquareOut size={11} />}
             </span>
           )}
         </div>
@@ -137,10 +148,27 @@ export default function LibraryItemCard({ item, orgslug, onRemove }: Props) {
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-52">
+            {type === 'media' && (
+              <DropdownMenuItem asChild>
+                <button
+                  onClick={() => setPreviewOpen(true)}
+                  className="w-full text-left flex items-center px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-50 rounded-md transition-colors"
+                >
+                  <Eye className="mr-2 h-4 w-4" /> {t('library.preview')}
+                </button>
+              </DropdownMenuItem>
+            )}
+            {downloadUrl && (
+              <DropdownMenuItem asChild>
+                <a href={downloadUrl} className="flex items-center cursor-pointer">
+                  <DownloadSimple className="mr-2 h-4 w-4" /> {t('media.download')}
+                </a>
+              </DropdownMenuItem>
+            )}
             {href && (
               <DropdownMenuItem asChild>
                 <a href={href} target="_blank" rel="noopener noreferrer" className="flex items-center cursor-pointer">
-                  {isUploadMedia ? (<><DownloadSimple className="mr-2 h-4 w-4" /> {t('media.download')}</>) : (<><ArrowSquareOut className="mr-2 h-4 w-4" /> {t('library.open')}</>)}
+                  <ArrowSquareOut className="mr-2 h-4 w-4" /> {t('library.open')}
                 </a>
               </DropdownMenuItem>
             )}
@@ -186,16 +214,26 @@ export default function LibraryItemCard({ item, orgslug, onRemove }: Props) {
         </DropdownMenu>
       </div>
 
-      {href ? (
-        <a href={href} target="_blank" rel="noopener noreferrer" className="block">
+      {type === 'media' ? (
+        // Media opens in-app rather than dumping the raw file in a new tab.
+        <button type="button" onClick={() => setPreviewOpen(true)} className="block w-full text-left">
           {body}
-        </a>
+        </button>
       ) : internalHref ? (
         <Link href={internalHref} className="block">
           {body}
         </Link>
       ) : (
         <div>{body}</div>
+      )}
+
+      {type === 'media' && (
+        <MediaLightbox
+          resource={resource}
+          mediaUuid={mediaUuid}
+          isOpen={previewOpen}
+          onOpenChange={setPreviewOpen}
+        />
       )}
 
       {type === 'media' && (

--- a/apps/web/components/Dashboard/Library/MediaPreview.tsx
+++ b/apps/web/components/Dashboard/Library/MediaPreview.tsx
@@ -14,6 +14,8 @@ import {
   Play,
 } from '@phosphor-icons/react'
 import PdfThumbnail from '@components/Dashboard/Library/PdfThumbnail'
+import { mediaKind } from '@/lib/media/mediaKind'
+import { youTubeId, vimeoId } from '@/lib/media/embedUrl'
 
 /*
  Shared media preview used by BOTH the dashboard and public library cards.
@@ -28,21 +30,18 @@ import PdfThumbnail from '@components/Dashboard/Library/PdfThumbnail'
  The component is read-only / presentational.
 */
 
-const IMAGE_FORMATS = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'avif']
-const VIDEO_FORMATS = ['mp4', 'webm', 'mov']
-const AUDIO_FORMATS = ['mp3', 'wav', 'ogg', 'm4a']
-
 // Amber tone matches the existing "media" tone used by the cards.
 const MEDIA_TONE = 'bg-amber-50 text-amber-500'
 
 function tileIcon(resource: any): React.ComponentType<any> {
-  if (resource?.media_type === 'EMBED') return LinkSimple
-  const f = (resource?.file_format || '').toLowerCase()
-  if (f === 'pdf') return FilePdf
-  if (VIDEO_FORMATS.includes(f)) return VideoCamera
-  if (IMAGE_FORMATS.includes(f)) return ImageIcon
-  if (AUDIO_FORMATS.includes(f)) return MusicNote
-  return FileIcon
+  switch (mediaKind(resource)) {
+    case 'embed': return LinkSimple
+    case 'pdf': return FilePdf
+    case 'video': return VideoCamera
+    case 'image': return ImageIcon
+    case 'audio': return MusicNote
+    default: return FileIcon
+  }
 }
 
 function IconTile({ Icon }: { Icon: React.ComponentType<any> }) {
@@ -51,37 +50,6 @@ function IconTile({ Icon }: { Icon: React.ComponentType<any> }) {
       <Icon size={46} weight="fill" />
     </div>
   )
-}
-
-/** Extract a YouTube video id from common URL shapes, or null. */
-function youTubeId(url: string): string | null {
-  try {
-    const u = new URL(url)
-    const host = u.hostname.replace(/^www\./, '')
-    if (host === 'youtu.be') {
-      const id = u.pathname.split('/').filter(Boolean)[0]
-      return id || null
-    }
-    if (host.endsWith('youtube.com') || host.endsWith('youtube-nocookie.com')) {
-      const v = u.searchParams.get('v')
-      if (v) return v
-      const parts = u.pathname.split('/').filter(Boolean)
-      const i = parts.findIndex((p) => p === 'embed' || p === 'shorts' || p === 'v')
-      if (i !== -1 && parts[i + 1]) return parts[i + 1]
-    }
-  } catch {
-    /* not a parseable URL */
-  }
-  return null
-}
-
-/** True if the url is a Vimeo link. */
-function isVimeo(url: string): boolean {
-  try {
-    return new URL(url).hostname.replace(/^www\./, '').endsWith('vimeo.com')
-  } catch {
-    return false
-  }
 }
 
 function YouTubePreview({ id }: { id: string }) {
@@ -207,24 +175,24 @@ export default function MediaPreview({
   resourceUuid?: string
 }) {
   const Icon = tileIcon(resource)
+  const kind = mediaKind(resource)
 
   // EMBED: parse the url.
-  if (resource?.media_type === 'EMBED') {
+  if (kind === 'embed') {
     const url: string = resource.url || ''
     if (!url) return <IconTile Icon={Icon} />
     const yt = youTubeId(url)
     if (yt) return <YouTubePreview id={yt} />
     // Vimeo and every other website link get a real preview (og:image / screenshot).
-    return <EmbedPreview url={url} video={isVimeo(url)} />
+    return <EmbedPreview url={url} video={!!vimeoId(url)} />
   }
 
   // UPLOAD: build the file url. file_id is no longer exposed by the API; the
   // authed /media/{uuid}/file endpoint is keyed only by media_uuid.
   const mediaUuid = resource?.media_uuid || resourceUuid
   const fileUrl = mediaUuid ? getMediaFileDirectory(orgUuid, mediaUuid) : null
-  const fmt = (resource?.file_format || '').toLowerCase()
 
-  if (fileUrl && IMAGE_FORMATS.includes(fmt)) {
+  if (fileUrl && kind === 'image') {
     return (
       <div
         className="relative aspect-video bg-gray-50 bg-cover bg-center"
@@ -233,11 +201,11 @@ export default function MediaPreview({
     )
   }
 
-  if (fileUrl && fmt === 'pdf') {
+  if (fileUrl && kind === 'pdf') {
     return <PdfThumbnail url={fileUrl} />
   }
 
-  if (fileUrl && VIDEO_FORMATS.includes(fmt)) {
+  if (fileUrl && kind === 'video') {
     return <UploadVideoPreview src={fileUrl} />
   }
 

--- a/apps/web/components/Dashboard/Library/ResourcePicker.tsx
+++ b/apps/web/components/Dashboard/Library/ResourcePicker.tsx
@@ -14,24 +14,27 @@ import {
   Check,
   Plus,
   Loader2,
+  File as FileIcon,
 } from 'lucide-react'
+import MediaPreview from '@components/Dashboard/Library/MediaPreview'
 import React from 'react'
 import toast from 'react-hot-toast'
 import useSWR from 'swr'
 import { useTranslation } from 'react-i18next'
 import { useLHAnalytics, AnalyticsEvent } from '@services/analytics'
 
-export type TabKey = 'courses' | 'podcasts' | 'communities' | 'boards' | 'playgrounds'
+export type TabKey = 'courses' | 'podcasts' | 'communities' | 'boards' | 'playgrounds' | 'media'
 
 // Singular resource kind stored on a resource activity's content.resource_type,
 // used by the student renderer to build the correct resource route.
-export type ResourceKind = 'course' | 'podcast' | 'community' | 'board' | 'playground'
+export type ResourceKind = 'course' | 'podcast' | 'community' | 'board' | 'playground' | 'media'
 
 export const TAB_META: Record<
   TabKey,
   { feature: string; icon: any; uuidKey: string; kind: ResourceKind }
 > = {
   courses: { feature: 'courses', icon: BookCopy, uuidKey: 'course_uuid', kind: 'course' },
+  media: { feature: 'library', icon: FileIcon, uuidKey: 'media_uuid', kind: 'media' },
   podcasts: { feature: 'podcasts', icon: Podcast, uuidKey: 'podcast_uuid', kind: 'podcast' },
   communities: { feature: 'communities', icon: Users, uuidKey: 'community_uuid', kind: 'community' },
   boards: { feature: 'boards', icon: LayoutGrid, uuidKey: 'board_uuid', kind: 'board' },
@@ -43,6 +46,8 @@ export function endpointFor(tab: TabKey, orgslug: string, org_id: any): string {
     case 'courses':
       // include_unpublished so drafts show too (this is an admin/editor context).
       return `${getAPIUrl()}courses/org_slug/${orgslug}/page/1/limit/100?include_unpublished=true`
+    case 'media':
+      return `${getAPIUrl()}media/org/${org_id}/page/1/limit/100`
     case 'podcasts':
       return `${getAPIUrl()}podcasts/org_slug/${orgslug}/page/1/limit/100`
     case 'communities':
@@ -58,6 +63,8 @@ export type SelectedResource = {
   resource_uuid: string
   resource_type: ResourceKind
   name?: string
+  /** The full row, so callers can cache display metadata without a refetch. */
+  resource?: any
 }
 
 type ResourceListProps = {
@@ -129,6 +136,7 @@ function ResourceList({
       resource_uuid: item[uuidKey],
       resource_type: TAB_META[tab].kind,
       name: item.name,
+      resource: item,
     })
   }
 
@@ -151,6 +159,41 @@ function ResourceList({
         </div>
       ) : filtered.length === 0 ? (
         <div className="py-10 text-center text-sm text-gray-400">{t('library.no_resources')}</div>
+      ) : tab === 'media' ? (
+        // Files need to be recognisable, so media gets thumbnails instead of rows.
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 max-h-[400px] overflow-y-auto pr-1">
+          {filtered.map((item) => {
+            const uuid = item[uuidKey]
+            const isAdded = added.has(uuid)
+            const isSelected = mode === 'select' && selectedUuid === uuid
+            return (
+              <button
+                key={uuid}
+                type="button"
+                onClick={() => (mode === 'add' ? handleAdd(uuid) : handleSelect(item))}
+                disabled={pending === uuid}
+                className={`group text-left rounded-xl overflow-hidden border transition-colors disabled:opacity-50 ${
+                  isSelected || isAdded ? 'border-black' : 'border-gray-100 hover:border-gray-300'
+                }`}
+              >
+                <MediaPreview resource={item} resourceUuid={uuid} />
+                <div className="p-2 flex items-center justify-between gap-2">
+                  <span className="text-xs font-medium text-gray-800 truncate">{item.name}</span>
+                  {isAdded || isSelected ? (
+                    <Check className="w-3.5 h-3.5 text-green-600 flex-shrink-0" />
+                  ) : (
+                    <Plus className="w-3.5 h-3.5 text-gray-400 flex-shrink-0" />
+                  )}
+                </div>
+                {item.public === false && (
+                  <p className="px-2 pb-2 text-[10px] text-amber-600 leading-tight">
+                    {t('library.private_media_warning')}
+                  </p>
+                )}
+              </button>
+            )
+          })}
+        </div>
       ) : (
         <div className="flex flex-col gap-1.5 max-h-[400px] overflow-y-auto">
           {filtered.map((item) => {
@@ -256,9 +299,16 @@ function TabButton({
   )
 }
 
+// The library "add content" flow places existing resources into a folder, and
+// media already lives in the library — offering it there would just file the
+// same asset twice. Callers that want media (the Library block) opt in.
+const DEFAULT_TABS: TabKey[] = ['courses', 'podcasts', 'communities', 'boards', 'playgrounds']
+
 type ResourcePickerProps = {
   orgslug: string
   mode: 'add' | 'select'
+  /** Which tabs to offer; defaults to every resource type except media. */
+  tabs?: TabKey[]
   // add mode
   folderUuid?: string
   onChanged?: () => void
@@ -270,6 +320,7 @@ type ResourcePickerProps = {
 function ResourcePicker({
   orgslug,
   mode,
+  tabs = DEFAULT_TABS,
   folderUuid,
   onChanged,
   onSelect,
@@ -277,7 +328,7 @@ function ResourcePicker({
 }: ResourcePickerProps) {
   const org = useOrg() as any
 
-  const enabledTabs = (Object.keys(TAB_META) as TabKey[]).filter((tab) => {
+  const enabledTabs = tabs.filter((tab) => {
     const feature = TAB_META[tab].feature
     return org?.config?.config?.resolved_features?.[feature]?.enabled ?? true
   })

--- a/apps/web/components/Objects/Activities/DynamicCanva/DynamicCanva.tsx
+++ b/apps/web/components/Objects/Activities/DynamicCanva/DynamicCanva.tsx
@@ -33,6 +33,7 @@ import VideoBlock from '@components/Objects/Editor/Extensions/Video/VideoBlock'
 import AudioBlock from '@components/Objects/Editor/Extensions/Audio/AudioBlock'
 import MathEquationBlock from '@components/Objects/Editor/Extensions/MathEquation/MathEquationBlock'
 import PDFBlock from '@components/Objects/Editor/Extensions/PDF/PDFBlock'
+import LibraryBlock from '@components/Objects/Editor/Extensions/Library/LibraryBlock'
 import QuizBlock from '@components/Objects/Editor/Extensions/Quiz/QuizBlock'
 import MagicBlock from '@components/Objects/Editor/Extensions/MagicBlocks/MagicBlock'
 
@@ -45,6 +46,7 @@ import EmbedObjects from '@components/Objects/Editor/Extensions/EmbedObjects/Emb
 import Badges from '@components/Objects/Editor/Extensions/Badges/Badges'
 import Buttons from '@components/Objects/Editor/Extensions/Buttons/Buttons'
 import Flipcard from '@components/Objects/Editor/Extensions/Flipcard/Flipcard'
+import FlipcardGrid from '@components/Objects/Editor/Extensions/Flipcard/FlipcardGrid'
 import Scenarios from '@components/Objects/Editor/Extensions/Scenarios/Scenarios'
 import CodePlayground from '@components/Objects/Editor/Extensions/CodePlayground/CodePlayground'
 import { Table } from '@tiptap/extension-table'
@@ -141,6 +143,10 @@ function Canva(props: Editor) {
         editable: true,
         activity: props.activity,
       }),
+      LibraryBlock.configure({
+        editable: isEditable,
+        activity: props.activity,
+      }),
       QuizBlock.configure({
         editable: isEditable,
         activity: props.activity,
@@ -177,6 +183,10 @@ function Canva(props: Editor) {
         activity: props.activity,
       }),
       Flipcard.configure({
+        editable: false,
+        activity: props.activity,
+      }),
+      FlipcardGrid.configure({
         editable: false,
         activity: props.activity,
       }),

--- a/apps/web/components/Objects/Activities/Embed/EmbedActivity.tsx
+++ b/apps/web/components/Objects/Activities/Embed/EmbedActivity.tsx
@@ -4,48 +4,7 @@ import { WarningCircle, Globe, FloppyDisk, SpinnerGap } from '@phosphor-icons/re
 import { updateActivity } from '@services/courses/activities'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
 import toast from 'react-hot-toast'
-
-function toEmbedUrl(url: string): string {
-  // Google Docs/Sheets/Slides → preview
-  const googleDocMatch = url.match(
-    /^(https?:\/\/docs\.google\.com\/(?:document|spreadsheets|presentation)\/d\/[^/]+)/
-  )
-  if (googleDocMatch) {
-    return `${googleDocMatch[1]}/preview`
-  }
-
-  // Google Forms → embedded
-  const googleFormMatch = url.match(
-    /^(https?:\/\/docs\.google\.com\/forms\/d\/[^/]+)/
-  )
-  if (googleFormMatch) {
-    return `${googleFormMatch[1]}/viewform?embedded=true`
-  }
-
-  // Figma → embed host
-  if (/^https?:\/\/(www\.)?figma\.com\//.test(url)) {
-    return `https://www.figma.com/embed?embed_host=learnhouse&url=${encodeURIComponent(url)}`
-  }
-
-  // Loom → /share/ to /embed/
-  const loomMatch = url.match(/^(https?:\/\/www\.loom\.com)\/share\/(.+)$/)
-  if (loomMatch) {
-    return `${loomMatch[1]}/embed/${loomMatch[2]}`
-  }
-
-  // Canva design → embed
-  if (url.includes('canva.com/design/')) {
-    return url.includes('?') ? `${url}&embed` : `${url}?embed`
-  }
-
-  // Miro → embed
-  const miroMatch = url.match(/^(https?:\/\/miro\.com\/app\/board\/)(.+)$/)
-  if (miroMatch) {
-    return `https://miro.com/app/live-embed/${miroMatch[2]}`
-  }
-
-  return url
-}
+import { toEmbedUrl } from '@/lib/media/embedUrl'
 
 interface EmbedActivityProps {
   activity: any
@@ -60,7 +19,7 @@ function EmbedActivity({ activity, editable = false, style }: EmbedActivityProps
 
   const [editUrl, setEditUrl] = useState(embedUrl)
   const [saving, setSaving] = useState(false)
-  const [error, setError] = useState(!embedUrl)
+  const [, setError] = useState(!embedUrl)
 
   const handleSaveUrl = async () => {
     if (!editUrl.trim()) return

--- a/apps/web/components/Objects/Activities/Resource/ResourceActivity.tsx
+++ b/apps/web/components/Objects/Activities/Resource/ResourceActivity.tsx
@@ -1,47 +1,14 @@
 'use client'
 import React from 'react'
 import { WarningCircle, SquaresFour, Microphone, UsersThree, Code, GraduationCap, ArrowSquareOut } from '@phosphor-icons/react'
-import { getUriWithOrg } from '@services/config/config'
+import { buildEmbedUrl, buildResourceUrl, type ResourceKind } from '@/lib/library/resourceEmbed'
 
-type ResourceKind = 'course' | 'podcast' | 'community' | 'board' | 'playground'
-
-const KIND_META: Record<ResourceKind, { label: string; icon: any; color: string }> = {
+const KIND_META: Partial<Record<ResourceKind, { label: string; icon: any; color: string }>> = {
   course: { label: 'Course', icon: GraduationCap, color: 'text-blue-500' },
   podcast: { label: 'Podcast', icon: Microphone, color: 'text-violet-500' },
   community: { label: 'Community', icon: UsersThree, color: 'text-emerald-500' },
   board: { label: 'Board', icon: SquaresFour, color: 'text-indigo-500' },
   playground: { label: 'Playground', icon: Code, color: 'text-amber-500' },
-}
-
-/**
- * Base internal route for a Library resource, mirroring resourceHref's
- * uuid-prefix handling. Boards live at a top-level chrome-free route; the other
- * kinds live under the (withmenu) group (see buildEmbedUrl for the chrome=none
- * suppression used when embedded in the activity player).
- */
-function buildResourceUrl(kind: ResourceKind, resourceUuid: string, orgslug: string): string | null {
-  if (!resourceUuid) return null
-  switch (kind) {
-    case 'board':
-      return getUriWithOrg(orgslug, `/board/${resourceUuid.replace('board_', '')}`)
-    case 'community':
-      return getUriWithOrg(orgslug, `/community/${resourceUuid.replace('community_', '')}`)
-    case 'podcast':
-      return getUriWithOrg(orgslug, `/podcast/${resourceUuid.replace('podcast_', '')}`)
-    case 'playground':
-      // Playgrounds use the full prefixed uuid.
-      return getUriWithOrg(orgslug, `/playground/${resourceUuid}`)
-    case 'course':
-      return getUriWithOrg(orgslug, `/course/${resourceUuid.replace('course_', '')}`)
-    default:
-      return null
-  }
-}
-
-// Boards already render chrome-free; the (withmenu) kinds need ?chrome=none.
-function buildEmbedUrl(kind: ResourceKind, baseUrl: string): string {
-  if (kind === 'board') return baseUrl
-  return baseUrl.includes('?') ? `${baseUrl}&chrome=none` : `${baseUrl}?chrome=none`
 }
 
 interface ResourceActivityProps {
@@ -53,9 +20,10 @@ interface ResourceActivityProps {
 function ResourceActivity({ activity, orgslug, style }: ResourceActivityProps) {
   const kind = (activity.content?.resource_type || '') as ResourceKind
   const resourceUuid = activity.content?.resource_uuid || ''
-  const baseUrl = KIND_META[kind] ? buildResourceUrl(kind, resourceUuid, orgslug) : null
+  const meta = KIND_META[kind]
+  const baseUrl = meta ? buildResourceUrl(kind, resourceUuid, orgslug) : null
 
-  if (!baseUrl) {
+  if (!meta || !baseUrl) {
     return (
       <div className="flex flex-col items-center justify-center py-20 gap-4">
         <WarningCircle size={40} className="text-red-400" />
@@ -64,7 +32,6 @@ function ResourceActivity({ activity, orgslug, style }: ResourceActivityProps) {
     )
   }
 
-  const meta = KIND_META[kind]
   const Icon = meta.icon
   const embedUrl = buildEmbedUrl(kind, baseUrl)
 

--- a/apps/web/components/Objects/Editor/AI/AIEditorSidePanel.tsx
+++ b/apps/web/components/Objects/Editor/AI/AIEditorSidePanel.tsx
@@ -113,6 +113,7 @@ function AIEditorSidePanel(props: AIEditorSidePanelProps) {
     blockImage: 'Image',
     blockVideo: 'Video',
     blockPDF: 'PDF',
+    blockLibrary: 'Library Item',
     blockEmbed: 'Embed',
     blockMathEquation: 'Math Equation',
     blockWebPreview: 'Web Preview',
@@ -124,6 +125,7 @@ function AIEditorSidePanel(props: AIEditorSidePanelProps) {
     badge: 'Badge',
     button: 'Button',
     flipcard: 'Flashcard',
+    flipcardGrid: 'Flashcard Grid',
     codeBlock: 'Code Block',
     blockquote: 'Quote',
     table: 'Table',
@@ -134,10 +136,10 @@ function AIEditorSidePanel(props: AIEditorSidePanelProps) {
 
   // Block types that are "interesting" to highlight (not just paragraphs)
   const INTERESTING_BLOCK_TYPES = [
-    'blockQuiz', 'blockImage', 'blockVideo', 'blockPDF', 'blockEmbed',
+    'blockQuiz', 'blockImage', 'blockVideo', 'blockPDF', 'blockLibrary', 'blockEmbed',
     'blockMathEquation', 'blockWebPreview', 'blockUser', 'blockMagic',
     'scenarios', 'calloutInfo', 'calloutWarning', 'badge', 'button',
-    'flipcard', 'codeBlock', 'blockquote', 'table', 'bulletList',
+    'flipcard', 'flipcardGrid', 'codeBlock', 'blockquote', 'table', 'bulletList',
     'orderedList', 'heading',
   ]
 
@@ -335,6 +337,7 @@ function AIEditorSidePanel(props: AIEditorSidePanelProps) {
     'blockImage',
     'blockVideo',
     'blockPDF',
+    'blockLibrary',
     'blockEmbed',
     'blockMathEquation',
     'blockWebPreview',

--- a/apps/web/components/Objects/Editor/Editor.tsx
+++ b/apps/web/components/Objects/Editor/Editor.tsx
@@ -32,6 +32,7 @@ import AudioBlock from './Extensions/Audio/AudioBlock'
 import { Eye, Monitor, History, AlertTriangle, RefreshCw, Loader2 } from 'lucide-react'
 import MathEquationBlock from './Extensions/MathEquation/MathEquationBlock'
 import PDFBlock from './Extensions/PDF/PDFBlock'
+import LibraryBlock from './Extensions/Library/LibraryBlock'
 import QuizBlock from './Extensions/Quiz/QuizBlock'
 import { Table } from '@tiptap/extension-table'
 import TableCell from '@tiptap/extension-table-cell'
@@ -57,6 +58,7 @@ import EmbedObjects from './Extensions/EmbedObjects/EmbedObjects'
 import Badges from './Extensions/Badges/Badges'
 import Buttons from './Extensions/Buttons/Buttons'
 import Flipcard from './Extensions/Flipcard/Flipcard'
+import FlipcardGrid from './Extensions/Flipcard/FlipcardGrid'
 import Scenarios from './Extensions/Scenarios/Scenarios'
 import CodePlayground from './Extensions/CodePlayground/CodePlayground'
 import { useMediaQuery } from 'usehooks-ts'
@@ -171,6 +173,7 @@ function Editor(props: EditorProps) {
       AudioBlock.configure({ editable: true, activity: stableActivity }),
       MathEquationBlock.configure({ editable: true, activity: stableActivity }),
       PDFBlock.configure({ editable: true, activity: stableActivity }),
+      LibraryBlock.configure({ editable: true, activity: stableActivity }),
       QuizBlock.configure({ editable: true, activity: stableActivity }),
       Youtube.configure({ controls: true, modestBranding: true }),
       CodeBlockLowlight.configure({ lowlight }),
@@ -185,6 +188,7 @@ function Editor(props: EditorProps) {
       getLinkExtension(),
       WebPreview.configure({ editable: true, activity: stableActivity }),
       Flipcard.configure({ editable: true, activity: stableActivity }),
+      FlipcardGrid.configure({ editable: true, activity: stableActivity }),
       Scenarios.configure({ editable: true, activity: stableActivity }),
       CodePlayground.configure({ editable: true, activity: stableActivity }),
       DragHandle,

--- a/apps/web/components/Objects/Editor/EditorPreview.tsx
+++ b/apps/web/components/Objects/Editor/EditorPreview.tsx
@@ -14,6 +14,7 @@ import VideoBlock from './Extensions/Video/VideoBlock'
 import AudioBlock from './Extensions/Audio/AudioBlock'
 import MathEquationBlock from './Extensions/MathEquation/MathEquationBlock'
 import PDFBlock from './Extensions/PDF/PDFBlock'
+import LibraryBlock from './Extensions/Library/LibraryBlock'
 import QuizBlock from './Extensions/Quiz/QuizBlock'
 import { Table } from '@tiptap/extension-table'
 import TableCell from '@tiptap/extension-table-cell'
@@ -25,6 +26,7 @@ import EmbedObjects from './Extensions/EmbedObjects/EmbedObjects'
 import Badges from './Extensions/Badges/Badges'
 import Buttons from './Extensions/Buttons/Buttons'
 import Flipcard from './Extensions/Flipcard/Flipcard'
+import FlipcardGrid from './Extensions/Flipcard/FlipcardGrid'
 import Scenarios from './Extensions/Scenarios/Scenarios'
 import CodePlayground from './Extensions/CodePlayground/CodePlayground'
 import UserBlock from './Extensions/Users/UserBlock'
@@ -85,6 +87,10 @@ function EditorPreview({ content, activity }: EditorPreviewProps) {
         editable: false,
         activity: activity,
       }),
+      LibraryBlock.configure({
+        editable: false,
+        activity: activity,
+      }),
       QuizBlock.configure({
         editable: false,
         activity: activity,
@@ -124,6 +130,10 @@ function EditorPreview({ content, activity }: EditorPreviewProps) {
         activity: activity,
       }),
       Flipcard.configure({
+        editable: false,
+        activity: activity,
+      }),
+      FlipcardGrid.configure({
         editable: false,
         activity: activity,
       }),

--- a/apps/web/components/Objects/Editor/Extensions/Audio/AudioBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Audio/AudioBlockComponent.tsx
@@ -3,7 +3,7 @@ import { Node } from '@tiptap/core'
 import {
   Loader2, Headphones, Upload, X, ArrowLeftRight,
   CheckCircle2, AlertCircle, Play, Pause, Music, Radio, List,
-  SkipBack, SkipForward, Volume2, VolumeX, Clock, Sparkles, Users
+  SkipBack, SkipForward, Clock, Sparkles, Users
 } from 'lucide-react'
 import React from 'react'
 import toast from 'react-hot-toast'
@@ -18,6 +18,7 @@ import { constructAcceptValue } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 import { getOrgPodcasts, getPodcastMeta, type Podcast, type PodcastEpisode, type PodcastMeta } from '@services/podcasts/podcasts'
 import { safePlay } from '@/lib/media/safePlay'
+import InlineAudioPlayer, { formatTime } from '@components/Objects/Media/InlineAudioPlayer'
 
 const SUPPORTED_FILES = constructAcceptValue(['mp3', 'wav', 'ogg', 'm4a'])
 
@@ -112,182 +113,6 @@ interface ExtendedNodeViewProps extends Omit<NodeViewProps, 'extension'> {
   }
 }
 
-// ─── Inline Audio Player (podcast-player inspired) ───
-
-function formatTime(seconds: number): string {
-  const s = Math.floor(seconds)
-  const h = Math.floor(s / 3600)
-  const m = Math.floor((s % 3600) / 60)
-  const r = s % 60
-  if (h > 0) return `${h}:${m.toString().padStart(2, '0')}:${r.toString().padStart(2, '0')}`
-  return `${m}:${r.toString().padStart(2, '0')}`
-}
-
-function InlineAudioPlayer({ src, title }: { src: string; title?: string }) {
-  const audioRef = React.useRef<HTMLAudioElement>(null)
-  const progressRef = React.useRef<HTMLDivElement>(null)
-  const [isPlaying, setIsPlaying] = React.useState(false)
-  const [currentTime, setCurrentTime] = React.useState(0)
-  const [duration, setDuration] = React.useState(0)
-  const [volume, setVolume] = React.useState(1)
-  const [isMuted, setIsMuted] = React.useState(false)
-  const [prevVolume, setPrevVolume] = React.useState(1)
-
-  React.useEffect(() => {
-    const audio = audioRef.current
-    if (!audio) return
-
-    const onTimeUpdate = () => setCurrentTime(audio.currentTime)
-    const onLoadedMetadata = () => setDuration(audio.duration)
-    const onEnded = () => setIsPlaying(false)
-
-    audio.addEventListener('timeupdate', onTimeUpdate)
-    audio.addEventListener('loadedmetadata', onLoadedMetadata)
-    audio.addEventListener('ended', onEnded)
-    return () => {
-      audio.removeEventListener('timeupdate', onTimeUpdate)
-      audio.removeEventListener('loadedmetadata', onLoadedMetadata)
-      audio.removeEventListener('ended', onEnded)
-    }
-  }, [src])
-
-  const togglePlay = () => {
-    const audio = audioRef.current
-    if (!audio) return
-    if (isPlaying) { audio.pause() } else { safePlay(audio) }
-    setIsPlaying(!isPlaying)
-  }
-
-  const skip = (delta: number) => {
-    const audio = audioRef.current
-    if (!audio) return
-    audio.currentTime = Math.max(0, Math.min(audio.currentTime + delta, duration))
-  }
-
-  const seekTo = (e: React.MouseEvent<HTMLDivElement>) => {
-    const audio = audioRef.current
-    const bar = progressRef.current
-    if (!audio || !bar) return
-    const rect = bar.getBoundingClientRect()
-    const ratio = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width))
-    audio.currentTime = ratio * duration
-  }
-
-  const toggleMute = () => {
-    const audio = audioRef.current
-    if (!audio) return
-    if (isMuted) {
-      audio.volume = prevVolume
-      setVolume(prevVolume)
-    } else {
-      setPrevVolume(volume)
-      audio.volume = 0
-      setVolume(0)
-    }
-    setIsMuted(!isMuted)
-  }
-
-  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const v = parseFloat(e.target.value)
-    if (audioRef.current) audioRef.current.volume = v
-    setVolume(v)
-    setIsMuted(v === 0)
-  }
-
-  const progress = duration > 0 ? (currentTime / duration) * 100 : 0
-
-  return (
-    <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
-      <audio ref={audioRef} src={src} preload="metadata" />
-
-      {/* Title bar */}
-      {title && (
-        <div className="px-4 pt-3 pb-1 flex items-center gap-2">
-          <Headphones size={14} className="text-gray-400 flex-shrink-0" />
-          <span className="text-sm font-semibold text-gray-900 truncate">{title}</span>
-        </div>
-      )}
-
-      {/* Player controls */}
-      <div className="px-4 py-3 flex items-center gap-3">
-        {/* Skip back */}
-        <button
-          onClick={() => skip(-15)}
-          className="p-1.5 rounded-full hover:bg-gray-100 transition-colors outline-none"
-          title="Skip back 15s"
-        >
-          <SkipBack size={16} className="text-gray-600" />
-        </button>
-
-        {/* Play/Pause */}
-        <button
-          onClick={togglePlay}
-          className="rounded-full bg-gray-900 hover:bg-gray-800 p-2.5 transition-colors outline-none"
-        >
-          {isPlaying ? (
-            <Pause size={16} className="text-white" fill="white" />
-          ) : (
-            <Play size={16} className="text-white" fill="white" />
-          )}
-        </button>
-
-        {/* Skip forward */}
-        <button
-          onClick={() => skip(15)}
-          className="p-1.5 rounded-full hover:bg-gray-100 transition-colors outline-none"
-          title="Skip forward 15s"
-        >
-          <SkipForward size={16} className="text-gray-600" />
-        </button>
-
-        {/* Time + Progress */}
-        <span className="text-xs text-gray-500 w-10 text-right tabular-nums flex-shrink-0">
-          {formatTime(currentTime)}
-        </span>
-
-        <div
-          ref={progressRef}
-          onClick={seekTo}
-          className="flex-1 h-1.5 bg-gray-200 rounded-full cursor-pointer relative group"
-        >
-          <div
-            className="h-full bg-gray-900 rounded-full transition-all duration-100"
-            style={{ width: `${progress}%` }}
-          />
-          <div
-            className="absolute top-1/2 -translate-y-1/2 w-3 h-3 bg-gray-900 rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
-            style={{ left: `calc(${progress}% - 6px)` }}
-          />
-        </div>
-
-        <span className="text-xs text-gray-500 w-10 tabular-nums flex-shrink-0">
-          {formatTime(duration)}
-        </span>
-
-        {/* Volume */}
-        <button
-          onClick={toggleMute}
-          className="p-1.5 rounded-full hover:bg-gray-100 transition-colors outline-none"
-        >
-          {isMuted || volume === 0 ? (
-            <VolumeX size={16} className="text-gray-600" />
-          ) : (
-            <Volume2 size={16} className="text-gray-600" />
-          )}
-        </button>
-        <input
-          type="range"
-          min="0"
-          max="1"
-          step="0.01"
-          value={volume}
-          onChange={handleVolumeChange}
-          className="w-16 h-1 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-gray-900"
-        />
-      </div>
-    </div>
-  )
-}
 
 // ─── Playlist Player (podcast-player inspired episode list) ───
 

--- a/apps/web/components/Objects/Editor/Extensions/Flipcard/FlipcardExtension.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Flipcard/FlipcardExtension.tsx
@@ -1,6 +1,6 @@
 import { NodeViewWrapper } from '@tiptap/react'
 import React, { useState, useRef, useEffect } from 'react'
-import { RotateCw, Edit, AlignLeft, AlignCenter, AlignRight, Palette, Maximize2, Minimize2, Square } from 'lucide-react'
+import { RotateCw, Edit, AlignLeft, AlignCenter, AlignRight, Group, Palette, Maximize2, Minimize2, Square } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useEditorProvider } from '@components/Contexts/Editor/EditorContext'
 import { useTranslation } from 'react-i18next'
@@ -77,6 +77,37 @@ const FlipcardExtension: React.FC = (props: any) => {
     })
   }
 
+  // Inside a flipcardGrid the container owns the layout: the card fills its cell
+  // and per-card alignment stops meaning anything.
+  const inGrid = (() => {
+    const pos = typeof props.getPos === 'function' ? props.getPos() : null
+    if (pos === null || pos === undefined) return false
+    try {
+      return props.editor.state.doc.resolve(pos).parent.type.name === 'flipcardGrid'
+    } catch {
+      return false
+    }
+  })()
+
+  /** Wrap this standalone card in a grid so more cards can sit beside it. */
+  const groupIntoGrid = () => {
+    const pos = typeof props.getPos === 'function' ? props.getPos() : null
+    if (pos === null || pos === undefined) return
+    props.editor
+      .chain()
+      .focus()
+      .command(({ tr, state, dispatch }: any) => {
+        const node = tr.doc.nodeAt(pos)
+        const gridType = state.schema.nodes.flipcardGrid
+        if (!node || !gridType) return false
+        if (dispatch) {
+          tr.replaceWith(pos, pos + node.nodeSize, gridType.create({ columns: 2 }, node))
+        }
+        return true
+      })
+      .run()
+  }
+
   const getAlignmentClass = () => {
     switch (alignment) {
       case 'left': return 'justify-start';
@@ -150,8 +181,17 @@ const FlipcardExtension: React.FC = (props: any) => {
   }
 
   return (
-    <NodeViewWrapper className={cn("flipcard-wrapper flex my-4", getAlignmentClass())}>
-      <div className={cn("flipcard-container relative", getSizeClass())}>
+    <NodeViewWrapper
+      className={cn("flipcard-wrapper flex", inGrid ? "w-full" : cn("my-4", getAlignmentClass()))}
+    >
+      <div
+        className={cn(
+          "flipcard-container relative",
+          // In a grid the cell dictates the width; the height must stay explicit
+          // because the front/back faces are absolutely positioned.
+          inGrid ? cn("w-full", getSizeClass().split(' ')[1]) : getSizeClass()
+        )}
+      >
         <div
           className={cn("flipcard-inner cursor-pointer", isFlipped && "flipped")}
           onClick={handleFlip}
@@ -244,7 +284,8 @@ const FlipcardExtension: React.FC = (props: any) => {
         {/* Editor Controls */}
         {isEditable && (
           <div className="flex mt-3 gap-1 justify-center opacity-60 hover:opacity-100 transition-opacity">
-            {/* Alignment Controls */}
+            {/* Alignment Controls — the grid container owns alignment when nested */}
+            {!inGrid && (<>
             <button
               onClick={(e) => {
                 e.stopPropagation()
@@ -286,6 +327,7 @@ const FlipcardExtension: React.FC = (props: any) => {
             </button>
 
             <div className="w-px h-4 bg-neutral-300 self-center mx-1"></div>
+            </>)}
 
             {/* Size Controls */}
             <button
@@ -351,6 +393,18 @@ const FlipcardExtension: React.FC = (props: any) => {
             >
               <RotateCw size={12} />
             </button>
+            {!inGrid && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  groupIntoGrid()
+                }}
+                className="p-1.5 bg-neutral-200 hover:bg-neutral-300 text-neutral-600 rounded-md transition-colors text-xs"
+                title={t('activities.group_into_grid')}
+              >
+                <Group size={12} />
+              </button>
+            )}
           </div>
         )}
 

--- a/apps/web/components/Objects/Editor/Extensions/Flipcard/FlipcardGrid.ts
+++ b/apps/web/components/Objects/Editor/Extensions/Flipcard/FlipcardGrid.ts
@@ -1,0 +1,52 @@
+import { ReactNodeViewRenderer } from "@tiptap/react";
+import { mergeAttributes, Node } from "@tiptap/core";
+import dynamic from "next/dynamic";
+
+const FlipcardGridExtension = dynamic(() => import("./FlipcardGridExtension"), {
+  ssr: false,
+});
+
+/**
+ * Container that lays its flipcards out side by side.
+ *
+ * A flipcard is `group: 'block'`, so two of them can never share a row on their
+ * own — the grid has to come from a parent node. Existing standalone flipcards
+ * are untouched; they keep rendering as full-width rows.
+ */
+export default Node.create({
+  name: "flipcardGrid",
+  group: "block",
+  content: "flipcard+",
+  draggable: true,
+
+  addAttributes() {
+    return {
+      columns: {
+        default: 2,
+        // Round-tripped through HTML so the layout survives serialization
+        // (mirrors the Callout block's data-attribute mapping).
+        parseHTML: (element) => {
+          const raw = parseInt(element.getAttribute("data-columns") || "2", 10);
+          return Number.isNaN(raw) ? 2 : Math.min(4, Math.max(1, raw));
+        },
+        renderHTML: (attributes) => ({ "data-columns": attributes.columns }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: "flipcard-grid",
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["flipcard-grid", mergeAttributes(HTMLAttributes), 0];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(FlipcardGridExtension as any);
+  },
+});

--- a/apps/web/components/Objects/Editor/Extensions/Flipcard/FlipcardGridExtension.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Flipcard/FlipcardGridExtension.tsx
@@ -1,0 +1,131 @@
+import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
+import React from 'react'
+import { Columns2, Columns3, Columns4, Plus, Ungroup } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useEditorProvider } from '@components/Contexts/Editor/EditorContext'
+import { useTranslation } from 'react-i18next'
+
+const COLUMN_OPTIONS: { value: number; Icon: any; labelKey: string }[] = [
+  { value: 2, Icon: Columns2, labelKey: 'activities.grid_columns_2' },
+  { value: 3, Icon: Columns3, labelKey: 'activities.grid_columns_3' },
+  { value: 4, Icon: Columns4, labelKey: 'activities.grid_columns_4' },
+]
+
+// Explicit class names so Tailwind keeps them; the count is dynamic.
+const COLUMN_CLASS: Record<number, string> = {
+  1: 'sm:grid-cols-1',
+  2: 'sm:grid-cols-2',
+  3: 'sm:grid-cols-3',
+  4: 'sm:grid-cols-4',
+}
+
+const FlipcardGridExtension: React.FC = (props: any) => {
+  const { t } = useTranslation()
+  const editorState = useEditorProvider() as any
+  const isEditable = editorState.isEditable
+  const columns: number = props.node.attrs.columns || 2
+
+  const setColumns = (value: number) => {
+    props.updateAttributes({ columns: value })
+  }
+
+  /** Append an extra card at the end of the grid. */
+  const addCard = () => {
+    const pos = typeof props.getPos === 'function' ? props.getPos() : null
+    if (pos === null || pos === undefined) return
+    // nodeSize - 1 lands just inside the closing token, i.e. after the last card.
+    const insertAt = pos + props.node.nodeSize - 1
+    props.editor
+      .chain()
+      .focus()
+      .insertContentAt(insertAt, {
+        type: 'flipcard',
+        attrs: {
+          question: 'Click to reveal the answer',
+          answer: 'This is the answer',
+          color: 'blue',
+          alignment: 'center',
+          size: 'medium',
+        },
+      })
+      .run()
+  }
+
+  /** Drop the container, leaving the cards as ordinary stacked blocks. */
+  const ungroup = () => {
+    const pos = typeof props.getPos === 'function' ? props.getPos() : null
+    if (pos === null || pos === undefined) return
+    props.editor
+      .chain()
+      .focus()
+      .command(({ tr, dispatch }: any) => {
+        const node = tr.doc.nodeAt(pos)
+        if (!node) return false
+        if (dispatch) tr.replaceWith(pos, pos + node.nodeSize, node.content)
+        return true
+      })
+      .run()
+  }
+
+  return (
+    <NodeViewWrapper className="flipcard-grid my-4">
+      <NodeViewContent
+        className={cn('grid grid-cols-1 gap-4 justify-items-center', COLUMN_CLASS[columns] || COLUMN_CLASS[2])}
+      />
+
+      {isEditable && (
+        <div
+          className="flex mt-3 gap-1 justify-center opacity-60 hover:opacity-100 transition-opacity"
+          contentEditable={false}
+        >
+          {COLUMN_OPTIONS.map(({ value, Icon, labelKey }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                setColumns(value)
+              }}
+              className={cn(
+                'p-1.5 rounded-md transition-colors text-xs',
+                columns === value
+                  ? 'bg-neutral-700 text-white'
+                  : 'bg-neutral-200 hover:bg-neutral-300 text-neutral-600'
+              )}
+              title={t(labelKey)}
+            >
+              <Icon size={12} />
+            </button>
+          ))}
+
+          <div className="w-px h-4 bg-neutral-300 self-center mx-1" />
+
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              addCard()
+            }}
+            className="p-1.5 bg-neutral-200 hover:bg-neutral-300 text-neutral-600 rounded-md transition-colors text-xs"
+            title={t('activities.add_card')}
+          >
+            <Plus size={12} />
+          </button>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              ungroup()
+            }}
+            className="p-1.5 bg-neutral-200 hover:bg-neutral-300 text-neutral-600 rounded-md transition-colors text-xs"
+            title={t('activities.ungroup_cards')}
+          >
+            <Ungroup size={12} />
+          </button>
+        </div>
+      )}
+    </NodeViewWrapper>
+  )
+}
+
+export default FlipcardGridExtension

--- a/apps/web/components/Objects/Editor/Extensions/Flipcard/FlipcardGridExtension.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Flipcard/FlipcardGridExtension.tsx
@@ -11,14 +11,6 @@ const COLUMN_OPTIONS: { value: number; Icon: any; labelKey: string }[] = [
   { value: 4, Icon: Columns4, labelKey: 'activities.grid_columns_4' },
 ]
 
-// Explicit class names so Tailwind keeps them; the count is dynamic.
-const COLUMN_CLASS: Record<number, string> = {
-  1: 'sm:grid-cols-1',
-  2: 'sm:grid-cols-2',
-  3: 'sm:grid-cols-3',
-  4: 'sm:grid-cols-4',
-}
-
 const FlipcardGridExtension: React.FC = (props: any) => {
   const { t } = useTranslation()
   const editorState = useEditorProvider() as any
@@ -68,10 +60,14 @@ const FlipcardGridExtension: React.FC = (props: any) => {
   }
 
   return (
-    <NodeViewWrapper className="flipcard-grid my-4">
-      <NodeViewContent
-        className={cn('grid grid-cols-1 gap-4 justify-items-center', COLUMN_CLASS[columns] || COLUMN_CLASS[2])}
-      />
+    <NodeViewWrapper
+      className="flipcard-grid my-4"
+      style={{ ['--flipcard-grid-columns' as any]: columns }}
+    >
+      {/* The column count rides a CSS variable rather than a Tailwind class:
+          Tiptap injects its own content holder inside this element, so the grid
+          has to be declared in CSS where that holder can be dissolved. */}
+      <NodeViewContent className="flipcard-grid-content" />
 
       {isEditable && (
         <div

--- a/apps/web/components/Objects/Editor/Extensions/Library/LibraryBlock.ts
+++ b/apps/web/components/Objects/Editor/Extensions/Library/LibraryBlock.ts
@@ -1,0 +1,58 @@
+import { mergeAttributes, Node } from '@tiptap/core'
+import { ReactNodeViewRenderer } from '@tiptap/react'
+import dynamic from 'next/dynamic'
+
+const LibraryBlockComponent = dynamic(() => import('./LibraryBlockComponent'), {
+  ssr: false,
+})
+
+/**
+ * A reference to something that already lives in the org Library — a media file
+ * or embed, or any other library resource (course, podcast, community, board,
+ * playground).
+ *
+ * Unlike the typed upload blocks, this node stores no file of its own: it holds
+ * the library resource's uuid, so the asset stays reusable and the file keeps
+ * being served through the authed /media/{uuid}/file endpoint. `snapshot` is a
+ * cached copy of the display metadata so the block paints before the live
+ * refetch lands.
+ */
+export default Node.create({
+  name: 'blockLibrary',
+  group: 'block',
+  draggable: true,
+  atom: true,
+
+  addAttributes() {
+    return {
+      resourceUuid: {
+        default: null,
+      },
+      resourceType: {
+        default: null,
+      },
+      snapshot: {
+        default: null,
+      },
+      display: {
+        default: 'inline',
+      },
+    }
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'block-library',
+      },
+    ]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['block-library', mergeAttributes(HTMLAttributes)]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(LibraryBlockComponent as any)
+  },
+})

--- a/apps/web/components/Objects/Editor/Extensions/Library/LibraryBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Library/LibraryBlockComponent.tsx
@@ -1,0 +1,350 @@
+import { NodeViewProps, NodeViewWrapper } from '@tiptap/react'
+import React from 'react'
+import toast from 'react-hot-toast'
+import {
+  ArrowLeftRight,
+  BookCopy,
+  Download,
+  ExternalLink,
+  Expand,
+  Gamepad2,
+  LayoutGrid,
+  Library,
+  Loader2,
+  Podcast,
+  Trash2,
+  Upload,
+  Users,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { useOrg } from '@components/Contexts/OrgContext'
+import { useEditorProvider } from '@components/Contexts/Editor/EditorContext'
+import { useLHSession } from '@components/Contexts/LHSessionContext'
+import Modal from '@components/Objects/StyledElements/Modal/Modal'
+import MediaViewer from '@components/Objects/Media/MediaViewer'
+import MediaLightbox from '@components/Objects/Media/MediaLightbox'
+import ResourcePicker, {
+  type SelectedResource,
+} from '@components/Dashboard/Library/ResourcePicker'
+import { createMedia, getMediaById, getMediaFileDirectory } from '@services/media/media-resource'
+import { buildEmbedUrl, buildResourceUrl, type ResourceKind } from '@/lib/library/resourceEmbed'
+
+const UPLOAD_ACCEPT =
+  'image/*,video/*,audio/*,application/pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.zip'
+
+const RESOURCE_ICONS: Partial<Record<ResourceKind, any>> = {
+  course: BookCopy,
+  podcast: Podcast,
+  community: Users,
+  board: LayoutGrid,
+  playground: Gamepad2,
+}
+
+/** The subset of a Media row the block caches so it can paint before refetching. */
+function snapshotOf(resource: any) {
+  if (!resource) return null
+  return {
+    name: resource.name ?? '',
+    media_type: resource.media_type ?? null,
+    file_format: resource.file_format ?? null,
+    file_mime: resource.file_mime ?? null,
+    file_size: resource.file_size ?? null,
+    url: resource.url ?? null,
+    thumbnail_image: resource.thumbnail_image ?? null,
+  }
+}
+
+function LibraryBlockComponent(props: NodeViewProps) {
+  const { t } = useTranslation()
+  const org = useOrg() as any
+  const session = useLHSession() as any
+  const access_token = session?.data?.tokens?.access_token
+  const editorState = useEditorProvider() as any
+  const isEditable = editorState.isEditable
+
+  const resourceUuid: string | null = props.node.attrs.resourceUuid
+  const resourceType: ResourceKind | null = props.node.attrs.resourceType
+  const snapshot = props.node.attrs.snapshot
+  const display: string = props.node.attrs.display || 'inline'
+
+  const [pickerOpen, setPickerOpen] = React.useState(false)
+  const [lightboxOpen, setLightboxOpen] = React.useState(false)
+  const [uploading, setUploading] = React.useState(false)
+  const fileInputRef = React.useRef<HTMLInputElement>(null)
+
+  const isMedia = resourceType === 'media'
+
+  // The snapshot is a point-in-time copy; refresh it so a renamed or replaced
+  // asset doesn't keep showing stale metadata (same approach as the video block).
+  React.useEffect(() => {
+    if (!isMedia || !resourceUuid || !access_token) return
+    let cancelled = false
+    getMediaById(resourceUuid, access_token)
+      .then((fresh: any) => {
+        if (cancelled || !fresh?.media_uuid) return
+        const next = snapshotOf(fresh)
+        if (JSON.stringify(next) !== JSON.stringify(snapshot)) {
+          props.updateAttributes({ snapshot: next })
+        }
+      })
+      .catch(() => {
+        /* no access or deleted — the viewer renders its own fallback */
+      })
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMedia, resourceUuid, access_token])
+
+  const applySelection = (selected: SelectedResource) => {
+    props.updateAttributes({
+      resourceUuid: selected.resource_uuid,
+      resourceType: selected.resource_type,
+      snapshot: selected.resource_type === 'media' ? snapshotOf(selected.resource) : {
+        name: selected.name ?? '',
+      },
+    })
+    setPickerOpen(false)
+  }
+
+  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file || !org?.id) return
+    setUploading(true)
+    const toastId = toast.loading(t('media.uploading_media'))
+    try {
+      const formData = new FormData()
+      formData.append('org_id', String(org.id))
+      formData.append('name', file.name.replace(/\.[^.]+$/, ''))
+      formData.append('media_type', 'UPLOAD')
+      formData.append('public', 'true')
+      formData.append('file', file)
+      // Uploading here creates a real Library asset, so the file stays reusable
+      // instead of being buried under this one activity.
+      const created = await createMedia(formData, access_token)
+      props.updateAttributes({
+        resourceUuid: created.media_uuid,
+        resourceType: 'media',
+        snapshot: snapshotOf(created),
+      })
+      toast.success(t('media.media_uploaded_success'))
+    } catch (error: any) {
+      toast.error(error?.message || t('media.media_uploaded_error'))
+    } finally {
+      toast.dismiss(toastId)
+      setUploading(false)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+  }
+
+  const clearSelection = () => {
+    props.updateAttributes({ resourceUuid: null, resourceType: null, snapshot: null })
+  }
+
+  const picker = (
+    <Modal
+      isDialogOpen={pickerOpen}
+      onOpenChange={setPickerOpen}
+      minWidth="md"
+      minHeight="no-min"
+      dialogTitle={t('library.choose_from_library')}
+      dialogContent={
+        <ResourcePicker
+          orgslug={org?.slug}
+          mode="select"
+          tabs={['media', 'courses', 'podcasts', 'communities', 'boards', 'playgrounds']}
+          onSelect={applySelection}
+          selectedUuid={resourceUuid || undefined}
+        />
+      }
+    />
+  )
+
+  // ─── Empty ───
+  if (!resourceUuid) {
+    if (!isEditable) {
+      return (
+        <NodeViewWrapper className="my-4">
+          <div className="flex items-center justify-center gap-3 py-8 bg-white rounded-lg nice-shadow">
+            <Library className="text-slate-300" size={32} />
+            <p className="text-slate-500">{t('library.no_resource_selected')}</p>
+          </div>
+        </NodeViewWrapper>
+      )
+    }
+    return (
+      <NodeViewWrapper className="my-4">
+        <div
+          className="flex flex-col items-center justify-center gap-4 py-8 bg-white rounded-lg text-slate-700 px-4 border-2 border-dashed border-slate-200 text-sm"
+          contentEditable={false}
+        >
+          {uploading ? (
+            <Loader2 className="animate-spin text-slate-400" size={32} />
+          ) : (
+            <>
+              <Library className="text-slate-300" size={40} />
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setPickerOpen(true)}
+                  className="p-2 px-4 bg-slate-700 hover:bg-slate-800 rounded-lg text-white transition-colors gap-2 items-center flex text-sm font-medium"
+                >
+                  <Library size={16} />
+                  <span>{t('library.choose_from_library')}</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  className="p-2 px-4 bg-slate-100 hover:bg-slate-200 rounded-lg text-slate-700 transition-colors gap-2 items-center flex text-sm font-medium"
+                >
+                  <Upload size={16} />
+                  <span>{t('library.upload_to_library')}</span>
+                </button>
+              </div>
+              <p className="text-xs text-slate-400">{t('library.upload_to_library_hint')}</p>
+            </>
+          )}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept={UPLOAD_ACCEPT}
+            className="hidden"
+            onChange={handleUpload}
+          />
+        </div>
+        {picker}
+      </NodeViewWrapper>
+    )
+  }
+
+  // ─── Filled ───
+  const name = snapshot?.name || t('library.untitled')
+  const downloadUrl =
+    isMedia && snapshot?.media_type !== 'EMBED'
+      ? getMediaFileDirectory(org?.org_uuid, resourceUuid, undefined, { download: true })
+      : null
+
+  const toolbar = (
+    <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+      {isMedia && (
+        <button
+          type="button"
+          onClick={() => setLightboxOpen(true)}
+          title={t('library.preview')}
+          className="p-1.5 rounded-md bg-white/90 backdrop-blur-sm hover:bg-white nice-shadow text-slate-600"
+        >
+          <Expand size={14} />
+        </button>
+      )}
+      {downloadUrl && (
+        <a
+          href={downloadUrl}
+          title={t('media.download')}
+          className="p-1.5 rounded-md bg-white/90 backdrop-blur-sm hover:bg-white nice-shadow text-slate-600"
+        >
+          <Download size={14} />
+        </a>
+      )}
+      {isEditable && (
+        <>
+          <button
+            type="button"
+            onClick={() => setPickerOpen(true)}
+            title={t('library.replace_resource')}
+            className="p-1.5 rounded-md bg-white/90 backdrop-blur-sm hover:bg-white nice-shadow text-slate-600"
+          >
+            <ArrowLeftRight size={14} />
+          </button>
+          <button
+            type="button"
+            onClick={clearSelection}
+            title={t('library.remove_resource')}
+            className="p-1.5 rounded-md bg-white/90 backdrop-blur-sm hover:bg-white nice-shadow text-rose-600"
+          >
+            <Trash2 size={14} />
+          </button>
+        </>
+      )}
+    </div>
+  )
+
+  if (isMedia) {
+    return (
+      <NodeViewWrapper className="my-4">
+        <div className="group relative" contentEditable={false}>
+          <div className="absolute top-2 right-2 z-10">{toolbar}</div>
+          <MediaViewer
+            resource={{ ...snapshot, name }}
+            mediaUuid={resourceUuid}
+            maxHeightClass="max-h-[60vh]"
+          />
+        </div>
+        <MediaLightbox
+          resource={{ ...snapshot, name }}
+          mediaUuid={resourceUuid}
+          isOpen={lightboxOpen}
+          onOpenChange={setLightboxOpen}
+        />
+        {picker}
+      </NodeViewWrapper>
+    )
+  }
+
+  // Other library resources (course, podcast, community, board, playground).
+  const kind = (resourceType || 'course') as ResourceKind
+  const Icon = RESOURCE_ICONS[kind] || Library
+  const baseUrl = org?.slug ? buildResourceUrl(kind, resourceUuid, org.slug) : null
+
+  return (
+    <NodeViewWrapper className="my-4">
+      <div className="group relative" contentEditable={false}>
+        <div className="absolute top-2 right-2 z-10">{toolbar}</div>
+
+        {display === 'embed' && baseUrl ? (
+          <div className="w-full rounded-xl overflow-hidden nice-shadow bg-white" style={{ height: '70vh', minHeight: 420 }}>
+            <iframe
+              src={buildEmbedUrl(kind, baseUrl)}
+              title={name}
+              className="w-full h-full border-0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"
+              allowFullScreen
+            />
+          </div>
+        ) : (
+          <div className="flex items-center gap-3 bg-white rounded-xl nice-shadow px-4 py-3">
+            <Icon size={22} className="text-slate-400 flex-shrink-0" />
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-semibold text-gray-900 truncate">{name}</p>
+              <p className="text-[10px] font-bold uppercase tracking-wider text-gray-400">
+                {t(`library.tabs.${kind}s`)}
+              </p>
+            </div>
+            {baseUrl && (
+              <a
+                href={baseUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-800 transition-colors"
+              >
+                <ExternalLink size={14} /> {t('library.open')}
+              </a>
+            )}
+          </div>
+        )}
+
+        {isEditable && baseUrl && (
+          <button
+            type="button"
+            onClick={() =>
+              props.updateAttributes({ display: display === 'embed' ? 'card' : 'embed' })
+            }
+            className="mt-2 text-xs font-medium text-gray-400 hover:text-gray-700 transition-colors"
+          >
+            {display === 'embed' ? t('library.show_as_card') : t('library.show_inline')}
+          </button>
+        )}
+      </div>
+      {picker}
+    </NodeViewWrapper>
+  )
+}
+
+export default LibraryBlockComponent

--- a/apps/web/components/Objects/Editor/Extensions/SlashCommands/slashCommandsConfig.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/SlashCommands/slashCommandsConfig.tsx
@@ -7,6 +7,7 @@ import {
   FileText,
   Globe,
   GitBranch,
+  Grid2x2,
   Headphones,
   Heading1,
   Heading2,
@@ -15,6 +16,7 @@ import {
   Heading5,
   Heading6,
   ImagePlus,
+  Library,
   List,
   ListOrdered,
   MousePointerClick,
@@ -220,6 +222,17 @@ export const slashCommands: SlashCommandItem[] = [
       editor.chain().focus().insertContent({ type: 'blockAudio' }).run()
     },
   },
+  {
+    id: 'library',
+    title: 'Library',
+    description: 'Insert a file or resource from your Library',
+    icon: <Library size={18} />,
+    category: 'media',
+    keywords: ['library', 'file', 'media', 'resource', 'reuse', 'existing', 'folder'],
+    command: (editor) => {
+      editor.chain().focus().insertContent({ type: 'blockLibrary' }).run()
+    },
+  },
 
   // Interactive category
   {
@@ -284,6 +297,28 @@ export const slashCommands: SlashCommandItem[] = [
           alignment: 'center',
           size: 'medium',
         },
+      }).run()
+    },
+  },
+  {
+    id: 'flipcardGrid',
+    title: 'Flashcard Grid',
+    description: 'Lay several flashcards out side by side',
+    icon: <Grid2x2 size={18} />,
+    category: 'interactive',
+    keywords: ['flipcard', 'flashcard', 'grid', 'columns', 'row', 'horizontal', 'deck'],
+    command: (editor) => {
+      const card = (question: string, answer: string) => ({
+        type: 'flipcard',
+        attrs: { question, answer, color: 'blue', alignment: 'center', size: 'medium' },
+      })
+      editor.chain().focus().insertContent({
+        type: 'flipcardGrid',
+        attrs: { columns: 2 },
+        content: [
+          card('Click to reveal the answer', 'This is the answer'),
+          card('Click to reveal the answer', 'This is the answer'),
+        ],
       }).run()
     },
   },

--- a/apps/web/components/Objects/Editor/Toolbar/ToolbarButtons.tsx
+++ b/apps/web/components/Objects/Editor/Toolbar/ToolbarButtons.tsx
@@ -3,6 +3,7 @@ import {
   ArrowCounterClockwise,
   ArrowClockwise,
   ArrowsClockwise,
+  Books,
   BracketsCurly,
   CaretDown,
   CheckCircle,
@@ -44,7 +45,7 @@ import lrnaiIcon from 'public/lrnai_icon.png'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { useTranslation } from 'react-i18next'
 
-export const ToolbarButtons = React.memo(({ editor, props }: any) => {
+export const ToolbarButtons = React.memo(({ editor }: any) => {
   const { t } = useTranslation()
   const [showTableMenu, setShowTableMenu] = React.useState(false)
   const [showListMenu, setShowListMenu] = React.useState(false)
@@ -122,12 +123,7 @@ export const ToolbarButtons = React.memo(({ editor, props }: any) => {
     // Store the current selection
     const { from, to } = editor.state.selection
 
-    if (editor.isActive('link')) {
-      const currentLink = editor.getAttributes('link')
-      setShowLinkInput(true)
-    } else {
-      setShowLinkInput(true)
-    }
+    setShowLinkInput(true)
 
     // Restore the selection after a small delay to ensure the tooltip is rendered
     setTimeout(() => {
@@ -425,6 +421,23 @@ export const ToolbarButtons = React.memo(({ editor, props }: any) => {
           <FileText size={15} weight="fill" />
         </div>
       </ToolTip>
+      <ToolTip content={t('editor.blocks.library')}>
+        <div
+          className="editor-tool-btn editor-tool-btn-document"
+          onClick={() =>
+            editor
+              .chain()
+              .focus()
+              .insertContent({
+                type: 'blockLibrary',
+              })
+              .run()
+          }
+          aria-label={t('editor.blocks.library')}
+        >
+          <Books size={15} weight="fill" />
+        </div>
+      </ToolTip>
       <ToolTip content={t('editor.blocks.quiz')}>
         <div
           className="editor-tool-btn editor-tool-btn-interactive"
@@ -638,3 +651,5 @@ export const ToolbarButtons = React.memo(({ editor, props }: any) => {
     </div>
   )
 })
+
+ToolbarButtons.displayName = 'ToolbarButtons'

--- a/apps/web/components/Objects/Editor/editorPreload.ts
+++ b/apps/web/components/Objects/Editor/editorPreload.ts
@@ -9,6 +9,7 @@ const COMPONENT_LOADERS: Record<string, () => Promise<unknown>> = {
   blockMathEquation: () =>
     import('./Extensions/MathEquation/MathEquationBlockComponent'),
   blockPDF: () => import('./Extensions/PDF/PDFBlockComponent'),
+  blockLibrary: () => import('./Extensions/Library/LibraryBlockComponent'),
   blockQuiz: () => import('./Extensions/Quiz/QuizBlockComponent'),
   blockEmbed: () => import('./Extensions/EmbedObjects/EmbedObjectsComponent'),
   blockUser: () => import('./Extensions/Users/UserBlockComponent'),
@@ -17,6 +18,7 @@ const COMPONENT_LOADERS: Record<string, () => Promise<unknown>> = {
   blockCode: () => import('./Extensions/CodePlayground/CodePlaygroundComponent'),
   scenarios: () => import('./Extensions/Scenarios/ScenariosExtension'),
   flipcard: () => import('./Extensions/Flipcard/FlipcardExtension'),
+  flipcardGrid: () => import('./Extensions/Flipcard/FlipcardGridExtension'),
 }
 
 function collectNodeTypes(node: any, types: Set<string>): void {

--- a/apps/web/components/Objects/Media/InlineAudioPlayer.tsx
+++ b/apps/web/components/Objects/Media/InlineAudioPlayer.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import React from 'react'
+import {
+  Headphones,
+  Pause,
+  Play,
+  SkipBack,
+  SkipForward,
+  Volume2,
+  VolumeX,
+} from 'lucide-react'
+import { safePlay } from '@/lib/media/safePlay'
+
+/*
+ Compact audio player over the native <audio> element. Extracted from the Audio
+ editor block so the Library preview and the Library block can play audio with
+ the same controls; the Audio block imports it back from here.
+*/
+
+export function formatTime(seconds: number): string {
+  const s = Math.floor(seconds)
+  const h = Math.floor(s / 3600)
+  const m = Math.floor((s % 3600) / 60)
+  const r = s % 60
+  if (h > 0) return `${h}:${m.toString().padStart(2, '0')}:${r.toString().padStart(2, '0')}`
+  return `${m}:${r.toString().padStart(2, '0')}`
+}
+
+function InlineAudioPlayer({ src, title }: { src: string; title?: string }) {
+  const audioRef = React.useRef<HTMLAudioElement>(null)
+  const progressRef = React.useRef<HTMLDivElement>(null)
+  const [isPlaying, setIsPlaying] = React.useState(false)
+  const [currentTime, setCurrentTime] = React.useState(0)
+  const [duration, setDuration] = React.useState(0)
+  const [volume, setVolume] = React.useState(1)
+  const [isMuted, setIsMuted] = React.useState(false)
+  const [prevVolume, setPrevVolume] = React.useState(1)
+
+  React.useEffect(() => {
+    const audio = audioRef.current
+    if (!audio) return
+
+    const onTimeUpdate = () => setCurrentTime(audio.currentTime)
+    const onLoadedMetadata = () => setDuration(audio.duration)
+    const onEnded = () => setIsPlaying(false)
+
+    audio.addEventListener('timeupdate', onTimeUpdate)
+    audio.addEventListener('loadedmetadata', onLoadedMetadata)
+    audio.addEventListener('ended', onEnded)
+    return () => {
+      audio.removeEventListener('timeupdate', onTimeUpdate)
+      audio.removeEventListener('loadedmetadata', onLoadedMetadata)
+      audio.removeEventListener('ended', onEnded)
+    }
+  }, [src])
+
+  const togglePlay = () => {
+    const audio = audioRef.current
+    if (!audio) return
+    if (isPlaying) { audio.pause() } else { safePlay(audio) }
+    setIsPlaying(!isPlaying)
+  }
+
+  const skip = (delta: number) => {
+    const audio = audioRef.current
+    if (!audio) return
+    audio.currentTime = Math.max(0, Math.min(audio.currentTime + delta, duration))
+  }
+
+  const seekTo = (e: React.MouseEvent<HTMLDivElement>) => {
+    const audio = audioRef.current
+    const bar = progressRef.current
+    if (!audio || !bar) return
+    const rect = bar.getBoundingClientRect()
+    const ratio = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width))
+    audio.currentTime = ratio * duration
+  }
+
+  const toggleMute = () => {
+    const audio = audioRef.current
+    if (!audio) return
+    if (isMuted) {
+      audio.volume = prevVolume
+      setVolume(prevVolume)
+    } else {
+      setPrevVolume(volume)
+      audio.volume = 0
+      setVolume(0)
+    }
+    setIsMuted(!isMuted)
+  }
+
+  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = parseFloat(e.target.value)
+    if (audioRef.current) audioRef.current.volume = v
+    setVolume(v)
+    setIsMuted(v === 0)
+  }
+
+  const progress = duration > 0 ? (currentTime / duration) * 100 : 0
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+      <audio ref={audioRef} src={src} preload="metadata" />
+
+      {/* Title bar */}
+      {title && (
+        <div className="px-4 pt-3 pb-1 flex items-center gap-2">
+          <Headphones size={14} className="text-gray-400 flex-shrink-0" />
+          <span className="text-sm font-semibold text-gray-900 truncate">{title}</span>
+        </div>
+      )}
+
+      {/* Player controls */}
+      <div className="px-4 py-3 flex items-center gap-3">
+        {/* Skip back */}
+        <button
+          type="button"
+          onClick={() => skip(-15)}
+          className="p-1.5 rounded-full hover:bg-gray-100 transition-colors outline-none"
+          title="Skip back 15s"
+        >
+          <SkipBack size={16} className="text-gray-600" />
+        </button>
+
+        {/* Play/Pause */}
+        <button
+          type="button"
+          onClick={togglePlay}
+          className="rounded-full bg-gray-900 hover:bg-gray-800 p-2.5 transition-colors outline-none"
+        >
+          {isPlaying ? (
+            <Pause size={16} className="text-white" fill="white" />
+          ) : (
+            <Play size={16} className="text-white" fill="white" />
+          )}
+        </button>
+
+        {/* Skip forward */}
+        <button
+          type="button"
+          onClick={() => skip(15)}
+          className="p-1.5 rounded-full hover:bg-gray-100 transition-colors outline-none"
+          title="Skip forward 15s"
+        >
+          <SkipForward size={16} className="text-gray-600" />
+        </button>
+
+        {/* Time + Progress */}
+        <span className="text-xs text-gray-500 w-10 text-right tabular-nums flex-shrink-0">
+          {formatTime(currentTime)}
+        </span>
+
+        <div
+          ref={progressRef}
+          onClick={seekTo}
+          className="flex-1 h-1.5 bg-gray-200 rounded-full cursor-pointer relative group"
+        >
+          <div
+            className="h-full bg-gray-900 rounded-full transition-all duration-100"
+            style={{ width: `${progress}%` }}
+          />
+          <div
+            className="absolute top-1/2 -translate-y-1/2 w-3 h-3 bg-gray-900 rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
+            style={{ left: `calc(${progress}% - 6px)` }}
+          />
+        </div>
+
+        <span className="text-xs text-gray-500 w-10 tabular-nums flex-shrink-0">
+          {formatTime(duration)}
+        </span>
+
+        {/* Volume */}
+        <button
+          type="button"
+          onClick={toggleMute}
+          className="p-1.5 rounded-full hover:bg-gray-100 transition-colors outline-none"
+        >
+          {isMuted || volume === 0 ? (
+            <VolumeX size={16} className="text-gray-600" />
+          ) : (
+            <Volume2 size={16} className="text-gray-600" />
+          )}
+        </button>
+        <input
+          type="range"
+          min="0"
+          max="1"
+          step="0.01"
+          value={volume}
+          onChange={handleVolumeChange}
+          className="w-16 h-1 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-gray-900"
+        />
+      </div>
+    </div>
+  )
+}
+
+export default InlineAudioPlayer

--- a/apps/web/components/Objects/Media/MediaLightbox.tsx
+++ b/apps/web/components/Objects/Media/MediaLightbox.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import React from 'react'
+import { ArrowSquareOut, DownloadSimple, LinkSimple } from '@phosphor-icons/react'
+import { useTranslation } from 'react-i18next'
+import { useLHSession } from '@components/Contexts/LHSessionContext'
+import Modal from '@components/Objects/StyledElements/Modal/Modal'
+import MediaViewer from '@components/Objects/Media/MediaViewer'
+import { shareMediaLink } from '@components/Dashboard/Library/shareFolder'
+import { safeExternalUrl } from '@components/Dashboard/Library/resourceLink'
+import { getMediaFileDirectory } from '@services/media/media-resource'
+import { formatFileSize, mediaKind, type MediaLike } from '@/lib/media/mediaKind'
+
+/*
+ Full-screen preview for a Library media asset: the viewer plus the actions that
+ used to be the only thing a click could do (download / open elsewhere). Shared
+ by the dashboard and public library cards and by the Library editor block.
+*/
+
+type Props = {
+  resource: MediaLike & { name?: string; file_size?: number | null; media_uuid?: string }
+  /** Falls back to the folder item's resource_uuid when the row lacks media_uuid. */
+  mediaUuid?: string
+  isOpen: boolean
+  onOpenChange: (_open: boolean) => void
+}
+
+export default function MediaLightbox({ resource, mediaUuid, isOpen, onOpenChange }: Props) {
+  const { t } = useTranslation()
+  const session = useLHSession() as any
+  const access_token = session?.data?.tokens?.access_token
+
+  const uuid = resource?.media_uuid || mediaUuid
+  const kind = mediaKind(resource)
+  const isUpload = kind !== 'embed'
+  const name = resource?.name || t('library.untitled')
+  const size = formatFileSize(resource?.file_size)
+  const externalUrl = isUpload
+    ? uuid
+      ? getMediaFileDirectory(undefined, uuid)
+      : null
+    : safeExternalUrl(resource?.url)
+  const downloadUrl =
+    isUpload && uuid
+      ? getMediaFileDirectory(undefined, uuid, undefined, { download: true })
+      : null
+
+  const subtitle = [
+    (resource?.file_format || '').replace(/^\./, '').toUpperCase(),
+    size,
+  ]
+    .filter(Boolean)
+    .join(' · ')
+
+  return (
+    <Modal
+      isDialogOpen={isOpen}
+      onOpenChange={onOpenChange}
+      minWidth="lg"
+      minHeight="no-min"
+      dialogTitle={
+        <span className="flex flex-col">
+          <span className="truncate">{name}</span>
+          {subtitle && (
+            <span className="text-[11px] font-medium uppercase tracking-wider text-gray-400">
+              {subtitle}
+            </span>
+          )}
+        </span>
+      }
+      dialogContent={
+        <div className="space-y-4">
+          <MediaViewer resource={resource} mediaUuid={uuid} />
+
+          <div className="flex flex-wrap items-center gap-2">
+            {downloadUrl && (
+              <a
+                href={downloadUrl}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-black px-3 py-2 text-xs font-semibold text-white nice-shadow hover:bg-neutral-800 transition-colors"
+              >
+                <DownloadSimple size={14} /> {t('media.download')}
+              </a>
+            )}
+            {isUpload && uuid && access_token && (
+              <button
+                type="button"
+                onClick={() =>
+                  shareMediaLink(
+                    uuid,
+                    access_token,
+                    t('library.link_copied'),
+                    t('library.link_copy_error')
+                  )
+                }
+                className="inline-flex items-center gap-1.5 rounded-lg bg-gray-100 px-3 py-2 text-xs font-semibold text-gray-700 hover:bg-gray-200 transition-colors"
+              >
+                <LinkSimple size={14} /> {t('library.copy_link')}
+              </button>
+            )}
+            {externalUrl && (
+              <a
+                href={externalUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 rounded-lg bg-gray-100 px-3 py-2 text-xs font-semibold text-gray-700 hover:bg-gray-200 transition-colors"
+              >
+                <ArrowSquareOut size={14} /> {t('library.open')}
+              </a>
+            )}
+          </div>
+        </div>
+      }
+    />
+  )
+}

--- a/apps/web/components/Objects/Media/MediaViewer.tsx
+++ b/apps/web/components/Objects/Media/MediaViewer.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import React from 'react'
+import dynamic from 'next/dynamic'
+import { Download, File as FileIcon, FileArchive, FileSpreadsheet, FileText, Lock, Presentation } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { getMediaFileDirectory } from '@services/media/media-resource'
+import { formatFileSize, mediaKind, type MediaKind, type MediaLike } from '@/lib/media/mediaKind'
+import { toEmbedUrl } from '@/lib/media/embedUrl'
+import { safeExternalUrl } from '@components/Dashboard/Library/resourceLink'
+import InlineAudioPlayer from '@components/Objects/Media/InlineAudioPlayer'
+
+// video.js touches window on import; keep it out of the server bundle.
+const LearnHousePlayer = dynamic(
+  () => import('@components/Objects/Activities/Video/LearnHousePlayer'),
+  { ssr: false }
+)
+
+/*
+ The actual in-app player/reader for a Library media asset — no modal chrome,
+ no card. Used by MediaLightbox (library views) and by the Library editor block,
+ so "watch / read / listen / download" behaves identically in both.
+*/
+
+const OFFICE_ICONS: Record<string, React.ComponentType<any>> = {
+  doc: FileText, docx: FileText, txt: FileText, rtf: FileText, pdf: FileText,
+  xls: FileSpreadsheet, xlsx: FileSpreadsheet, csv: FileSpreadsheet,
+  ppt: Presentation, pptx: Presentation,
+  zip: FileArchive, rar: FileArchive, '7z': FileArchive,
+}
+
+function fileIcon(format?: string | null): React.ComponentType<any> {
+  return OFFICE_ICONS[(format || '').toLowerCase().replace(/^\./, '')] || FileIcon
+}
+
+/** Media that cannot be rendered in-app: name it, size it, offer the download. */
+function FileCard({
+  name,
+  fileFormat,
+  fileSize,
+  downloadUrl,
+}: {
+  name: string
+  fileFormat?: string | null
+  fileSize?: number | null
+  downloadUrl: string | null
+}) {
+  const { t } = useTranslation()
+  const Icon = fileIcon(fileFormat)
+  const size = formatFileSize(fileSize)
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-12 px-6 bg-gray-50 rounded-xl">
+      {/* eslint-disable-next-line react-hooks/static-components */}
+      <Icon size={56} className="text-gray-400" strokeWidth={1.25} />
+      <div className="text-center">
+        <p className="text-sm font-semibold text-gray-900 break-all">{name}</p>
+        <p className="text-xs text-gray-500 mt-1 uppercase tracking-wider">
+          {[(fileFormat || '').replace(/^\./, ''), size].filter(Boolean).join(' · ')}
+        </p>
+      </div>
+      {downloadUrl && (
+        <a
+          href={downloadUrl}
+          className="inline-flex items-center gap-2 rounded-lg bg-black px-4 py-2 text-sm font-semibold text-white nice-shadow hover:bg-neutral-800 transition-colors"
+        >
+          <Download size={16} /> {t('media.download')}
+        </a>
+      )}
+    </div>
+  )
+}
+
+/** A learner can legitimately lack access when the file sits in a private folder. */
+function NoAccessCard() {
+  const { t } = useTranslation()
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 py-12 px-6 bg-gray-50 rounded-xl">
+      <Lock size={40} className="text-gray-400" strokeWidth={1.25} />
+      <p className="text-sm text-gray-600">{t('library.no_access')}</p>
+    </div>
+  )
+}
+
+export type MediaViewerProps = {
+  /** A Media row (or the Library block's cached snapshot of one). */
+  resource: MediaLike & { name?: string; file_size?: number | null }
+  /** Falls back to item.resource_uuid when the row has no media_uuid. */
+  mediaUuid?: string
+  /** Caps the viewer height; the lightbox and the block want different ones. */
+  maxHeightClass?: string
+}
+
+export default function MediaViewer({
+  resource,
+  mediaUuid,
+  maxHeightClass = 'max-h-[70vh]',
+}: MediaViewerProps) {
+  const [denied, setDenied] = React.useState(false)
+  const kind: MediaKind = mediaKind(resource)
+  const name = resource?.name || ''
+  const fileUrl = mediaUuid ? getMediaFileDirectory(undefined, mediaUuid) : null
+  const downloadUrl = mediaUuid
+    ? getMediaFileDirectory(undefined, mediaUuid, undefined, { download: true })
+    : null
+
+  // A 401/403 on the file endpoint means "private folder", not "broken file".
+  React.useEffect(() => {
+    setDenied(false)
+    if (!fileUrl || kind === 'embed') return
+    let cancelled = false
+    fetch(fileUrl, { method: 'HEAD', credentials: 'include' })
+      .then((r) => {
+        if (!cancelled && (r.status === 401 || r.status === 403)) setDenied(true)
+      })
+      .catch(() => {
+        /* network errors fall through to the element's own error handling */
+      })
+    return () => { cancelled = true }
+  }, [fileUrl, kind])
+
+  if (kind === 'embed') {
+    const url = safeExternalUrl(resource?.url)
+    if (!url) return <NoAccessCard />
+    return (
+      <div className={`w-full ${maxHeightClass} aspect-video bg-black rounded-xl overflow-hidden`}>
+        <iframe
+          src={toEmbedUrl(url)}
+          title={name || 'Embedded media'}
+          className="w-full h-full border-0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"
+          allowFullScreen
+        />
+      </div>
+    )
+  }
+
+  if (!fileUrl) return <NoAccessCard />
+  if (denied) return <NoAccessCard />
+
+  if (kind === 'image') {
+    return (
+      <div className={`flex items-center justify-center bg-gray-50 rounded-xl overflow-hidden ${maxHeightClass}`}>
+        <img src={fileUrl} alt={name} className="max-w-full max-h-full object-contain" />
+      </div>
+    )
+  }
+
+  if (kind === 'video') {
+    return (
+      <div className={`w-full ${maxHeightClass} bg-black rounded-xl overflow-hidden`}>
+        <LearnHousePlayer src={fileUrl} />
+      </div>
+    )
+  }
+
+  if (kind === 'audio') {
+    return <InlineAudioPlayer src={fileUrl} title={name} />
+  }
+
+  if (kind === 'pdf') {
+    return (
+      <iframe
+        src={fileUrl}
+        title={name || 'PDF document'}
+        className={`w-full ${maxHeightClass} h-[70vh] rounded-xl border border-gray-200 bg-white`}
+      />
+    )
+  }
+
+  return (
+    <FileCard
+      name={name}
+      fileFormat={resource?.file_format}
+      fileSize={resource?.file_size}
+      downloadUrl={downloadUrl}
+    />
+  )
+}

--- a/apps/web/lib/library/resourceEmbed.ts
+++ b/apps/web/lib/library/resourceEmbed.ts
@@ -1,0 +1,49 @@
+import { getUriWithOrg } from '@services/config/config'
+
+/*
+ Route resolution for a Library resource, shared by the Resource activity and
+ the Library editor block. Mirrors resourceHref's uuid-prefix handling.
+*/
+
+export type ResourceKind =
+  | 'course'
+  | 'podcast'
+  | 'community'
+  | 'board'
+  | 'playground'
+  | 'media'
+
+/**
+ * Base internal route for a Library resource. Boards live at a top-level
+ * chrome-free route; the other kinds live under the (withmenu) group (see
+ * buildEmbedUrl for the chrome=none suppression used when embedding).
+ * `media` has no page of its own — it is rendered by MediaViewer instead.
+ */
+export function buildResourceUrl(
+  kind: ResourceKind,
+  resourceUuid: string,
+  orgslug: string
+): string | null {
+  if (!resourceUuid) return null
+  switch (kind) {
+    case 'board':
+      return getUriWithOrg(orgslug, `/board/${resourceUuid.replace('board_', '')}`)
+    case 'community':
+      return getUriWithOrg(orgslug, `/community/${resourceUuid.replace('community_', '')}`)
+    case 'podcast':
+      return getUriWithOrg(orgslug, `/podcast/${resourceUuid.replace('podcast_', '')}`)
+    case 'playground':
+      // Playgrounds use the full prefixed uuid.
+      return getUriWithOrg(orgslug, `/playground/${resourceUuid}`)
+    case 'course':
+      return getUriWithOrg(orgslug, `/course/${resourceUuid.replace('course_', '')}`)
+    default:
+      return null
+  }
+}
+
+// Boards already render chrome-free; the (withmenu) kinds need ?chrome=none.
+export function buildEmbedUrl(kind: ResourceKind, baseUrl: string): string {
+  if (kind === 'board') return baseUrl
+  return baseUrl.includes('?') ? `${baseUrl}&chrome=none` : `${baseUrl}?chrome=none`
+}

--- a/apps/web/lib/media/embedUrl.ts
+++ b/apps/web/lib/media/embedUrl.ts
@@ -1,0 +1,87 @@
+/*
+ Turn a user-pasted URL into something an <iframe> can actually render.
+
+ Shared by the Embed activity and the Library media viewer, so an EMBED media
+ row plays in-app instead of sending the user off to the original site.
+*/
+
+/** Extract a YouTube video id from common URL shapes, or null. */
+export function youTubeId(url: string): string | null {
+  try {
+    const u = new URL(url)
+    const host = u.hostname.replace(/^www\./, '')
+    if (host === 'youtu.be') {
+      return u.pathname.split('/').filter(Boolean)[0] || null
+    }
+    if (host.endsWith('youtube.com') || host.endsWith('youtube-nocookie.com')) {
+      const v = u.searchParams.get('v')
+      if (v) return v
+      const parts = u.pathname.split('/').filter(Boolean)
+      const i = parts.findIndex((p) => p === 'embed' || p === 'shorts' || p === 'v')
+      if (i !== -1 && parts[i + 1]) return parts[i + 1]
+    }
+  } catch {
+    /* not a parseable URL */
+  }
+  return null
+}
+
+/** Vimeo video id, or null. */
+export function vimeoId(url: string): string | null {
+  try {
+    const u = new URL(url)
+    if (!u.hostname.replace(/^www\./, '').endsWith('vimeo.com')) return null
+    const id = u.pathname.split('/').filter(Boolean).find((p) => /^\d+$/.test(p))
+    return id || null
+  } catch {
+    return null
+  }
+}
+
+export function toEmbedUrl(url: string): string {
+  const yt = youTubeId(url)
+  if (yt) return `https://www.youtube.com/embed/${yt}?autoplay=0&rel=0`
+
+  const vimeo = vimeoId(url)
+  if (vimeo) return `https://player.vimeo.com/video/${vimeo}`
+
+  // Google Docs/Sheets/Slides → preview
+  const googleDocMatch = url.match(
+    /^(https?:\/\/docs\.google\.com\/(?:document|spreadsheets|presentation)\/d\/[^/]+)/
+  )
+  if (googleDocMatch) {
+    return `${googleDocMatch[1]}/preview`
+  }
+
+  // Google Forms → embedded
+  const googleFormMatch = url.match(
+    /^(https?:\/\/docs\.google\.com\/forms\/d\/[^/]+)/
+  )
+  if (googleFormMatch) {
+    return `${googleFormMatch[1]}/viewform?embedded=true`
+  }
+
+  // Figma → embed host
+  if (/^https?:\/\/(www\.)?figma\.com\//.test(url)) {
+    return `https://www.figma.com/embed?embed_host=learnhouse&url=${encodeURIComponent(url)}`
+  }
+
+  // Loom → /share/ to /embed/
+  const loomMatch = url.match(/^(https?:\/\/www\.loom\.com)\/share\/(.+)$/)
+  if (loomMatch) {
+    return `${loomMatch[1]}/embed/${loomMatch[2]}`
+  }
+
+  // Canva design → embed
+  if (url.includes('canva.com/design/')) {
+    return url.includes('?') ? `${url}&embed` : `${url}?embed`
+  }
+
+  // Miro → embed
+  const miroMatch = url.match(/^(https?:\/\/miro\.com\/app\/board\/)(.+)$/)
+  if (miroMatch) {
+    return `https://miro.com/app/live-embed/${miroMatch[2]}`
+  }
+
+  return url
+}

--- a/apps/web/lib/media/mediaKind.ts
+++ b/apps/web/lib/media/mediaKind.ts
@@ -1,0 +1,60 @@
+/*
+ Single source of truth for "what kind of thing is this Library media row".
+
+ The format tables used to be copy-pasted into every card and preview component,
+ which is how they drifted. `file_mime` is on the model and is more reliable than
+ the extension, so it wins when present.
+*/
+
+export type MediaKind = 'image' | 'video' | 'audio' | 'pdf' | 'embed' | 'file'
+
+export const IMAGE_FORMATS = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'avif']
+export const VIDEO_FORMATS = ['mp4', 'webm', 'mov']
+export const AUDIO_FORMATS = ['mp3', 'wav', 'ogg', 'm4a']
+
+/** Minimal shape shared by Media rows and the block's cached snapshot. */
+export type MediaLike = {
+  media_type?: string | null
+  file_format?: string | null
+  file_mime?: string | null
+  url?: string | null
+} | null | undefined
+
+export function mediaKind(resource: MediaLike): MediaKind {
+  if (resource?.media_type === 'EMBED') return 'embed'
+
+  const mime = (resource?.file_mime || '').toLowerCase()
+  if (mime) {
+    if (mime === 'application/pdf') return 'pdf'
+    if (mime.startsWith('image/')) return 'image'
+    if (mime.startsWith('video/')) return 'video'
+    if (mime.startsWith('audio/')) return 'audio'
+  }
+
+  const format = (resource?.file_format || '').toLowerCase().replace(/^\./, '')
+  if (format === 'pdf') return 'pdf'
+  if (IMAGE_FORMATS.includes(format)) return 'image'
+  if (VIDEO_FORMATS.includes(format)) return 'video'
+  if (AUDIO_FORMATS.includes(format)) return 'audio'
+
+  return 'file'
+}
+
+/** True when the kind has a real in-app viewer (rather than the download card). */
+export function isPreviewableKind(kind: MediaKind): boolean {
+  return kind !== 'file'
+}
+
+const SIZE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB']
+
+export function formatFileSize(bytes?: number | null): string {
+  if (bytes === null || bytes === undefined || Number.isNaN(bytes)) return ''
+  if (bytes < 1) return '0 B'
+  let value = bytes
+  let unit = 0
+  while (value >= 1024 && unit < SIZE_UNITS.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+  return `${unit === 0 ? Math.round(value) : value.toFixed(value < 10 ? 1 : 0)} ${SIZE_UNITS[unit]}`
+}

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -1272,7 +1272,18 @@
       "drag_to_reorder": "Drag to reorder",
       "sort_error": "Could not update sort order",
       "reorder_error": "Could not save the new order"
-    }
+    },
+    "preview": "Preview",
+    "no_access": "You don't have access to this file.",
+    "choose_from_library": "Choose from Library",
+    "upload_to_library": "Upload",
+    "upload_to_library_hint": "Uploaded files are added to your Library, so you can reuse them elsewhere.",
+    "no_resource_selected": "No library item selected.",
+    "private_media_warning": "Private — learners without access will not see this.",
+    "replace_resource": "Replace",
+    "remove_resource": "Remove",
+    "show_as_card": "Show as card",
+    "show_inline": "Show inline"
   },
   "media": {
     "media": "Media",
@@ -1410,7 +1421,13 @@
     "autosave_unsaved": "Unsaved changes",
     "autosaved": "Saved",
     "autosaving": "Saving…",
-    "save_answers": "Save answers"
+    "save_answers": "Save answers",
+    "grid_columns_2": "2 Columns",
+    "grid_columns_3": "3 Columns",
+    "grid_columns_4": "4 Columns",
+    "add_card": "Add Card",
+    "ungroup_cards": "Ungroup Cards",
+    "group_into_grid": "Group into Grid"
   },
   "embed": {
     "not_supported_title": "This activity is not supported",
@@ -4827,11 +4844,6 @@
         "visit_site": "Visit Site",
         "align": "Align"
       },
-      "flipcard_block": {
-        "front": "Front",
-        "back": "Back",
-        "click_to_flip": "Click to flip"
-      },
       "button_block": {
         "enter_link_url": "Enter link URL"
       },
@@ -4872,7 +4884,9 @@
         "suggestion_calculator_prompt": "Create a calculator that shows step-by-step solutions for basic equations",
         "suggestion_timeline": "Timeline",
         "suggestion_timeline_prompt": "Create an interactive timeline showing major historical events with expandable details"
-      }
+      },
+      "library": "Library",
+      "flipcard_grid": "Flashcard Grid"
     }
   },
   "analytics": {

--- a/apps/web/services/ai/courseplanning.ts
+++ b/apps/web/services/ai/courseplanning.ts
@@ -132,9 +132,9 @@ export async function startCoursePlanningSession(
   orgId: number,
   prompt: string,
   accessToken: string,
-  onChunk: (chunk: string) => void,
-  onComplete: (sessionUuid: string) => void,
-  onError: (error: string) => void,
+  onChunk: (_chunk: string) => void,
+  onComplete: (_sessionUuid: string) => void,
+  onError: (_error: string) => void,
   language: string = 'en',
   attachments?: Attachment[]
 ): Promise<void> {
@@ -182,9 +182,9 @@ export async function iterateCoursePlanning(
   sessionUuid: string,
   message: string,
   accessToken: string,
-  onChunk: (chunk: string) => void,
-  onComplete: (sessionUuid: string) => void,
-  onError: (error: string) => void,
+  onChunk: (_chunk: string) => void,
+  onComplete: (_sessionUuid: string) => void,
+  onError: (_error: string) => void,
   currentPlan?: CoursePlan | null,
   attachments?: Attachment[]
 ): Promise<void> {
@@ -276,9 +276,9 @@ export async function generateActivityContent(
   courseName: string,
   courseDescription: string,
   accessToken: string,
-  onChunk: (chunk: string) => void,
-  onComplete: (sessionUuid: string) => void,
-  onError: (error: string) => void,
+  onChunk: (_chunk: string) => void,
+  onComplete: (_sessionUuid: string) => void,
+  onError: (_error: string) => void,
   prompt?: string
 ): Promise<void> {
   const data = {
@@ -343,7 +343,8 @@ export async function saveActivityContent(
       }
     }
 
-    const data = await response.json()
+    // Drain the body so the connection can be reused; the payload isn't needed.
+    await response.json().catch(() => ({}))
     return { success: true }
   } catch (error) {
     console.error('[saveActivityContent] Exception:', error)
@@ -395,9 +396,9 @@ export async function getCoursePlanningSession(
  */
 async function processStream(
   response: Response,
-  onChunk: (chunk: string) => void,
-  onComplete: (sessionUuid: string) => void | Promise<void>,
-  onError: (error: string) => void
+  onChunk: (_chunk: string) => void,
+  onComplete: (_sessionUuid: string) => void | Promise<void>,
+  onError: (_error: string) => void
 ): Promise<void> {
   const reader = response.body?.getReader()
   if (!reader) {
@@ -527,7 +528,8 @@ function validateProseMirrorDoc(content: any): { valid: boolean; error?: string 
     'codeBlock', 'blockQuiz', 'flipcard', 'calloutInfo', 'calloutWarning',
     'blockEmbed', 'blockImage', 'blockVideo', 'blockPDF', 'blockMathEquation',
     'table', 'tableRow', 'tableCell', 'tableHeader', 'horizontalRule',
-    'hardBreak', 'text', 'scenarios', 'blockUser', 'blockWebPreview', 'button', 'badge'
+    'hardBreak', 'text', 'scenarios', 'blockUser', 'blockWebPreview', 'button', 'badge',
+    'blockLibrary', 'flipcardGrid'
   ])
 
   function checkNode(node: any, path: string): { valid: boolean; error?: string } {

--- a/apps/web/services/media/media-resource.ts
+++ b/apps/web/services/media/media-resource.ts
@@ -22,15 +22,21 @@ import {
  * sends the session cookie (same-origin), so private-folder files are only
  * served to authorized users, and the storage path is never exposed. The
  * orgUuid/fileId params are kept for signature stability but unused.
+ *
+ * Pass `{ download: true }` for a save-as URL: the `download` attribute on an
+ * anchor is ignored cross-origin, and media is served from the API host, so the
+ * attachment disposition has to come from the server.
  */
 export function getMediaFileDirectory(
   _orgUuid?: string,
   mediaUuid?: string,
-  _fileId?: string
+  _fileId?: string,
+  options?: { download?: boolean }
 ) {
   // _orgUuid/_fileId are accepted for backward-compatible call sites but no
   // longer used: media is served via the authed endpoint keyed by media_uuid.
-  return `${getAPIUrl()}media/${mediaUuid}/file`
+  const base = `${getAPIUrl()}media/${mediaUuid}/file`
+  return options?.download ? `${base}?download=true` : base
 }
 
 /**
@@ -47,8 +53,9 @@ export async function createMediaShareLink(media_uuid: string, access_token: str
 }
 
 /** Build the shareable, token-based file URL (random + unique every time). */
-export function getMediaShareFileUrl(token: string) {
-  return `${getAPIUrl()}media/shared/${token}/file`
+export function getMediaShareFileUrl(token: string, options?: { download?: boolean }) {
+  const base = `${getAPIUrl()}media/shared/${token}/file`
+  return options?.download ? `${base}?download=true` : base
 }
 
 export async function getOrgMedia(

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -502,8 +502,29 @@
   transform: rotateY(180deg);
 }
 
-/* Flipcard grid: cards fill their cell instead of claiming a full row. Spacing
-   comes from the grid gap, so the card's own vertical margin has to go. */
+/* Flipcard grid: cards sit side by side instead of each claiming a full row. */
+.flipcard-grid-content {
+  display: grid;
+  grid-template-columns: repeat(var(--flipcard-grid-columns, 2), minmax(0, 1fr));
+  gap: 1rem;
+  align-items: start;
+}
+
+/* Tiptap mounts the child nodes inside a holder div of its own, which would
+   otherwise be the grid's only item and stack the cards. Dissolving it makes
+   the flipcards themselves the grid items. */
+.flipcard-grid-content > [data-node-view-content-react] {
+  display: contents;
+}
+
+/* One column on narrow screens — three cards side by side is unreadable. */
+@media (max-width: 640px) {
+  .flipcard-grid-content {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+/* Spacing comes from the grid gap, so the card's own vertical margin has to go. */
 .flipcard-grid .flipcard-wrapper {
   margin-top: 0;
   margin-bottom: 0;

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -502,6 +502,18 @@
   transform: rotateY(180deg);
 }
 
+/* Flipcard grid: cards fill their cell instead of claiming a full row. Spacing
+   comes from the grid gap, so the card's own vertical margin has to go. */
+.flipcard-grid .flipcard-wrapper {
+  margin-top: 0;
+  margin-bottom: 0;
+  width: 100%;
+}
+
+.flipcard-grid .flipcard-container {
+  width: 100%;
+}
+
 /* AI Canva Bubble Menu Styles */
 .ai-canva-bubble-menu {
   position: fixed !important;


### PR DESCRIPTION
The Library and the activity editor were disconnected: authors had to re-upload files they'd already put in the Library, and block media lived in its own storage tree. This connects them, replaces raw-file link-outs in library views with real in-app previews, and lets flashcards share a row instead of always stacking full-width.

- New `blockLibrary` editor node (slash command `/library`, toolbar): pick an existing Library resource or upload one that becomes a real, reusable Library asset. Media renders inline with expand/download/replace; other resource types render as a card with an iframe embed toggle.
- Library and public library views now open a lightbox (video/PDF/audio/image player, download, copy link) instead of navigating away to a raw file URL. Non-previewable files get an info card. Private-folder media a viewer can't access shows a "no access" card.
- New `flipcardGrid` node lets flashcards share a row (1-4 columns) instead of always stacking full-width. Existing standalone cards are untouched.

Fixed first, since the above depends on both: Library "Download" never actually downloaded cross-origin (added `?download=true`, which now sends `Content-Disposition: attachment`), and folder-contents/library-search responses were leaking `storage_key`/`file_id` by serializing the raw Media model instead of `MediaRead`.

Also deduplicated a media-format table that had been copy-pasted into four components, extracted the inline audio player and embed-URL builders into shared modules, and added both new node types to the AI content-schema allowlists so generated content doesn't strip them.

API: full suite passed (4319 passed, 23 skipped), with new tests for the download fix and the storage_key leak. Web: `next build` compiles, eslint is clean on changed files. No manual browser pass yet: uploads, the learner view, the private-folder path, and the grid round-trip still need a look. `next build`'s type-check fails locally on a pre-existing, unrelated case collision (`CatalogPagination.tsx` vs `catalogPagination.ts`); CI's case-sensitive filesystem doesn't hit it.