### PR TITLE
Editor and course UI improvements split out of #772

### DIFF
--- a/apps/api/src/services/courses/activities/activities.py
+++ b/apps/api/src/services/courses/activities/activities.py
@@ -389,9 +389,13 @@ async def update_activity(
     update_data = activity_object.model_dump(exclude_unset=True)
 
     # Create a version snapshot before updating content
-    # This preserves the current state for version history
+    # This preserves the current state for version history.
+    # resolve_acting_user_id unwraps APITokenUser → the creating human's id,
+    # because current_user.id on a token is 0 (the token id, not a user id)
+    # and created_by_id is an FK to user.id — writing 0 triggers a FK
+    # violation and the whole update 500s.
     if 'content' in update_data and activity.content:
-        user_id = current_user.id if hasattr(current_user, 'id') else None
+        user_id = resolve_acting_user_id(current_user)
         await create_activity_version(activity, user_id, db_session)
         # Increment version number
         activity.current_version = (activity.current_version or 1) + 1

--- a/apps/api/src/services/courses/activities/versioning.py
+++ b/apps/api/src/services/courses/activities/versioning.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException, Request
 from datetime import datetime, timezone
 from typing import List, Optional
 
+from src.security.auth import resolve_acting_user_id
 from src.security.rbac import check_resource_access, AccessAction
 from src.security.features_utils.usage import check_feature_access
 from src.services.webhooks.dispatch import dispatch_webhooks
@@ -315,8 +316,10 @@ async def restore_activity_version(
             detail="Version not found",
         )
 
-    # Create a version of the current state before restoring
-    user_id = current_user.id if hasattr(current_user, 'id') else None
+    # Create a version of the current state before restoring. Unwrap API
+    # tokens via resolve_acting_user_id — raw current_user.id is 0 on a
+    # token, and created_by_id is an FK to user.id (writing 0 fails).
+    user_id = resolve_acting_user_id(current_user)
     await create_activity_version(activity, user_id, db_session)
 
     # Restore content and update metadata

--- a/apps/api/src/services/utils/link_preview.py
+++ b/apps/api/src/services/utils/link_preview.py
@@ -12,6 +12,35 @@ from src.services.utils.ssrf_guard import (
 
 _MAX_RESPONSE_SIZE = 5 * 1024 * 1024  # 5MB
 
+# Many sites (Cloudflare, Akamai, WAFs) return 403 to non-browser UAs.
+_BROWSER_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+
+def _minimal_preview(url: str) -> Dict[str, Optional[str]]:
+    parsed = urlparse(url)
+    favicon = (
+        f"{parsed.scheme}://{parsed.netloc}/favicon.ico"
+        if parsed.scheme and parsed.netloc
+        else None
+    )
+    return {
+        "title": None,
+        "description": None,
+        "og_image": None,
+        "favicon": favicon,
+        "og_type": None,
+        "og_url": url,
+        "url": url,
+    }
+
 
 async def fetch_link_preview(url: str) -> Dict[str, Optional[str]]:
     try:
@@ -23,8 +52,13 @@ async def fetch_link_preview(url: str) -> Dict[str, Optional[str]]:
         follow_redirects=False,
         timeout=10,
         max_redirects=0,
+        headers=_BROWSER_HEADERS,
     ) as client:
-        response = await client.get(url)
+        try:
+            response = await client.get(url)
+        except httpx.HTTPError:
+            return _minimal_preview(url)
+
         try:
             assert_connected_peer_allowed(response, validated_ips)
         except SSRFBlockedError as exc:
@@ -34,84 +68,121 @@ async def fetch_link_preview(url: str) -> Dict[str, Optional[str]]:
         redirect_count = 0
         while response.is_redirect and redirect_count < 5:
             redirect_count += 1
-            redirect_url = str(response.next_request.url) if response.next_request else None
+            redirect_url = (
+                str(response.next_request.url) if response.next_request else None
+            )
             if not redirect_url:
                 break
             try:
                 validated_ips = resolve_and_validate_url(redirect_url)
             except SSRFBlockedError as exc:
                 raise HTTPException(status_code=400, detail=str(exc))
-            response = await client.get(redirect_url)
+            try:
+                response = await client.get(redirect_url)
+            except httpx.HTTPError:
+                return _minimal_preview(url)
             try:
                 assert_connected_peer_allowed(response, validated_ips)
             except SSRFBlockedError as exc:
                 raise HTTPException(status_code=400, detail=str(exc))
 
-        response.raise_for_status()
+        # Non-success upstream → return a URL-only preview so the editor can
+        # still render a basic card instead of showing a hard error.
+        if response.status_code >= 400:
+            return _minimal_preview(url)
 
-        # Limit response size
+        # Reject anything that is clearly too large; this is a hint only,
+        # since servers may omit Content-Length.
         content_length = response.headers.get("content-length")
-        if content_length and int(content_length) > _MAX_RESPONSE_SIZE:
-            raise HTTPException(status_code=400, detail="Response too large")
+        if content_length:
+            try:
+                if int(content_length) > _MAX_RESPONSE_SIZE:
+                    return _minimal_preview(url)
+            except ValueError:
+                pass
 
-        html = response.text[:_MAX_RESPONSE_SIZE]
+        # Skip parsing non-HTML payloads (PDFs, images, JSON, …).
+        content_type = response.headers.get("content-type", "").lower()
+        if content_type and not (
+            "html" in content_type or "xml" in content_type
+        ):
+            return _minimal_preview(url)
 
-    soup = BeautifulSoup(html, 'html.parser')
+        try:
+            html = response.text[:_MAX_RESPONSE_SIZE]
+        except Exception:
+            return _minimal_preview(url)
 
-    def get_meta(property_name: str, attr: str = 'property') -> Optional[str]:
-        tag = soup.find('meta', attrs={attr: property_name})
-        if tag and isinstance(tag, Tag) and tag.has_attr('content'):
-            content = tag['content']
+    try:
+        soup = BeautifulSoup(html, "html.parser")
+    except Exception:
+        return _minimal_preview(url)
+
+    def get_meta(property_name: str, attr: str = "property") -> Optional[str]:
+        tag = soup.find("meta", attrs={attr: property_name})
+        if tag and isinstance(tag, Tag) and tag.has_attr("content"):
+            content = tag["content"]
             if isinstance(content, str):
-                return content
+                stripped = content.strip()
+                return stripped or None
         return None
 
-    # Title
-    title = soup.title.string.strip() if soup.title and soup.title.string else None
-    # Description
-    description = get_meta('og:description') or get_meta('description', 'name')
-    # OG Image
-    og_image = get_meta('og:image')
-    if og_image and isinstance(og_image, str) and not og_image.startswith('http'):
+    raw_title = (
+        soup.title.string.strip() if soup.title and soup.title.string else None
+    )
+    title = " ".join(raw_title.split()) if raw_title else None
+
+    description = (
+        get_meta("og:description")
+        or get_meta("twitter:description", "name")
+        or get_meta("twitter:description")
+        or get_meta("description", "name")
+    )
+
+    og_image = (
+        get_meta("og:image")
+        or get_meta("og:image:url")
+        or get_meta("twitter:image", "name")
+        or get_meta("twitter:image")
+    )
+    if og_image and not og_image.startswith("http"):
         og_image = urljoin(url, og_image)
-    # Favicon (robust)
+
     favicon = None
-    icon_rels = [
-        'icon',
-        'shortcut icon',
-        'apple-touch-icon',
-        'apple-touch-icon-precomposed',
-    ]
-    for link in soup.find_all('link'):
+    icon_rels = {
+        "icon",
+        "shortcut icon",
+        "apple-touch-icon",
+        "apple-touch-icon-precomposed",
+    }
+    for link in soup.find_all("link"):
         if not isinstance(link, Tag):
             continue
-        rels = link.get('rel')
-        href = link.get('href')
+        rels = link.get("rel")
+        href = link.get("href")
         if rels and href:
             rels_lower = [r.lower() for r in rels]
             if any(rel in rels_lower for rel in icon_rels):
                 if isinstance(href, str):
                     favicon = href
                     break
-    # Fallback to /favicon.ico if not found
+
     if not favicon:
         parsed = urlparse(url)
         favicon = f"{parsed.scheme}://{parsed.netloc}/favicon.ico"
-    elif favicon and not favicon.startswith('http'):
+    elif not favicon.startswith("http"):
         favicon = urljoin(url, favicon)
-    # OG Title
-    og_title = get_meta('og:title')
-    # OG Type
-    og_type = get_meta('og:type')
-    # OG URL
-    og_url = get_meta('og:url')
+
+    og_title = get_meta("og:title") or get_meta("twitter:title", "name")
+    og_type = get_meta("og:type")
+    og_url = get_meta("og:url")
 
     return {
-        'title': og_title or title,
-        'description': description,
-        'og_image': og_image,
-        'favicon': favicon,
-        'og_type': og_type,
-        'og_url': og_url or url,
-        'url': url,
+        "title": og_title or title,
+        "description": description,
+        "og_image": og_image,
+        "favicon": favicon,
+        "og_type": og_type,
+        "og_url": og_url or url,
+        "url": url,
     }

--- a/apps/api/src/tests/services/test_link_preview_service.py
+++ b/apps/api/src/tests/services/test_link_preview_service.py
@@ -242,7 +242,7 @@ async def test_fetch_link_preview_blocks_peer_validation_errors():
 
 
 @pytest.mark.asyncio
-async def test_fetch_link_preview_rejects_oversized_responses():
+async def test_fetch_link_preview_falls_back_for_oversized_responses():
     response = _make_response(
         content_length=5 * 1024 * 1024 + 1,
         html="<html><head><title>Too big</title></head></html>",
@@ -258,11 +258,17 @@ async def test_fetch_link_preview_rejects_oversized_responses():
         "src.services.utils.link_preview.httpx.AsyncClient",
         return_value=fake_client,
     ):
-        with pytest.raises(HTTPException) as exc_info:
-            await fetch_link_preview("https://example.com/page")
+        result = await fetch_link_preview("https://example.com/page")
 
-    assert exc_info.value.status_code == 400
-    assert exc_info.value.detail == "Response too large"
+    assert result == {
+        "title": None,
+        "description": None,
+        "og_image": None,
+        "favicon": "https://example.com/favicon.ico",
+        "og_type": None,
+        "og_url": "https://example.com/page",
+        "url": "https://example.com/page",
+    }
 
 
 @pytest.mark.asyncio
@@ -349,3 +355,255 @@ async def test_fetch_link_preview_uses_fallback_favicon_for_relative_icon():
         result = await fetch_link_preview("https://example.com/page")
 
     assert result["favicon"] == "https://example.com/favicon-alt.ico"
+
+
+_MINIMAL_PREVIEW = {
+    "title": None,
+    "description": None,
+    "og_image": None,
+    "favicon": "https://example.com/favicon.ico",
+    "og_type": None,
+    "og_url": "https://example.com/page",
+    "url": "https://example.com/page",
+}
+
+
+@pytest.mark.asyncio
+async def test_fetch_link_preview_falls_back_when_upstream_returns_4xx():
+    response = _make_response(
+        status_code=403,
+        html="<html><body>blocked by waf</body></html>",
+    )
+    fake_client = _FakeAsyncClient([response])
+
+    with patch(
+        "src.services.utils.link_preview.resolve_and_validate_url",
+        return_value={"93.184.216.34"},
+    ), patch(
+        "src.services.utils.link_preview.assert_connected_peer_allowed"
+    ), patch(
+        "src.services.utils.link_preview.httpx.AsyncClient",
+        return_value=fake_client,
+    ):
+        result = await fetch_link_preview("https://example.com/page")
+
+    assert result == _MINIMAL_PREVIEW
+
+
+@pytest.mark.asyncio
+async def test_fetch_link_preview_falls_back_for_non_html_content_type():
+    response = _make_response(
+        html="%PDF-1.4 not html",
+    )
+    response.headers["content-type"] = "application/pdf"
+    fake_client = _FakeAsyncClient([response])
+
+    with patch(
+        "src.services.utils.link_preview.resolve_and_validate_url",
+        return_value={"93.184.216.34"},
+    ), patch(
+        "src.services.utils.link_preview.assert_connected_peer_allowed"
+    ), patch(
+        "src.services.utils.link_preview.httpx.AsyncClient",
+        return_value=fake_client,
+    ):
+        result = await fetch_link_preview("https://example.com/page")
+
+    assert result == _MINIMAL_PREVIEW
+
+
+@pytest.mark.asyncio
+async def test_fetch_link_preview_falls_back_when_httpx_raises():
+    import httpx
+
+    class _RaisingClient(_FakeAsyncClient):
+        async def get(self, url):
+            self.requested_urls.append(url)
+            raise httpx.ConnectError("connection refused")
+
+    fake_client = _RaisingClient([])
+
+    with patch(
+        "src.services.utils.link_preview.resolve_and_validate_url",
+        return_value={"93.184.216.34"},
+    ), patch(
+        "src.services.utils.link_preview.assert_connected_peer_allowed"
+    ), patch(
+        "src.services.utils.link_preview.httpx.AsyncClient",
+        return_value=fake_client,
+    ):
+        result = await fetch_link_preview("https://example.com/page")
+
+    assert result == _MINIMAL_PREVIEW
+    assert fake_client.requested_urls == ["https://example.com/page"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_link_preview_sends_browser_user_agent():
+    response = _make_response(html="<html><head><title>OK</title></head></html>")
+    fake_client = _FakeAsyncClient([response])
+
+    with patch(
+        "src.services.utils.link_preview.resolve_and_validate_url",
+        return_value={"93.184.216.34"},
+    ), patch(
+        "src.services.utils.link_preview.assert_connected_peer_allowed"
+    ), patch(
+        "src.services.utils.link_preview.httpx.AsyncClient",
+        return_value=fake_client,
+    ) as mock_client_cls:
+        await fetch_link_preview("https://example.com/page")
+
+    headers = mock_client_cls.call_args.kwargs["headers"]
+    assert "Mozilla/5.0" in headers["User-Agent"]
+    assert "html" in headers["Accept"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_link_preview_falls_back_when_redirect_get_raises():
+    """A network error while following a redirect must fall back to a minimal
+    preview rather than propagating (covers the redirect-hop httpx.HTTPError)."""
+    import httpx
+
+    redirect_url = "https://example.com/redirected"
+
+    class _RedirectThenRaiseClient(_FakeAsyncClient):
+        async def get(self, url):
+            self.requested_urls.append(url)
+            if len(self.requested_urls) == 1:
+                return self._responses.pop(0)
+            raise httpx.HTTPError("redirect hop failed")
+
+    fake_client = _RedirectThenRaiseClient(
+        [
+            _make_response(
+                is_redirect=True,
+                next_request_url=redirect_url,
+                html="<html><head><title>Redirect</title></head></html>",
+            )
+        ]
+    )
+
+    with patch(
+        "src.services.utils.link_preview.resolve_and_validate_url",
+        side_effect=[{"93.184.216.34"}, {"93.184.216.34"}],
+    ), patch(
+        "src.services.utils.link_preview.assert_connected_peer_allowed"
+    ), patch(
+        "src.services.utils.link_preview.httpx.AsyncClient",
+        return_value=fake_client,
+    ):
+        result = await fetch_link_preview("https://example.com/page")
+
+    assert result == _MINIMAL_PREVIEW
+    assert fake_client.requested_urls == ["https://example.com/page", redirect_url]
+
+
+@pytest.mark.asyncio
+async def test_fetch_link_preview_ignores_non_integer_content_length():
+    """A non-integer Content-Length must be ignored (ValueError swallowed) and
+    parsing must continue normally."""
+    response = _make_response(
+        html="<html><head><title>Parsed OK</title></head></html>",
+    )
+    response.headers["content-length"] = "not-a-number"
+    fake_client = _FakeAsyncClient([response])
+
+    with patch(
+        "src.services.utils.link_preview.resolve_and_validate_url",
+        return_value={"93.184.216.34"},
+    ), patch(
+        "src.services.utils.link_preview.assert_connected_peer_allowed"
+    ), patch(
+        "src.services.utils.link_preview.httpx.AsyncClient",
+        return_value=fake_client,
+    ):
+        result = await fetch_link_preview("https://example.com/page")
+
+    assert result["title"] == "Parsed OK"
+
+
+@pytest.mark.asyncio
+async def test_fetch_link_preview_falls_back_when_body_decode_raises():
+    """If reading the response body raises, fall back to a minimal preview."""
+
+    class _RaisingTextResponse:
+        def __init__(self):
+            self.status_code = 200
+            self.is_redirect = False
+            self.next_request = None
+            self.headers = {}
+
+        @property
+        def text(self):
+            raise ValueError("cannot decode body")
+
+    fake_client = _FakeAsyncClient([_RaisingTextResponse()])
+
+    with patch(
+        "src.services.utils.link_preview.resolve_and_validate_url",
+        return_value={"93.184.216.34"},
+    ), patch(
+        "src.services.utils.link_preview.assert_connected_peer_allowed"
+    ), patch(
+        "src.services.utils.link_preview.httpx.AsyncClient",
+        return_value=fake_client,
+    ):
+        result = await fetch_link_preview("https://example.com/page")
+
+    assert result == _MINIMAL_PREVIEW
+
+
+@pytest.mark.asyncio
+async def test_fetch_link_preview_falls_back_when_soup_parse_raises():
+    """A BeautifulSoup parse failure must fall back to a minimal preview."""
+    response = _make_response(
+        html="<html><head><title>Title</title></head></html>",
+    )
+    fake_client = _FakeAsyncClient([response])
+
+    with patch(
+        "src.services.utils.link_preview.resolve_and_validate_url",
+        return_value={"93.184.216.34"},
+    ), patch(
+        "src.services.utils.link_preview.assert_connected_peer_allowed"
+    ), patch(
+        "src.services.utils.link_preview.httpx.AsyncClient",
+        return_value=fake_client,
+    ), patch(
+        "src.services.utils.link_preview.BeautifulSoup",
+        side_effect=ValueError("broken parser"),
+    ):
+        result = await fetch_link_preview("https://example.com/page")
+
+    assert result == _MINIMAL_PREVIEW
+
+
+@pytest.mark.asyncio
+async def test_fetch_link_preview_prefers_twitter_card_when_og_missing():
+    response = _make_response(
+        html=(
+            "<html><head>"
+            "<title>Fallback Title</title>"
+            '<meta name="twitter:title" content="Twitter Title">'
+            '<meta name="twitter:description" content="From twitter card">'
+            '<meta name="twitter:image" content="https://cdn.example.com/tw.png">'
+            "</head></html>"
+        )
+    )
+    fake_client = _FakeAsyncClient([response])
+
+    with patch(
+        "src.services.utils.link_preview.resolve_and_validate_url",
+        return_value={"93.184.216.34"},
+    ), patch(
+        "src.services.utils.link_preview.assert_connected_peer_allowed"
+    ), patch(
+        "src.services.utils.link_preview.httpx.AsyncClient",
+        return_value=fake_client,
+    ):
+        result = await fetch_link_preview("https://example.com/page")
+
+    assert result["title"] == "Twitter Title"
+    assert result["description"] == "From twitter card"
+    assert result["og_image"] == "https://cdn.example.com/tw.png"

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/course/[courseuuid]/course.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/course/[courseuuid]/course.tsx
@@ -10,7 +10,8 @@ import GeneralWrapperStyled from '@components/Objects/StyledElements/Wrappers/Ge
 import {
   getCourseThumbnailMediaDirectory,
 } from '@services/media/media'
-import { ArrowRight, Backpack, Check, File, StickyNote, Video, Square, Image as ImageIcon, Layers, BookCopy, Lock } from 'lucide-react'
+import { ArrowRight, Backpack, Check, File, StickyNote, Video, Square, Image as ImageIcon, Layers, BookCopy, Lock, Globe, Package, Puzzle } from 'lucide-react'
+import { MarkdownLogo } from '@phosphor-icons/react'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { CourseProvider } from '@components/Contexts/CourseContext'
 import { useMediaQuery } from 'usehooks-ts'
@@ -212,7 +213,9 @@ const CourseClient = (props: any) => {
     setLearnings(learningItems)
   }
 
-  const getActivityTypeLabel = (activityType: string) => {
+  const getActivityTypeLabel = (activityType: string, activitySubType?: string) => {
+    if (activitySubType === 'SUBTYPE_DYNAMIC_MARKDOWN') return t('activities.markdown')
+    if (activitySubType === 'SUBTYPE_DYNAMIC_EMBED') return t('activities.embed')
     switch (activityType) {
       case 'TYPE_VIDEO':
         return t('activities.video')
@@ -222,8 +225,33 @@ const CourseClient = (props: any) => {
         return t('activities.page')
       case 'TYPE_ASSIGNMENT':
         return t('activities.assignment')
+      case 'TYPE_SCORM':
+        return t('activities.scorm')
+      case 'TYPE_CUSTOM':
+        return t('activities.custom')
       default:
         return t('activities.learning_material')
+    }
+  }
+
+  const getActivityTypeIcon = (activityType: string, activitySubType?: string, size: number = 10) => {
+    if (activitySubType === 'SUBTYPE_DYNAMIC_MARKDOWN') return <MarkdownLogo size={size} />
+    if (activitySubType === 'SUBTYPE_DYNAMIC_EMBED') return <Globe size={size} />
+    switch (activityType) {
+      case 'TYPE_VIDEO':
+        return <Video size={size} />
+      case 'TYPE_DOCUMENT':
+        return <File size={size} />
+      case 'TYPE_DYNAMIC':
+        return <StickyNote size={size} />
+      case 'TYPE_ASSIGNMENT':
+        return <Backpack size={size} />
+      case 'TYPE_SCORM':
+        return <Package size={size} />
+      case 'TYPE_CUSTOM':
+        return <Puzzle size={size} />
+      default:
+        return <Layers size={size} />
     }
   }
 
@@ -615,19 +643,8 @@ const CourseClient = (props: any) => {
                                     )}
                                   </div>
                                   <div className="flex items-center space-x-1.5 mt-0.5 text-neutral-400">
-                                    {activity.activity_type === 'TYPE_DYNAMIC' && (
-                                      <StickyNote size={10} />
-                                    )}
-                                    {activity.activity_type === 'TYPE_VIDEO' && (
-                                      <Video size={10} />
-                                    )}
-                                    {activity.activity_type === 'TYPE_DOCUMENT' && (
-                                      <File size={10} />
-                                    )}
-                                    {activity.activity_type === 'TYPE_ASSIGNMENT' && (
-                                      <Backpack size={10} />
-                                    )}
-                                    <span className="text-xs font-medium">{getActivityTypeLabel(activity.activity_type)}</span>
+                                    {getActivityTypeIcon(activity.activity_type, activity.activity_sub_type, 10)}
+                                    <span className="text-xs font-medium">{getActivityTypeLabel(activity.activity_type, activity.activity_sub_type)}</span>
                                   </div>
                                 </div>
                                 <div className={`transition-colors ${locked ? 'text-neutral-200' : 'text-neutral-300 group-hover:text-neutral-400 cursor-pointer'}`}>

--- a/apps/web/components/Dashboard/Misc/CourseOverviewTop.tsx
+++ b/apps/web/components/Dashboard/Misc/CourseOverviewTop.tsx
@@ -189,6 +189,8 @@ export function CourseOverviewTop({
           <button
             onClick={togglePublishStatus}
             disabled={isPublishing}
+            aria-label={isPublished ? 'Unpublish course' : 'Publish course'}
+            title={isPublished ? 'Click to unpublish' : 'Click to publish'}
             className={`group px-2.5 sm:px-3.5 py-2 text-sm font-semibold flex items-center space-x-1.5 transition-colors ${
               isPublished
                 ? 'bg-green-50/70 text-green-700 hover:bg-green-100/70'
@@ -196,11 +198,11 @@ export function CourseOverviewTop({
             } ${isPublishing ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
           >
             {isPublishing ? (
-              <Loader2 className="w-4 h-4 animate-spin" />
+              <Loader2 className="w-4 h-4 animate-spin flex-none" />
             ) : isPublished ? (
-              <Globe className="w-4 h-4" />
+              <Globe className="w-4 h-4 flex-none" />
             ) : (
-              <GlobeLock className="w-4 h-4" />
+              <GlobeLock className="w-4 h-4 flex-none" />
             )}
             <span className="hidden sm:inline">
               {isPublishing
@@ -231,6 +233,7 @@ export function CourseOverviewTop({
                     <button
                       onClick={indexCourseForAI}
                       disabled={isIndexing}
+                      aria-label={isIndexing ? 'Indexing course' : isIndexed ? 'Course indexed' : 'Index course for AI'}
                       className={`group px-2.5 sm:px-3.5 py-2 text-sm font-semibold flex items-center space-x-1.5 transition-colors ${
                         isIndexed
                           ? 'bg-blue-50/70 text-blue-700'
@@ -238,11 +241,11 @@ export function CourseOverviewTop({
                       } ${isIndexing ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
                     >
                       {isIndexing ? (
-                        <Loader2 className="w-4 h-4 animate-spin" />
+                        <Loader2 className="w-4 h-4 animate-spin flex-none" />
                       ) : isIndexed ? (
-                        <Check className="w-4 h-4" />
+                        <Check className="w-4 h-4 flex-none" />
                       ) : (
-                        <BrainCircuit className="w-4 h-4" />
+                        <BrainCircuit className="w-4 h-4 flex-none" />
                       )}
                       <span className="hidden sm:inline">
                         {isIndexing ? 'Indexing...' : isIndexed ? 'Indexed' : 'Index for AI'}
@@ -260,6 +263,8 @@ export function CourseOverviewTop({
           <Link
             href={getUriWithOrg(org?.slug, '') + `/course/${params.courseuuid}`}
             target="_blank"
+            aria-label={t('dashboard.courses.preview')}
+            title={t('dashboard.courses.preview')}
             className="px-2.5 sm:px-3.5 py-2 text-sm font-semibold text-neutral-600 bg-neutral-50/70 hover:bg-neutral-100/70 transition-colors flex items-center space-x-1.5"
           >
             <Eye className="w-4 h-4" />

--- a/apps/web/components/Dashboard/Pages/Course/EditCourseStructure/DraggableElements/ActivityElement.tsx
+++ b/apps/web/components/Dashboard/Pages/Course/EditCourseStructure/DraggableElements/ActivityElement.tsx
@@ -27,6 +27,7 @@ import {
   MoreVertical,
   Package,
   Pencil,
+  Puzzle,
   Save,
   Sparkles,
   Trash2,
@@ -53,6 +54,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@components/ui/dropdown-menu'
+import { ActivityPreviewHoverCard } from '@components/Objects/Activities/ActivityPreview/ActivityPreview'
 
 type ActivitiyElementProps = {
   orgslug: string
@@ -314,7 +316,11 @@ function ActivityElement(props: ActivitiyElementProps) {
                 </ToolTip>
               </div>
             ) : (
-              <p className="first-letter:uppercase text-sm text-gray-600 truncate">{props.activity.name}</p>
+              <ActivityPreviewHoverCard activity={props.activity}>
+                <p className="first-letter:uppercase text-sm text-gray-600 truncate cursor-default">
+                  {props.activity.name}
+                </p>
+              </ActivityPreviewHoverCard>
             )}
           </div>
 
@@ -531,8 +537,14 @@ const ACTIVITIES = {
   'TYPE_SCORM': {
     displayNameKey: 'scorm',
     Icon: Package
+  },
+  'TYPE_CUSTOM': {
+    displayNameKey: 'custom',
+    Icon: Puzzle
   }
 }
+
+const UNKNOWN_ACTIVITY = { displayNameKey: 'dynamic', Icon: Sparkles }
 
 const ActivityTypeIndicator = ({activityType, activitySubType, isMobile} : { activityType: keyof typeof ACTIVITIES, activitySubType?: string, isMobile: boolean}) => {
   const { t } = useTranslation()
@@ -545,7 +557,7 @@ const ActivityTypeIndicator = ({activityType, activitySubType, isMobile} : { act
     ? { displayNameKey: 'embed', Icon: GlobePhosphor }
     : isResource
     ? { displayNameKey: 'resource', Icon: Cube }
-    : ACTIVITIES[activityType]
+    : ACTIVITIES[activityType] ?? UNKNOWN_ACTIVITY
 
   return (
     <div className="flex items-center gap-1.5 flex-shrink-0">

--- a/apps/web/components/Objects/Activities/ActivityPreview/ActivityPreview.tsx
+++ b/apps/web/components/Objects/Activities/ActivityPreview/ActivityPreview.tsx
@@ -1,0 +1,557 @@
+'use client'
+
+import React, { useEffect, useMemo, useState } from 'react'
+import ReactMarkdown, { Components as MarkdownComponents } from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '@components/ui/hover-card'
+import { useLHSession } from '@components/Contexts/LHSessionContext'
+import { useOrg } from '@components/Contexts/OrgContext'
+import { useCourse } from '@components/Contexts/CourseContext'
+import { getActivity } from '@services/courses/activities'
+import { getActivityBlockMediaDirectory } from '@services/media/media'
+import { Loader2 } from 'lucide-react'
+
+// Shared, lightweight activity preview. Two surfaces:
+//
+//   <ActivityPreview activity={...} />         // inline body (modals, panels)
+//   <ActivityPreviewHoverCard activity={...}>  // hover-card wrapper around a trigger
+//     <p>Activity name</p>
+//   </ActivityPreviewHoverCard>
+//
+// The inline form renders content directly from whatever `activity` it was
+// given. If the activity only has metadata (no `content` field), it can be
+// asked to fetch the full detail by passing `autoFetch`. Callers that want
+// to preview *unsaved* edits should merge their draft into the `activity`
+// object and pass `autoFetch`
+// as false so the component doesn't overwrite the draft with the saved
+// version.
+
+export type ActivityPreviewProps = {
+  /**
+   * Activity object to preview. May be a metadata-only summary, a full
+   * detail record returned by `getActivity`, or a draft (saved + edits)
+   * the caller wants to preview before applying.
+   */
+  activity: any
+  /**
+   * When true and `activity.content` is missing/empty, fetch the full
+   * activity detail via the API. Defaults to true. Set false when the
+   * caller is supplying a draft and doesn't want it overwritten.
+   */
+  autoFetch?: boolean
+  /** Optional extra class on the scroll container. */
+  className?: string
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// ProseMirror/TipTap JSON → React renderer
+// ──────────────────────────────────────────────────────────────────────────
+
+type RendererCtx = {
+  orgUuid?: string
+  courseUuid?: string
+  activityUuid?: string
+}
+
+function applyMarks(text: React.ReactNode, marks?: any[]): React.ReactNode {
+  if (!marks || marks.length === 0) return text
+  return marks.reduce<React.ReactNode>((acc, mark) => {
+    switch (mark.type) {
+      case 'bold':
+      case 'strong':
+        return <strong className="font-semibold">{acc}</strong>
+      case 'italic':
+      case 'em':
+        return <em>{acc}</em>
+      case 'underline':
+        return <span className="underline">{acc}</span>
+      case 'strike':
+        return <span className="line-through">{acc}</span>
+      case 'code':
+        return (
+          <code className="px-1 py-[1px] rounded bg-gray-100 text-[11px] font-mono text-gray-800">
+            {acc}
+          </code>
+        )
+      case 'link': {
+        const href: string = mark.attrs?.href || '#'
+        return (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="text-blue-600 hover:underline"
+          >
+            {acc}
+          </a>
+        )
+      }
+      default:
+        return acc
+    }
+  }, text)
+}
+
+function renderChildren(nodes: any[] | undefined, ctx: RendererCtx): React.ReactNode {
+  if (!nodes) return null
+  return nodes.map((n, i) => <PMNode key={i} node={n} ctx={ctx} />)
+}
+
+function PMNode({ node, ctx }: { node: any; ctx: RendererCtx }): React.ReactElement | null {
+  if (!node) return null
+  switch (node.type) {
+    case 'doc':
+      return <>{renderChildren(node.content, ctx)}</>
+    case 'paragraph':
+      return (
+        <p className="text-xs text-gray-700 leading-relaxed my-1.5">
+          {renderChildren(node.content, ctx)}
+        </p>
+      )
+    case 'heading': {
+      const lvl = Math.min(Math.max(node.attrs?.level || 2, 1), 6)
+      const cls = [
+        '',
+        'text-base font-bold text-gray-800 mt-3 mb-1',
+        'text-sm font-bold text-gray-800 mt-3 mb-1',
+        'text-sm font-semibold text-gray-800 mt-2 mb-1',
+        'text-xs font-semibold text-gray-700 mt-2 mb-1',
+        'text-xs font-semibold text-gray-700 mt-1.5 mb-1',
+        'text-[11px] font-semibold uppercase tracking-wider text-gray-500 mt-1.5 mb-1',
+      ][lvl]
+      const Tag = `h${lvl}` as keyof React.JSX.IntrinsicElements
+      return <Tag className={cls}>{renderChildren(node.content, ctx)}</Tag>
+    }
+    case 'bulletList':
+      return (
+        <ul className="list-disc pl-5 my-1.5 text-xs text-gray-700 leading-relaxed space-y-0.5">
+          {renderChildren(node.content, ctx)}
+        </ul>
+      )
+    case 'orderedList':
+      return (
+        <ol className="list-decimal pl-5 my-1.5 text-xs text-gray-700 leading-relaxed space-y-0.5">
+          {renderChildren(node.content, ctx)}
+        </ol>
+      )
+    case 'listItem':
+      return <li>{renderChildren(node.content, ctx)}</li>
+    case 'blockquote':
+      return (
+        <blockquote className="border-l-2 border-gray-200 pl-3 my-2 text-xs text-gray-600 italic">
+          {renderChildren(node.content, ctx)}
+        </blockquote>
+      )
+    case 'codeBlock':
+      return (
+        <pre className="my-2 p-2 rounded-md bg-gray-50 border border-gray-100 text-[11px] font-mono text-gray-800 overflow-x-auto whitespace-pre-wrap">
+          <code>{renderChildren(node.content, ctx)}</code>
+        </pre>
+      )
+    case 'horizontalRule':
+      return <hr className="my-2 border-gray-100" />
+    case 'hardBreak':
+      return <br />
+    case 'text':
+      return <>{applyMarks(node.text || '', node.marks)}</>
+    case 'image': {
+      const src = node.attrs?.src
+      if (!src) return null
+      return (
+        <img
+          src={src}
+          alt={node.attrs?.alt || ''}
+          loading="lazy"
+          className="my-2 rounded-md max-w-full h-auto border border-gray-100"
+        />
+      )
+    }
+    case 'blockImage': {
+      const unsplashUrl: string | undefined = node.attrs?.unsplash_url || undefined
+      const blockObject = node.attrs?.blockObject
+      let src: string | undefined = unsplashUrl || undefined
+      if (!src && blockObject && ctx.orgUuid && ctx.courseUuid) {
+        const fileId = `${blockObject.content?.file_id}.${blockObject.content?.file_format}`
+        src = getActivityBlockMediaDirectory(
+          ctx.orgUuid,
+          ctx.courseUuid,
+          blockObject.content?.activity_uuid || ctx.activityUuid || '',
+          blockObject.block_uuid,
+          fileId,
+          'imageBlock',
+        )
+      }
+      if (!src) return null
+      const align = node.attrs?.alignment || 'center'
+      const justify =
+        align === 'left' ? 'justify-start' : align === 'right' ? 'justify-end' : 'justify-center'
+      return (
+        <div className={`flex ${justify} my-2`}>
+          <img
+            src={src}
+            alt=""
+            loading="lazy"
+            className="rounded-md max-w-full h-auto border border-gray-100"
+            style={{ maxHeight: 180 }}
+          />
+        </div>
+      )
+    }
+    default:
+      // Fall back to rendering children so unknown wrappers don't swallow text.
+      if (Array.isArray(node.content)) {
+        return <>{renderChildren(node.content, ctx)}</>
+      }
+      return null
+  }
+}
+
+function hasAnyRenderableContent(content: any): boolean {
+  if (!content || typeof content !== 'object') return false
+  if (Array.isArray(content.content) && content.content.length > 0) return true
+  return false
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Markdown rendering (used for SUBTYPE_DYNAMIC_MARKDOWN + assignments)
+// ──────────────────────────────────────────────────────────────────────────
+
+function toRawUrl(url: string): string {
+  const gh = url.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/blob\/(.+)$/)
+  if (gh) return `https://raw.githubusercontent.com/${gh[1]}/${gh[2]}/${gh[3]}`
+  const gl = url.match(/^(https?:\/\/gitlab\.com\/.+)\/-\/blob\/(.+)$/)
+  if (gl) return `${gl[1]}/-/raw/${gl[2]}`
+  const bb = url.match(/^(https?:\/\/bitbucket\.org\/[^/]+\/[^/]+)\/src\/(.+)$/)
+  if (bb) return `${bb[1]}/raw/${bb[2]}`
+  return url
+}
+
+const markdownComponents: MarkdownComponents = {
+  h1: ({ node: _node, ...p }) => <h1 className="text-base font-bold text-gray-800 mt-3 mb-1" {...p} />,
+  h2: ({ node: _node, ...p }) => <h2 className="text-sm font-bold text-gray-800 mt-3 mb-1" {...p} />,
+  h3: ({ node: _node, ...p }) => <h3 className="text-sm font-semibold text-gray-800 mt-2 mb-1" {...p} />,
+  h4: ({ node: _node, ...p }) => <h4 className="text-xs font-semibold text-gray-700 mt-2 mb-1" {...p} />,
+  h5: ({ node: _node, ...p }) => <h5 className="text-xs font-semibold text-gray-700 mt-1.5 mb-1" {...p} />,
+  h6: ({ node: _node, ...p }) => (
+    <h6 className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 mt-1.5 mb-1" {...p} />
+  ),
+  p: ({ node: _node, ...p }) => <p className="my-1.5" {...p} />,
+  ul: ({ node: _node, ...p }) => <ul className="list-disc pl-5 my-1.5 space-y-0.5" {...p} />,
+  ol: ({ node: _node, ...p }) => <ol className="list-decimal pl-5 my-1.5 space-y-0.5" {...p} />,
+  li: ({ node: _node, ...p }) => <li {...p} />,
+  blockquote: ({ node: _node, ...p }) => (
+    <blockquote className="border-l-2 border-gray-200 pl-3 my-2 text-gray-600 italic" {...p} />
+  ),
+  hr: () => <hr className="my-2 border-gray-100" />,
+  a: ({ node: _node, ...p }) => (
+    <a
+      {...p}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={(e) => e.stopPropagation()}
+      className="text-blue-600 hover:underline"
+    />
+  ),
+  strong: ({ node: _node, ...p }) => <strong className="font-semibold" {...p} />,
+  code: ({ node: _node, className, children, ...p }) => {
+    const isInline = !className
+    if (isInline) {
+      return (
+        <code className="px-1 py-[1px] rounded bg-gray-100 text-[11px] font-mono text-gray-800" {...p}>
+          {children}
+        </code>
+      )
+    }
+    return (
+      <code className={`block font-mono text-[11px] text-gray-800 ${className || ''}`} {...p}>
+        {children}
+      </code>
+    )
+  },
+  pre: ({ node: _node, ...p }) => (
+    <pre
+      className="my-2 p-2 rounded-md bg-gray-50 border border-gray-100 overflow-x-auto whitespace-pre-wrap"
+      {...p}
+    />
+  ),
+  img: ({ node: _node, ...p }) => (
+    <img
+      {...p}
+      loading="lazy"
+      className="my-2 rounded-md max-w-full h-auto border border-gray-100"
+      style={{ maxHeight: 180 }}
+    />
+  ),
+  table: ({ node: _node, ...p }) => (
+    <div className="my-2 overflow-x-auto">
+      <table className="text-[11px] border-collapse" {...p} />
+    </div>
+  ),
+  th: ({ node: _node, ...p }) => <th className="border border-gray-200 px-2 py-1 bg-gray-50 text-left" {...p} />,
+  td: ({ node: _node, ...p }) => <td className="border border-gray-200 px-2 py-1" {...p} />,
+}
+
+function MarkdownPreview({ url }: { url: string }) {
+  const [state, setState] = useState<
+    | { kind: 'idle' }
+    | { kind: 'loading' }
+    | { kind: 'error'; message: string }
+    | { kind: 'ready'; text: string }
+  >({ kind: 'idle' })
+
+  useEffect(() => {
+    if (!url) {
+      setState({ kind: 'error', message: 'No markdown URL configured' })
+      return
+    }
+    let cancelled = false
+    setState({ kind: 'loading' })
+    fetch(toRawUrl(url))
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        return res.text()
+      })
+      .then((text) => {
+        if (!cancelled) setState({ kind: 'ready', text })
+      })
+      .catch((err) => {
+        if (!cancelled)
+          setState({ kind: 'error', message: err?.message || 'Failed to load' })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [url])
+
+  if (state.kind === 'loading') {
+    return (
+      <div className="flex items-center gap-2 text-xs text-gray-400 py-4">
+        <Loader2 size={12} className="animate-spin" />
+        Loading markdown…
+      </div>
+    )
+  }
+  if (state.kind === 'error') {
+    return <EmptyState text={state.message} />
+  }
+  if (state.kind === 'ready') {
+    return (
+      <div className="text-xs text-gray-700 leading-relaxed">
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+          {state.text.slice(0, 6000)}
+        </ReactMarkdown>
+      </div>
+    )
+  }
+  return null
+}
+
+function EmptyState({ text }: { text: string }) {
+  return <p className="text-xs text-gray-400 italic">{text}</p>
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Body renderer — picks a strategy per activity type
+// ──────────────────────────────────────────────────────────────────────────
+
+function PreviewBody({ activity }: { activity: any }) {
+  const org = useOrg() as any
+  const course = useCourse() as any
+  const type = activity.activity_type
+  const sub = activity.activity_sub_type
+  const content = activity.content || {}
+
+  const rendererCtx: RendererCtx = useMemo(
+    () => ({
+      orgUuid: org?.org_uuid,
+      courseUuid: course?.courseStructure?.course_uuid,
+      activityUuid: activity?.activity_uuid,
+    }),
+    [org?.org_uuid, course?.courseStructure?.course_uuid, activity?.activity_uuid],
+  )
+
+  if (type === 'TYPE_DYNAMIC' && sub === 'SUBTYPE_DYNAMIC_MARKDOWN') {
+    return <MarkdownPreview url={content.markdown_url || ''} />
+  }
+
+  if (type === 'TYPE_DYNAMIC' && sub === 'SUBTYPE_DYNAMIC_EMBED') {
+    const url: string = content.embed_url || ''
+    if (!url) return <EmptyState text="No embed URL configured" />
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        className="text-xs text-blue-600 hover:underline break-all block"
+      >
+        {url}
+      </a>
+    )
+  }
+
+  if (type === 'TYPE_DYNAMIC') {
+    if (!hasAnyRenderableContent(content)) {
+      return <EmptyState text="This page is empty" />
+    }
+    return <PMNode node={content} ctx={rendererCtx} />
+  }
+
+  if (type === 'TYPE_VIDEO') {
+    if (content.uri) {
+      return (
+        <a
+          href={content.uri}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className="text-xs text-blue-600 hover:underline break-all block"
+        >
+          {content.uri}
+        </a>
+      )
+    }
+    if (content.filename) {
+      return <p className="text-xs text-gray-600 break-all">{content.filename}</p>
+    }
+    return <EmptyState text="No video source set" />
+  }
+
+  if (type === 'TYPE_DOCUMENT') {
+    if (content.filename) {
+      return <p className="text-xs text-gray-600 break-all">{content.filename}</p>
+    }
+    return <EmptyState text="No document attached" />
+  }
+
+  if (type === 'TYPE_ASSIGNMENT') {
+    const description: string = content.description || activity.description || ''
+    if (!description) return <EmptyState text="Assignment — open to view details" />
+    return (
+      <div className="text-xs text-gray-700 leading-relaxed">
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+          {description.slice(0, 4000)}
+        </ReactMarkdown>
+      </div>
+    )
+  }
+
+  if (type === 'TYPE_SCORM') {
+    return <EmptyState text="SCORM package — preview unavailable" />
+  }
+
+  if (type === 'TYPE_CUSTOM') {
+    return <EmptyState text="Custom activity — preview unavailable" />
+  }
+
+  return <EmptyState text="Preview unavailable for this activity type" />
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Public: inline preview
+// ──────────────────────────────────────────────────────────────────────────
+
+export default function ActivityPreview({
+  activity,
+  autoFetch = true,
+  className,
+}: ActivityPreviewProps) {
+  const session = useLHSession() as any
+  const accessToken: string | undefined = session?.data?.tokens?.access_token
+
+  const hasInlineContent =
+    activity?.content && Object.keys(activity.content).length > 0
+  const [fetched, setFetched] = useState<any | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!autoFetch || hasInlineContent || fetched || loading) return
+    if (!activity?.activity_uuid) return
+    let cancelled = false
+    setLoading(true)
+    getActivity(activity.activity_uuid, null, accessToken || '')
+      .then((res) => {
+        if (cancelled) return
+        if (res && !res.detail) {
+          setFetched(res)
+        } else {
+          setError(res?.detail || 'Could not load activity')
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err?.message || 'Could not load activity')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [autoFetch, hasInlineContent, fetched, loading, activity?.activity_uuid, accessToken])
+
+  // The caller's `activity` always wins so a draft passed in stays visible.
+  const display = hasInlineContent ? activity : fetched
+
+  return (
+    <div className={className}>
+      {loading && !display ? (
+        <div className="flex items-center gap-2 text-xs text-gray-400 py-4">
+          <Loader2 size={12} className="animate-spin" />
+          Loading preview…
+        </div>
+      ) : error && !display ? (
+        <EmptyState text={error} />
+      ) : display ? (
+        <PreviewBody activity={display} />
+      ) : (
+        <EmptyState text="No preview available" />
+      )}
+    </div>
+  )
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Public: hover-card wrapper
+// ──────────────────────────────────────────────────────────────────────────
+
+export type ActivityPreviewHoverCardProps = {
+  activity: any
+  children: React.ReactNode
+}
+
+export function ActivityPreviewHoverCard({
+  activity,
+  children,
+}: ActivityPreviewHoverCardProps) {
+  const [hasOpened, setHasOpened] = useState(false)
+
+  return (
+    <HoverCard
+      openDelay={350}
+      closeDelay={120}
+      onOpenChange={(open) => {
+        if (open) setHasOpened(true)
+      }}
+    >
+      <HoverCardTrigger asChild>{children}</HoverCardTrigger>
+      <HoverCardContent
+        align="start"
+        side="right"
+        sideOffset={8}
+        className="w-[420px] max-w-[90vw] p-0 border border-gray-200 bg-white shadow-xl rounded-xl overflow-hidden"
+      >
+        {hasOpened ? (
+          <ActivityPreview activity={activity} className="max-h-72 overflow-y-auto px-4 py-3" />
+        ) : (
+          <div className="max-h-72 px-4 py-3" />
+        )}
+      </HoverCardContent>
+    </HoverCard>
+  )
+}

--- a/apps/web/components/Objects/Courses/CourseProgress/CourseProgress.tsx
+++ b/apps/web/components/Objects/Courses/CourseProgress/CourseProgress.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
-import { Check, Square, ArrowRight, Folder, FileText, Video, Layers, BookOpenCheck } from 'lucide-react'
+import { Check, Square, ArrowRight, Folder, FileText, Video, Layers, BookOpenCheck, Package, Puzzle, Globe } from 'lucide-react'
+import { MarkdownLogo } from '@phosphor-icons/react'
 import { getUriWithOrg } from '@services/config/config'
 import Link from 'next/link'
 import Modal from '@components/Objects/StyledElements/Modal/Modal'
@@ -47,7 +48,9 @@ const CourseProgress: React.FC<CourseProgressProps> = ({ course, orgslug, isOpen
     return false
   }
 
-  const getActivityTypeIcon = (activityType: string) => {
+  const getActivityTypeIcon = (activityType: string, activitySubType?: string) => {
+    if (activitySubType === 'SUBTYPE_DYNAMIC_MARKDOWN') return <MarkdownLogo size={16} className="text-gray-400" />
+    if (activitySubType === 'SUBTYPE_DYNAMIC_EMBED') return <Globe size={16} className="text-gray-400" />
     switch (activityType) {
       case 'TYPE_VIDEO':
         return <Video size={16} className="text-gray-400" />
@@ -57,6 +60,10 @@ const CourseProgress: React.FC<CourseProgressProps> = ({ course, orgslug, isOpen
         return <Layers size={16} className="text-gray-400" />
       case 'TYPE_ASSIGNMENT':
         return <BookOpenCheck size={16} className="text-gray-400" />
+      case 'TYPE_SCORM':
+        return <Package size={16} className="text-gray-400" />
+      case 'TYPE_CUSTOM':
+        return <Puzzle size={16} className="text-gray-400" />
       default:
         return <FileText size={16} className="text-gray-400" />
     }
@@ -90,7 +97,7 @@ const CourseProgress: React.FC<CourseProgressProps> = ({ course, orgslug, isOpen
                         <Square size={18} className="stroke-[2] text-gray-300" />
                       )}
                       <div className="flex items-center space-x-2">
-                        {getActivityTypeIcon(activity.activity_type)}
+                        {getActivityTypeIcon(activity.activity_type, activity.activity_sub_type)}
                         <span className="text-gray-700 group-hover:text-gray-900">
                           {activity.name}
                         </span>

--- a/apps/web/components/Objects/Editor/ActivitySwitcher.tsx
+++ b/apps/web/components/Objects/Editor/ActivitySwitcher.tsx
@@ -1,0 +1,258 @@
+'use client'
+import React from 'react'
+import { useRouter } from 'next/navigation'
+import { useQuery } from '@tanstack/react-query'
+import { motion, AnimatePresence } from 'motion/react'
+import { ChevronLeft, ChevronRight, Folder } from 'lucide-react'
+import {
+  Backpack,
+  FileText,
+  Note,
+  Video,
+  Package,
+  PuzzlePiece,
+  MarkdownLogo,
+  Globe,
+} from '@phosphor-icons/react'
+
+import { useAuth } from '@components/Contexts/AuthContext'
+import { getCourseMetadata } from '@services/courses/courses'
+
+interface ActivitySwitcherProps {
+  course: { course_uuid: string }
+  activity: { activity_uuid: string; activity_type?: string; name?: string }
+  isDirty?: boolean
+  onSave?: () => Promise<void> | void
+}
+
+function ActivityTypeIcon({ type, subType, size = 12 }: { type?: string; subType?: string; size?: number }) {
+  if (subType === 'SUBTYPE_DYNAMIC_MARKDOWN') return <MarkdownLogo size={size} weight="fill" />
+  if (subType === 'SUBTYPE_DYNAMIC_EMBED') return <Globe size={size} weight="fill" />
+  switch (type) {
+    case 'TYPE_VIDEO':
+      return <Video size={size} weight="fill" />
+    case 'TYPE_DOCUMENT':
+      return <FileText size={size} weight="fill" />
+    case 'TYPE_ASSIGNMENT':
+      return <Backpack size={size} weight="fill" />
+    case 'TYPE_SCORM':
+      return <Package size={size} weight="fill" />
+    case 'TYPE_CUSTOM':
+      return <PuzzlePiece size={size} weight="fill" />
+    case 'TYPE_DYNAMIC':
+    default:
+      return <Note size={size} weight="fill" />
+  }
+}
+
+const ease: [number, number, number, number] = [0.22, 1, 0.36, 1]
+
+export default function ActivitySwitcher({
+  course,
+  activity,
+  isDirty,
+  onSave,
+}: ActivitySwitcherProps) {
+  const router = useRouter()
+  const { accessToken } = useAuth()
+  const [open, setOpen] = React.useState(false)
+  const closeTimerRef = React.useRef<number | null>(null)
+  const scrollRef = React.useRef<HTMLDivElement>(null)
+  const [canScrollLeft, setCanScrollLeft] = React.useState(false)
+  const [canScrollRight, setCanScrollRight] = React.useState(false)
+
+  const courseUuid = course?.course_uuid
+  const cleanCourseUuid = courseUuid?.replace('course_', '') ?? ''
+  const currentActivityUuid = activity?.activity_uuid
+
+  // Share the cache entry with CourseProvider's withUnpublishedActivities
+  // variant so a single fetch backs both consumers.
+  const { data } = useQuery({
+    queryKey: ['course', cleanCourseUuid, 'meta', 'withUnpublished'],
+    queryFn: () =>
+      getCourseMetadata(
+        cleanCourseUuid,
+        {},
+        accessToken ?? undefined,
+        { withUnpublishedActivities: true }
+      ),
+    enabled: !!cleanCourseUuid && !!accessToken,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    placeholderData: (prev) => prev,
+  })
+
+  const chapters: any[] = data?.chapters ?? []
+  const hasChapters = chapters.length > 0
+
+  const cancelClose = () => {
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current)
+      closeTimerRef.current = null
+    }
+  }
+
+  const handleEnter = () => {
+    cancelClose()
+    setOpen(true)
+  }
+
+  const handleLeave = () => {
+    cancelClose()
+    closeTimerRef.current = window.setTimeout(() => setOpen(false), 160)
+  }
+
+  React.useEffect(() => () => cancelClose(), [])
+
+  const updateScrollState = React.useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    setCanScrollLeft(el.scrollLeft > 2)
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 2)
+  }, [])
+
+  React.useEffect(() => {
+    if (!open) return
+    const id = requestAnimationFrame(updateScrollState)
+    return () => cancelAnimationFrame(id)
+  }, [open, chapters.length, updateScrollState])
+
+  const scrollByAmount = (delta: number) => {
+    scrollRef.current?.scrollBy({ left: delta, behavior: 'smooth' })
+  }
+
+  const handleSwitch = async (
+    event: React.MouseEvent<HTMLAnchorElement>,
+    href: string
+  ) => {
+    // Same-activity click — let the default no-op happen.
+    if (href.includes(`/activity/${(currentActivityUuid ?? '').replace('activity_', '')}/`)) {
+      return
+    }
+    event.preventDefault()
+    if (isDirty) {
+      const proceed = window.confirm(
+        'You have unsaved changes. Save before switching activities?\n\nOK = Save and switch\nCancel = Stay on this activity'
+      )
+      if (!proceed) return
+      try {
+        await onSave?.()
+      } catch (err) {
+        console.error('Save failed before switching activity', err)
+        return
+      }
+    }
+    router.push(href)
+  }
+
+  return (
+    <div
+      onMouseEnter={handleEnter}
+      onMouseLeave={handleLeave}
+      style={{
+        position: 'absolute',
+        top: -15,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 2,
+      }}
+    >
+      <motion.div
+        layout
+        transition={{ layout: { duration: 0.35, ease } }}
+        className="nice-shadow bg-white rounded-full overflow-hidden flex items-center"
+      >
+        {/* Always-visible 3-dot indicator */}
+        <div className="flex items-center justify-center gap-[3px] px-2.5 h-[22px] text-neutral-500 flex-shrink-0">
+          <span className="w-[3px] h-[3px] rounded-full bg-current" />
+          <span className="w-[3px] h-[3px] rounded-full bg-current" />
+          <span className="w-[3px] h-[3px] rounded-full bg-current" />
+        </div>
+
+        <AnimatePresence initial={false}>
+          {open && hasChapters && (
+            <motion.div
+              key="strip"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1, transition: { duration: 0.2, ease, delay: 0.08 } }}
+              exit={{ opacity: 0, transition: { duration: 0.12, ease } }}
+              className="flex items-center gap-1 pl-1 pr-1.5 py-0.5"
+            >
+              <button
+                type="button"
+                onClick={() => scrollByAmount(-200)}
+                disabled={!canScrollLeft}
+                aria-label="Scroll left"
+                className={
+                  'flex items-center justify-center w-6 h-6 rounded-full bg-neutral-100 text-neutral-600 hover:bg-neutral-200 active:bg-neutral-300 transition-all flex-shrink-0 ' +
+                  (canScrollLeft ? 'opacity-100' : 'opacity-30 pointer-events-none')
+                }
+              >
+                <ChevronLeft size={14} />
+              </button>
+              <div
+                ref={scrollRef}
+                onScroll={updateScrollState}
+                className="flex items-center gap-1 px-1.5 max-w-[min(70vw,760px)] overflow-x-auto scrollbar-hide"
+              >
+                {chapters.map((chapter: any, idx: number) => (
+                <React.Fragment key={chapter.id ?? chapter.chapter_uuid ?? idx}>
+                  {idx > 0 && (
+                    <div
+                      aria-hidden
+                      className="w-px h-3 bg-neutral-200 flex-shrink-0 mx-0.5"
+                    />
+                  )}
+                  <div
+                    className="flex items-center gap-1 text-[9px] text-neutral-400 font-semibold uppercase tracking-wide flex-shrink-0 px-1"
+                    title={chapter.name}
+                  >
+                    <Folder size={9} />
+                    <span className="truncate max-w-[100px]">{chapter.name}</span>
+                  </div>
+                  {(chapter.activities ?? []).map((act: any) => {
+                    const isCurrent = act.activity_uuid === currentActivityUuid
+                    const cleanActivityUuid =
+                      (act.activity_uuid ?? '').replace('activity_', '')
+                    const href = `/course/${cleanCourseUuid}/activity/${cleanActivityUuid}/edit`
+                    return (
+                      <a
+                        key={act.id ?? act.activity_uuid}
+                        href={href}
+                        onClick={(e) => handleSwitch(e, href)}
+                        aria-current={isCurrent ? 'page' : undefined}
+                        className={
+                          'flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium whitespace-nowrap transition-colors flex-shrink-0 ' +
+                          (isCurrent
+                            ? 'bg-neutral-900 text-white'
+                            : 'bg-neutral-100 text-neutral-700 hover:bg-neutral-200')
+                        }
+                        title={act.name}
+                      >
+                        <ActivityTypeIcon type={act.activity_type} subType={act.activity_sub_type} size={11} />
+                        <span className="max-w-[150px] truncate">{act.name}</span>
+                      </a>
+                    )
+                  })}
+                </React.Fragment>
+              ))}
+              </div>
+              <button
+                type="button"
+                onClick={() => scrollByAmount(200)}
+                disabled={!canScrollRight}
+                aria-label="Scroll right"
+                className={
+                  'flex items-center justify-center w-6 h-6 rounded-full bg-neutral-100 text-neutral-600 hover:bg-neutral-200 active:bg-neutral-300 transition-all flex-shrink-0 ' +
+                  (canScrollRight ? 'opacity-100' : 'opacity-30 pointer-events-none')
+                }
+              >
+                <ChevronRight size={14} />
+              </button>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </motion.div>
+    </div>
+  )
+}

--- a/apps/web/components/Objects/Editor/Editor.tsx
+++ b/apps/web/components/Objects/Editor/Editor.tsx
@@ -73,6 +73,7 @@ import { PlanLevel } from '@services/plans/plans'
 import { useOrg } from '@components/Contexts/OrgContext'
 const VersionHistoryPanel = dynamic(() => import('./VersionHistory/VersionHistoryPanel'), { ssr: false, loading: () => null })
 const MergeConflictModal = dynamic(() => import('./VersionHistory/MergeConflictModal'), { ssr: false, loading: () => null })
+const ActivitySwitcher = dynamic(() => import('./ActivitySwitcher'), { ssr: false, loading: () => null })
 import { usePlan } from '@components/Hooks/usePlan'
 import {
   createBeforeUnloadHandler,
@@ -347,6 +348,18 @@ function Editor(props: EditorProps) {
     }
   }, [editor, conflictInfo, props.setContent, markEditorContentSaved])
 
+  // Cmd+S / Ctrl+S → save. The save handler shows its own toast.
+  React.useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 's') {
+        e.preventDefault()
+        handleSave(false)
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [handleSave])
+
   // Handler to reload with remote changes
   const handleReloadRemote = React.useCallback(() => {
     // Reload the page to get the latest version
@@ -442,6 +455,12 @@ function Editor(props: EditorProps) {
 
       <CourseProvider courseuuid={props.course.course_uuid} initialCourseStructure={props.course}>
           <div className="activity-editor-top">
+            <ActivitySwitcher
+              course={props.course}
+              activity={props.activity}
+              isDirty={hasUnsavedChanges}
+              onSave={() => handleSave(false)}
+            />
             <div className="activity-editor-doc-section">
               <div className="activity-editor-info-wrapper">
                 <Link href="/">

--- a/apps/web/components/Objects/Editor/Extensions/Audio/AudioBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Audio/AudioBlockComponent.tsx
@@ -1,10 +1,10 @@
 import { NodeViewProps, NodeViewWrapper } from '@tiptap/react'
 import { Node } from '@tiptap/core'
 import {
-  Loader2, Headphones, Upload, X, ArrowLeftRight,
-  CheckCircle2, AlertCircle, Play, Pause, Music, Radio, List,
-  SkipBack, SkipForward, Clock, Sparkles, Users
-} from 'lucide-react'
+  CircleNotch, Headphones, UploadSimple, X, ArrowsLeftRight,
+  CheckCircle, WarningCircle, Play, Pause, MusicNote, Radio, List,
+  SkipBack, SkipForward, Clock, Sparkle, Users
+} from '@phosphor-icons/react'
 import React from 'react'
 import toast from 'react-hot-toast'
 import { uploadNewAudioFile, generateAudioBlock, generateScript, type GenerateAudioSpeaker } from '../../../../../services/blocks/Audio/audio'
@@ -202,7 +202,7 @@ function PlaylistPlayer({
 
       {/* Header */}
       <div className="px-4 pt-3 pb-2 border-b border-gray-100 flex items-center gap-2">
-        <Radio size={14} className="text-gray-400 flex-shrink-0" />
+        <Radio weight="duotone" size={14} className="text-gray-400 flex-shrink-0" />
         <span className="text-sm font-semibold text-gray-900">{podcastName}</span>
         <span className="text-xs text-gray-400 ml-auto">{episodes.length} episodes</span>
       </div>
@@ -229,9 +229,9 @@ function PlaylistPlayer({
                 )}
               >
                 {isEpPlaying ? (
-                  <Pause size={14} className={isCurrent ? 'text-white' : 'text-gray-600'} fill={isCurrent ? 'white' : 'currentColor'} />
+                  <Pause weight="duotone" size={14} className={isCurrent ? 'text-white' : 'text-gray-600'} fill={isCurrent ? 'white' : 'currentColor'} />
                 ) : (
-                  <Play size={14} className={isCurrent ? 'text-white' : 'text-gray-600'} fill={isCurrent ? 'white' : 'currentColor'} />
+                  <Play weight="duotone" size={14} className={isCurrent ? 'text-white' : 'text-gray-600'} fill={isCurrent ? 'white' : 'currentColor'} />
                 )}
               </div>
 
@@ -242,7 +242,7 @@ function PlaylistPlayer({
                 </h4>
                 {ep.duration_seconds > 0 && (
                   <span className="text-xs text-gray-400 flex items-center gap-1 mt-0.5">
-                    <Clock size={10} />
+                    <Clock weight="duotone" size={10} />
                     {formatTime(ep.duration_seconds)}
                   </span>
                 )}
@@ -257,14 +257,14 @@ function PlaylistPlayer({
         <div className="border-t border-gray-200 px-4 py-3 bg-gray-50">
           {/* Now playing title */}
           <div className="flex items-center gap-2 mb-2">
-            <Music size={12} className="text-gray-400 flex-shrink-0" />
+            <MusicNote weight="duotone" size={12} className="text-gray-400 flex-shrink-0" />
             <span className="text-xs font-medium text-gray-700 truncate">{activeEpisode.title}</span>
           </div>
 
           {/* Controls row */}
           <div className="flex items-center gap-2">
             <button onClick={() => skip(-15)} className="p-1 rounded-full hover:bg-gray-200 transition-colors outline-none">
-              <SkipBack size={14} className="text-gray-600" />
+              <SkipBack weight="duotone" size={14} className="text-gray-600" />
             </button>
 
             <button
@@ -272,14 +272,14 @@ function PlaylistPlayer({
               className="rounded-full bg-gray-900 hover:bg-gray-800 p-2 transition-colors outline-none"
             >
               {isPlaying ? (
-                <Pause size={14} className="text-white" fill="white" />
+                <Pause weight="duotone" size={14} className="text-white" fill="white" />
               ) : (
-                <Play size={14} className="text-white" fill="white" />
+                <Play weight="duotone" size={14} className="text-white" fill="white" />
               )}
             </button>
 
             <button onClick={() => skip(15)} className="p-1 rounded-full hover:bg-gray-200 transition-colors outline-none">
-              <SkipForward size={14} className="text-gray-600" />
+              <SkipForward weight="duotone" size={14} className="text-gray-600" />
             </button>
 
             <span className="text-xs text-gray-500 tabular-nums flex-shrink-0 w-8 text-right">
@@ -644,7 +644,7 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                 />
               ) : (
                 <div className="bg-white border border-gray-200 rounded-xl shadow-sm px-4 py-6 text-center">
-                  <Loader2 className="w-5 h-5 animate-spin mx-auto text-gray-400" />
+                  <CircleNotch weight="duotone" className="w-5 h-5 animate-spin mx-auto text-gray-400" />
                   <p className="text-sm text-gray-400 mt-2">Loading playlist...</p>
                 </div>
               )
@@ -662,12 +662,12 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
         {/* Header */}
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">
-            <Headphones className="text-neutral-400" size={16} />
+            <Headphones weight="duotone" className="text-neutral-400" size={16} />
             <span className="uppercase tracking-widest text-xs font-bold text-neutral-400">Audio</span>
           </div>
           {blockObject && (
             <button onClick={handleRemove} className="text-neutral-400 hover:text-red-500 transition-colors">
-              <X size={16} />
+              <X weight="duotone" size={16} />
             </button>
           )}
         </div>
@@ -678,9 +678,9 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
             {/* Tabs */}
             <div className="flex gap-1 bg-neutral-100 rounded-lg p-1">
               {([
-                { key: 'upload' as TabType, icon: Upload, label: 'Upload' },
-                { key: 'generate' as TabType, icon: Sparkles, label: 'Generate' },
-                { key: 'episode' as TabType, icon: Music, label: 'Episode' },
+                { key: 'upload' as TabType, icon: UploadSimple, label: 'Upload' },
+                { key: 'generate' as TabType, icon: Sparkle, label: 'Generate' },
+                { key: 'episode' as TabType, icon: MusicNote, label: 'Episode' },
                 { key: 'podcast' as TabType, icon: List, label: 'Playlist' },
               ]).map((tab) => (
                 <button
@@ -717,7 +717,7 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                 >
                   {isLoading ? (
                     <div className="space-y-3">
-                      <Loader2 className="w-8 h-8 animate-spin mx-auto text-blue-500" />
+                      <CircleNotch weight="duotone" className="w-8 h-8 animate-spin mx-auto text-blue-500" />
                       <p className="text-sm text-neutral-600">Uploading... {uploadProgress}%</p>
                       <div className="w-48 h-1 bg-neutral-200 rounded-full mx-auto overflow-hidden">
                         <div className="h-full bg-blue-500 rounded-full transition-all duration-200" style={{ width: `${uploadProgress}%` }} />
@@ -725,7 +725,7 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                     </div>
                   ) : (
                     <div className="space-y-3">
-                      <Upload className="w-8 h-8 mx-auto text-neutral-400" />
+                      <UploadSimple weight="duotone" className="w-8 h-8 mx-auto text-neutral-400" />
                       <div>
                         <p className="text-sm font-medium text-neutral-700">Drop an audio file or click to browse</p>
                         <p className="text-xs text-neutral-500 mt-1">Supports MP3, WAV, OGG, M4A</p>
@@ -742,7 +742,7 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                 {/* Mode toggle */}
                 <div className="flex gap-1 bg-neutral-100 rounded-lg p-1">
                   {([
-                    { key: 'tts' as const, icon: Sparkles, label: 'Text to speech' },
+                    { key: 'tts' as const, icon: Sparkle, label: 'Text to speech' },
                     { key: 'podcast' as const, icon: Users, label: 'Podcast (2 voices)' },
                     { key: 'speak' as const, icon: Radio, label: 'Speak' },
                   ]).map((m) => (
@@ -876,9 +876,9 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                     )}
                   >
                     {isGeneratingScript ? (
-                      <><Loader2 size={15} className="animate-spin" /> {genMode === 'podcast' ? 'Writing the discussion…' : 'Writing the talk…'}</>
+                      <><CircleNotch size={15} className="animate-spin" /> {genMode === 'podcast' ? 'Writing the discussion…' : 'Writing the talk…'}</>
                     ) : (
-                      <><Sparkles size={15} /> {genMode === 'podcast' ? 'Generate discussion script' : 'Generate talk script'}</>
+                      <><Sparkle size={15} /> {genMode === 'podcast' ? 'Generate discussion script' : 'Generate talk script'}</>
                     )}
                   </button>
                 )}
@@ -895,9 +895,9 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                   )}
                 >
                   {isGenerating ? (
-                    <><Loader2 size={15} className="animate-spin" /> Generating…</>
+                    <><CircleNotch size={15} className="animate-spin" /> Generating…</>
                   ) : (
-                    <><Sparkles size={15} /> Generate audio</>
+                    <><Sparkle size={15} /> Generate audio</>
                   )}
                 </button>
                 <p className="text-[11px] text-center text-neutral-400">
@@ -913,7 +913,7 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
               <div className="space-y-3">
                 {podcastsLoading ? (
                   <div className="flex items-center justify-center py-6">
-                    <Loader2 className="w-5 h-5 animate-spin text-neutral-400" />
+                    <CircleNotch weight="duotone" className="w-5 h-5 animate-spin text-neutral-400" />
                   </div>
                 ) : !selectedPodcast ? (
                   <div className="space-y-1 max-h-60 overflow-y-auto">
@@ -926,7 +926,7 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                           onClick={() => handleSelectPodcast(p)}
                           className="flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer hover:bg-neutral-100 transition-colors"
                         >
-                          <Radio size={14} className="text-neutral-400 flex-shrink-0" />
+                          <Radio weight="duotone" size={14} className="text-neutral-400 flex-shrink-0" />
                           <span className="text-sm text-neutral-700 truncate">{p.name}</span>
                         </div>
                       ))
@@ -943,7 +943,7 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                     <p className="text-sm font-medium text-neutral-700">{selectedPodcast.name}</p>
                     {episodesLoading ? (
                       <div className="flex items-center justify-center py-4">
-                        <Loader2 className="w-5 h-5 animate-spin text-neutral-400" />
+                        <CircleNotch weight="duotone" className="w-5 h-5 animate-spin text-neutral-400" />
                       </div>
                     ) : (
                       <div className="space-y-1 max-h-48 overflow-y-auto">
@@ -956,7 +956,7 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                               onClick={() => handleSelectEpisode(ep)}
                               className="flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer hover:bg-blue-50 transition-colors"
                             >
-                              <Music size={14} className="text-neutral-400 flex-shrink-0" />
+                              <MusicNote weight="duotone" size={14} className="text-neutral-400 flex-shrink-0" />
                               <span className="text-sm text-neutral-700 truncate">{ep.title}</span>
                             </div>
                           ))
@@ -973,7 +973,7 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
               <div className="space-y-3">
                 {podcastsLoading ? (
                   <div className="flex items-center justify-center py-6">
-                    <Loader2 className="w-5 h-5 animate-spin text-neutral-400" />
+                    <CircleNotch weight="duotone" className="w-5 h-5 animate-spin text-neutral-400" />
                   </div>
                 ) : (
                   <div className="space-y-1 max-h-60 overflow-y-auto">
@@ -986,7 +986,7 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                           onClick={() => handleSelectPodcastPlaylist(p)}
                           className="flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer hover:bg-blue-50 transition-colors"
                         >
-                          <Radio size={14} className="text-neutral-400 flex-shrink-0" />
+                          <Radio weight="duotone" size={14} className="text-neutral-400 flex-shrink-0" />
                           <div className="min-w-0">
                             <span className="text-sm text-neutral-700 truncate block">{p.name}</span>
                             <span className="text-xs text-neutral-400">{p.description}</span>
@@ -1001,7 +1001,7 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
 
             {error && (
               <div className="flex items-center gap-2 text-sm text-red-500 font-medium bg-red-50 rounded-lg p-3">
-                <AlertCircle size={16} />
+                <WarningCircle weight="duotone" size={16} />
                 {error}
               </div>
             )}
@@ -1014,7 +1014,7 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
             {/* Size Controls */}
             <div className="flex items-center gap-2 flex-wrap">
               <div className="text-sm text-neutral-500 font-medium flex items-center gap-1">
-                <ArrowLeftRight size={14} />
+                <ArrowsLeftRight weight="duotone" size={14} />
                 Size:
               </div>
               {(Object.keys(AUDIO_SIZES) as AudioSize[]).map((size) => (
@@ -1028,7 +1028,7 @@ function AudioBlockComponent(props: ExtendedNodeViewProps) {
                       : 'bg-neutral-200 text-neutral-700 hover:bg-neutral-300'
                   )}
                 >
-                  {size === selectedSize && <CheckCircle2 size={14} />}
+                  {size === selectedSize && <CheckCircle weight="duotone" size={14} />}
                   {AUDIO_SIZES[size].label}
                 </button>
               ))}

--- a/apps/web/components/Objects/Editor/Extensions/Badges/BadgesExtension.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Badges/BadgesExtension.tsx
@@ -1,7 +1,7 @@
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
 import React, { useState, useRef, useEffect, lazy, Suspense } from 'react'
 const Picker = lazy(() => import('@emoji-mart/react'))
-import { ChevronDown, ChevronRight, Palette } from 'lucide-react'
+import { CaretDown, CaretRight, Palette } from '@phosphor-icons/react'
 import { twMerge } from 'tailwind-merge'
 import { useEditorProvider } from '@components/Contexts/Editor/EditorContext'
 
@@ -144,7 +144,7 @@ const BadgesExtension: React.FC = (props: any) => {
             <span className='text'>{emoji}</span>
             {isEditable && (
               <button onClick={() => setShowEmojiPicker(!showEmojiPicker)}>
-                <ChevronDown size={14} />
+                <CaretDown weight="duotone" size={14} />
               </button>
             )}
           </div>
@@ -156,7 +156,7 @@ const BadgesExtension: React.FC = (props: any) => {
           {isEditable && (
             <div className="flex items-center justify-center space-x-2 relative">
               <button onClick={() => setShowColorPicker(!showColorPicker)}>
-                <Palette size={14} />
+                <Palette weight="duotone" size={14} />
               </button>
               {showColorPicker && (
                 <div ref={colorPickerRef} className="absolute left-full ml-2 p-2 bg-white rounded-full nice-shadow">
@@ -180,7 +180,7 @@ const BadgesExtension: React.FC = (props: any) => {
             onClick={() => setShowPredefinedCallouts(!showPredefinedCallouts)}
             className="text-neutral-300 hover:text-neutral-400 transition-colors"
           >
-            <ChevronRight size={16} />
+            <CaretRight weight="duotone" size={16} />
           </button>
         )}
 

--- a/apps/web/components/Objects/Editor/Extensions/Buttons/ButtonsExtension.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Buttons/ButtonsExtension.tsx
@@ -2,7 +2,7 @@ import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
 import { safeHref } from '@services/security/url'
 import React, { useState, useRef, useEffect, lazy, Suspense } from 'react'
 const Picker = lazy(() => import('@emoji-mart/react'))
-import { ArrowRight, ChevronDown, Link, AlignLeft, AlignCenter, AlignRight, Palette } from 'lucide-react'
+import { ArrowRight, CaretDown, Link, TextAlignLeft, TextAlignCenter, TextAlignRight, Palette } from '@phosphor-icons/react'
 import { twMerge } from 'tailwind-merge'
 import { useEditorProvider } from '@components/Contexts/Editor/EditorContext'
 import { useTranslation } from 'react-i18next'
@@ -111,27 +111,27 @@ const ButtonsExtension: React.FC = (props: any) => {
         >
           <span>{emoji}</span>
           <NodeViewContent className="content" />
-          <ArrowRight size={14} />
+          <ArrowRight weight="duotone" size={14} />
         </button>
         {isEditable && (
           <div className="flex mt-2 space-x-2">
             <button onClick={() => setShowEmojiPicker(!showEmojiPicker)} className="p-1 bg-gray-200 rounded-md">
-              <ChevronDown size={14} />
+              <CaretDown weight="duotone" size={14} />
             </button>
             <button onClick={() => setShowLinkInput(!showLinkInput)} className="p-1 bg-gray-200 rounded-md">
-              <Link size={14} />
+              <Link weight="duotone" size={14} />
             </button>
             <button onClick={() => handleAlignmentChange('left')} className="p-1 bg-gray-200 rounded-md">
-              <AlignLeft size={14} />
+              <TextAlignLeft weight="duotone" size={14} />
             </button>
             <button onClick={() => handleAlignmentChange('center')} className="p-1 bg-gray-200 rounded-md">
-              <AlignCenter size={14} />
+              <TextAlignCenter weight="duotone" size={14} />
             </button>
             <button onClick={() => handleAlignmentChange('right')} className="p-1 bg-gray-200 rounded-md">
-              <AlignRight size={14} />
+              <TextAlignRight weight="duotone" size={14} />
             </button>
             <button onClick={() => setShowColorPicker(!showColorPicker)} className="p-1 bg-gray-200 rounded-md">
-              <Palette size={14} />
+              <Palette weight="duotone" size={14} />
             </button>
           </div>
         )}

--- a/apps/web/components/Objects/Editor/Extensions/CodePlayground/CodePlaygroundComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/CodePlayground/CodePlaygroundComponent.tsx
@@ -4,30 +4,30 @@ import React, { useState, useCallback, useEffect, useRef } from 'react'
 import {
   Play,
   Plus,
-  Trash2,
-  CheckCircle2,
+  Trash,
+  CheckCircle,
   XCircle,
-  Loader2,
-  ChevronDown,
-  ChevronRight,
+  CircleNotch,
+  CaretDown,
+  CaretRight,
   Terminal,
   Clock,
-  MemoryStick,
-  CircleDot,
-  RotateCcw,
+  Memory,
+  Circle,
+  ArrowCounterClockwise,
   Lightbulb,
-  Code2,
-  FlaskConical,
+  Code,
+  Flask,
   FileText,
   Copy,
-  ClipboardCheck,
+  ClipboardText,
   Lock,
   Eye,
-  Settings2,
+  GearSix,
   Database,
-  Upload,
-  History,
-} from 'lucide-react'
+  UploadSimple,
+  ClockCounterClockwise,
+} from '@phosphor-icons/react'
 import { useEditorProvider } from '@components/Contexts/Editor/EditorContext'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
 import { useOrg } from '@components/Contexts/OrgContext'
@@ -958,11 +958,11 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
   const diff = DIFFICULTY_CONFIG[difficulty]
 
   const tabs: { id: RightTab; label: string; icon: React.ReactNode; badge?: React.ReactNode }[] = [
-    { id: 'description', label: 'Description', icon: <FileText size={13} /> },
+    { id: 'description', label: 'Description', icon: <FileText weight="duotone" size={13} /> },
     {
       id: 'tests',
       label: 'Test Cases',
-      icon: <FlaskConical size={13} />,
+      icon: <Flask weight="duotone" size={13} />,
       badge:
         results && testCases.length > 0 ? (
           <span
@@ -979,12 +979,12 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
     {
       id: 'output',
       label: 'Output',
-      icon: <Terminal size={13} />,
+      icon: <Terminal weight="duotone" size={13} />,
       badge: results ? (
         <span className="w-2 h-2 rounded-full bg-neutral-400 animate-pulse" />
       ) : null,
     },
-    { id: 'history' as RightTab, icon: <History size={13} />, label: 'History' },
+    { id: 'history' as RightTab, icon: <ClockCounterClockwise weight="duotone" size={13} />, label: 'History' },
   ]
 
   const visibleTabs = isEditable ? tabs.filter(t => t.id !== 'history') : tabs
@@ -998,7 +998,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
         className={`p-1 rounded-md transition-colors ${copied ? 'text-emerald-400' : 'text-neutral-500 hover:text-neutral-300'} ${className}`}
         title="Copy to clipboard"
       >
-        {copied ? <ClipboardCheck size={12} /> : <Copy size={12} />}
+        {copied ? <ClipboardText weight="duotone" size={12} /> : <Copy weight="duotone" size={12} />}
       </button>
     )
   }
@@ -1048,7 +1048,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
             <div className="flex items-center justify-between mb-1.5">
               <label className="text-[11px] font-semibold text-neutral-400 uppercase tracking-wider">Hints</label>
               <button onClick={addHint} className="flex items-center gap-1 text-[11px] font-medium text-neutral-400 hover:text-neutral-600 transition-colors">
-                <Plus size={11} /> Add
+                <Plus weight="duotone" size={11} /> Add
               </button>
             </div>
             {hints.map((hint, i) => (
@@ -1060,7 +1060,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
                   placeholder={`Hint ${i + 1}...`}
                 />
                 <button onClick={() => removeHint(i)} className="p-1.5 hover:bg-red-50 rounded-lg transition-colors">
-                  <Trash2 size={12} className="text-red-400" />
+                  <Trash weight="duotone" size={12} className="text-red-400" />
                 </button>
               </div>
             ))}
@@ -1074,13 +1074,13 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
               </label>
               {sqliteDbPath ? (
                 <div className="flex items-center gap-2 bg-neutral-50 border border-neutral-200 rounded-lg px-3 py-2.5 nice-shadow">
-                  <Database size={14} className="text-neutral-500 shrink-0" />
+                  <Database weight="duotone" size={14} className="text-neutral-500 shrink-0" />
                   <span className="text-[12px] text-neutral-700 truncate flex-1">{sqliteDbName || 'database.sqlite'}</span>
                   <button
                     onClick={removeSqliteDb}
                     className="p-1 hover:bg-red-50 rounded transition-colors shrink-0"
                   >
-                    <Trash2 size={12} className="text-red-400" />
+                    <Trash weight="duotone" size={12} className="text-red-400" />
                   </button>
                 </div>
               ) : (
@@ -1089,9 +1089,9 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
                   className="flex flex-col items-center gap-2 bg-neutral-50 border-2 border-dashed border-neutral-200 rounded-lg px-3 py-4 cursor-pointer hover:border-neutral-300 hover:bg-neutral-100 transition-all"
                 >
                   {isUploadingSqlite ? (
-                    <Loader2 size={16} className="text-neutral-400 animate-spin" />
+                    <CircleNotch weight="duotone" size={16} className="text-neutral-400 animate-spin" />
                   ) : (
-                    <Upload size={16} className="text-neutral-400" />
+                    <UploadSimple weight="duotone" size={16} className="text-neutral-400" />
                   )}
                   <span className="text-[11px] text-neutral-400">
                     {isUploadingSqlite ? 'Uploading...' : 'Upload .sqlite / .db file'}
@@ -1117,9 +1117,9 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
               onClick={() => setShowAdvanced(!showAdvanced)}
               className="flex items-center gap-2 text-[11px] font-semibold text-neutral-400 uppercase tracking-wider hover:text-neutral-600 transition-colors w-full"
             >
-              <Settings2 size={12} />
+              <GearSix weight="duotone" size={12} />
               Advanced
-              <ChevronRight size={12} className={`ml-auto transition-transform ${showAdvanced ? 'rotate-90' : ''}`} />
+              <CaretRight weight="duotone" size={12} className={`ml-auto transition-transform ${showAdvanced ? 'rotate-90' : ''}`} />
             </button>
             {showAdvanced && (
               <div className="mt-3 space-y-3">
@@ -1190,7 +1190,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
                   <div className="flex items-center justify-between mb-1.5">
                     <label className="text-[11px] font-semibold text-neutral-400 uppercase tracking-wider">Additional Files</label>
                     <button onClick={addAdditionalFile} className="flex items-center gap-1 text-[11px] font-medium text-neutral-400 hover:text-neutral-600 transition-colors">
-                      <Plus size={11} /> Add File
+                      <Plus weight="duotone" size={11} /> Add File
                     </button>
                   </div>
                   <p className="text-[10px] text-neutral-400 mb-2">Files available to the student's code (e.g., data.txt, utils.py).</p>
@@ -1204,7 +1204,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
                           placeholder="filename.ext"
                         />
                         <button onClick={() => removeAdditionalFile(i)} className="p-1 hover:bg-red-50 rounded transition-colors">
-                          <Trash2 size={11} className="text-red-400" />
+                          <Trash weight="duotone" size={11} className="text-red-400" />
                         </button>
                       </div>
                       <textarea
@@ -1235,7 +1235,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
 
           {isSqlLanguage && sqliteDbPath && (
             <div className="flex items-center gap-1.5 text-[11px] px-2.5 py-1.5 rounded-lg text-neutral-500 bg-neutral-50 border border-neutral-100 nice-shadow w-fit">
-              <Database size={10} className="text-neutral-400" />
+              <Database weight="duotone" size={10} className="text-neutral-400" />
               Runs against: {sqliteDbName || 'database.sqlite'}
             </div>
           )}
@@ -1244,13 +1244,13 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
             <div className="flex flex-wrap items-center gap-2">
               {timeComplexity && (
                 <span className="inline-flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg text-neutral-500 border border-neutral-100 nice-shadow">
-                  <Clock size={10} className="text-neutral-400" />
+                  <Clock weight="duotone" size={10} className="text-neutral-400" />
                   Speed: {getComplexityLabel(timeComplexity)}
                 </span>
               )}
               {spaceComplexity && (
                 <span className="inline-flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg text-neutral-500 border border-neutral-100 nice-shadow">
-                  <MemoryStick size={10} className="text-neutral-400" />
+                  <Memory weight="duotone" size={10} className="text-neutral-400" />
                   Memory: {getComplexityLabel(spaceComplexity)}
                 </span>
               )}
@@ -1262,7 +1262,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
               <span className="text-[10px] font-semibold text-neutral-400 uppercase tracking-wider">Available Files</span>
               {additionalFiles.map((f, i) => (
                 <div key={i} className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg text-neutral-500 bg-neutral-50 border border-neutral-100 nice-shadow w-fit">
-                  <FileText size={10} className="text-neutral-400" />
+                  <FileText weight="duotone" size={10} className="text-neutral-400" />
                   {f.name}
                 </div>
               ))}
@@ -1276,12 +1276,12 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
                   onClick={() => setShowSolution(!showSolution)}
                   className="flex items-center gap-2 px-3 py-2 rounded-lg text-[12px] font-semibold text-neutral-700 bg-neutral-50 border border-neutral-200 hover:bg-neutral-100 transition-colors nice-shadow"
                 >
-                  <Eye size={13} />
+                  <Eye weight="duotone" size={13} />
                   {showSolution ? 'Hide Solution' : 'View Solution'}
                 </button>
               ) : (
                 <div className="flex items-center gap-2 text-[11px] text-neutral-400">
-                  <Lock size={11} />
+                  <Lock weight="duotone" size={11} />
                   <span>Solution available after {maxAttemptsBeforeReveal - attemptCount} more {maxAttemptsBeforeReveal - attemptCount === 1 ? 'attempt' : 'attempts'}</span>
                 </div>
               )}
@@ -1318,14 +1318,14 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
           {hints.length > 0 && (
             <div className="space-y-2">
               <span className="text-[11px] font-semibold text-neutral-400 uppercase tracking-wider flex items-center gap-1.5">
-                <Lightbulb size={12} className="text-amber-400" /> Hints
+                <Lightbulb weight="duotone" size={12} className="text-amber-400" /> Hints
               </span>
               {hints.map((hint, i) => (
                 <button key={i} onClick={() => toggleHint(i)} className="w-full text-left">
                   <div className="flex items-center gap-2.5 px-3 py-2 rounded-lg bg-amber-50/60 border border-amber-100 hover:bg-amber-50 transition-colors nice-shadow">
-                    <Lightbulb size={12} className="text-amber-400 flex-shrink-0" />
+                    <Lightbulb weight="duotone" size={12} className="text-amber-400 flex-shrink-0" />
                     <span className="text-[12px] font-medium text-amber-700 flex-1">Hint {i + 1}</span>
-                    <ChevronRight size={12} className={`text-amber-300 transition-transform ${expandedHints.has(i) ? 'rotate-90' : ''}`} />
+                    <CaretRight weight="duotone" size={12} className={`text-amber-300 transition-transform ${expandedHints.has(i) ? 'rotate-90' : ''}`} />
                   </div>
                   {expandedHints.has(i) && (
                     <div className="mt-1.5 ml-8 mr-3 text-[12px] text-neutral-600 leading-relaxed pb-1">{hint}</div>
@@ -1345,7 +1345,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
       {isEditable && (
         <div className="flex justify-end mb-1">
           <button onClick={addTestCase} className="flex items-center gap-1 text-[11px] font-medium text-neutral-400 hover:text-neutral-600 transition-colors">
-            <Plus size={12} /> Add Test Case
+            <Plus weight="duotone" size={12} /> Add Test Case
           </button>
         </div>
       )}
@@ -1366,9 +1366,9 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
               >
                 <div className="flex items-center gap-3 px-3.5 py-2.5">
                   {r ? (
-                    r.passed ? <CheckCircle2 size={15} className="text-emerald-500 flex-shrink-0" /> : <XCircle size={15} className="text-red-500 flex-shrink-0" />
+                    r.passed ? <CheckCircle weight="duotone" size={15} className="text-emerald-500 flex-shrink-0" /> : <XCircle weight="duotone" size={15} className="text-red-500 flex-shrink-0" />
                   ) : (
-                    <CircleDot size={15} className="text-neutral-300 flex-shrink-0" />
+                    <Circle weight="duotone" size={15} className="text-neutral-300 flex-shrink-0" />
                   )}
                   <div className="flex-1 min-w-0">
                     {isEditable ? (
@@ -1381,7 +1381,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
                     {r?.time && <span className="text-[10px] text-neutral-400 font-mono">{r.time}s</span>}
                     {isEditable && (
                       <button onClick={() => removeTestCase(tc.id)} className="p-1 hover:bg-red-50 rounded-lg transition-colors">
-                        <Trash2 size={12} className="text-red-400" />
+                        <Trash weight="duotone" size={12} className="text-red-400" />
                       </button>
                     )}
                   </div>
@@ -1425,7 +1425,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
               onClick={addStudentTestCase}
               className="flex items-center gap-1 text-[11px] font-medium text-blue-500 hover:text-blue-600 transition-colors"
             >
-              <Plus size={11} /> Add
+              <Plus weight="duotone" size={11} /> Add
             </button>
           </div>
           {studentTestCases.length === 0 && (
@@ -1440,7 +1440,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
                   className="flex-1 text-[12px] font-medium text-neutral-700 bg-white border border-neutral-200 rounded px-2 py-1 outline-none focus:border-blue-300"
                 />
                 <button onClick={() => removeStudentTestCase(tc.id)} className="p-1 hover:bg-red-50 rounded transition-colors">
-                  <Trash2 size={11} className="text-red-400" />
+                  <Trash weight="duotone" size={11} className="text-red-400" />
                 </button>
               </div>
               <div className="space-y-1.5">
@@ -1529,7 +1529,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
           {!stdout && !stderr && !compileOut && <pre className="text-[12px] font-mono text-neutral-500 italic">(no output)</pre>}
           {time && (
             <div className="flex items-center gap-1.5 mt-3 pt-2 border-t border-white/5">
-              <Clock size={10} className="text-neutral-500" />
+              <Clock weight="duotone" size={10} className="text-neutral-500" />
               <span className="text-[10px] font-mono text-neutral-500">{(parseFloat(time) * 1000).toFixed(0)}ms</span>
             </div>
           )}
@@ -1541,7 +1541,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
       <div className="p-5 space-y-3 overflow-y-auto h-full">
         {!results ? (
           <div className="flex flex-col items-center justify-center py-14 text-neutral-300">
-            <Terminal size={24} className="mb-2" strokeWidth={1.5} />
+            <Terminal weight="duotone" size={24} className="mb-2" />
             <span className="text-[13px] text-neutral-400">Run your code to see output</span>
           </div>
         ) : (
@@ -1559,7 +1559,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
                   <div className={`h-full rounded-full transition-all duration-500 ${allPassed ? 'bg-emerald-400' : 'bg-amber-400'}`} style={{ width: `${(passedCount / totalCount) * 100}%` }} />
                 </div>
                 <div className="flex items-center gap-1.5 mt-2">
-                  <CheckCircle2 size={11} className={allPassed ? 'text-emerald-500' : 'text-amber-500'} />
+                  <CheckCircle weight="duotone" size={11} className={allPassed ? 'text-emerald-500' : 'text-amber-500'} />
                   <span className={`text-[11px] font-medium ${allPassed ? 'text-emerald-600' : 'text-amber-600'}`}>
                     {allPassed ? 'All test cases passed' : `${passedCount} of ${totalCount} passed`}
                   </span>
@@ -1571,7 +1571,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
             {results?.map((r) => (
               <div key={r.id} className={`rounded-lg border overflow-hidden nice-shadow ${r.passed ? 'border-emerald-100 bg-emerald-50/20' : 'border-red-100 bg-red-50/20'}`}>
                 <div className="flex items-center gap-2 px-3.5 py-2">
-                  {r.passed ? <CheckCircle2 size={13} className="text-emerald-500" /> : <XCircle size={13} className="text-red-500" />}
+                  {r.passed ? <CheckCircle weight="duotone" size={13} className="text-emerald-500" /> : <XCircle weight="duotone" size={13} className="text-red-500" />}
                   <span className="text-[12px] font-semibold text-neutral-700">{r.label}</span>
                   <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${r.passed ? 'bg-emerald-100 text-emerald-600' : 'bg-red-100 text-red-600'}`}>
                     {r.status?.description || (r.passed ? 'Accepted' : 'Failed')}
@@ -1663,7 +1663,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
         <div className="flex relative" style={{ height: 560 }}>
           {timedMode && !isEditable && !challengeStarted && (
             <div className="absolute inset-0 z-20 bg-[#1a1b26]/95 flex flex-col items-center justify-center gap-4">
-              <Clock size={32} className="text-neutral-400" />
+              <Clock weight="duotone" size={32} className="text-neutral-400" />
               <span className="text-[14px] font-semibold text-neutral-200">Timed Challenge</span>
               <span className="text-[12px] text-neutral-400">
                 You have {Math.floor(timedDurationMs / 60000)} minutes to complete this challenge.
@@ -1698,7 +1698,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
             {/* Header bar — dark */}
             <div className="flex items-center justify-between px-4 border-b border-white/[0.06] shrink-0">
               <div className="flex items-center gap-2.5 py-3">
-                <Code2 size={14} className="text-neutral-500" />
+                <Code weight="duotone" size={14} className="text-neutral-500" />
                 <span className="text-[12px] font-semibold text-neutral-300 tracking-tight">
                   Code Playground
                 </span>
@@ -1715,7 +1715,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
                       className="flex items-center gap-1.5 text-neutral-500 hover:text-neutral-300 font-medium py-1.5 px-1 text-[12px] transition-colors outline-none"
                     >
                       {languageName}
-                      <ChevronDown size={11} className="text-neutral-500" />
+                      <CaretDown weight="duotone" size={11} className="text-neutral-500" />
                     </button>
                     {showLangDropdown && (
                       <div className="absolute right-0 top-full mt-1 bg-[#24283b] rounded-lg py-1 z-50 max-h-60 overflow-y-auto w-44 border border-white/[0.08] shadow-xl">
@@ -1746,7 +1746,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
                     className="flex items-center text-neutral-500 hover:text-neutral-300 py-1.5 px-1 text-[12px] transition-colors outline-none"
                     title="Reset code"
                   >
-                    <RotateCcw size={13} />
+                    <ArrowCounterClockwise weight="duotone" size={13} />
                   </button>
                 )}
               </div>
@@ -1762,7 +1762,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
                       : 'text-neutral-500 hover:text-neutral-300 hover:bg-white/[0.03]'
                   }`}
                 >
-                  <Code2 size={12} />
+                  <Code weight="duotone" size={12} />
                   main
                 </button>
                 {additionalFiles.map((file, i) => (
@@ -1775,7 +1775,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
                         : 'text-neutral-500 hover:text-neutral-300 hover:bg-white/[0.03]'
                     }`}
                   >
-                    <FileText size={12} />
+                    <FileText weight="duotone" size={12} />
                     {file.name || `file-${i + 1}`}
                   </button>
                 ))}
@@ -1841,9 +1841,9 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
                   }`}
                 >
                   {isRunning ? (
-                    <Loader2 size={14} className="animate-spin" />
+                    <CircleNotch weight="duotone" size={14} className="animate-spin" />
                   ) : (
-                    <Play size={14} />
+                    <Play weight="duotone" size={14} />
                   )}
                   {isEditable ? 'Test Run' : 'Run Code'}
                 </button>
@@ -1857,7 +1857,7 @@ const CodePlaygroundComponent: React.FC = (props: any) => {
                 )}
                 {allPassed && !isEditable && !isRunning && (
                   <div className="flex items-center gap-1.5">
-                    <CheckCircle2 size={13} className="text-emerald-400" />
+                    <CheckCircle weight="duotone" size={13} className="text-emerald-400" />
                     <span className="text-[12px] font-semibold text-emerald-400">All passed</span>
                   </div>
                 )}

--- a/apps/web/components/Objects/Editor/Extensions/CodePlayground/SubmissionHistory.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/CodePlayground/SubmissionHistory.tsx
@@ -1,15 +1,15 @@
 'use client'
 import React, { useState, useEffect, useCallback } from 'react'
 import {
-  CheckCircle2,
+  CheckCircle,
   XCircle,
-  ChevronDown,
-  ChevronRight,
+  CaretDown,
+  CaretRight,
   Clock,
-  RotateCcw,
-  Loader2,
-  ChevronLeft,
-} from 'lucide-react'
+  ArrowCounterClockwise,
+  CircleNotch,
+  CaretLeft,
+} from '@phosphor-icons/react'
 import { getAPIUrl } from '@services/config/config'
 
 interface Submission {
@@ -84,7 +84,7 @@ export default function SubmissionHistory({
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <Loader2 className="animate-spin text-neutral-400" size={20} />
+        <CircleNotch weight="duotone" className="animate-spin text-neutral-400" size={20} />
       </div>
     )
   }
@@ -137,15 +137,15 @@ export default function SubmissionHistory({
               className="w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-neutral-100/60 transition-colors"
             >
               {isExpanded ? (
-                <ChevronDown size={14} className="text-neutral-400 shrink-0" />
+                <CaretDown weight="duotone" size={14} className="text-neutral-400 shrink-0" />
               ) : (
-                <ChevronRight size={14} className="text-neutral-400 shrink-0" />
+                <CaretRight weight="duotone" size={14} className="text-neutral-400 shrink-0" />
               )}
 
               {sub.passed ? (
-                <CheckCircle2 size={15} className="text-emerald-500 shrink-0" />
+                <CheckCircle weight="duotone" size={15} className="text-emerald-500 shrink-0" />
               ) : (
-                <XCircle size={15} className="text-red-400 shrink-0" />
+                <XCircle weight="duotone" size={15} className="text-red-400 shrink-0" />
               )}
 
               <span className="text-xs font-semibold text-neutral-700">
@@ -154,7 +154,7 @@ export default function SubmissionHistory({
 
               {sub.execution_time_ms !== null && (
                 <span className="flex items-center gap-0.5 text-[10px] text-neutral-400 ml-auto">
-                  <Clock size={10} />
+                  <Clock weight="duotone" size={10} />
                   {sub.execution_time_ms}ms
                 </span>
               )}
@@ -175,7 +175,7 @@ export default function SubmissionHistory({
                     onClick={() => onRestoreCode(sub.source_code)}
                     className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-neutral-600 hover:text-neutral-800 bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors"
                   >
-                    <RotateCcw size={12} />
+                    <ArrowCounterClockwise weight="duotone" size={12} />
                     Restore this code
                   </button>
                 </div>
@@ -195,7 +195,7 @@ export default function SubmissionHistory({
               onClick={() => setPage((p) => p - 1)}
               className="flex items-center gap-1 text-xs text-neutral-500 hover:text-neutral-700 disabled:opacity-30 disabled:cursor-not-allowed"
             >
-              <ChevronLeft size={14} />
+              <CaretLeft weight="duotone" size={14} />
               Previous
             </button>
             <span className="text-[11px] text-neutral-400">
@@ -207,7 +207,7 @@ export default function SubmissionHistory({
               className="flex items-center gap-1 text-xs text-neutral-500 hover:text-neutral-700 disabled:opacity-30 disabled:cursor-not-allowed"
             >
               Next
-              <ChevronRight size={14} />
+              <CaretRight weight="duotone" size={14} />
             </button>
           </div>
         )

--- a/apps/web/components/Objects/Editor/Extensions/DragHandle/DragHandle.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/DragHandle/DragHandle.tsx
@@ -2,9 +2,41 @@ import { Extension } from '@tiptap/core'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { EditorView } from '@tiptap/pm/view'
 import { NodeSelection } from '@tiptap/pm/state'
-import { Slice, Fragment } from '@tiptap/pm/model'
+import { Slice, Fragment, Node as PMNode } from '@tiptap/pm/model'
 
 const DRAG_HANDLE_KEY = new PluginKey('dragHandle')
+
+// Copy a single block to the system clipboard so it can be pasted into another
+// TipTap editor instance. We use view.serializeForClipboard so ProseMirror
+// embeds the slice metadata it needs for native paste to round-trip exactly.
+function copyBlockToClipboard(view: EditorView, node: PMNode, button: HTMLElement) {
+  const slice = new Slice(Fragment.from(node), 0, 0)
+  const { dom, text } = view.serializeForClipboard(slice)
+  const html = (dom as HTMLElement).outerHTML
+
+  const onCopy = (event: ClipboardEvent) => {
+    event.preventDefault()
+    event.clipboardData?.setData('text/html', html)
+    event.clipboardData?.setData('text/plain', text)
+  }
+
+  document.addEventListener('copy', onCopy, { once: true })
+  const succeeded = document.execCommand('copy')
+
+  if (!succeeded) {
+    document.removeEventListener('copy', onCopy)
+    navigator.clipboard?.writeText(text).catch(() => {})
+  }
+
+  const tooltip = button.querySelector('.tooltip-text') as HTMLElement | null
+  if (tooltip) {
+    const original = tooltip.textContent
+    tooltip.textContent = 'Copied!'
+    setTimeout(() => {
+      if (tooltip.textContent === 'Copied!') tooltip.textContent = original
+    }, 1200)
+  }
+}
 
 function createDragHandlePlugin() {
   let dragHandle: HTMLElement | null = null
@@ -19,36 +51,31 @@ function createDragHandlePlugin() {
     dragHandle.className = 'editor-drag-handle nice-shadow'
     dragHandle.innerHTML = `
       <div class="drag-grip" draggable="true">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
-          <circle cx="9" cy="5" r="2"/>
-          <circle cx="9" cy="12" r="2"/>
-          <circle cx="9" cy="19" r="2"/>
-          <circle cx="15" cy="5" r="2"/>
-          <circle cx="15" cy="12" r="2"/>
-          <circle cx="15" cy="19" r="2"/>
+        <svg width="14" height="14" viewBox="0 0 256 256" fill="currentColor">
+          <path d="M104,60A12,12,0,1,1,92,48,12,12,0,0,1,104,60Zm60,12a12,12,0,1,0-12-12A12,12,0,0,0,164,72ZM92,116a12,12,0,1,0,12,12A12,12,0,0,0,92,116Zm72,0a12,12,0,1,0,12,12A12,12,0,0,0,164,116ZM92,184a12,12,0,1,0,12,12A12,12,0,0,0,92,184Zm72,0a12,12,0,1,0,12,12A12,12,0,0,0,164,184Z"/>
         </svg>
       </div>
       <button class="action-btn clear-btn" data-action="clear">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
-          <path d="M3 3v5h5"/>
+        <svg width="14" height="14" viewBox="0 0 256 256" fill="currentColor">
+          <path d="M224,128a96,96,0,0,1-94.71,96H128A95.38,95.38,0,0,1,62.1,197.8a8,8,0,0,1,11-11.63A80,80,0,1,0,71.43,71.39a3.07,3.07,0,0,1-.26.25L44.59,96H72a8,8,0,0,1,0,16H24a8,8,0,0,1-8-8V56a8,8,0,0,1,16,0V85.8L60.25,60A96,96,0,0,1,224,128Z"/>
         </svg>
         <span class="tooltip-text">Clear</span>
       </button>
       <button class="action-btn duplicate-btn" data-action="duplicate">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <rect width="14" height="14" x="8" y="8" rx="2" ry="2"/>
-          <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>
+        <svg width="14" height="14" viewBox="0 0 256 256" fill="currentColor">
+          <path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z"/>
         </svg>
         <span class="tooltip-text">Duplicate</span>
       </button>
+      <button class="action-btn copy-btn" data-action="copy">
+        <svg width="14" height="14" viewBox="0 0 256 256" fill="currentColor">
+          <path d="M168,152a8,8,0,0,1-8,8H96a8,8,0,0,1,0-16h64A8,8,0,0,1,168,152Zm-8-40H96a8,8,0,0,0,0,16h64a8,8,0,0,0,0-16Zm56-64V216a16,16,0,0,1-16,16H56a16,16,0,0,1-16-16V48A16,16,0,0,1,56,32H92.26a47.92,47.92,0,0,1,71.48,0H200A16,16,0,0,1,216,48ZM96,64h64a32,32,0,0,0-64,0ZM200,48H173.25A47.93,47.93,0,0,1,176,64v8a8,8,0,0,1-8,8H88a8,8,0,0,1-8-8V64a47.93,47.93,0,0,1,2.75-16H56V216H200Z"/>
+        </svg>
+        <span class="tooltip-text">Copy</span>
+      </button>
       <button class="action-btn delete-btn" data-action="delete">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M3 6h18"/>
-          <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/>
-          <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/>
-          <line x1="10" x2="10" y1="11" y2="17"/>
-          <line x1="14" x2="14" y1="11" y2="17"/>
+        <svg width="14" height="14" viewBox="0 0 256 256" fill="currentColor">
+          <path d="M216,48H176V40a24,24,0,0,0-24-24H104A24,24,0,0,0,80,40v8H40a8,8,0,0,0,0,16h8V208a16,16,0,0,0,16,16H192a16,16,0,0,0,16-16V64h8a8,8,0,0,0,0-16ZM96,40a8,8,0,0,1,8-8h48a8,8,0,0,1,8,8v8H96Zm96,168H64V64H192ZM112,104v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Zm48,0v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Z"/>
         </svg>
         <span class="tooltip-text">Delete</span>
       </button>
@@ -151,6 +178,9 @@ function createDragHandlePlugin() {
         const slice = new Slice(Fragment.from(node), 0, 0)
         const tr = view.state.tr.insert(nodePos + node.nodeSize, slice.content)
         view.dispatch(tr)
+      } else if (action === 'copy') {
+        copyBlockToClipboard(view, node, button)
+        return
       } else if (action === 'clear') {
         // Create an empty version of the same node type
         const emptyNode = view.state.schema.nodes[node.type.name].create(

--- a/apps/web/components/Objects/Editor/Extensions/EmbedObjects/EmbedObjectsComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/EmbedObjects/EmbedObjectsComponent.tsx
@@ -1,6 +1,6 @@
 import { NodeViewWrapper } from '@tiptap/react'
 import React, { useState, useRef, useEffect, useMemo } from 'react'
-import { Link as LinkIcon, GripVertical, GripHorizontal, AlignCenter, Code, X, Palette } from 'lucide-react'
+import { Link as LinkIcon, DotsSixVertical, DotsSix, TextAlignCenter, Code, X, Palette } from '@phosphor-icons/react'
 import { useEditorProvider } from '@components/Contexts/Editor/EditorContext'
 import { SiGithub, SiReplit, SiSpotify, SiLoom, SiGooglemaps, SiNotion, SiGoogledocs, SiX, SiFigma, SiGiphy, SiYoutube } from '@icons-pack/react-simple-icons'
 import DOMPurify from 'dompurify'
@@ -418,14 +418,14 @@ function EmbedObjectsComponent(props: any) {
                     className="p-1.5 rounded-md hover:bg-neutral-100 text-neutral-600"
                     title={alignment === 'center' ? t('editor.blocks.common.align_left') : t('editor.blocks.common.align_center')}
                   >
-                    <AlignCenter size={16} />
+                    <TextAlignCenter weight="duotone" size={16} />
                   </button>
                   <button
                     onClick={handleRemove}
                     className="p-1.5 rounded-md hover:bg-neutral-100 text-neutral-600 hover:text-red-500 transition-colors"
                     title={t('editor.blocks.embed_block.remove_embed')}
                   >
-                    <X size={16} />
+                    <X weight="duotone" size={16} />
                   </button>
                 </div>
               )}
@@ -465,7 +465,7 @@ function EmbedObjectsComponent(props: any) {
                     }}
                     className="flex items-center gap-1.5 px-3 py-1.5 bg-neutral-200 hover:bg-neutral-300 rounded-lg text-sm text-neutral-700 transition-colors"
                   >
-                    <LinkIcon size={14} />
+                    <LinkIcon weight="duotone" size={14} />
                     <span>URL</span>
                   </button>
                   <button
@@ -475,7 +475,7 @@ function EmbedObjectsComponent(props: any) {
                     }}
                     className="flex items-center gap-1.5 px-3 py-1.5 bg-neutral-200 hover:bg-neutral-300 rounded-lg text-sm text-neutral-700 transition-colors"
                   >
-                    <Code size={14} />
+                    <Code weight="duotone" size={14} />
                     <span>Code</span>
                   </button>
                 </div>
@@ -512,7 +512,7 @@ function EmbedObjectsComponent(props: any) {
                     onClick={() => setActiveInput('none')}
                     className="p-1 rounded-full hover:bg-neutral-100 text-neutral-500"
                   >
-                    <X size={20} />
+                    <X weight="duotone" size={20} />
                   </button>
                 </div>
 
@@ -520,7 +520,7 @@ function EmbedObjectsComponent(props: any) {
                   <>
                     <div className="relative mb-2">
                       <div className="absolute left-3 top-1/2 transform -translate-y-1/2 text-neutral-500">
-                        <LinkIcon size={16} />
+                        <LinkIcon weight="duotone" size={16} />
                       </div>
                       <input
                         ref={urlInputRef}
@@ -592,13 +592,13 @@ function EmbedObjectsComponent(props: any) {
                 className="absolute right-0 top-0 bottom-0 w-4 cursor-ew-resize flex items-center justify-center bg-white/70 hover:bg-white/90 transition-opacity"
                 onMouseDown={(e) => handleResizeStart(e, 'horizontal')}
               >
-                <GripVertical size={16} className="text-neutral-500" />
+                <DotsSixVertical weight="duotone" size={16} className="text-neutral-500" />
               </div>
               <div
                 className="absolute left-0 right-0 bottom-0 h-4 cursor-ns-resize flex items-center justify-center bg-white/70 hover:bg-white/90 transition-opacity"
                 onMouseDown={(e) => handleResizeStart(e, 'vertical')}
               >
-                <GripHorizontal size={16} className="text-neutral-500" />
+                <DotsSix weight="duotone" size={16} className="text-neutral-500" />
               </div>
             </>
           )}

--- a/apps/web/components/Objects/Editor/Extensions/Flipcard/FlipcardExtension.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Flipcard/FlipcardExtension.tsx
@@ -1,6 +1,6 @@
 import { NodeViewWrapper } from '@tiptap/react'
 import React, { useState, useRef, useEffect } from 'react'
-import { RotateCw, Edit, AlignLeft, AlignCenter, AlignRight, Group, Palette, Maximize2, Minimize2, Square } from 'lucide-react'
+import { ArrowClockwise, PencilSimple, TextAlignLeft, TextAlignCenter, TextAlignRight, Palette, ArrowsOutSimple, ArrowsInSimple, Square, SquaresFour } from '@phosphor-icons/react'
 import { cn } from '@/lib/utils'
 import { useEditorProvider } from '@components/Contexts/Editor/EditorContext'
 import { useTranslation } from 'react-i18next'
@@ -204,7 +204,7 @@ const FlipcardExtension: React.FC = (props: any) => {
             )}
           >
             <div className="flex items-center justify-center mb-3 select-none pointer-events-none">
-              <RotateCw size={getIconSizeClass()} className="opacity-70" />
+              <ArrowClockwise weight="duotone" size={getIconSizeClass()} className="opacity-70" />
             </div>
             <div className="flex-1 flex items-center justify-center">
               {isEditable && isEditingQuestion ? (
@@ -227,7 +227,7 @@ const FlipcardExtension: React.FC = (props: any) => {
                       }}
                       className="ml-2 opacity-60 hover:opacity-100 flex-shrink-0 pointer-events-auto"
                     >
-                      <Edit size={14} />
+                      <PencilSimple weight="duotone" size={14} />
                     </button>
                   )}
                 </div>
@@ -246,7 +246,7 @@ const FlipcardExtension: React.FC = (props: any) => {
             )}
           >
             <div className="flex items-center justify-center mb-3 select-none pointer-events-none">
-              <RotateCw size={getIconSizeClass()} className="opacity-70 rotate-180" />
+              <ArrowClockwise weight="duotone" size={getIconSizeClass()} className="opacity-70 rotate-180" />
             </div>
             <div className="flex-1 flex items-center justify-center">
               {isEditable && isEditingAnswer ? (
@@ -269,7 +269,7 @@ const FlipcardExtension: React.FC = (props: any) => {
                       }}
                       className="ml-2 opacity-60 hover:opacity-100 flex-shrink-0 pointer-events-auto"
                     >
-                      <Edit size={14} />
+                      <PencilSimple weight="duotone" size={14} />
                     </button>
                   )}
                 </div>
@@ -297,7 +297,7 @@ const FlipcardExtension: React.FC = (props: any) => {
               )}
               title={t('activities.align_left')}
             >
-              <AlignLeft size={12} />
+              <TextAlignLeft weight="duotone" size={12} />
             </button>
             <button
               onClick={(e) => {
@@ -310,7 +310,7 @@ const FlipcardExtension: React.FC = (props: any) => {
               )}
               title={t('activities.align_center')}
             >
-              <AlignCenter size={12} />
+              <TextAlignCenter weight="duotone" size={12} />
             </button>
             <button
               onClick={(e) => {
@@ -323,7 +323,7 @@ const FlipcardExtension: React.FC = (props: any) => {
               )}
               title={t('activities.align_right')}
             >
-              <AlignRight size={12} />
+              <TextAlignRight weight="duotone" size={12} />
             </button>
 
             <div className="w-px h-4 bg-neutral-300 self-center mx-1"></div>
@@ -341,7 +341,7 @@ const FlipcardExtension: React.FC = (props: any) => {
               )}
               title={t('activities.size_small')}
             >
-              <Minimize2 size={12} />
+              <ArrowsInSimple weight="duotone" size={12} />
             </button>
             <button
               onClick={(e) => {
@@ -354,7 +354,7 @@ const FlipcardExtension: React.FC = (props: any) => {
               )}
               title={t('activities.size_medium')}
             >
-              <Square size={12} />
+              <Square weight="duotone" size={12} />
             </button>
             <button
               onClick={(e) => {
@@ -367,7 +367,7 @@ const FlipcardExtension: React.FC = (props: any) => {
               )}
               title={t('activities.size_large')}
             >
-              <Maximize2 size={12} />
+              <ArrowsOutSimple weight="duotone" size={12} />
             </button>
 
             <div className="w-px h-4 bg-neutral-300 self-center mx-1"></div>
@@ -381,7 +381,7 @@ const FlipcardExtension: React.FC = (props: any) => {
               className="p-1.5 bg-neutral-200 hover:bg-neutral-300 text-neutral-600 rounded-md transition-colors text-xs"
               title={t('activities.change_color')}
             >
-              <Palette size={12} />
+              <Palette weight="duotone" size={12} />
             </button>
             <button
               onClick={(e) => {
@@ -391,7 +391,7 @@ const FlipcardExtension: React.FC = (props: any) => {
               className="p-1.5 bg-neutral-200 hover:bg-neutral-300 text-neutral-600 rounded-md transition-colors text-xs"
               title={t('activities.preview_flip')}
             >
-              <RotateCw size={12} />
+              <ArrowClockwise weight="duotone" size={12} />
             </button>
             {!inGrid && (
               <button
@@ -402,7 +402,7 @@ const FlipcardExtension: React.FC = (props: any) => {
                 className="p-1.5 bg-neutral-200 hover:bg-neutral-300 text-neutral-600 rounded-md transition-colors text-xs"
                 title={t('activities.group_into_grid')}
               >
-                <Group size={12} />
+                <SquaresFour weight="duotone" size={12} />
               </button>
             )}
           </div>

--- a/apps/web/components/Objects/Editor/Extensions/Image/ImageBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Image/ImageBlockComponent.tsx
@@ -1,7 +1,7 @@
 import { NodeViewWrapper } from '@tiptap/react'
 import React, { useEffect } from 'react'
 import { Resizable } from 're-resizable'
-import { Image, Download, AlignLeft, AlignCenter, AlignRight, Expand, Upload, Loader2, AlertCircle } from 'lucide-react'
+import { Image, DownloadSimple, TextAlignLeft, TextAlignCenter, TextAlignRight, ArrowsOut, UploadSimple, CircleNotch, WarningCircle } from '@phosphor-icons/react'
 import toast from 'react-hot-toast'
 import { uploadNewImageFile } from '../../../../../services/blocks/Image/images'
 import { getActivityBlockMediaDirectory } from '@services/media/media'
@@ -227,7 +227,7 @@ function ImageBlockComponent(props: any) {
                   className="p-2 outline-none bg-black/50 hover:bg-black/70 rounded-lg transition-colors"
                   title={t('editor.blocks.image_block.expand_image')}
                 >
-                  <Expand className="w-4 h-4 text-white" />
+                  <ArrowsOut weight="duotone" className="w-4 h-4 text-white" />
                 </button>
                 {blockObject && (
                   <button
@@ -235,7 +235,7 @@ function ImageBlockComponent(props: any) {
                     className="p-2 outline-none bg-black/50 hover:bg-black/70 rounded-lg transition-colors"
                     title={t('editor.blocks.image_block.download_image')}
                   >
-                    <Download className="w-4 h-4 text-white" />
+                    <DownloadSimple weight="duotone" className="w-4 h-4 text-white" />
                   </button>
                 )}
               </div>
@@ -280,8 +280,8 @@ function ImageBlockComponent(props: any) {
         <div className="bg-neutral-50 rounded-xl px-5 py-4 nice-shadow transition-all ease-linear">
           {/* Header */}
           <div className="flex items-center gap-2 mb-3">
-            {/* eslint-disable-next-line jsx-a11y/alt-text -- `Image` is a lucide-react icon, not an <img> element */}
-            <Image className="text-neutral-400" size={16} />
+            {/* eslint-disable-next-line jsx-a11y/alt-text -- `Image` is a phosphor-icons icon, not an <img> element */}
+            <Image weight="duotone" className="text-neutral-400" size={16} />
             <span className="uppercase tracking-widest text-xs font-bold text-neutral-400">
               {t('editor.blocks.image')}
             </span>
@@ -316,7 +316,7 @@ function ImageBlockComponent(props: any) {
                 />
                 {isLoading ? (
                   <div className="space-y-3">
-                    <Loader2 className="w-8 h-8 animate-spin mx-auto text-neutral-500" />
+                    <CircleNotch weight="duotone" className="w-8 h-8 animate-spin mx-auto text-neutral-500" />
                     <p className="text-sm text-neutral-600">{t('editor.blocks.image_block.uploading')} {progress}%</p>
                     <div
                       className="w-48 h-1 bg-neutral-200 rounded-full mx-auto overflow-hidden"
@@ -333,7 +333,7 @@ function ImageBlockComponent(props: any) {
                   </div>
                 ) : (
                   <div className="space-y-2">
-                    <Upload className="w-7 h-7 mx-auto text-neutral-400" />
+                    <UploadSimple weight="duotone" className="w-7 h-7 mx-auto text-neutral-400" />
                     <div>
                       <p className="text-sm font-medium text-neutral-700">
                         {t('editor.blocks.image_block.drop_or_browse')}
@@ -375,7 +375,7 @@ function ImageBlockComponent(props: any) {
           {/* Error display */}
           {error && (
             <div className="mt-3 flex items-center gap-2 text-sm text-red-500 font-medium bg-red-50 rounded-lg p-3">
-              <AlertCircle size={16} />
+              <WarningCircle weight="duotone" size={16} />
               {error}
             </div>
           )}
@@ -432,21 +432,21 @@ function ImageBlockComponent(props: any) {
                       className={`p-1.5 rounded-md transition-colors outline-none ${alignment === 'left' ? 'bg-neutral-200 text-neutral-700' : 'hover:bg-neutral-100 text-neutral-500'}`}
                       title={t('editor.blocks.common.align_left')}
                     >
-                      <AlignLeft size={14} />
+                      <TextAlignLeft weight="duotone" size={14} />
                     </button>
                     <button
                       onClick={() => handleAlignmentChange('center')}
                       className={`p-1.5 rounded-md transition-colors outline-none ${alignment === 'center' ? 'bg-neutral-200 text-neutral-700' : 'hover:bg-neutral-100 text-neutral-500'}`}
                       title={t('editor.blocks.common.align_center')}
                     >
-                      <AlignCenter size={14} />
+                      <TextAlignCenter weight="duotone" size={14} />
                     </button>
                     <button
                       onClick={() => handleAlignmentChange('right')}
                       className={`p-1.5 rounded-md transition-colors outline-none ${alignment === 'right' ? 'bg-neutral-200 text-neutral-700' : 'hover:bg-neutral-100 text-neutral-500'}`}
                       title={t('editor.blocks.common.align_right')}
                     >
-                      <AlignRight size={14} />
+                      <TextAlignRight weight="duotone" size={14} />
                     </button>
                     <div className="w-px h-4 bg-neutral-200 mx-0.5"></div>
                     <button
@@ -454,7 +454,7 @@ function ImageBlockComponent(props: any) {
                       className="p-1.5 rounded-md hover:bg-neutral-100 text-neutral-500 transition-colors outline-none"
                       title={t('editor.blocks.image_block.expand_image')}
                     >
-                      <Expand size={14} />
+                      <ArrowsOut weight="duotone" size={14} />
                     </button>
                   </div>
                 </div>

--- a/apps/web/components/Objects/Editor/Extensions/MathEquation/MathEquationBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/MathEquation/MathEquationBlockComponent.tsx
@@ -5,7 +5,7 @@ const BlockMath = lazy(() => {
   import('katex/dist/katex.min.css')
   return import('react-katex').then(m => ({ default: m.BlockMath }))
 })
-import { Save, Sigma, ExternalLink, ChevronDown, BookOpen, Lightbulb } from 'lucide-react'
+import { FloppyDisk, Sigma, ArrowSquareOut, CaretDown, BookOpen, Lightbulb } from '@phosphor-icons/react'
 import Link from 'next/link'
 import { useEditorProvider } from '@components/Contexts/Editor/EditorContext'
 import { useTranslation } from 'react-i18next'
@@ -176,7 +176,7 @@ function MathEquationBlockComponent(props: any) {
       <div className="bg-neutral-50 rounded-xl px-5 py-4 nice-shadow transition-all ease-linear">
         {/* Header */}
         <div className="flex items-center gap-2 mb-3">
-          <Sigma className="text-neutral-400" size={16} />
+          <Sigma weight="duotone" className="text-neutral-400" size={16} />
           <span className="uppercase tracking-widest text-xs font-bold text-neutral-400">
             {t('editor.blocks.math')}
           </span>
@@ -198,9 +198,9 @@ function MathEquationBlockComponent(props: any) {
                   onClick={() => setShowTemplates(!showTemplates)}
                   className="flex items-center gap-1.5 px-3 py-1.5 bg-neutral-200 hover:bg-neutral-300 text-neutral-700 rounded-lg text-sm transition-colors outline-none"
                 >
-                  <BookOpen size={14} />
+                  <BookOpen weight="duotone" size={14} />
                   <span>{t('editor.blocks.math_block.templates')}</span>
-                  <ChevronDown size={14} className={`transition-transform ${showTemplates ? 'rotate-180' : ''}`} />
+                  <CaretDown weight="duotone" size={14} className={`transition-transform ${showTemplates ? 'rotate-180' : ''}`} />
                 </button>
 
                 {showTemplates && (
@@ -230,9 +230,9 @@ function MathEquationBlockComponent(props: any) {
                   onClick={() => setShowSymbols(!showSymbols)}
                   className="flex items-center gap-1.5 px-3 py-1.5 bg-neutral-200 hover:bg-neutral-300 text-neutral-700 rounded-lg text-sm transition-colors outline-none"
                 >
-                  <Sigma size={14} />
+                  <Sigma weight="duotone" size={14} />
                   <span>{t('editor.blocks.math_block.symbols')}</span>
-                  <ChevronDown size={14} className={`transition-transform ${showSymbols ? 'rotate-180' : ''}`} />
+                  <CaretDown weight="duotone" size={14} className={`transition-transform ${showSymbols ? 'rotate-180' : ''}`} />
                 </button>
 
                 {showSymbols && (
@@ -262,9 +262,9 @@ function MathEquationBlockComponent(props: any) {
                   onClick={() => setShowHelp(!showHelp)}
                   className="flex items-center gap-1.5 px-3 py-1.5 bg-neutral-200 hover:bg-neutral-300 text-neutral-700 rounded-lg text-sm transition-colors outline-none"
                 >
-                  <Lightbulb size={14} />
+                  <Lightbulb weight="duotone" size={14} />
                   <span>{t('editor.blocks.math_block.help')}</span>
-                  <ChevronDown size={14} className={`transition-transform ${showHelp ? 'rotate-180' : ''}`} />
+                  <CaretDown weight="duotone" size={14} className={`transition-transform ${showHelp ? 'rotate-180' : ''}`} />
                 </button>
 
                 {showHelp && (
@@ -298,7 +298,7 @@ function MathEquationBlockComponent(props: any) {
                           target="_blank"
                         >
                           {t('editor.blocks.math_block.view_reference')}
-                          <ExternalLink size={10} className="ml-1" />
+                          <ArrowSquareOut weight="duotone" size={10} className="ml-1" />
                         </Link>
                       </div>
                     </div>
@@ -321,7 +321,7 @@ function MathEquationBlockComponent(props: any) {
                 onClick={() => saveEquation()}
                 className="flex items-center justify-center w-8 h-8 bg-neutral-100 hover:bg-neutral-200 text-neutral-600 rounded-md transition-colors"
               >
-                <Save size={15} />
+                <FloppyDisk weight="duotone" size={15} />
               </button>
             </div>
 
@@ -334,7 +334,7 @@ function MathEquationBlockComponent(props: any) {
                 target="_blank"
               >
                 {t('editor.blocks.math_block.guide')}
-                <ExternalLink size={12} className="ml-1" />
+                <ArrowSquareOut weight="duotone" size={12} className="ml-1" />
               </Link>
               <span>{t('editor.blocks.math_block.for_functions')}</span>
             </div>

--- a/apps/web/components/Objects/Editor/Extensions/PDF/PDFBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/PDF/PDFBlockComponent.tsx
@@ -1,6 +1,6 @@
 import { NodeViewWrapper } from '@tiptap/react'
 import React, { useEffect } from 'react'
-import { FileText, Download, Expand, Upload, Loader2, AlertCircle } from 'lucide-react'
+import { FileText, DownloadSimple, ArrowsOut, UploadSimple, CircleNotch, WarningCircle } from '@phosphor-icons/react'
 import toast from 'react-hot-toast'
 import { uploadNewPDFFile } from '../../../../../services/blocks/Pdf/pdf'
 import { getActivityBlockMediaDirectory } from '@services/media/media'
@@ -115,7 +115,7 @@ function PDFBlockComponent(props: any) {
       <NodeViewWrapper className="block-pdf">
         <div className="bg-neutral-50 rounded-xl px-5 py-4 nice-shadow">
           <div className="flex items-center justify-center gap-3 py-8 bg-white rounded-lg nice-shadow">
-            <FileText className="text-neutral-300" size={32} />
+            <FileText weight="duotone" className="text-neutral-300" size={32} />
             <p className="text-neutral-500">{t('editor.blocks.pdf_block.no_pdf')}</p>
           </div>
         </div>
@@ -140,14 +140,14 @@ function PDFBlockComponent(props: any) {
                 className="p-2 outline-none bg-black/50 hover:bg-black/70 rounded-lg transition-colors"
                 title={t('editor.blocks.pdf_block.expand_pdf')}
               >
-                <Expand className="w-4 h-4 text-white" />
+                <ArrowsOut weight="duotone" className="w-4 h-4 text-white" />
               </button>
               <button
                 onClick={handleDownload}
                 className="p-2 outline-none bg-black/50 hover:bg-black/70 rounded-lg transition-colors"
                 title={t('editor.blocks.pdf_block.download_pdf')}
               >
-                <Download className="w-4 h-4 text-white" />
+                <DownloadSimple weight="duotone" className="w-4 h-4 text-white" />
               </button>
             </div>
           </div>
@@ -180,7 +180,7 @@ function PDFBlockComponent(props: any) {
         <div className="bg-neutral-50 rounded-xl px-5 py-4 transition-all ease-linear">
           {/* Header */}
           <div className="flex items-center gap-2 mb-3">
-            <FileText className="text-neutral-400" size={16} />
+            <FileText weight="duotone" className="text-neutral-400" size={16} />
             <span className="uppercase tracking-widest text-xs font-bold text-neutral-400">
               {t('editor.blocks.pdf')}
             </span>
@@ -206,7 +206,7 @@ function PDFBlockComponent(props: any) {
                 />
                 {isLoading ? (
                   <div className="space-y-3">
-                    <Loader2 className="w-8 h-8 animate-spin mx-auto text-blue-500" />
+                    <CircleNotch weight="duotone" className="w-8 h-8 animate-spin mx-auto text-blue-500" />
                     <p className="text-sm text-neutral-600">{t('editor.blocks.pdf_block.uploading')} {progress}%</p>
                     <div
                       className="w-48 h-1 bg-neutral-200 rounded-full mx-auto overflow-hidden"
@@ -223,7 +223,7 @@ function PDFBlockComponent(props: any) {
                   </div>
                 ) : (
                   <div className="space-y-3">
-                    <Upload className="w-8 h-8 mx-auto text-neutral-400" />
+                    <UploadSimple weight="duotone" className="w-8 h-8 mx-auto text-neutral-400" />
                     <div>
                       <p className="text-sm font-medium text-neutral-700">
                         {pdf ? pdf.name : t('editor.blocks.pdf_block.drop_or_browse')}
@@ -242,14 +242,14 @@ function PDFBlockComponent(props: any) {
                     disabled={isLoading}
                     className="flex items-center gap-2 px-4 py-2 bg-neutral-700 hover:bg-neutral-800 text-white rounded-lg text-sm transition-colors disabled:opacity-50"
                   >
-                    <Upload size={14} />
+                    <UploadSimple weight="duotone" size={14} />
                     {t('editor.blocks.pdf_block.upload_pdf')}
                   </button>
                 </div>
               )}
               {error && (
                 <div className="mt-3 flex items-center gap-2 text-sm text-red-500 font-medium bg-red-50 rounded-lg p-3">
-                  <AlertCircle size={16} />
+                  <WarningCircle weight="duotone" size={16} />
                   {error}
                 </div>
               )}
@@ -270,14 +270,14 @@ function PDFBlockComponent(props: any) {
                   className="p-2 outline-none bg-black/50 hover:bg-black/70 rounded-lg transition-colors"
                   title={t('editor.blocks.pdf_block.expand_pdf')}
                 >
-                  <Expand className="w-4 h-4 text-white" />
+                  <ArrowsOut weight="duotone" className="w-4 h-4 text-white" />
                 </button>
                 <button
                   onClick={handleDownload}
                   className="p-2 outline-none bg-black/50 hover:bg-black/70 rounded-lg transition-colors"
                   title={t('editor.blocks.pdf_block.download_pdf')}
                 >
-                  <Download className="w-4 h-4 text-white" />
+                  <DownloadSimple weight="duotone" className="w-4 h-4 text-white" />
                 </button>
               </div>
             </div>

--- a/apps/web/components/Objects/Editor/Extensions/Quiz/QuizBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Quiz/QuizBlockComponent.tsx
@@ -2,8 +2,16 @@ import { NodeViewWrapper } from '@tiptap/react'
 import { v4 as uuidv4 } from 'uuid'
 import { cn } from '@/lib/utils'
 import React from 'react'
-import { BadgeHelp, Check, Minus, Plus, RefreshCcw } from 'lucide-react'
-import { Sparkle } from '@phosphor-icons/react'
+import {
+  Question as QuestionIcon,
+  Check,
+  CheckCircle,
+  Plus,
+  ArrowCounterClockwise,
+  Trash,
+  X,
+  Sparkle,
+} from '@phosphor-icons/react'
 import dynamic from 'next/dynamic'
 const ReactConfetti = dynamic(() => import('react-confetti'), { ssr: false })
 const AIQuizGeneratorModal = dynamic(() => import('@components/Objects/AI/AIQuizGeneratorModal'), { ssr: false })
@@ -49,16 +57,19 @@ function QuizBlockComponent(props: any) {
   }
 
   const handleAnswerClick = (question_id: string, answer_id: string) => {
-    if (submitted) return;
+    if (isEditable || submitted) return
 
     const existingAnswerIndex = userAnswers.findIndex(
-      (answer: any) => answer.question_id === question_id && answer.answer_id === answer_id
-    );
+      (answer: any) =>
+        answer.question_id === question_id && answer.answer_id === answer_id
+    )
 
     if (existingAnswerIndex !== -1) {
-      setUserAnswers(userAnswers.filter((_, index) => index !== existingAnswerIndex));
+      setUserAnswers(
+        userAnswers.filter((_, index) => index !== existingAnswerIndex)
+      )
     } else {
-      setUserAnswers([...userAnswers, { question_id, answer_id }]);
+      setUserAnswers([...userAnswers, { question_id, answer_id }])
     }
   }
 
@@ -69,82 +80,73 @@ function QuizBlockComponent(props: any) {
   }
 
   const handleUserSubmission = () => {
-    setSubmitted(true);
+    setSubmitted(true)
 
     const correctAnswers = questions.every((question: Question) => {
-      const correctAnswers = question.answers.filter((answer: Answer) => answer.correct);
+      const correctAnswers = question.answers.filter(
+        (answer: Answer) => answer.correct
+      )
       const userAnswersForQuestion = userAnswers.filter(
         (userAnswer: any) => userAnswer.question_id === question.question_id
-      );
+      )
 
       if (correctAnswers.length === 0 && userAnswersForQuestion.length === 0) {
-        return true;
+        return true
       }
 
       return (
         correctAnswers.length === userAnswersForQuestion.length &&
         correctAnswers.every((correctAnswer: Answer) =>
           userAnswersForQuestion.some(
-            (userAnswer: any) => userAnswer.answer_id === correctAnswer.answer_id
+            (userAnswer: any) =>
+              userAnswer.answer_id === correctAnswer.answer_id
           )
         )
-      );
-    });
+      )
+    })
 
-    setSubmissionMessage(correctAnswers ? 'correct' : 'incorrect');
+    setSubmissionMessage(correctAnswers ? 'correct' : 'incorrect')
   }
 
-  const getAnswerID = (answerIndex: number, _questionId: string) => {
+  const getAnswerLetter = (answerIndex: number) => {
     const alphabet = Array.from({ length: 26 }, (_, i) =>
       String.fromCharCode('A'.charCodeAt(0) + i)
     )
-    let alphabetID = alphabet[answerIndex]
-    return `${alphabetID}`
+    return alphabet[answerIndex] ?? '?'
   }
 
-  const saveQuestions = (questions: any) => {
-    props.updateAttributes({
-      questions: questions,
-    })
-    setQuestions(questions)
+  const saveQuestions = (newQuestions: Question[]) => {
+    props.updateAttributes({ questions: newQuestions })
+    setQuestions(newQuestions)
   }
 
   const addSampleQuestion = () => {
-    const newQuestion = {
+    const newQuestion: Question = {
       question_id: uuidv4(),
       question: '',
       type: 'multiple_choice',
-      answers: [
-        {
-          answer_id: uuidv4(),
-          answer: '',
-          correct: false,
-        },
-      ],
+      answers: [{ answer_id: uuidv4(), answer: '', correct: false }],
     }
-    setQuestions([...questions, newQuestion])
+    saveQuestions([...questions, newQuestion])
   }
 
   const addAnswer = (question_id: string) => {
-    const newAnswer = {
+    const question: any = questions.find(
+      (q: Question) => q.question_id === question_id
+    )
+    if (!question || question.answers.length >= 5) return
+
+    const newAnswer: Answer = {
       answer_id: uuidv4(),
       answer: '',
       correct: false,
     }
 
-    const question: any = questions.find(
-      (question: Question) => question.question_id === question_id
+    const newQuestions = questions.map((q: Question) =>
+      q.question_id === question_id
+        ? { ...q, answers: [...q.answers, newAnswer] }
+        : q
     )
-    if (question.answers.length >= 5) {
-      return
-    }
-
-    const newQuestions = questions.map((question: Question) => {
-      if (question.question_id === question_id) {
-        question.answers.push(newAnswer)
-      }
-      return question
-    })
 
     saveQuestions(newQuestions)
   }
@@ -154,98 +156,91 @@ function QuizBlockComponent(props: any) {
     answer_id: string,
     value: string
   ) => {
-    const newQuestions = questions.map((question: Question) => {
-      if (question.question_id === question_id) {
-        question.answers.map((answer: Answer) => {
-          if (answer.answer_id === answer_id) {
-            answer.answer = value
+    const newQuestions = questions.map((question: Question) =>
+      question.question_id === question_id
+        ? {
+            ...question,
+            answers: question.answers.map((answer: Answer) =>
+              answer.answer_id === answer_id
+                ? { ...answer, answer: value }
+                : answer
+            ),
           }
-          return answer
-        })
-      }
-      return question
-    })
-    saveQuestions(newQuestions)
-  }
-
-  const changeQuestionValue = (question_id: string, value: string) => {
-    const newQuestions = questions.map((question: Question) => {
-      if (question.question_id === question_id) {
-        question.question = value
-      }
-      return question
-    })
-    saveQuestions(newQuestions)
-  }
-
-  const deleteQuestion = (question_id: string) => {
-    const newQuestions = questions.filter(
-      (question: Question) => question.question_id !== question_id
+        : question
     )
     saveQuestions(newQuestions)
   }
 
+  const changeQuestionValue = (question_id: string, value: string) => {
+    const newQuestions = questions.map((question: Question) =>
+      question.question_id === question_id
+        ? { ...question, question: value }
+        : question
+    )
+    saveQuestions(newQuestions)
+  }
+
+  const deleteQuestion = (question_id: string) => {
+    saveQuestions(
+      questions.filter((q: Question) => q.question_id !== question_id)
+    )
+  }
+
   const deleteAnswer = (question_id: string, answer_id: string) => {
-    const newQuestions = questions.map((question: Question) => {
-      if (question.question_id === question_id) {
-        question.answers = question.answers.filter(
-          (answer: Answer) => answer.answer_id !== answer_id
-        )
-      }
-      return question
-    })
+    const newQuestions = questions.map((question: Question) =>
+      question.question_id === question_id
+        ? {
+            ...question,
+            answers: question.answers.filter(
+              (answer: Answer) => answer.answer_id !== answer_id
+            ),
+          }
+        : question
+    )
     saveQuestions(newQuestions)
   }
 
   const markAnswerCorrect = (question_id: string, answer_id: string) => {
-    const newQuestions = questions.map((question: Question) => {
-      if (question.question_id === question_id) {
-        question.answers = question.answers.map((answer: Answer) => ({
-          ...answer,
-          correct: answer.answer_id === answer_id ? !answer.correct : answer.correct,
-        }));
-      }
-      return question;
-    });
-    saveQuestions(newQuestions);
+    const newQuestions = questions.map((question: Question) =>
+      question.question_id === question_id
+        ? {
+            ...question,
+            answers: question.answers.map((answer: Answer) => ({
+              ...answer,
+              correct:
+                answer.answer_id === answer_id
+                  ? !answer.correct
+                  : answer.correct,
+            })),
+          }
+        : question
+    )
+    saveQuestions(newQuestions)
   }
+
+  const totalQuestions = questions.length
+  const hasAnyAnswer = userAnswers.length > 0
 
   return (
     <NodeViewWrapper className="block-quiz">
-      <div className="bg-neutral-50 rounded-xl px-5 py-4 nice-shadow transition-all ease-linear">
-        {/* Header section */}
-        <div className="flex flex-wrap gap-2 items-center text-sm mb-3">
-          {submitted && submissionMessage === 'correct' && (
-            <ReactConfetti
-              numberOfPieces={submitted ? 1400 : 0}
-              recycle={false}
-              className="w-full h-screen"
-            />
-          )}
+      <div className="bg-neutral-50 rounded-xl px-4 py-3 nice-shadow transition-all ease-linear">
+        {submitted && submissionMessage === 'correct' && (
+          <ReactConfetti
+            numberOfPieces={1400}
+            recycle={false}
+            className="w-full h-screen"
+          />
+        )}
+
+        {/* Header */}
+        <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-2">
-            <BadgeHelp className="text-neutral-400" size={16} />
-            <span className="uppercase tracking-widest text-xs font-bold text-neutral-400">
+            <QuestionIcon weight="duotone" className="text-neutral-400" size={15} />
+            <span className="uppercase tracking-widest text-[11px] font-bold text-neutral-400">
               {t('editor.blocks.quiz')}
             </span>
           </div>
 
-          {/* Submission message */}
-          {submitted && (
-            <div className={cn(
-              "text-xs font-medium px-2 py-1 rounded-md",
-              submissionMessage === 'correct'
-                ? 'bg-emerald-100 text-emerald-700'
-                : 'bg-red-100 text-red-700'
-            )}>
-              {submissionMessage === 'correct'
-                ? t('editor.blocks.quiz_block.all_correct')
-                : t('editor.blocks.quiz_block.some_incorrect')}
-            </div>
-          )}
-
-          <div className="grow"></div>
-
-          {/* Action buttons */}
           {isEditable ? (
             <div className="flex items-center gap-1.5">
               <button
@@ -257,23 +252,31 @@ function QuizBlockComponent(props: any) {
               </button>
               <button
                 onClick={addSampleQuestion}
-                className="bg-neutral-200 hover:bg-neutral-300 text-neutral-700 font-medium py-1.5 px-3 rounded-lg text-xs transition-colors outline-none"
+                className="flex items-center gap-1 bg-neutral-200 hover:bg-neutral-300 text-neutral-700 text-xs font-medium px-2.5 py-1 rounded-md transition-colors outline-none"
               >
+                <Plus weight="duotone" size={12} />
                 {t('editor.blocks.quiz_block.add_question')}
               </button>
             </div>
           ) : (
             <div className="flex items-center gap-1">
               <button
-                onClick={() => refreshUserSubmission()}
-                className="p-1.5 rounded-md hover:bg-neutral-200 transition-colors"
+                onClick={refreshUserSubmission}
+                disabled={!hasAnyAnswer && !submitted}
+                className="p-1 rounded-md text-neutral-400 hover:text-neutral-700 hover:bg-neutral-200 transition-colors disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-neutral-400 disabled:cursor-not-allowed outline-none"
                 title={t('editor.blocks.quiz_block.reset_answers')}
               >
-                <RefreshCcw className="text-neutral-500" size={15} />
+                <ArrowCounterClockwise weight="duotone" size={13} />
               </button>
               <button
-                onClick={() => handleUserSubmission()}
-                className="bg-neutral-200 hover:bg-neutral-300 text-neutral-700 font-medium py-1.5 px-3 rounded-lg text-xs transition-colors outline-none"
+                onClick={handleUserSubmission}
+                disabled={submitted || !hasAnyAnswer || totalQuestions === 0}
+                className={cn(
+                  'text-xs font-medium px-2.5 py-1 rounded-md transition-colors outline-none',
+                  submitted || !hasAnyAnswer || totalQuestions === 0
+                    ? 'bg-neutral-200/60 text-neutral-400 cursor-not-allowed'
+                    : 'bg-neutral-700 hover:bg-neutral-800 text-white'
+                )}
               >
                 {t('editor.blocks.quiz_block.submit')}
               </button>
@@ -281,159 +284,290 @@ function QuizBlockComponent(props: any) {
           )}
         </div>
 
-        {/* Questions section */}
-        <div className="space-y-4">
-          {questions.map((question: Question) => (
-            <div key={question.question_id} className="bg-white rounded-lg p-4 nice-shadow">
-              {/* Question */}
-              <div className="flex items-start gap-2 mb-3">
-                <div className="flex-1">
-                  {isEditable ? (
-                    <input
-                      value={question.question}
-                      placeholder={t('editor.blocks.quiz_block.question_placeholder')}
-                      onChange={(e) =>
-                        changeQuestionValue(
-                          question.question_id,
-                          e.target.value
-                        )
-                      }
-                      className="text-neutral-800 bg-transparent border-2 border-dashed border-neutral-200 rounded-lg text-base font-semibold w-full p-2 focus:border-neutral-300 outline-none transition-colors"
-                    />
-                  ) : (
-                    <p className="text-neutral-800 text-base font-semibold p-2 break-words">
-                      {question.question}
-                    </p>
-                  )}
-                </div>
-                {isEditable && (
-                  <button
-                    onClick={() => deleteQuestion(question.question_id)}
-                    className="w-7 h-7 flex items-center justify-center rounded-lg bg-neutral-100 hover:bg-neutral-200 transition-colors"
-                  >
-                    <Minus className="text-neutral-500" size={14} />
-                  </button>
-                )}
-              </div>
+        {/* Empty state */}
+        {totalQuestions === 0 && (
+          <div className="bg-white rounded-lg nice-shadow flex items-center justify-center gap-2 py-6">
+            <QuestionIcon weight="duotone" className="text-neutral-300" size={20} />
+            <p className="text-xs text-neutral-500">
+              {isEditable
+                ? t('editor.blocks.quiz_block.empty_editable', {
+                    defaultValue:
+                      'No questions yet. Add your first one to get started.',
+                  })
+                : t('editor.blocks.quiz_block.empty_readonly', {
+                    defaultValue: 'This quiz has no questions yet.',
+                  })}
+            </p>
+          </div>
+        )}
 
-              {/* Answers */}
-              <div className="space-y-2">
-                {question.answers.map((answer: Answer) => {
-                  const isSelected = userAnswers.some(
-                    (userAnswer: any) =>
-                      userAnswer.question_id === question.question_id &&
-                      userAnswer.answer_id === answer.answer_id
-                  );
-                  const isCorrectAnswer = answer.correct;
-                  const isIncorrectSelection = submitted && isSelected && !isCorrectAnswer;
-
-                  return (
-                    <div
-                      key={answer.answer_id}
-                      onClick={() => handleAnswerClick(question.question_id, answer.answer_id)}
-                      className={cn(
-                        "flex items-stretch rounded-lg border-2 transition-all cursor-pointer min-h-[44px]",
-                        // Default state
-                        !isEditable && !submitted && !isSelected && "border-neutral-200 bg-neutral-50 hover:border-neutral-300 hover:bg-neutral-100",
-                        // Selected (not submitted)
-                        !isEditable && !submitted && isSelected && "border-blue-400 bg-blue-50",
-                        // Correct answer (submitted)
-                        submitted && isCorrectAnswer && "border-emerald-400 bg-emerald-50",
-                        // Incorrect selection (submitted)
-                        isIncorrectSelection && "border-red-400 bg-red-50",
-                        // Edit mode - correct marked
-                        isEditable && isCorrectAnswer && "border-emerald-400 bg-emerald-50",
-                        // Edit mode - not marked
-                        isEditable && !isCorrectAnswer && "border-neutral-200 bg-neutral-50"
-                      )}
-                    >
-                      {/* Answer Letter */}
-                      <div
-                        className={cn(
-                          "w-10 flex items-center justify-center rounded-l-md font-bold text-sm flex-shrink-0",
-                          // Default
-                          !isEditable && !submitted && !isSelected && "bg-neutral-100 text-neutral-600",
-                          // Selected (not submitted)
-                          !isEditable && !submitted && isSelected && "bg-blue-400 text-white",
-                          // Correct (submitted)
-                          submitted && isCorrectAnswer && "bg-emerald-400 text-white",
-                          // Incorrect selection
-                          isIncorrectSelection && "bg-red-400 text-white",
-                          // Edit mode - correct
-                          isEditable && isCorrectAnswer && "bg-emerald-400 text-white",
-                          // Edit mode - not correct
-                          isEditable && !isCorrectAnswer && "bg-neutral-100 text-neutral-600"
+        {/* Questions */}
+        {totalQuestions > 0 && (
+          <div className="space-y-3">
+            {questions.map((question: Question, qIndex: number) => (
+              <div key={question.question_id}>
+                {/* Question header */}
+                <div className="flex items-start justify-between gap-2 mb-1.5 px-1">
+                  <div className="flex-1 min-w-0">
+                    <div className="text-[10px] uppercase tracking-widest font-bold text-neutral-400 mb-0.5">
+                      {t('editor.blocks.quiz_block.question_label', {
+                        defaultValue: 'Question',
+                      })}{' '}
+                      {qIndex + 1}
+                    </div>
+                    {isEditable ? (
+                      <input
+                        value={question.question}
+                        placeholder={t(
+                          'editor.blocks.quiz_block.question_placeholder'
                         )}
-                      >
-                        {getAnswerID(question.answers.indexOf(answer), question.question_id)}
-                      </div>
-
-                      {/* Answer Text */}
-                      <div className="flex-1 flex items-center px-3 py-2">
-                        {isEditable ? (
-                          <input
-                            value={answer.answer}
-                            onChange={(e) =>
-                              changeAnswerValue(
-                                question.question_id,
-                                answer.answer_id,
-                                e.target.value
-                              )
-                            }
-                            placeholder={t('editor.blocks.quiz_block.answer_placeholder')}
-                            className="w-full text-neutral-700 bg-transparent border-0 text-sm font-medium outline-none"
-                            onClick={(e) => e.stopPropagation()}
-                          />
-                        ) : (
-                          <span className="text-neutral-700 text-sm font-medium break-words">
-                            {answer.answer}
+                        onChange={(e) =>
+                          changeQuestionValue(
+                            question.question_id,
+                            e.target.value
+                          )
+                        }
+                        className="w-full text-neutral-800 bg-transparent text-sm font-semibold outline-none placeholder:text-neutral-300"
+                      />
+                    ) : (
+                      <p className="text-neutral-800 text-sm font-semibold break-words leading-snug">
+                        {question.question || (
+                          <span className="text-neutral-300 italic font-normal">
+                            {t(
+                              'editor.blocks.quiz_block.question_placeholder'
+                            )}
                           </span>
                         )}
-                      </div>
+                      </p>
+                    )}
+                  </div>
+                  {isEditable && (
+                    <button
+                      onClick={() => deleteQuestion(question.question_id)}
+                      className="shrink-0 w-6 h-6 flex items-center justify-center rounded-md text-neutral-400 hover:text-red-500 hover:bg-red-50 transition-colors outline-none"
+                      title={t('editor.blocks.quiz_block.delete_question', {
+                        defaultValue: 'Delete question',
+                      })}
+                    >
+                      <Trash weight="duotone" size={12} />
+                    </button>
+                  )}
+                </div>
 
-                      {/* Edit Actions */}
-                      {isEditable && (
-                        <div className="flex items-center gap-1 px-2">
+                {/* Answers */}
+                <div className="space-y-1">
+                  {question.answers.map((answer: Answer, aIndex: number) => {
+                    const isSelected = userAnswers.some(
+                      (userAnswer: any) =>
+                        userAnswer.question_id === question.question_id &&
+                        userAnswer.answer_id === answer.answer_id
+                    )
+                    const isMarkedCorrect = answer.correct
+                    const isCorrectReveal = submitted && isMarkedCorrect
+                    const isWrongSelection =
+                      submitted && isSelected && !isMarkedCorrect
+                    const letter = getAnswerLetter(aIndex)
+
+                    const row = cn(
+                      'group flex items-center gap-2 rounded-lg nice-shadow px-2 py-1.5 transition-colors',
+                      // Take mode — default
+                      !isEditable &&
+                        !submitted &&
+                        !isSelected &&
+                        'bg-white hover:bg-neutral-50 cursor-pointer',
+                      // Take mode — selected
+                      !isEditable &&
+                        !submitted &&
+                        isSelected &&
+                        'bg-blue-50 cursor-pointer',
+                      // Submitted — correct
+                      isCorrectReveal && 'bg-emerald-50',
+                      // Submitted — wrong selection
+                      isWrongSelection && 'bg-red-50',
+                      // Submitted — neutral (not selected, not correct)
+                      submitted &&
+                        !isMarkedCorrect &&
+                        !isSelected &&
+                        'bg-white opacity-60',
+                      // Edit — marked correct
+                      isEditable && isMarkedCorrect && 'bg-emerald-50',
+                      // Edit — not marked
+                      isEditable &&
+                        !isMarkedCorrect &&
+                        'bg-white hover:bg-neutral-50'
+                    )
+
+                    const chip = cn(
+                      'shrink-0 w-6 h-6 rounded-md flex items-center justify-center text-[11px] font-bold transition-colors',
+                      // Take mode — default
+                      !isEditable &&
+                        !submitted &&
+                        !isSelected &&
+                        'bg-neutral-100 text-neutral-500',
+                      // Take mode — selected
+                      !isEditable &&
+                        !submitted &&
+                        isSelected &&
+                        'bg-blue-500 text-white',
+                      // Submitted — correct
+                      isCorrectReveal && 'bg-emerald-500 text-white',
+                      // Submitted — wrong selection
+                      isWrongSelection && 'bg-red-500 text-white',
+                      // Submitted — neutral
+                      submitted &&
+                        !isMarkedCorrect &&
+                        !isSelected &&
+                        'bg-neutral-100 text-neutral-400',
+                      // Edit — correct
+                      isEditable &&
+                        isMarkedCorrect &&
+                        'bg-emerald-500 text-white',
+                      // Edit — not correct
+                      isEditable &&
+                        !isMarkedCorrect &&
+                        'bg-neutral-100 text-neutral-500'
+                    )
+
+                    return (
+                      <div
+                        key={answer.answer_id}
+                        onClick={() =>
+                          handleAnswerClick(
+                            question.question_id,
+                            answer.answer_id
+                          )
+                        }
+                        className={row}
+                      >
+                        {/* Letter chip — clickable in edit mode to toggle correct */}
+                        {isEditable ? (
                           <button
                             onClick={(e) => {
-                              e.stopPropagation();
-                              markAnswerCorrect(question.question_id, answer.answer_id);
+                              e.stopPropagation()
+                              markAnswerCorrect(
+                                question.question_id,
+                                answer.answer_id
+                              )
                             }}
-                            className="w-7 h-7 flex items-center justify-center rounded-lg bg-emerald-100 hover:bg-emerald-200 transition-colors"
-                            title={answer.correct ? t('editor.blocks.quiz_block.mark_incorrect') : t('editor.blocks.quiz_block.mark_correct')}
+                            className={cn(chip, 'cursor-pointer outline-none')}
+                            title={
+                              answer.correct
+                                ? t('editor.blocks.quiz_block.mark_incorrect')
+                                : t('editor.blocks.quiz_block.mark_correct')
+                            }
                           >
-                            <Check className="text-emerald-700" size={14} />
+                            {answer.correct ? <Check weight="duotone" size={12} /> : letter}
                           </button>
+                        ) : (
+                          <div className={chip}>{letter}</div>
+                        )}
+
+                        {/* Answer text */}
+                        <div className="flex-1 min-w-0">
+                          {isEditable ? (
+                            <input
+                              value={answer.answer}
+                              onChange={(e) =>
+                                changeAnswerValue(
+                                  question.question_id,
+                                  answer.answer_id,
+                                  e.target.value
+                                )
+                              }
+                              placeholder={t(
+                                'editor.blocks.quiz_block.answer_placeholder'
+                              )}
+                              className="w-full bg-transparent border-0 text-sm text-neutral-700 placeholder:text-neutral-400 outline-none"
+                              onClick={(e) => e.stopPropagation()}
+                            />
+                          ) : (
+                            <span
+                              className={cn(
+                                'text-sm break-words',
+                                isCorrectReveal
+                                  ? 'text-emerald-900 font-medium'
+                                  : isWrongSelection
+                                  ? 'text-red-900 font-medium'
+                                  : 'text-neutral-700'
+                              )}
+                            >
+                              {answer.answer || (
+                                <span className="text-neutral-300 italic">
+                                  {t(
+                                    'editor.blocks.quiz_block.answer_placeholder'
+                                  )}
+                                </span>
+                              )}
+                            </span>
+                          )}
+                        </div>
+
+                        {/* Trailing — status icon (take mode) or delete (edit) */}
+                        {isEditable ? (
                           <button
                             onClick={(e) => {
-                              e.stopPropagation();
-                              deleteAnswer(question.question_id, answer.answer_id);
+                              e.stopPropagation()
+                              deleteAnswer(
+                                question.question_id,
+                                answer.answer_id
+                              )
                             }}
-                            className="w-7 h-7 flex items-center justify-center rounded-lg bg-neutral-100 hover:bg-neutral-200 transition-colors"
+                            className="shrink-0 w-6 h-6 flex items-center justify-center rounded-md text-neutral-400 hover:text-red-500 hover:bg-neutral-100 transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100 outline-none"
                             title={t('editor.blocks.quiz_block.delete_answer')}
                           >
-                            <Minus className="text-neutral-500" size={14} />
+                            <Trash weight="duotone" size={12} />
                           </button>
-                        </div>
-                      )}
-                    </div>
-                  );
-                })}
+                        ) : isCorrectReveal ? (
+                          <CheckCircle
+                            weight="duotone"
+                            className="shrink-0 text-emerald-500"
+                            size={14}
+                          />
+                        ) : isWrongSelection ? (
+                          <X weight="duotone" className="shrink-0 text-red-500" size={14} />
+                        ) : null}
+                      </div>
+                    )
+                  })}
 
-                {/* Add Answer Button */}
-                {isEditable && (
-                  <button
-                    onClick={() => addAnswer(question.question_id)}
-                    className="w-full flex items-center justify-center gap-1 h-11 border-2 border-dashed border-neutral-200 rounded-lg text-neutral-600 hover:border-neutral-300 hover:bg-neutral-50 transition-colors"
-                  >
-                    <Plus size={15} />
-                    <span className="text-sm font-medium">{t('editor.blocks.quiz_block.add_answer')}</span>
-                  </button>
-                )}
+                  {/* Add answer */}
+                  {isEditable && question.answers.length < 5 && (
+                    <button
+                      onClick={() => addAnswer(question.question_id)}
+                      className="w-full flex items-center justify-center gap-1 h-7 rounded-lg text-[11px] font-medium text-neutral-500 hover:text-neutral-700 border border-dashed border-neutral-200 hover:border-neutral-300 hover:bg-white transition-colors outline-none"
+                    >
+                      <Plus weight="duotone" size={11} />
+                      {t('editor.blocks.quiz_block.add_answer')}
+                    </button>
+                  )}
+                </div>
               </div>
+            ))}
+          </div>
+        )}
+
+        {/* Submission message */}
+        {submitted && (
+          <div className="mt-2.5">
+            <div
+              className={cn(
+                'inline-flex items-center gap-1.5 text-[11px] font-medium px-2 py-1 rounded-md',
+                submissionMessage === 'correct'
+                  ? 'bg-emerald-50 text-emerald-700'
+                  : 'bg-red-50 text-red-700'
+              )}
+            >
+              {submissionMessage === 'correct' ? (
+                <CheckCircle weight="duotone" size={12} />
+              ) : (
+                <X weight="duotone" size={12} />
+              )}
+              {submissionMessage === 'correct'
+                ? t('editor.blocks.quiz_block.all_correct')
+                : t('editor.blocks.quiz_block.some_incorrect')}
             </div>
-          ))}
-        </div>
+          </div>
+        )}
       </div>
       {showAIGenerator && (
         <AIQuizGeneratorModal

--- a/apps/web/components/Objects/Editor/Extensions/Scenarios/ScenariosExtension.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Scenarios/ScenariosExtension.tsx
@@ -1,7 +1,6 @@
 import { NodeViewWrapper } from '@tiptap/react'
 import React, { useState } from 'react'
-import { RotateCcw, ArrowRight, CheckCircle, GitBranch, RefreshCcw } from 'lucide-react'
-import { Sparkle } from '@phosphor-icons/react'
+import { ArrowCounterClockwise, ArrowRight, CheckCircle, GitBranch, Sparkle } from '@phosphor-icons/react'
 import dynamic from 'next/dynamic'
 import { useEditorProvider } from '@components/Contexts/Editor/EditorContext'
 import ScenariosModal from './ScenariosModal'
@@ -75,7 +74,7 @@ const ScenariosExtension: React.FC = (props: any) => {
         {/* Header section */}
         <div className="flex flex-wrap gap-2 items-center text-sm mb-3">
           <div className="flex items-center gap-2">
-            <GitBranch className="text-neutral-400" size={16} />
+            <GitBranch weight="duotone" className="text-neutral-400" size={16} />
             <span className="uppercase tracking-widest text-xs font-bold text-neutral-400">
               Interactive Scenario
             </span>
@@ -113,7 +112,7 @@ const ScenariosExtension: React.FC = (props: any) => {
               className="p-1.5 rounded-md hover:bg-neutral-200 transition-colors"
               title="Reset scenario"
             >
-              <RefreshCcw className="text-neutral-500" size={15} />
+              <ArrowCounterClockwise weight="duotone" className="text-neutral-500" size={15} />
             </button>
           )}
         </div>
@@ -143,7 +142,7 @@ const ScenariosExtension: React.FC = (props: any) => {
         ) : scenarioComplete ? (
           <div className="bg-white rounded-lg p-6 nice-shadow text-center">
             <div className="w-16 h-16 bg-emerald-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <CheckCircle size={28} className="text-emerald-600" />
+              <CheckCircle weight="duotone" size={28} className="text-emerald-600" />
             </div>
             <h4 className="text-xl font-bold text-neutral-900 mb-2">Scenario Complete!</h4>
             <p className="text-neutral-600 mb-6 leading-relaxed max-w-md mx-auto">
@@ -153,7 +152,7 @@ const ScenariosExtension: React.FC = (props: any) => {
               onClick={resetScenario}
               className="inline-flex items-center gap-2 px-4 py-2 bg-neutral-700 hover:bg-neutral-800 text-white rounded-lg transition-colors font-medium text-sm"
             >
-              <RotateCcw size={16} />
+              <ArrowCounterClockwise weight="duotone" size={16} />
               Start Over
             </button>
           </div>
@@ -165,7 +164,7 @@ const ScenariosExtension: React.FC = (props: any) => {
                 return (
                   <div className="bg-white rounded-lg p-6 nice-shadow text-center">
                     <div className="w-12 h-12 bg-neutral-100 rounded-full flex items-center justify-center mx-auto mb-3">
-                      <GitBranch size={20} className="text-neutral-400" />
+                      <GitBranch weight="duotone" size={20} className="text-neutral-400" />
                     </div>
                     <h3 className="text-base font-medium text-neutral-900 mb-2">Scenario Not Found</h3>
                     <p className="text-neutral-500 text-sm">Please check your scenario configuration and try again.</p>
@@ -211,7 +210,7 @@ const ScenariosExtension: React.FC = (props: any) => {
                           <div className="flex-1 text-neutral-700 font-medium group-hover:text-blue-900 transition-colors">
                             {option.text}
                           </div>
-                          <ArrowRight size={16} className="text-neutral-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all" />
+                          <ArrowRight weight="duotone" size={16} className="text-neutral-400 group-hover:text-blue-500 group-hover:translate-x-1 transition-all" />
                         </div>
                       </button>
                     ))}

--- a/apps/web/components/Objects/Editor/Extensions/Users/UserBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Users/UserBlockComponent.tsx
@@ -5,22 +5,22 @@ import { getUserByUsername, getUser } from '@services/users/users'
 import { Input } from "@components/ui/input"
 import { Button } from "@components/ui/button"
 import {
-  Loader2,
+  CircleNotch,
   User,
-  ExternalLink,
+  ArrowSquareOut,
   Briefcase,
   GraduationCap,
   MapPin,
-  Building2,
+  BuildingApartment,
   Globe,
-  Laptop2,
-  Award,
+  Laptop,
+  Medal,
   BookOpen,
   Link,
   Users,
   Calendar,
   Lightbulb
-} from 'lucide-react'
+} from '@phosphor-icons/react'
 import { Badge } from "@components/ui/badge"
 import { useRouter } from 'next/navigation'
 import UserAvatar from '@components/Objects/UserAvatar'
@@ -50,11 +50,11 @@ const AVAILABLE_ICONS = {
   'briefcase': Briefcase,
   'graduation-cap': GraduationCap,
   'map-pin': MapPin,
-  'building-2': Building2,
+  'building-2': BuildingApartment,
   'speciality': Lightbulb,
   'globe': Globe,
-  'laptop-2': Laptop2,
-  'award': Award,
+  'laptop-2': Laptop,
+  'award': Medal,
   'book-open': BookOpen,
   'link': Link,
   'users': Users,
@@ -63,8 +63,8 @@ const AVAILABLE_ICONS = {
 
 const IconComponent = ({ iconName }: { iconName: string }) => {
   const IconElement = AVAILABLE_ICONS[iconName as keyof typeof AVAILABLE_ICONS]
-  if (!IconElement) return <User className="w-4 h-4 text-neutral-500" />
-  return <IconElement className="w-4 h-4 text-neutral-500" />
+  if (!IconElement) return <User weight="duotone" className="w-4 h-4 text-neutral-500" />
+  return <IconElement weight="duotone" className="w-4 h-4 text-neutral-500" />
 }
 
 function UserBlockComponent(props: any) {
@@ -148,7 +148,7 @@ function UserBlockComponent(props: any) {
         <div className="bg-neutral-50 rounded-xl px-5 py-4 nice-shadow transition-all ease-linear">
           {/* Header */}
           <div className="flex items-center gap-2 mb-3">
-            <User className="text-neutral-400" size={16} />
+            <User weight="duotone" className="text-neutral-400" size={16} />
             <span className="uppercase tracking-widest text-xs font-bold text-neutral-400">
               {t('editor.blocks.user')}
             </span>
@@ -166,7 +166,7 @@ function UserBlockComponent(props: any) {
                 />
                 <Button type="submit" disabled={isLoading} className="bg-neutral-700 hover:bg-neutral-800">
                   {isLoading ? (
-                    <Loader2 className="w-4 h-4 animate-spin" />
+                    <CircleNotch weight="duotone" className="w-4 h-4 animate-spin" />
                   ) : (
                     t('editor.blocks.user_block.load_user')
                   )}
@@ -188,7 +188,7 @@ function UserBlockComponent(props: any) {
       <NodeViewWrapper className="block-user">
         <div className="bg-neutral-50 rounded-xl px-5 py-4 nice-shadow">
           <div className="flex items-center justify-center py-8">
-            <Loader2 className="w-6 h-6 animate-spin text-neutral-400" />
+            <CircleNotch weight="duotone" className="w-6 h-6 animate-spin text-neutral-400" />
           </div>
         </div>
       </NodeViewWrapper>
@@ -215,7 +215,7 @@ function UserBlockComponent(props: any) {
       <NodeViewWrapper className="block-user">
         <div className="bg-neutral-50 rounded-xl px-5 py-4 nice-shadow">
           <div className="flex items-center justify-center gap-3 py-8 bg-white rounded-lg nice-shadow">
-            <User className="text-neutral-300" size={32} />
+            <User weight="duotone" className="text-neutral-300" size={32} />
             <span className="text-neutral-500">{t('editor.blocks.user_block.no_user')}</span>
           </div>
         </div>
@@ -262,7 +262,7 @@ function UserBlockComponent(props: any) {
                     className="h-7 w-7 text-neutral-500 hover:text-neutral-700 flex-shrink-0"
                     onClick={() => userData.username && router.push(`/user/${userData.username}`)}
                   >
-                    <ExternalLink className="w-4 h-4" />
+                    <ArrowSquareOut weight="duotone" className="w-4 h-4" />
                   </Button>
                 </div>
                 {userData.bio && (
@@ -299,7 +299,7 @@ function UserBlockComponent(props: any) {
       <div className="bg-neutral-50 rounded-xl px-5 py-4 nice-shadow transition-all ease-linear">
         {/* Header */}
         <div className="flex items-center gap-2 mb-3">
-          <User className="text-neutral-400" size={16} />
+          <User weight="duotone" className="text-neutral-400" size={16} />
           <span className="uppercase tracking-widest text-xs font-bold text-neutral-400">
             User Profile
           </span>
@@ -341,7 +341,7 @@ function UserBlockComponent(props: any) {
                     className="h-7 w-7 text-neutral-500 hover:text-neutral-700 flex-shrink-0"
                     onClick={() => userData.username && router.push(`/user/${userData.username}`)}
                   >
-                    <ExternalLink className="w-4 h-4" />
+                    <ArrowSquareOut weight="duotone" className="w-4 h-4" />
                   </Button>
                 </div>
                 {userData.bio && (

--- a/apps/web/components/Objects/Editor/Extensions/Video/VideoBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/Video/VideoBlockComponent.tsx
@@ -1,9 +1,9 @@
 import { NodeViewProps, NodeViewWrapper } from '@tiptap/react'
 import { Node } from '@tiptap/core'
 import {
-  Loader2, Video, Upload, X, ArrowLeftRight,
-  CheckCircle2, AlertCircle, Expand,
-} from 'lucide-react'
+  CircleNotch, VideoCamera, UploadSimple, X, ArrowsLeftRight,
+  CheckCircle, WarningCircle, ArrowsOut,
+} from '@phosphor-icons/react'
 import React from 'react'
 import toast from 'react-hot-toast'
 import { uploadNewVideoFileWithProgress, getVideoBlock } from '../../../../../services/blocks/Video/video'
@@ -322,7 +322,7 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
                     className="p-2 outline-none bg-black/50 hover:bg-black/70 rounded-lg transition-colors"
                     title={t('editor.blocks.video_block.expand_video')}
                   >
-                    <Expand className="w-4 h-4 text-white" />
+                    <ArrowsOut weight="duotone" className="w-4 h-4 text-white" />
                   </button>
                 </div>
               </div>
@@ -362,7 +362,7 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
         {/* Header */}
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">
-            <Video className="text-neutral-400" size={16} />
+            <VideoCamera weight="duotone" className="text-neutral-400" size={16} />
             <span className="uppercase tracking-widest text-xs font-bold text-neutral-400">
               {t('editor.blocks.video')}
             </span>
@@ -372,7 +372,7 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
               onClick={handleRemove}
               className="text-neutral-400 hover:text-red-500 transition-colors"
             >
-              <X size={16} />
+              <X weight="duotone" size={16} />
             </button>
           )}
         </div>
@@ -404,7 +404,7 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
             >
               {isLoading ? (
                 <div className="space-y-3">
-                  <Loader2 className="w-8 h-8 animate-spin mx-auto text-blue-500" />
+                  <CircleNotch weight="duotone" className="w-8 h-8 animate-spin mx-auto text-blue-500" />
                   <p className="text-sm text-neutral-600">{t('editor.blocks.video_block.uploading')} {uploadProgress}%</p>
                   <div className="w-48 h-1 bg-neutral-200 rounded-full mx-auto overflow-hidden">
                     <div
@@ -415,7 +415,7 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
                 </div>
               ) : (
                 <div className="space-y-3">
-                  <Upload className="w-8 h-8 mx-auto text-neutral-400" />
+                  <UploadSimple weight="duotone" className="w-8 h-8 mx-auto text-neutral-400" />
                   <div>
                     <p className="text-sm font-medium text-neutral-700">
                       {t('editor.blocks.video_block.drop_or_browse')}
@@ -430,7 +430,7 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
 
             {error && (
               <div className="flex items-center gap-2 text-sm text-red-500 font-medium bg-red-50 rounded-lg p-3">
-                <AlertCircle size={16} />
+                <WarningCircle weight="duotone" size={16} />
                 {error}
               </div>
             )}
@@ -443,7 +443,7 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
             {/* Size Controls */}
             <div className="flex items-center gap-2 flex-wrap">
               <div className="text-sm text-neutral-500 font-medium flex items-center gap-1">
-                <ArrowLeftRight size={14} />
+                <ArrowsLeftRight weight="duotone" size={14} />
                 {t('editor.blocks.common.size')}:
               </div>
               {(Object.keys(VIDEO_SIZES) as VideoSize[]).map((size) => (
@@ -457,7 +457,7 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
                       : "bg-neutral-200 text-neutral-700 hover:bg-neutral-300"
                   )}
                 >
-                  {size === selectedSize && <CheckCircle2 size={14} />}
+                  {size === selectedSize && <CheckCircle weight="duotone" size={14} />}
                   {t(`editor.blocks.common.${size}`)}
                 </button>
               ))}
@@ -476,7 +476,7 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
                 <div className="relative w-full aspect-video rounded-lg overflow-hidden bg-black nice-shadow">
                   {isLoading && (
                     <div className="absolute inset-0 z-40 flex items-center justify-center bg-black/10 backdrop-blur-sm">
-                      <Loader2 className="w-8 h-8 animate-spin text-white" />
+                      <CircleNotch weight="duotone" className="w-8 h-8 animate-spin text-white" />
                     </div>
                   )}
                   <LearnHousePlayer {...playerProps} />
@@ -486,7 +486,7 @@ function VideoBlockComponent(props: ExtendedNodeViewProps) {
                       className="p-2 outline-none bg-black/50 hover:bg-black/70 rounded-lg transition-colors"
                       title={t('editor.blocks.video_block.expand_video')}
                     >
-                      <Expand className="w-4 h-4 text-white" />
+                      <ArrowsOut weight="duotone" className="w-4 h-4 text-white" />
                     </button>
                   </div>
                 </div>

--- a/apps/web/components/Objects/Editor/Extensions/WebPreview/WebPreviewComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/WebPreview/WebPreviewComponent.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { NodeViewWrapper } from '@tiptap/react';
-import { Edit2, Save, X, AlignLeft, AlignCenter, AlignRight, Trash } from 'lucide-react';
+import { PencilSimple, FloppyDisk, X, TextAlignLeft, TextAlignCenter, TextAlignRight, Trash } from '@phosphor-icons/react';
 import { useEditorProvider } from '@components/Contexts/Editor/EditorContext';
 import { getUrlPreview } from '@services/courses/activities';
 import Modal from '@components/Objects/StyledElements/Modal/Modal';
@@ -18,15 +18,15 @@ interface EditorContext {
 
 interface WebPreviewProps {
   node: any;
-  updateAttributes: (attrs: any) => void;
+  updateAttributes: (_attrs: any) => void;
   extension: any;
   deleteNode?: () => void;
 }
 
 const ALIGNMENTS = [
-  { value: 'left', label: <AlignLeft size={16} /> },
-  { value: 'center', label: <AlignCenter size={16} /> },
-  { value: 'right', label: <AlignRight size={16} /> },
+  { value: 'left', label: <TextAlignLeft weight="duotone" size={16} /> },
+  { value: 'center', label: <TextAlignCenter weight="duotone" size={16} /> },
+  { value: 'right', label: <TextAlignRight weight="duotone" size={16} /> },
 ];
 
 const WebPreviewComponent: React.FC<WebPreviewProps> = ({ node, updateAttributes, deleteNode }) => {
@@ -181,7 +181,7 @@ const WebPreviewComponent: React.FC<WebPreviewProps> = ({ node, updateAttributes
                 title={t('editor.blocks.web_preview_block.edit_url')}
                 type="button"
               >
-                <Edit2 size={16} />
+                <PencilSimple weight="duotone" size={16} />
               </button>
               <button
                 className="flex items-center justify-center bg-red-50 text-red-700 border border-red-200 shadow-md rounded-md p-1.5 hover:bg-red-100"
@@ -189,7 +189,7 @@ const WebPreviewComponent: React.FC<WebPreviewProps> = ({ node, updateAttributes
                 title={t('editor.blocks.web_preview_block.delete_card')}
                 type="button"
               >
-                <Trash size={16} />
+                <Trash weight="duotone" size={16} />
               </button>
             </div>
           )}
@@ -276,10 +276,10 @@ const WebPreviewComponent: React.FC<WebPreviewProps> = ({ node, updateAttributes
                 {error && <div className="text-red-600 text-xs mt-2">{error}</div>}
                 <div className="flex justify-end gap-2 mt-2">
                   <Button type="button" variant="outline" onClick={handleCancelEdit}>
-                    <span className="flex items-center"><X size={16} className="mr-1" /> {t('editor.blocks.common.cancel')}</span>
+                    <span className="flex items-center"><X weight="duotone" size={16} className="mr-1" /> {t('editor.blocks.common.cancel')}</span>
                   </Button>
                   <Button type="submit" disabled={loading || !inputUrl}>
-                    <span className="flex items-center"><Save size={16} className="mr-1" /> {t('editor.blocks.common.save')}</span>
+                    <span className="flex items-center"><FloppyDisk weight="duotone" size={16} className="mr-1" /> {t('editor.blocks.common.save')}</span>
                   </Button>
                 </div>
               </form>
@@ -305,26 +305,18 @@ const WebPreviewComponent: React.FC<WebPreviewProps> = ({ node, updateAttributes
                   </div>
                 )}
                 <div className="pt-4 pb-2">
-                  <a
-                    href={previewData.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="no-underline hover:no-underline focus:no-underline active:no-underline"
+                  <span
+                    className="font-semibold text-lg text-[#232323] mb-1.5 leading-tight no-underline hover:no-underline focus:no-underline active:no-underline"
                     style={{ textDecoration: 'none', borderBottom: 'none' }}
                   >
-                    <span
-                      className="font-semibold text-lg text-[#232323] mb-1.5 leading-tight no-underline hover:no-underline focus:no-underline active:no-underline"
-                      style={{ textDecoration: 'none', borderBottom: 'none' }}
-                    >
-                      {previewData.title}
-                    </span>
-                    <span
-                      className="block text-gray-700 text-sm mb-3 leading-snug no-underline hover:no-underline focus:no-underline active:no-underline"
-                      style={{ textDecoration: 'none', borderBottom: 'none' }}
-                    >
-                      {previewData.description}
-                    </span>
-                  </a>
+                    {previewData.title}
+                  </span>
+                  <span
+                    className="block text-gray-700 text-sm mb-3 leading-snug no-underline hover:no-underline focus:no-underline active:no-underline"
+                    style={{ textDecoration: 'none', borderBottom: 'none' }}
+                  >
+                    {previewData.description}
+                  </span>
                 </div>
               </a>
               <div className="flex items-center mt-0 pt-2 border-t border-gray-100">

--- a/apps/web/components/Pages/Activity/ActivityChapterDropdown.tsx
+++ b/apps/web/components/Pages/Activity/ActivityChapterDropdown.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useMediaQuery } from 'usehooks-ts'
-import { Check, FileText, ListTree, Video, X, StickyNote, Backpack, ArrowRight } from 'lucide-react'
+import { Check, FileText, ListTree, Video, X, StickyNote, Backpack, ArrowRight, Package, Puzzle, Globe } from 'lucide-react'
+import { MarkdownLogo } from '@phosphor-icons/react'
 import { getUriWithOrg } from '@services/config/config'
 import Link from 'next/link'
 import React from 'react'
@@ -55,7 +56,9 @@ export default function ActivityChapterDropdown(props: ActivityChapterDropdownPr
   };
 
   // Function to get the appropriate icon for activity type
-  const getActivityTypeIcon = (activityType: string) => {
+  const getActivityTypeIcon = (activityType: string, activitySubType?: string) => {
+    if (activitySubType === 'SUBTYPE_DYNAMIC_MARKDOWN') return <MarkdownLogo size={10} />;
+    if (activitySubType === 'SUBTYPE_DYNAMIC_EMBED') return <Globe size={10} />;
     switch (activityType) {
       case 'TYPE_VIDEO':
         return <Video size={10} />;
@@ -65,12 +68,18 @@ export default function ActivityChapterDropdown(props: ActivityChapterDropdownPr
         return <StickyNote size={10} />;
       case 'TYPE_ASSIGNMENT':
         return <Backpack size={10} />;
+      case 'TYPE_SCORM':
+        return <Package size={10} />;
+      case 'TYPE_CUSTOM':
+        return <Puzzle size={10} />;
       default:
         return <FileText size={10} />;
     }
   };
 
-  const getActivityTypeLabel = (activityType: string) => {
+  const getActivityTypeLabel = (activityType: string, activitySubType?: string) => {
+    if (activitySubType === 'SUBTYPE_DYNAMIC_MARKDOWN') return t('activities.markdown');
+    if (activitySubType === 'SUBTYPE_DYNAMIC_EMBED') return t('activities.embed');
     switch (activityType) {
       case 'TYPE_VIDEO':
         return t('activities.video');
@@ -80,6 +89,10 @@ export default function ActivityChapterDropdown(props: ActivityChapterDropdownPr
         return t('activities.page');
       case 'TYPE_ASSIGNMENT':
         return t('activities.assignment');
+      case 'TYPE_SCORM':
+        return t('activities.scorm');
+      case 'TYPE_CUSTOM':
+        return t('activities.custom');
       default:
         return t('activities.learning_material');
     }
@@ -175,9 +188,9 @@ export default function ActivityChapterDropdown(props: ActivityChapterDropdownPr
                                 )}
                               </div>
                               <div className="flex items-center space-x-1 mt-0.5 text-neutral-400">
-                                {getActivityTypeIcon(activity.activity_type)}
+                                {getActivityTypeIcon(activity.activity_type, activity.activity_sub_type)}
                                 <span className="text-[10px] font-medium">
-                                  {getActivityTypeLabel(activity.activity_type)}
+                                  {getActivityTypeLabel(activity.activity_type, activity.activity_sub_type)}
                                 </span>
                               </div>
                             </div>

--- a/apps/web/components/Pages/Courses/ActivityIndicators.tsx
+++ b/apps/web/components/Pages/Courses/ActivityIndicators.tsx
@@ -1,5 +1,6 @@
 'use client'
-import { BookOpenCheck, Check, FileText, Layers, Video, ChevronLeft, ChevronRight, ChevronDown, Trophy } from 'lucide-react'
+import { BookOpenCheck, Check, FileText, Layers, Video, ChevronLeft, ChevronRight, ChevronDown, Trophy, Package, Puzzle, Globe } from 'lucide-react'
+import { MarkdownLogo } from '@phosphor-icons/react'
 import React, { useMemo, memo, useState, useRef, useEffect, useCallback } from 'react'
 import ToolTip from '@components/Objects/StyledElements/Tooltip/Tooltip'
 import { getUriWithOrg } from '@services/config/config'
@@ -17,7 +18,9 @@ interface Props {
 }
 
 // Helper functions
-function getActivityTypeLabel(activityType: string, t: any): string {
+function getActivityTypeLabel(activityType: string, t: any, activitySubType?: string): string {
+  if (activitySubType === 'SUBTYPE_DYNAMIC_MARKDOWN') return t('activities.markdown')
+  if (activitySubType === 'SUBTYPE_DYNAMIC_EMBED') return t('activities.embed')
   switch (activityType) {
     case 'TYPE_VIDEO':
       return t('activities.video')
@@ -27,6 +30,10 @@ function getActivityTypeLabel(activityType: string, t: any): string {
       return t('activities.interactive')
     case 'TYPE_ASSIGNMENT':
       return t('activities.assignment')
+    case 'TYPE_SCORM':
+      return t('activities.scorm')
+    case 'TYPE_CUSTOM':
+      return t('activities.custom')
     default:
       return t('common.unknown')
   }
@@ -42,13 +49,19 @@ function getActivityTypeBadgeColor(activityType: string): string {
       return 'bg-green-100 text-green-700'
     case 'TYPE_ASSIGNMENT':
       return 'bg-orange-100 text-orange-700'
+    case 'TYPE_SCORM':
+      return 'bg-indigo-100 text-indigo-700'
+    case 'TYPE_CUSTOM':
+      return 'bg-pink-100 text-pink-700'
     default:
       return 'bg-gray-100 text-gray-700'
   }
 }
 
 // Memoized activity type icon component
-const ActivityTypeIcon = memo(({ activityType }: { activityType: string }) => {
+const ActivityTypeIcon = memo(({ activityType, activitySubType }: { activityType: string; activitySubType?: string }) => {
+  if (activitySubType === 'SUBTYPE_DYNAMIC_MARKDOWN') return <MarkdownLogo size={16} className="text-gray-400" />
+  if (activitySubType === 'SUBTYPE_DYNAMIC_EMBED') return <Globe size={16} className="text-gray-400" />
   switch (activityType) {
     case 'TYPE_VIDEO':
       return <Video size={16} className="text-gray-400" />
@@ -58,6 +71,10 @@ const ActivityTypeIcon = memo(({ activityType }: { activityType: string }) => {
       return <Layers size={16} className="text-gray-400" />
     case 'TYPE_ASSIGNMENT':
       return <BookOpenCheck size={16} className="text-gray-400" />
+    case 'TYPE_SCORM':
+      return <Package size={16} className="text-gray-400" />
+    case 'TYPE_CUSTOM':
+      return <Puzzle size={16} className="text-gray-400" />
     default:
       return <FileText size={16} className="text-gray-400" />
   }
@@ -79,7 +96,7 @@ const ActivityTooltipContent = memo(({
   return (
   <div className="bg-white rounded-lg nice-shadow py-3 px-4 min-w-[200px] animate-in fade-in duration-200">
     <div className="flex items-center gap-2">
-      <ActivityTypeIcon activityType={activity.activity_type} />
+      <ActivityTypeIcon activityType={activity.activity_type} activitySubType={activity.activity_sub_type} />
       <span className="text-sm text-gray-700">{activity.name}</span>
       {isDone && (
         <span className="ml-auto text-gray-400">
@@ -89,7 +106,7 @@ const ActivityTooltipContent = memo(({
     </div>
     <div className="flex items-center gap-2 mt-2">
       <span className={`text-xs px-2 py-0.5 rounded-full ${getActivityTypeBadgeColor(activity.activity_type)}`}>
-        {getActivityTypeLabel(activity.activity_type, t)}
+        {getActivityTypeLabel(activity.activity_type, t, activity.activity_sub_type)}
       </span>
       <span className="text-xs text-gray-400">
         {isCurrent ? t('activities.current_activity') : isDone ? t('common.completed') : t('activities.not_started')}
@@ -263,7 +280,7 @@ const MobileChapterSelector = memo(({
                       <div className={`w-[6px] h-[6px] rounded-full shrink-0 ${
                         isDone ? 'bg-teal-500' : isCurrent ? 'bg-gray-500 animate-pulse' : 'bg-zinc-200'
                       }`} />
-                      <ActivityTypeIcon activityType={activity.activity_type} />
+                      <ActivityTypeIcon activityType={activity.activity_type} activitySubType={activity.activity_sub_type} />
                       <span className="truncate">{activity.name}</span>
                       {isDone && <Check size={12} className="text-teal-500 ml-auto shrink-0" />}
                     </Link>

--- a/apps/web/locales/bn.json
+++ b/apps/web/locales/bn.json
@@ -1004,7 +1004,10 @@
     "autosave_unsaved": "অসংরক্ষিত পরিবর্তন",
     "autosaved": "সংরক্ষিত",
     "autosaving": "সংরক্ষণ করা হচ্ছে…",
-    "save_answers": "উত্তর সংরক্ষণ করুন"
+    "save_answers": "উত্তর সংরক্ষণ করুন",
+    "markdown": "মার্কডাউন",
+    "custom": "কাস্টম",
+    "scorm": "স্কর্ম"
   },
   "assignments": {
     "submit_assignment": "অ্যাসাইনমেন্ট জমা দিন",
@@ -2136,7 +2139,8 @@
             "scorm": "SCORM",
             "markdown": "Markdown",
             "embed": "এমবেড",
-            "resource": "রিসোর্স"
+            "resource": "রিসোর্স",
+            "custom": "কাস্টম"
           },
           "toasts": {
             "deleting": "কার্যক্রম মোছা হচ্ছে...",

--- a/apps/web/locales/de.json
+++ b/apps/web/locales/de.json
@@ -982,7 +982,10 @@
     "autosave_unsaved": "Ungespeicherte Änderungen",
     "autosaved": "Gespeichert",
     "autosaving": "Wird gespeichert…",
-    "save_answers": "Antworten speichern"
+    "save_answers": "Antworten speichern",
+    "markdown": "Markdown",
+    "custom": "Benutzerdefiniert",
+    "scorm": "SCORM"
   },
   "assignments": {
     "submit_assignment": "Aufgabe einreichen",
@@ -2114,7 +2117,8 @@
             "scorm": "SCORM",
             "markdown": "Markdown",
             "embed": "Einbettung",
-            "resource": "Ressource"
+            "resource": "Ressource",
+            "custom": "Benutzerdefiniert"
           },
           "toasts": {
             "deleting": "Aktivität wird gelöscht...",

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -1427,7 +1427,10 @@
     "grid_columns_4": "4 Columns",
     "add_card": "Add Card",
     "ungroup_cards": "Ungroup Cards",
-    "group_into_grid": "Group into Grid"
+    "group_into_grid": "Group into Grid",
+    "markdown": "Markdown",
+    "custom": "Custom",
+    "scorm": "SCORM"
   },
   "embed": {
     "not_supported_title": "This activity is not supported",
@@ -2634,7 +2637,8 @@
             "scorm": "Scorm",
             "markdown": "Markdown",
             "embed": "Embed",
-            "resource": "Resource"
+            "resource": "Resource",
+            "custom": "Custom"
           },
           "toasts": {
             "deleting": "Deleting activity...",
@@ -4797,7 +4801,11 @@
         "reset_answers": "Reset answers",
         "mark_correct": "Mark as correct",
         "mark_incorrect": "Mark as incorrect",
-        "delete_answer": "Delete answer"
+        "delete_answer": "Delete answer",
+        "question_label": "Question",
+        "delete_question": "Delete question",
+        "empty_editable": "No questions yet. Add your first one to get started.",
+        "empty_readonly": "This quiz has no questions yet."
       },
       "math_block": {
         "templates": "Templates",

--- a/apps/web/locales/es.json
+++ b/apps/web/locales/es.json
@@ -982,7 +982,10 @@
     "autosave_unsaved": "Cambios sin guardar",
     "autosaved": "Guardado",
     "autosaving": "Guardando…",
-    "save_answers": "Guardar respuestas"
+    "save_answers": "Guardar respuestas",
+    "markdown": "Markdown",
+    "custom": "Personalizado",
+    "scorm": "SCORM"
   },
   "assignments": {
     "submit_assignment": "Enviar tarea",
@@ -2114,7 +2117,8 @@
             "scorm": "Scorm",
             "markdown": "Markdown",
             "embed": "Embed",
-            "resource": "Recurso"
+            "resource": "Recurso",
+            "custom": "Personalizado"
           },
           "toasts": {
             "deleting": "Eliminando actividad...",

--- a/apps/web/locales/fr.json
+++ b/apps/web/locales/fr.json
@@ -982,7 +982,10 @@
     "autosave_unsaved": "Modifications non enregistrées",
     "autosaved": "Enregistré",
     "autosaving": "Enregistrement…",
-    "save_answers": "Enregistrer les réponses"
+    "save_answers": "Enregistrer les réponses",
+    "markdown": "Markdown",
+    "custom": "Personnalisé",
+    "scorm": "SCORM"
   },
   "assignments": {
     "submit_assignment": "Rendre le devoir",
@@ -2114,7 +2117,8 @@
             "scorm": "SCORM",
             "markdown": "Markdown",
             "embed": "Intégration",
-            "resource": "Ressource"
+            "resource": "Ressource",
+            "custom": "Personnalisé"
           },
           "toasts": {
             "deleting": "Suppression de l'activité...",

--- a/apps/web/locales/hi.json
+++ b/apps/web/locales/hi.json
@@ -1004,7 +1004,10 @@
     "autosave_unsaved": "न सहेजे गए बदलाव",
     "autosaved": "सहेजा गया",
     "autosaving": "सहेजा जा रहा है…",
-    "save_answers": "जवाब सहेजें"
+    "save_answers": "जवाब सहेजें",
+    "markdown": "मार्कडाउन",
+    "custom": "कस्टम",
+    "scorm": "स्कॉर्म"
   },
   "assignments": {
     "submit_assignment": "असाइनमेंट सबमिट करें",
@@ -2136,7 +2139,8 @@
             "scorm": "SCORM",
             "markdown": "Markdown",
             "embed": "एम्बेड",
-            "resource": "संसाधन"
+            "resource": "संसाधन",
+            "custom": "कस्टम"
           },
           "toasts": {
             "deleting": "गतिविधि हटाई जा रही है...",

--- a/apps/web/locales/id.json
+++ b/apps/web/locales/id.json
@@ -1004,7 +1004,10 @@
     "autosave_unsaved": "Perubahan belum disimpan",
     "autosaved": "Tersimpan",
     "autosaving": "Menyimpan…",
-    "save_answers": "Simpan jawaban"
+    "save_answers": "Simpan jawaban",
+    "markdown": "Markdown",
+    "custom": "Kustom",
+    "scorm": "SCORM"
   },
   "assignments": {
     "submit_assignment": "Kirim Tugas",
@@ -2136,7 +2139,8 @@
             "scorm": "SCORM",
             "markdown": "Markdown",
             "embed": "Embed",
-            "resource": "Sumber daya"
+            "resource": "Sumber daya",
+            "custom": "Kustom"
           },
           "toasts": {
             "deleting": "Menghapus aktivitas...",

--- a/apps/web/locales/it.json
+++ b/apps/web/locales/it.json
@@ -982,7 +982,10 @@
     "autosave_unsaved": "Modifiche non salvate",
     "autosaved": "Salvato",
     "autosaving": "Salvataggio…",
-    "save_answers": "Salva risposte"
+    "save_answers": "Salva risposte",
+    "markdown": "Markdown",
+    "custom": "Personalizzato",
+    "scorm": "SCORM"
   },
   "assignments": {
     "submit_assignment": "Invia compito",
@@ -2114,7 +2117,8 @@
             "scorm": "SCORM",
             "markdown": "Markdown",
             "embed": "Embed",
-            "resource": "Risorsa"
+            "resource": "Risorsa",
+            "custom": "Personalizzato"
           },
           "toasts": {
             "deleting": "Eliminazione attività...",

--- a/apps/web/locales/ja.json
+++ b/apps/web/locales/ja.json
@@ -992,7 +992,10 @@
     "autosave_unsaved": "未保存の変更",
     "autosaved": "保存済み",
     "autosaving": "保存中…",
-    "save_answers": "回答を保存"
+    "save_answers": "回答を保存",
+    "markdown": "マークダウン",
+    "custom": "カスタム",
+    "scorm": "SCORM"
   },
   "assignments": {
     "submit_assignment": "課題を提出",
@@ -2124,7 +2127,8 @@
             "scorm": "SCORM",
             "markdown": "Markdown",
             "embed": "埋め込み",
-            "resource": "リソース"
+            "resource": "リソース",
+            "custom": "カスタム"
           },
           "toasts": {
             "deleting": "アクティビティを削除中...",

--- a/apps/web/locales/ko.json
+++ b/apps/web/locales/ko.json
@@ -992,7 +992,10 @@
     "autosave_unsaved": "저장되지 않은 변경사항",
     "autosaved": "저장됨",
     "autosaving": "저장 중…",
-    "save_answers": "답변 저장"
+    "save_answers": "답변 저장",
+    "markdown": "마크다운",
+    "custom": "사용자 정의",
+    "scorm": "SCORM"
   },
   "assignments": {
     "submit_assignment": "과제 제출",
@@ -2124,7 +2127,8 @@
             "scorm": "Scorm",
             "markdown": "Markdown",
             "embed": "Embed",
-            "resource": "자료"
+            "resource": "자료",
+            "custom": "사용자 정의"
           },
           "toasts": {
             "deleting": "활동 삭제 중...",

--- a/apps/web/locales/nl.json
+++ b/apps/web/locales/nl.json
@@ -982,7 +982,10 @@
     "autosave_unsaved": "Niet-opgeslagen wijzigingen",
     "autosaved": "Opgeslagen",
     "autosaving": "Opslaan…",
-    "save_answers": "Antwoorden opslaan"
+    "save_answers": "Antwoorden opslaan",
+    "markdown": "Markdown",
+    "custom": "Aangepast",
+    "scorm": "SCORM"
   },
   "assignments": {
     "submit_assignment": "Opdracht indienen",
@@ -2114,7 +2117,8 @@
             "scorm": "Scorm",
             "markdown": "Markdown",
             "embed": "Embed",
-            "resource": "Bron"
+            "resource": "Bron",
+            "custom": "Aangepast"
           },
           "toasts": {
             "deleting": "Activiteit verwijderen...",

--- a/apps/web/locales/pl.json
+++ b/apps/web/locales/pl.json
@@ -1004,7 +1004,10 @@
     "autosave_unsaved": "Niezapisane zmiany",
     "autosaved": "Zapisano",
     "autosaving": "Zapisywanie…",
-    "save_answers": "Zapisz odpowiedzi"
+    "save_answers": "Zapisz odpowiedzi",
+    "markdown": "Markdown",
+    "custom": "Niestandardowy",
+    "scorm": "SCORM"
   },
   "assignments": {
     "submit_assignment": "Wyślij zadanie",
@@ -2136,7 +2139,8 @@
             "scorm": "SCORM",
             "markdown": "Markdown",
             "embed": "Osadzenie",
-            "resource": "Materiał"
+            "resource": "Materiał",
+            "custom": "Niestandardowy"
           },
           "toasts": {
             "deleting": "Usuwanie aktywności...",

--- a/apps/web/locales/pt.json
+++ b/apps/web/locales/pt.json
@@ -982,7 +982,10 @@
     "autosave_unsaved": "Alterações não salvas",
     "autosaved": "Salvo",
     "autosaving": "Salvando…",
-    "save_answers": "Salvar respostas"
+    "save_answers": "Salvar respostas",
+    "markdown": "Markdown",
+    "custom": "Personalizado",
+    "scorm": "SCORM"
   },
   "assignments": {
     "submit_assignment": "Enviar Tarefa",
@@ -2114,7 +2117,8 @@
             "scorm": "SCORM",
             "markdown": "Markdown",
             "embed": "Embed",
-            "resource": "Recurso"
+            "resource": "Recurso",
+            "custom": "Personalizado"
           },
           "toasts": {
             "deleting": "Excluindo atividade...",

--- a/apps/web/locales/ru.json
+++ b/apps/web/locales/ru.json
@@ -1004,7 +1004,10 @@
     "autosave_unsaved": "Несохранённые изменения",
     "autosaved": "Сохранено",
     "autosaving": "Сохранение…",
-    "save_answers": "Сохранить ответы"
+    "save_answers": "Сохранить ответы",
+    "markdown": "Markdown",
+    "custom": "Пользовательский",
+    "scorm": "SCORM"
   },
   "assignments": {
     "submit_assignment": "Сдать задание",
@@ -2136,7 +2139,8 @@
             "scorm": "Scorm",
             "markdown": "Markdown",
             "embed": "Embed",
-            "resource": "Материал"
+            "resource": "Материал",
+            "custom": "Пользовательский"
           },
           "toasts": {
             "deleting": "Удаление занятия...",

--- a/apps/web/locales/th.json
+++ b/apps/web/locales/th.json
@@ -1004,7 +1004,10 @@
     "autosave_unsaved": "การเปลี่ยนแปลงที่ยังไม่ได้บันทึก",
     "autosaved": "บันทึกแล้ว",
     "autosaving": "กำลังบันทึก…",
-    "save_answers": "บันทึกคำตอบ"
+    "save_answers": "บันทึกคำตอบ",
+    "markdown": "มาร์กดาวน์",
+    "custom": "กำหนดเอง",
+    "scorm": "สกอร์ม"
   },
   "assignments": {
     "submit_assignment": "ส่งงาน",
@@ -2136,7 +2139,8 @@
             "scorm": "SCORM",
             "markdown": "Markdown",
             "embed": "ฝังเนื้อหา",
-            "resource": "แหล่งข้อมูล"
+            "resource": "แหล่งข้อมูล",
+            "custom": "กำหนดเอง"
           },
           "toasts": {
             "deleting": "กำลังลบกิจกรรม...",

--- a/apps/web/locales/tr.json
+++ b/apps/web/locales/tr.json
@@ -1004,7 +1004,10 @@
     "autosave_unsaved": "Kaydedilmemiş değişiklikler",
     "autosaved": "Kaydedildi",
     "autosaving": "Kaydediliyor…",
-    "save_answers": "Yanıtları kaydet"
+    "save_answers": "Yanıtları kaydet",
+    "markdown": "Markdown",
+    "custom": "Özel",
+    "scorm": "SCORM"
   },
   "assignments": {
     "submit_assignment": "Ödevi Gönder",
@@ -2136,7 +2139,8 @@
             "scorm": "SCORM",
             "markdown": "Markdown",
             "embed": "Gömme",
-            "resource": "Kaynak"
+            "resource": "Kaynak",
+            "custom": "Özel"
           },
           "toasts": {
             "deleting": "Aktivite siliniyor...",

--- a/apps/web/locales/vi.json
+++ b/apps/web/locales/vi.json
@@ -1004,7 +1004,10 @@
     "autosave_unsaved": "Thay đổi chưa lưu",
     "autosaved": "Đã lưu",
     "autosaving": "Đang lưu…",
-    "save_answers": "Lưu câu trả lời"
+    "save_answers": "Lưu câu trả lời",
+    "markdown": "Markdown",
+    "custom": "Tùy chỉnh",
+    "scorm": "SCORM"
   },
   "assignments": {
     "submit_assignment": "Nộp bài tập",
@@ -2136,7 +2139,8 @@
             "scorm": "Scorm",
             "markdown": "Markdown",
             "embed": "Nhúng",
-            "resource": "Tài nguyên"
+            "resource": "Tài nguyên",
+            "custom": "Tùy chỉnh"
           },
           "toasts": {
             "deleting": "Đang xóa hoạt động...",

--- a/apps/web/locales/zh.json
+++ b/apps/web/locales/zh.json
@@ -992,7 +992,10 @@
     "autosave_unsaved": "未保存的更改",
     "autosaved": "已保存",
     "autosaving": "正在保存…",
-    "save_answers": "保存答案"
+    "save_answers": "保存答案",
+    "markdown": "Markdown",
+    "custom": "自定义",
+    "scorm": "SCORM"
   },
   "assignments": {
     "submit_assignment": "提交作业",
@@ -2124,7 +2127,8 @@
             "scorm": "Scorm",
             "markdown": "Markdown",
             "embed": "Embed",
-            "resource": "资源"
+            "resource": "资源",
+            "custom": "自定义"
           },
           "toasts": {
             "deleting": "正在删除活动...",

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -657,6 +657,16 @@
   color: #f59e0b;
 }
 
+.editor-drag-handle .copy-btn:hover {
+  background: #dbeafe;
+  color: #2563eb;
+}
+
+.editor-drag-handle .copy-btn:active {
+  background: #bfdbfe;
+  color: #2563eb;
+}
+
 .editor-drag-handle .delete-btn:hover {
   background: #fee2e2;
   color: #dc2626;


### PR DESCRIPTION
Splits the non-AI half of #772 out for review: the editor and course UI work mixed into that Atlas/MCP PR. Rebased onto dev, 48 files, five commits.

- update_activity and restore_activity_version wrote current_user.id into ActivityVersion.created_by_id, an FK to user.id. For an API-token user that id is 0, so every token update or restore 500'd. Fixed via resolve_acting_user_id.
- link_preview sends browser-like headers so WAF'd sites stop 403ing, and returns a URL-only preview on any failure instead of raising. 19 new tests.
- Editor blocks moved from lucide-react to phosphor icons, plus a copy-block button on the drag handle. New ActivitySwitcher (hover rail of chapters/activities), Cmd/Ctrl+S save, and ActivityPreview components.
- Quiz redesign, same stored data, different behavior: adding a question now persists immediately, the letter chip marks correctness instead of toggling "my answer," submit is disabled until something's selected (blocking legacy no-correct-answer quizzes), and delete/add-answer are hover-only and capped at 5 answers.
- SCORM, custom, markdown, and embed activities get real icons and labels instead of a generic fallback; icon-only toolbar buttons get accessible labels.

eslint/tsc clean; pytest passes for link-preview and activity/versioning suites.

#772's agent tools hit the same FK bug, so this merges first and #772 rebases onto it.
