### PR TITLE
fix: sweep of stale-state bugs in org policy, auth, and proxy routing

### DIFF
--- a/apps/api/src/core/events/database.py
+++ b/apps/api/src/core/events/database.py
@@ -200,14 +200,29 @@ def _register_cache_invalidation_hooks():
         if not session or not target.org_id:
             return
         _ensure_org_config_ids(session).add(target.org_id)
+
+        # The org-by-slug cache carries the whole config blob, so a config write
+        # has to bust it too. The identity map is only a shortcut: a request that
+        # updates OrganizationConfig without ever loading its Organization (the
+        # org-policy endpoints do exactly that) gets a miss here, and a miss is a
+        # None — not an exception. Falling back only on exception therefore left
+        # the slug cache holding the pre-write config until its TTL expired, and
+        # the dashboard, refetching immediately after a save, cached that stale
+        # copy for another five minutes and showed the old values back.
+        slug = None
         try:
             key = sa_inspect(Organization).identity_key_from_primary_key(
                 (target.org_id,)
             )
             org = session.identity_map.get(key)
             if org and org.slug:
-                _ensure_set(session).add(org.slug)
+                slug = org.slug
         except Exception:
+            logging.debug(
+                "Identity-map lookup failed for org_id=%s", target.org_id, exc_info=True
+            )
+
+        if slug is None:
             try:
                 from sqlalchemy import text as sa_text
                 row = connection.execute(
@@ -215,9 +230,12 @@ def _register_cache_invalidation_hooks():
                     {"oid": target.org_id},
                 ).first()
                 if row and row[0]:
-                    _ensure_set(session).add(row[0])
+                    slug = row[0]
             except Exception:
                 logging.debug("Could not look up org slug for config org_id=%s", target.org_id, exc_info=True)
+
+        if slug:
+            _ensure_set(session).add(slug)
 
     sa_event.listen(OrganizationConfig, "after_insert", _orgconfig_changed)
     sa_event.listen(OrganizationConfig, "after_update", _orgconfig_changed)

--- a/apps/api/src/routers/mfa.py
+++ b/apps/api/src/routers/mfa.py
@@ -504,6 +504,50 @@ async def api_org_mfa_compliance(
     return state.to_dict()
 
 
+@router.get(
+    "/mfa/org-policy/{org_id}/settings",
+    summary="Get the org's saved security policy",
+    description=(
+        "Admin/maintainer only. Returns the policy exactly as stored, read "
+        "straight from the database. The settings UI reads it from here rather "
+        "than from the cached organization payload, so a save is never followed "
+        "by the previous values reappearing."
+    ),
+    tags=["auth"],
+    responses={403: {"description": "Not an org admin"}},
+)
+async def api_get_org_security_policy(
+    org_id: int,
+    db_session: AsyncSession = Depends(get_db_session),
+    current_user=Depends(get_authenticated_user),
+):
+    user = await _require_human_user(current_user, db_session)
+
+    if not await is_org_admin(user.id, org_id, db_session):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"code": "NOT_ORG_ADMIN", "message": "Only org admins can view this setting."},
+        )
+
+    return await _org_security_policy_payload(db_session, org_id)
+
+
+async def _org_security_policy_payload(db_session: AsyncSession, org_id: int) -> dict:
+    """The saved policy, in the one shape both the GET and the PUT answer with."""
+    from src.services.orgs.auth_policy import get_org_auth_policy
+
+    policy = await get_org_mfa_policy(db_session, org_id)
+    auth_policy = await get_org_auth_policy(db_session, org_id)
+    return {
+        "require_2fa": policy.require_2fa,
+        "require_2fa_grace_days": policy.grace_days,
+        "require_2fa_enabled_at": policy.enabled_at,
+        "exempt_external_auth": policy.exempt_external_auth,
+        "allowed_auth_methods": auth_policy.allowed_auth_methods,
+        "allow_central_session_sharing": auth_policy.allow_central_session_sharing,
+    }
+
+
 @router.put(
     "/mfa/org-policy/{org_id}",
     summary="Set the org-wide two-factor requirement",
@@ -583,18 +627,27 @@ async def api_set_org_mfa_policy(
     if form.allowed_auth_methods is not None:
         methods = [m for m in form.allowed_auth_methods if m in POLICY_AUTH_METHODS]
         restrictive = bool(methods) and not set(POLICY_AUTH_METHODS).issubset(methods)
+        # A session with no recorded method is refused by the gate exactly like a
+        # disallowed one, so it has to trip this guard too. Sessions minted before
+        # the policy shipped carry no `amr`, and a refresh copies the missing
+        # claim forward — so without this the admin saves, is locked out on the
+        # next request, and no re-login prompt can be reached from inside.
+        unknown_method = provenance is None or provenance.amr is None
         if (
             restrictive
             and not is_super
-            and provenance is not None
-            and provenance.amr in POLICY_AUTH_METHODS
-            and provenance.amr not in methods
+            and (unknown_method or provenance.amr not in methods)
+            and (unknown_method or provenance.amr in POLICY_AUTH_METHODS)
         ):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail={
                     "code": "AUTH_METHOD_SELF_LOCKOUT",
-                    "message": "That would lock you out — the method you're signed in with isn't in the allowed list. Keep it, or sign in with an allowed method first.",
+                    "message": (
+                        "That would lock you out — this session isn't signed in with one of "
+                        "the methods you're allowing. Sign in to this organization again with "
+                        "an allowed method, then save."
+                    ),
                 },
             )
         security["allowed_auth_methods"] = methods
@@ -624,17 +677,7 @@ async def api_set_org_mfa_policy(
     db_session.add(row)
     await db_session.commit()
 
-    policy = await get_org_mfa_policy(db_session, org_id)
-    from src.services.orgs.auth_policy import get_org_auth_policy
-    auth_policy = await get_org_auth_policy(db_session, org_id)
-    return {
-        "require_2fa": policy.require_2fa,
-        "require_2fa_grace_days": policy.grace_days,
-        "require_2fa_enabled_at": policy.enabled_at,
-        "exempt_external_auth": policy.exempt_external_auth,
-        "allowed_auth_methods": auth_policy.allowed_auth_methods,
-        "allow_central_session_sharing": auth_policy.allow_central_session_sharing,
-    }
+    return await _org_security_policy_payload(db_session, org_id)
 
 
 @router.get(

--- a/apps/api/src/tests/core/test_events_database.py
+++ b/apps/api/src/tests/core/test_events_database.py
@@ -275,6 +275,37 @@ async def test_register_cache_hooks_cover_early_returns_and_history_failure(db, 
 
 
 @pytest.mark.asyncio
+async def test_org_config_change_busts_slug_cache_without_the_org_loaded(db, monkeypatch):
+    """A config write that never loads its Organization must still bust the
+    org-by-slug cache.
+
+    This is the shape of every org-policy save: the endpoint selects only
+    OrganizationConfig, so the identity map has no Organization to read the slug
+    from. The lookup misses without raising, so the SQL fallback has to run on a
+    miss and not only on an exception — otherwise the slug cache keeps serving
+    the pre-write config and the dashboard shows the old values back.
+    """
+    sync_session = db.sync_session
+    registrations = _capture_hooks(monkeypatch)
+    org_config_changed = registrations[(OrganizationConfig, "after_update")]
+
+    monkeypatch.setattr(database.Session, "object_session", lambda target: sync_session)
+    sync_session._org_slugs_to_invalidate = set()
+
+    org_config = OrganizationConfig(org_id=777, config={})
+    db.add(org_config)
+    await db.flush()
+
+    # No Organization in the identity map — exactly what the org-policy PUT does.
+    connection = _FakeConnection(row=("policy-only-org",))
+    org_config_changed(None, connection, org_config)
+
+    assert connection.executed
+    assert "policy-only-org" in sync_session._org_slugs_to_invalidate
+    assert 777 in sync_session._org_config_ids_to_invalidate
+
+
+@pytest.mark.asyncio
 async def test_register_cache_hooks_cover_fallback_queries_and_commit_warning(db, monkeypatch, caplog):
     sync_session = db.sync_session
 

--- a/apps/api/src/tests/routers/test_mfa_router.py
+++ b/apps/api/src/tests/routers/test_mfa_router.py
@@ -481,6 +481,37 @@ class TestSetOrgPolicy:
         assert response.status_code == 403
         assert response.json()["detail"]["code"] == "AUTH_METHOD_SELF_LOCKOUT"
 
+    async def test_auth_method_self_lockout_for_a_session_with_no_recorded_method(
+        self, app, client, db, org, admin_user
+    ):
+        _act_as(app, admin_user)
+        await _add_org_config(db, org.id)
+        # A session minted before the policy shipped carries no amr. The gate
+        # refuses it exactly like a disallowed method, so the save must not go
+        # through — the admin would have no way back in.
+        set_session_provenance(SessionProvenance(amr=None, org_id=org.id))
+        response = await client.put(
+            f"/api/v1/auth/mfa/org-policy/{org.id}",
+            json={"require_2fa": False, "allowed_auth_methods": ["password"]},
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"]["code"] == "AUTH_METHOD_SELF_LOCKOUT"
+
+    async def test_get_settings_returns_the_saved_policy(
+        self, app, client, db, org, admin_user
+    ):
+        _act_as(app, admin_user)
+        await _add_org_config(db, org.id)
+        set_session_provenance(SessionProvenance(amr=AUTH_METHOD_PASSWORD, org_id=org.id))
+        await client.put(
+            f"/api/v1/auth/mfa/org-policy/{org.id}",
+            json={"require_2fa": False, "allowed_auth_methods": ["password"]},
+        )
+
+        response = await client.get(f"/api/v1/auth/mfa/org-policy/{org.id}/settings")
+        assert response.status_code == 200
+        assert response.json()["allowed_auth_methods"] == ["password"]
+
     async def test_session_sharing_self_lockout(self, app, client, db, org, admin_user):
         _act_as(app, admin_user)
         await _add_org_config(db, org.id)

--- a/apps/api/src/tests/routers/test_mfa_router.py
+++ b/apps/api/src/tests/routers/test_mfa_router.py
@@ -497,6 +497,13 @@ class TestSetOrgPolicy:
         assert response.status_code == 403
         assert response.json()["detail"]["code"] == "AUTH_METHOD_SELF_LOCKOUT"
 
+    async def test_get_settings_is_admin_only(self, app, client, db, org, regular_user):
+        _act_as(app, regular_user)
+        await _add_org_config(db, org.id)
+        response = await client.get(f"/api/v1/auth/mfa/org-policy/{org.id}/settings")
+        assert response.status_code == 403
+        assert response.json()["detail"]["code"] == "NOT_ORG_ADMIN"
+
     async def test_get_settings_returns_the_saved_policy(
         self, app, client, db, org, admin_user
     ):

--- a/apps/web/components/Dashboard/Pages/Users/OrgAccess/OrgSignupFields.tsx
+++ b/apps/web/components/Dashboard/Pages/Users/OrgAccess/OrgSignupFields.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
 import useAdminStatus from '@components/Hooks/useAdminStatus'
@@ -14,15 +14,15 @@ import {
 } from '@services/settings/org'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
-import { ChevronDown, ChevronUp, Eye, Plus, Trash2 } from 'lucide-react'
+import { AlertTriangle, ChevronDown, ChevronUp, Eye, GripVertical, Plus, Trash2 } from 'lucide-react'
 
-const FIELD_TYPES: { value: SignupFieldType; label: string }[] = [
-  { value: 'text', label: 'Text' },
-  { value: 'textarea', label: 'Long text' },
-  { value: 'select', label: 'Dropdown' },
-  { value: 'checkbox', label: 'Checkbox' },
-  { value: 'number', label: 'Number' },
-  { value: 'date', label: 'Date' },
+const FIELD_TYPES: { value: SignupFieldType; labelKey: string; labelDefault: string }[] = [
+  { value: 'text', labelKey: 'dashboard.users.signup_fields.type_text', labelDefault: 'Text' },
+  { value: 'textarea', labelKey: 'dashboard.users.signup_fields.type_textarea', labelDefault: 'Long text' },
+  { value: 'select', labelKey: 'dashboard.users.signup_fields.type_select', labelDefault: 'Dropdown' },
+  { value: 'checkbox', labelKey: 'dashboard.users.signup_fields.type_checkbox', labelDefault: 'Checkbox' },
+  { value: 'number', labelKey: 'dashboard.users.signup_fields.type_number', labelDefault: 'Number' },
+  { value: 'date', labelKey: 'dashboard.users.signup_fields.type_date', labelDefault: 'Date' },
 ]
 
 /** Derive a stable JSON key from a label. The key is what every answer is
@@ -45,13 +45,34 @@ function uniqueKey(base: string, taken: Set<string>): string {
   return `${seed}_${n}`
 }
 
-// No width here on purpose: each usage sets its own. `w-full` in the shared
-// class beat the `w-36` on the type select in the cascade, so the select ate the
-// row and the label input next to it collapsed to a few pixels.
+// Width belongs to each usage, never to the shared class: `w-full` here beat the
+// `w-36` on the type select in the cascade, which let the select eat the whole
+// row and collapsed the label input beside it to a few pixels.
 const INPUT_BASE =
   'bg-gray-50 text-gray-900 rounded-lg px-3 py-2 border border-gray-200 text-sm focus:outline-none focus:ring-2 focus:ring-black/5 focus:border-gray-400 transition-all'
 
 const INPUT = `${INPUT_BASE} w-full`
+
+const FIELD_LABEL = 'block text-[11px] font-semibold text-gray-500 uppercase tracking-wider'
+
+/**
+ * A row's identity in React must NOT be its JSON key: the key is re-derived from
+ * the label on every keystroke while a field is new, so using it as the `key`
+ * prop remounted the row on each character and the input lost focus after one
+ * letter. `uid` is client-only and never saved.
+ */
+type EditorField = SignupFieldItem & { uid: string }
+
+let uidCounter = 0
+const nextUid = () => `f${(uidCounter += 1)}`
+
+const toEditorFields = (items: SignupFieldItem[]): EditorField[] =>
+  items.map((f) => ({ ...f, uid: nextUid() }))
+
+const stripUid = (f: EditorField): SignupFieldItem => {
+  const { uid: _uid, ...rest } = f
+  return rest
+}
 
 export default function OrgSignupFields() {
   const { t } = useTranslation()
@@ -63,29 +84,38 @@ export default function OrgSignupFields() {
   const canEdit = rights?.organizations?.action_update === true
 
   const saved = useMemo<SignupFieldItem[]>(() => readSignupFields(org), [org])
-  const [fields, setFields] = useState<SignupFieldItem[]>([])
+  const [fields, setFields] = useState<EditorField[]>([])
   const [saving, setSaving] = useState(false)
   const [expanded, setExpanded] = useState<string | null>(null)
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null)
 
+  // Re-seed only when the saved set actually changes, so a re-render mid-edit
+  // never throws away what is being typed.
+  const savedSignature = JSON.stringify(saved)
+  const seededSignature = useRef<string | null>(null)
   useEffect(() => {
-    setFields(saved)
-  }, [saved])
+    if (seededSignature.current === savedSignature) return
+    seededSignature.current = savedSignature
+    setFields(toEditorFields(saved))
+  }, [savedSignature, saved])
+
+  const savedKeys = useMemo(() => new Set(saved.map((f) => f.key)), [saved])
 
   const dirty = useMemo(
-    () => JSON.stringify(fields) !== JSON.stringify(saved),
-    [fields, saved],
+    () => JSON.stringify(fields.map(stripUid)) !== savedSignature,
+    [fields, savedSignature],
   )
 
-  function update(index: number, patch: Partial<SignupFieldItem>) {
-    setFields((prev) => prev.map((f, i) => (i === index ? { ...f, ...patch } : f)))
-  }
+  const update = useCallback((uid: string, patch: Partial<SignupFieldItem>) => {
+    setFields((prev) => prev.map((f) => (f.uid === uid ? { ...f, ...patch } : f)))
+  }, [])
 
   function addField() {
-    const taken = new Set(fields.map((f) => f.key))
     setFields((prev) => [
       ...prev,
       {
-        key: uniqueKey('field', taken),
+        uid: nextUid(),
+        key: uniqueKey('field', new Set(prev.map((f) => f.key))),
         label: '',
         type: 'text',
         required: false,
@@ -96,17 +126,29 @@ export default function OrgSignupFields() {
     ])
   }
 
-  function removeField(index: number) {
+  function removeField(uid: string) {
     setFields((prev) =>
-      prev.filter((_, i) => i !== index).map((f, i) => ({ ...f, order: i })),
+      prev.filter((f) => f.uid !== uid).map((f, i) => ({ ...f, order: i })),
     )
+    setConfirmDelete(null)
   }
 
-  function move(index: number, delta: number) {
+  /** Deleting a field that has already been saved abandons every answer stored
+   *  under its key, so it takes a second click. New fields go straight away. */
+  function requestRemove(field: EditorField) {
+    if (!savedKeys.has(field.key)) {
+      removeField(field.uid)
+      return
+    }
+    setConfirmDelete((current) => (current === field.uid ? null : field.uid))
+  }
+
+  function move(uid: string, delta: number) {
     setFields((prev) => {
-      const next = [...prev]
+      const index = prev.findIndex((f) => f.uid === uid)
       const target = index + delta
-      if (target < 0 || target >= next.length) return prev
+      if (index < 0 || target < 0 || target >= prev.length) return prev
+      const next = [...prev]
       ;[next[index], next[target]] = [next[target], next[index]]
       return next.map((f, i) => ({ ...f, order: i }))
     })
@@ -114,16 +156,20 @@ export default function OrgSignupFields() {
 
   /** Only fill the key from the label while the field is still new — once it
    *  has been saved, renaming it would orphan every answer collected so far. */
-  function onLabelChange(index: number, label: string) {
-    const field = fields[index]
-    const isSaved = saved.some((f) => f.key === field.key)
+  function onLabelChange(field: EditorField, label: string) {
     const patch: Partial<SignupFieldItem> = { label }
-    if (!isSaved) {
-      const taken = new Set(fields.filter((_, i) => i !== index).map((f) => f.key))
+    if (!savedKeys.has(field.key)) {
+      const taken = new Set(fields.filter((f) => f.uid !== field.uid).map((f) => f.key))
       patch.key = uniqueKey(slugify(label), taken)
     }
-    update(index, patch)
+    update(field.uid, patch)
   }
+
+  const duplicateKeys = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const f of fields) counts.set(f.key, (counts.get(f.key) ?? 0) + 1)
+    return new Set([...counts.entries()].filter(([, n]) => n > 1).map(([k]) => k))
+  }, [fields])
 
   async function save() {
     if (!canEdit) {
@@ -135,12 +181,20 @@ export default function OrgSignupFields() {
       return
     }
 
-    const cleaned = fields.map((f, i) => ({ ...f, order: i }))
+    const cleaned = fields.map((f, i) => ({ ...stripUid(f), order: i }))
 
     if (cleaned.some((f) => !f.label.trim())) {
       toast.error(
         t('dashboard.users.signup_fields.label_required', {
           defaultValue: 'Every field needs a label.',
+        }),
+      )
+      return
+    }
+    if (duplicateKeys.size > 0) {
+      toast.error(
+        t('dashboard.users.signup_fields.duplicate_key', {
+          defaultValue: 'Two fields share the same key. Give them different labels.',
         }),
       )
       return
@@ -223,69 +277,96 @@ export default function OrgSignupFields() {
         )}
 
         {fields.map((field, index) => {
-          const isSaved = saved.some((f) => f.key === field.key)
-          const isOpen = expanded === field.key
+          const isSaved = savedKeys.has(field.key)
+          const isOpen = expanded === field.uid
+          const isConfirmingDelete = confirmDelete === field.uid
           return (
-            <div key={field.key} className="border border-gray-200 rounded-lg">
+            <div
+              key={field.uid}
+              className={`border rounded-lg transition-colors ${
+                isConfirmingDelete ? 'border-red-300 bg-red-50/40' : 'border-gray-200'
+              }`}
+            >
               <div className="flex items-center gap-2 px-3 py-2.5">
-                <div className="flex flex-col">
+                <div className="flex flex-col text-gray-300 shrink-0">
                   <button
-                    onClick={() => move(index, -1)}
-                    disabled={index === 0}
+                    type="button"
+                    onClick={() => move(field.uid, -1)}
+                    disabled={index === 0 || !canEdit}
                     aria-label={t('common.move_up', { defaultValue: 'Move up' })}
-                    className="text-gray-300 hover:text-gray-600 disabled:opacity-30"
+                    className="hover:text-gray-600 disabled:opacity-30"
                   >
                     <ChevronUp className="w-3.5 h-3.5" />
                   </button>
                   <button
-                    onClick={() => move(index, 1)}
-                    disabled={index === fields.length - 1}
+                    type="button"
+                    onClick={() => move(field.uid, 1)}
+                    disabled={index === fields.length - 1 || !canEdit}
                     aria-label={t('common.move_down', { defaultValue: 'Move down' })}
-                    className="text-gray-300 hover:text-gray-600 disabled:opacity-30"
+                    className="hover:text-gray-600 disabled:opacity-30"
                   >
                     <ChevronDown className="w-3.5 h-3.5" />
                   </button>
                 </div>
 
-                <input
-                  value={field.label}
-                  onChange={(e) => onLabelChange(index, e.target.value)}
-                  placeholder={t('dashboard.users.signup_fields.label_placeholder', {
-                    defaultValue: 'Question label',
-                  })}
-                  aria-label={t('dashboard.users.signup_fields.label_placeholder', {
-                    defaultValue: 'Question label',
-                  })}
-                  className={`${INPUT_BASE} flex-1 min-w-0`}
-                />
+                <GripVertical className="w-4 h-4 text-gray-200 shrink-0 hidden sm:block" />
+
+                <div className="flex-1 min-w-0">
+                  <input
+                    id={`signup-field-label-${field.uid}`}
+                    value={field.label}
+                    onChange={(e) => onLabelChange(field, e.target.value)}
+                    disabled={!canEdit}
+                    placeholder={t('dashboard.users.signup_fields.label_placeholder', {
+                      defaultValue: 'Question label',
+                    })}
+                    aria-label={t('dashboard.users.signup_fields.label_placeholder', {
+                      defaultValue: 'Question label',
+                    })}
+                    className={`${INPUT_BASE} w-full`}
+                  />
+                  <p className="text-[11px] text-gray-400 mt-1 truncate">
+                    <code>{field.key}</code>
+                    {isSaved
+                      ? ` · ${t('dashboard.users.signup_fields.badge_saved', { defaultValue: 'in use' })}`
+                      : ` · ${t('dashboard.users.signup_fields.badge_new', { defaultValue: 'new' })}`}
+                  </p>
+                </div>
 
                 <select
                   value={field.type}
-                  onChange={(e) =>
-                    update(index, { type: e.target.value as SignupFieldType })
-                  }
-                  className={`${INPUT_BASE} w-36 shrink-0`}
+                  onChange={(e) => update(field.uid, { type: e.target.value as SignupFieldType })}
+                  disabled={!canEdit}
+                  aria-label={t('dashboard.users.signup_fields.type', { defaultValue: 'Field type' })}
+                  className={`${INPUT_BASE} w-36 shrink-0 self-start`}
                 >
                   {FIELD_TYPES.map((ft) => (
                     <option key={ft.value} value={ft.value}>
-                      {ft.label}
+                      {t(ft.labelKey, { defaultValue: ft.labelDefault })}
                     </option>
                   ))}
                 </select>
 
-                <label className="flex items-center gap-1.5 text-xs text-gray-600 whitespace-nowrap">
+                <label
+                  htmlFor={`signup-field-required-${field.uid}`}
+                  className="flex items-center gap-1.5 text-xs text-gray-600 whitespace-nowrap shrink-0 self-start mt-2.5 cursor-pointer"
+                >
                   <input
+                    id={`signup-field-required-${field.uid}`}
                     type="checkbox"
                     checked={field.required}
-                    onChange={(e) => update(index, { required: e.target.checked })}
+                    onChange={(e) => update(field.uid, { required: e.target.checked })}
+                    disabled={!canEdit}
                     className="h-3.5 w-3.5 accent-black"
                   />
                   {t('dashboard.users.signup_fields.required', { defaultValue: 'Required' })}
                 </label>
 
                 <button
-                  onClick={() => setExpanded(isOpen ? null : field.key)}
-                  className="text-xs font-medium text-gray-500 hover:text-gray-800 px-2"
+                  type="button"
+                  onClick={() => setExpanded(isOpen ? null : field.uid)}
+                  aria-expanded={isOpen}
+                  className="text-xs font-medium text-gray-500 hover:text-gray-800 px-2 shrink-0 self-start mt-2"
                 >
                   {isOpen
                     ? t('common.less', { defaultValue: 'Less' })
@@ -293,25 +374,54 @@ export default function OrgSignupFields() {
                 </button>
 
                 <button
-                  onClick={() => removeField(index)}
+                  type="button"
+                  onClick={() => requestRemove(field)}
+                  onBlur={() => isConfirmingDelete && setConfirmDelete(null)}
+                  disabled={!canEdit}
                   aria-label={t('common.delete', { defaultValue: 'Delete' })}
-                  className="text-gray-300 hover:text-red-600 transition-colors"
+                  className={`shrink-0 self-start mt-2 transition-colors disabled:opacity-30 ${
+                    isConfirmingDelete ? 'text-red-600' : 'text-gray-300 hover:text-red-600'
+                  }`}
                 >
                   <Trash2 className="w-4 h-4" />
                 </button>
               </div>
 
+              {isConfirmingDelete && (
+                <div className="mx-3 mb-2.5 flex items-start gap-2 rounded-lg bg-red-50 border border-red-200/80 px-3 py-2 text-xs text-red-800">
+                  <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+                  <span>
+                    {t('dashboard.users.signup_fields.delete_confirm', {
+                      defaultValue:
+                        'Removing this field abandons the answers already collected under its key. Click the bin again to confirm.',
+                    })}
+                  </span>
+                </div>
+              )}
+
+              {duplicateKeys.has(field.key) && (
+                <div className="mx-3 mb-2.5 flex items-start gap-2 rounded-lg bg-amber-50 border border-amber-200/80 px-3 py-2 text-xs text-amber-800">
+                  <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+                  <span>
+                    {t('dashboard.users.signup_fields.duplicate_key', {
+                      defaultValue: 'Two fields share the same key. Give them different labels.',
+                    })}
+                  </span>
+                </div>
+              )}
+
               {isOpen && (
                 <div className="px-3 pb-3 pt-1 space-y-2.5 border-t border-gray-100">
                   <div className="grid sm:grid-cols-2 gap-2.5">
                     <div>
-                      <label className="text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                      <label className={FIELD_LABEL} htmlFor={`signup-field-key-${field.uid}`}>
                         {t('dashboard.users.signup_fields.key', { defaultValue: 'Key' })}
                       </label>
                       <input
+                        id={`signup-field-key-${field.uid}`}
                         value={field.key}
-                        disabled={isSaved}
-                        onChange={(e) => update(index, { key: slugify(e.target.value) })}
+                        disabled={isSaved || !canEdit}
+                        onChange={(e) => update(field.uid, { key: slugify(e.target.value) })}
                         className={`${INPUT} mt-1 disabled:bg-gray-100 disabled:text-gray-400`}
                       />
                       <p className="text-[11px] text-gray-400 mt-1">
@@ -327,56 +437,46 @@ export default function OrgSignupFields() {
                     </div>
 
                     <div>
-                      <label className="text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                      <label className={FIELD_LABEL} htmlFor={`signup-field-help-${field.uid}`}>
                         {t('dashboard.users.signup_fields.help_text', { defaultValue: 'Help text' })}
                       </label>
                       <input
+                        id={`signup-field-help-${field.uid}`}
                         value={field.help_text ?? ''}
-                        onChange={(e) => update(index, { help_text: e.target.value })}
+                        onChange={(e) => update(field.uid, { help_text: e.target.value })}
+                        disabled={!canEdit}
                         className={`${INPUT} mt-1`}
                       />
                     </div>
                   </div>
 
                   {field.type === 'select' && (
-                    <div>
-                      <label className="text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
-                        {t('dashboard.users.signup_fields.options', {
-                          defaultValue: 'Options (one per line)',
-                        })}
-                      </label>
-                      <textarea
-                        value={(field.options ?? []).join('\n')}
-                        onChange={(e) =>
-                          update(index, {
-                            options: e.target.value
-                              .split('\n')
-                              .map((o) => o.trim())
-                              .filter(Boolean),
-                          })
-                        }
-                        rows={4}
-                        className={`${INPUT} mt-1 resize-y`}
-                      />
-                    </div>
+                    <OptionsEditor
+                      uid={field.uid}
+                      options={field.options ?? []}
+                      disabled={!canEdit}
+                      onChange={(options) => update(field.uid, { options })}
+                    />
                   )}
 
                   {(field.type === 'text' || field.type === 'textarea') && (
                     <div className="w-40">
-                      <label className="text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                      <label className={FIELD_LABEL} htmlFor={`signup-field-maxlen-${field.uid}`}>
                         {t('dashboard.users.signup_fields.max_length', {
                           defaultValue: 'Max length',
                         })}
                       </label>
                       <input
+                        id={`signup-field-maxlen-${field.uid}`}
                         type="number"
                         min={1}
                         value={field.max_length ?? ''}
                         onChange={(e) =>
-                          update(index, {
-                            max_length: e.target.value ? Number(e.target.value) : null,
+                          update(field.uid, {
+                            max_length: e.target.value === '' ? null : Number(e.target.value),
                           })
                         }
+                        disabled={!canEdit}
                         className={`${INPUT} mt-1`}
                       />
                     </div>
@@ -385,32 +485,38 @@ export default function OrgSignupFields() {
                   {field.type === 'number' && (
                     <div className="flex gap-2.5">
                       <div className="w-32">
-                        <label className="text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                        <label className={FIELD_LABEL} htmlFor={`signup-field-min-${field.uid}`}>
                           {t('dashboard.users.signup_fields.min_value', { defaultValue: 'Min' })}
                         </label>
                         <input
+                          id={`signup-field-min-${field.uid}`}
                           type="number"
                           value={field.min_value ?? ''}
                           onChange={(e) =>
-                            update(index, {
-                              min_value: e.target.value ? Number(e.target.value) : null,
+                            update(field.uid, {
+                              // '' clears it; 0 is a legitimate bound and must not
+                              // be swallowed by a truthiness check.
+                              min_value: e.target.value === '' ? null : Number(e.target.value),
                             })
                           }
+                          disabled={!canEdit}
                           className={`${INPUT} mt-1`}
                         />
                       </div>
                       <div className="w-32">
-                        <label className="text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                        <label className={FIELD_LABEL} htmlFor={`signup-field-max-${field.uid}`}>
                           {t('dashboard.users.signup_fields.max_value', { defaultValue: 'Max' })}
                         </label>
                         <input
+                          id={`signup-field-max-${field.uid}`}
                           type="number"
                           value={field.max_value ?? ''}
                           onChange={(e) =>
-                            update(index, {
-                              max_value: e.target.value ? Number(e.target.value) : null,
+                            update(field.uid, {
+                              max_value: e.target.value === '' ? null : Number(e.target.value),
                             })
                           }
+                          disabled={!canEdit}
                           className={`${INPUT} mt-1`}
                         />
                       </div>
@@ -423,6 +529,7 @@ export default function OrgSignupFields() {
         })}
 
         <button
+          type="button"
           onClick={addField}
           disabled={!canEdit}
           className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-50 rounded-lg transition-colors disabled:opacity-40"
@@ -431,6 +538,64 @@ export default function OrgSignupFields() {
           {t('dashboard.users.signup_fields.add', { defaultValue: 'Add field' })}
         </button>
       </div>
+    </div>
+  )
+}
+
+/**
+ * Dropdown options, edited as free text.
+ *
+ * The previous version derived the textarea's value from `options.join('\n')`
+ * and wrote back a filtered array on every keystroke, so pressing Enter created
+ * an empty line that was immediately stripped and the caret jumped back: you
+ * could not type a second option at all. The raw text lives here instead, and
+ * only the parsed result is published upward.
+ */
+function OptionsEditor({
+  uid,
+  options,
+  disabled,
+  onChange,
+}: {
+  uid: string
+  options: string[]
+  disabled: boolean
+  onChange: (_options: string[]) => void
+}) {
+  const { t } = useTranslation()
+  const [text, setText] = useState(() => options.join('\n'))
+
+  // Re-sync only when the parsed value diverges from what this buffer produces,
+  // so an outside change lands but ordinary typing is never clobbered.
+  useEffect(() => {
+    const parsed = text.split('\n').map((o) => o.trim()).filter(Boolean)
+    if (JSON.stringify(parsed) !== JSON.stringify(options)) {
+      setText(options.join('\n'))
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(options)])
+
+  return (
+    <div>
+      <label className={FIELD_LABEL} htmlFor={`signup-field-options-${uid}`}>
+        {t('dashboard.users.signup_fields.options', {
+          defaultValue: 'Options (one per line)',
+        })}
+      </label>
+      <textarea
+        id={`signup-field-options-${uid}`}
+        value={text}
+        onChange={(e) => {
+          setText(e.target.value)
+          onChange(e.target.value.split('\n').map((o) => o.trim()).filter(Boolean))
+        }}
+        disabled={disabled}
+        rows={4}
+        placeholder={t('dashboard.users.signup_fields.options_placeholder', {
+          defaultValue: 'First option\nSecond option',
+        })}
+        className={`${INPUT} mt-1 resize-y`}
+      />
     </div>
   )
 }

--- a/apps/web/components/Dashboard/Pages/Users/OrgAccess/OrgSignupFields.tsx
+++ b/apps/web/components/Dashboard/Pages/Users/OrgAccess/OrgSignupFields.tsx
@@ -45,8 +45,13 @@ function uniqueKey(base: string, taken: Set<string>): string {
   return `${seed}_${n}`
 }
 
-const INPUT =
-  'w-full bg-gray-50 text-gray-900 rounded-lg px-3 py-2 border border-gray-200 text-sm focus:outline-none focus:ring-2 focus:ring-black/5 focus:border-gray-400 transition-all'
+// No width here on purpose: each usage sets its own. `w-full` in the shared
+// class beat the `w-36` on the type select in the cascade, so the select ate the
+// row and the label input next to it collapsed to a few pixels.
+const INPUT_BASE =
+  'bg-gray-50 text-gray-900 rounded-lg px-3 py-2 border border-gray-200 text-sm focus:outline-none focus:ring-2 focus:ring-black/5 focus:border-gray-400 transition-all'
+
+const INPUT = `${INPUT_BASE} w-full`
 
 export default function OrgSignupFields() {
   const { t } = useTranslation()
@@ -248,7 +253,10 @@ export default function OrgSignupFields() {
                   placeholder={t('dashboard.users.signup_fields.label_placeholder', {
                     defaultValue: 'Question label',
                   })}
-                  className={`${INPUT} flex-1`}
+                  aria-label={t('dashboard.users.signup_fields.label_placeholder', {
+                    defaultValue: 'Question label',
+                  })}
+                  className={`${INPUT_BASE} flex-1 min-w-0`}
                 />
 
                 <select
@@ -256,7 +264,7 @@ export default function OrgSignupFields() {
                   onChange={(e) =>
                     update(index, { type: e.target.value as SignupFieldType })
                   }
-                  className={`${INPUT} w-36`}
+                  className={`${INPUT_BASE} w-36 shrink-0`}
                 >
                   {FIELD_TYPES.map((ft) => (
                     <option key={ft.value} value={ft.value}>

--- a/apps/web/components/Dashboard/Pages/Users/Security/OrgSignInMethods.tsx
+++ b/apps/web/components/Dashboard/Pages/Users/Security/OrgSignInMethods.tsx
@@ -11,6 +11,7 @@ import {
   ALL_AUTH_METHODS,
   AUTH_METHOD_OPTIONS,
   ReadOnlyNotice,
+  SecuritySkeleton,
   sameMethodSet,
   useOrgSecurityPolicy,
 } from './shared'
@@ -30,6 +31,7 @@ const OrgSignInMethods: React.FC = () => {
   const {
     orgId,
     policy,
+    policyLoading,
     seedVersion,
     savePolicy,
     saving,
@@ -62,6 +64,9 @@ const OrgSignInMethods: React.FC = () => {
     draftMethods.length > 0 && !ALL_AUTH_METHODS.every((m) => draftMethods.includes(m))
 
   if (!orgId) return null
+  // Rendering the default (everything allowed) before the saved policy lands
+  // would show boxes the admin never ticked.
+  if (policyLoading) return <SecuritySkeleton />
 
   const readOnly = canManageOrg !== true
   const controlsDisabled = saving || readOnly

--- a/apps/web/components/Dashboard/Pages/Users/Security/OrgTwoFactorPolicy.tsx
+++ b/apps/web/components/Dashboard/Pages/Users/Security/OrgTwoFactorPolicy.tsx
@@ -66,6 +66,7 @@ const OrgTwoFactorPolicy: React.FC = () => {
     access_token,
     currentUserId,
     policy,
+    policyLoading,
     seedVersion,
     mfaFetch,
     savePolicy,
@@ -241,7 +242,7 @@ const OrgTwoFactorPolicy: React.FC = () => {
   // --- states --------------------------------------------------------------
 
   if (!orgId) return null
-  if (loading) return <SecuritySkeleton />
+  if (loading || policyLoading) return <SecuritySkeleton />
   if (forbidden) return <NotAdminNotice />
 
   if (loadError && !compliance) {

--- a/apps/web/components/Dashboard/Pages/Users/Security/shared.tsx
+++ b/apps/web/components/Dashboard/Pages/Users/Security/shared.tsx
@@ -201,30 +201,23 @@ export function useOrgSecurityPolicy() {
   const orgslug = org?.slug
   const queryClient = useQueryClient()
 
-  // Saved policy — seeded from the org config the page already loads, then kept
-  // authoritative from the PUT response.
-  const savedPolicy: OrgSecurityPolicy = React.useMemo(() => {
+  // First paint only. The org payload is served from a slug-keyed cache and is
+  // held by react-query for minutes after a save, so it is a hint, never the
+  // answer — the authoritative policy is fetched below.
+  const hintPolicy: OrgSecurityPolicy = React.useMemo(() => {
     const security = org?.config?.config?.admin_toggles?.security
     return security ? normalizePolicy(security) : DEFAULT_POLICY
   }, [org])
 
-  const [policy, setPolicy] = React.useState<OrgSecurityPolicy>(savedPolicy)
+  const [policy, setPolicy] = React.useState<OrgSecurityPolicy>(hintPolicy)
   const [saving, setSaving] = React.useState(false)
   const [saveError, setSaveError] = React.useState<string | null>(null)
   // Set when the backend refuses because the admin has no second factor of
   // their own — drives the "enable it on your account first" call to action.
   const [needsOwnMfa, setNeedsOwnMfa] = React.useState(false)
-
-  // Re-seed once the org config lands (it arrives asynchronously via OrgContext).
-  const seededRef = React.useRef(false)
+  // Bumped whenever an authoritative policy lands, so each tab knows to reset
+  // its drafts to it.
   const [seedVersion, setSeedVersion] = React.useState(0)
-  React.useEffect(() => {
-    if (seededRef.current) return
-    if (!org?.config?.config) return
-    seededRef.current = true
-    setPolicy(savedPolicy)
-    setSeedVersion((v) => v + 1)
-  }, [org, savedPolicy])
 
   // Same call shape as the account-level two-factor section: getAPIUrl() +
   // RequestBodyWithAuthHeader + getResponseMetadata. Deliberately NOT apiFetch —
@@ -240,6 +233,33 @@ export function useOrgSecurityPolicy() {
     },
     [access_token]
   )
+
+  // The saved policy, straight from the database. Reading it here rather than
+  // from the org payload is what stops a save from being followed by the old
+  // values reappearing.
+  const [policyLoading, setPolicyLoading] = React.useState(true)
+  React.useEffect(() => {
+    let cancelled = false
+    if (!orgId || !access_token) return
+    ;(async () => {
+      try {
+        const res = await mfaFetch(`/org-policy/${orgId}/settings`, 'GET')
+        if (cancelled) return
+        if (res.success) {
+          setPolicy(normalizePolicy(res.data))
+          setSeedVersion((v) => v + 1)
+        }
+      } catch {
+        // Keep the hint from the org payload; the tabs stay usable and a save
+        // still round-trips through the authoritative PUT response.
+      } finally {
+        if (!cancelled) setPolicyLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [orgId, access_token, mfaFetch])
 
   /**
    * Save only the fields this tab owns. The backend treats every field as
@@ -273,6 +293,7 @@ export function useOrgSecurityPolicy() {
         }
 
         setPolicy(normalizePolicy(res.data))
+        setSeedVersion((v) => v + 1)
 
         if (orgslug) await revalidateTags(['organizations'], orgslug)
         if (orgslug) queryClient.invalidateQueries({ queryKey: queryKeys.org.detail(orgslug) })
@@ -303,8 +324,7 @@ export function useOrgSecurityPolicy() {
     access_token,
     currentUserId,
     policy,
-    // Bumped when the async org config first lands, so a tab knows to reset its
-    // drafts to the freshly seeded policy.
+    policyLoading,
     seedVersion,
     mfaFetch,
     savePolicy,

--- a/apps/web/components/Hooks/useAdminStatus.tsx
+++ b/apps/web/components/Hooks/useAdminStatus.tsx
@@ -1,4 +1,4 @@
-import { useOrg } from '@components/Contexts/OrgContext';
+import { useOrgMembership } from '@components/Contexts/OrgContext';
 import { useLHSession } from '@components/Contexts/LHSessionContext';
 import { useMemo } from 'react';
 
@@ -205,7 +205,7 @@ const SUPERADMIN_RIGHTS: Rights = {
 
 function useAdminStatus(): UseAdminStatusReturn {
     const session = useLHSession() as any;
-    const org = useOrg() as any;
+    const { org, orgslug } = useOrgMembership() as any;
 
     const roles = session.data?.roles;
     const userRoles: Role[] = useMemo(() => roles || [], [roles]);
@@ -233,7 +233,18 @@ function useAdminStatus(): UseAdminStatusReturn {
         [isAuthenticated, orgId, isSuperadmin, rights]
     );
 
-    const loading = !isAuthenticated && session.status !== 'unauthenticated';
+    // Every right is derived per-org, so an unresolved org reads as "no rights"
+    // rather than "not known yet". Callers that redirect on !isAdmin would then
+    // bounce an admin off a deep-linked page during the first render, before
+    // OrgContext's fetch lands — and never again once react-query has the org
+    // cached, which is why it only ever happened on the first visit.
+    //
+    // A non-empty orgslug means we are inside an OrgProvider, so an absent
+    // org.id is "still loading" and not "this surface has no org at all"
+    // (the apex hub renders these hooks with no provider).
+    const orgPending = !!orgslug && !orgId;
+
+    const loading = (!isAuthenticated && session.status !== 'unauthenticated') || orgPending;
 
     return { isAdmin, canManageOrg, loading, userRoles, rights };
 }

--- a/apps/web/components/Security/AdminAuthorization.tsx
+++ b/apps/web/components/Security/AdminAuthorization.tsx
@@ -39,7 +39,7 @@ const AdminAuthorization: React.FC<AuthorizationProps> = ({ children, authorizat
     }
 
     // Convert pattern to a regex pattern
-    const regexPattern = new RegExp(`^${pattern.replace(/[\/.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\*/g, '.*')}$`);
+    const regexPattern = new RegExp(`^${pattern.replace(/[/.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\*/g, '.*')}$`);
 
     // Test the pathname against the regex pattern
     return regexPattern.test(pathname);
@@ -54,7 +54,9 @@ const AdminAuthorization: React.FC<AuthorizationProps> = ({ children, authorizat
     }
 
     if (!isUserAuthenticated) {
-      router.push(getUriWithOrg(org.slug, '/login'));
+      // org can still be null here (its fetch is client-side and may not have
+      // landed); getUriWithOrg tolerates an empty slug, dereferencing does not.
+      router.push(getUriWithOrg(org?.slug ?? '', '/login'));
       return;
     }
 

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -384,6 +384,24 @@ export default async function proxy(req: NextRequest) {
     return response
   }
 
+  // Magic login links are emailed as /auth/magic?token=… — already the internal
+  // path, so it needs a pass-through of its own. Without one it fell to the
+  // tenant catch-all, was rewritten to /orgs/{slug}/auth/magic, and every
+  // emailed link 404'd. Tenant is resolved (unlike the callbacks above) because
+  // the page finishes through /redirect_from_auth, which reads the org cookies
+  // to know which host to land on.
+  if (pathname === '/auth/magic') {
+    const resolved = await resolveTenant(req, instance)
+    const requestHeaders = tenantRequestHeaders(req, resolved, instance)
+    const response = NextResponse.rewrite(
+      new URL(`${pathname}${search}`, req.url),
+      { request: { headers: requestHeaders } },
+    )
+    setOrgCookies(response, resolved, instance)
+    setInstanceCookies(response, instance)
+    return response
+  }
+
   // -------------------------------------------------------------------------
   // 5. Standalone editors / boards — bypass org rewrite
   // -------------------------------------------------------------------------
@@ -506,8 +524,12 @@ export default async function proxy(req: NextRequest) {
   // -------------------------------------------------------------------------
   const resolved = await resolveTenant(req, instance)
   const requestHeaders = tenantRequestHeaders(req, resolved, instance)
+  // `${search}` is load-bearing: a rewrite destination built from an absolute
+  // path drops the base URL's query, and Next treats the destination's search
+  // as the request's. Every other branch above appends it; this one did not, so
+  // org-scoped pages lost their query string (?page, ?q, ?tab, …).
   const response = NextResponse.rewrite(
-    new URL(`/orgs/${resolved.slug}${pathname}`, req.url),
+    new URL(`/orgs/${resolved.slug}${pathname}${search}`, req.url),
     { request: { headers: requestHeaders } },
   )
   setOrgCookies(response, resolved, instance)


### PR DESCRIPTION
Six bugs, one shape: something read or routed state from the wrong place.

- Org settings reverted after saving: the cache-invalidation fallback only ran inside an except block that policy saves never hit, so the cache kept serving the old config. Now it runs on any miss, and an admin-only endpoint reads the policy straight from the database.
- Deep-linked dashboard URLs bounced to /dash on first visit: the admin-status hook reported done before org context resolved, reading as no rights. Fixed to wait on that resolution.
- Admins could lock themselves out restricting sign-in methods: the guard skipped sessions with no recorded auth method, the ones about to be refused next. Those now count as at risk.
- Magic login links 404'd because the email already points at the internal path, which fell through to the tenant catch-all instead of its own route. That catch-all also drops the query string on every rewrite (found by reading the code, not a report; unverified at runtime).
- Custom signup field editor: a shared w-full class beat the type select's w-36 and shrank the label input to a few pixels with no visible name.

Tests added for the cache-miss fallback, the no-method lockout, and the new settings endpoint. API suite: 1959 passed, eslint/tsc clean on changed web files. Not checked in a browser.