### PR TITLE
fix: cross-org user authz bypass, auth redirect, course limit UI

### DIFF
--- a/apps/api/src/security/rbac/rbac.py
+++ b/apps/api/src/security/rbac/rbac.py
@@ -277,6 +277,64 @@ async def _load_applicable_roles(
     return (await db_session.execute(statement)).scalars().all()
 
 
+async def _shared_org_ids_with_target_user(
+    db_session: AsyncSession,
+    user_id: int,
+    target_user_uuid: str,
+) -> list[int] | None:
+    """Org ids where both the caller and the targeted user are members.
+
+    Returns ``None`` when ``target_user_uuid`` names no real user — the create
+    paths pass a placeholder (``user_x``), which has no target to be scoped
+    against and is gated by the endpoint instead.
+    """
+    from src.db.users import User
+
+    target_id = (
+        await db_session.execute(
+            select(User.id).where(User.user_uuid == target_user_uuid)
+        )
+    ).scalars().first()
+    if target_id is None:
+        return None
+
+    caller_orgs = set(
+        (
+            await db_session.execute(
+                select(UserOrganization.org_id).where(UserOrganization.user_id == user_id)
+            )
+        ).scalars().all()
+    )
+    target_orgs = set(
+        (
+            await db_session.execute(
+                select(UserOrganization.org_id).where(UserOrganization.user_id == target_id)
+            )
+        ).scalars().all()
+    )
+    return sorted(caller_orgs & target_orgs)
+
+
+async def _load_roles_for_user_target(
+    db_session: AsyncSession,
+    user_id: int,
+    shared_org_ids: list[int],
+):
+    """Roles that may act on a user account, scoped to shared organizations.
+
+    A user row carries no org of its own, so the generic resolver answers None
+    for it. Loading *every* role the caller holds there would let an admin of one
+    organization update or delete an account that only belongs to another.
+    """
+    statement = (
+        select(Role)
+        .join(UserOrganization)
+        .where(UserOrganization.user_id == user_id)
+        .where(Role.org_id.in_(shared_org_ids) | (Role.org_id == null()))  # type: ignore[union-attr]
+    )
+    return (await db_session.execute(statement)).scalars().all()
+
+
 # Tested and working
 async def authorization_verify_based_on_roles(
     request: Request,
@@ -297,9 +355,28 @@ async def authorization_verify_based_on_roles(
     # one of their org roles carries the permission.
     target_org_id = await get_element_organization_id(element_uuid, db_session)
 
-    user_roles_in_organization_and_standard_roles = await _load_applicable_roles(
-        db_session, user_id, target_org_id
-    )
+    if element_type == "users" and target_org_id is None:
+        # A user row has no org column, so the generic resolver returns None and
+        # the placeholder branch below would hand back every role the caller
+        # holds anywhere — letting an admin of one org act on an account that
+        # only belongs to another. Scope to the orgs the two actually share.
+        shared_org_ids = await _shared_org_ids_with_target_user(
+            db_session, user_id, element_uuid
+        )
+        if shared_org_ids is not None:
+            if not shared_org_ids:
+                return False
+            user_roles_in_organization_and_standard_roles = await _load_roles_for_user_target(
+                db_session, user_id, shared_org_ids
+            )
+        else:
+            user_roles_in_organization_and_standard_roles = await _load_applicable_roles(
+                db_session, user_id, target_org_id
+            )
+    else:
+        user_roles_in_organization_and_standard_roles = await _load_applicable_roles(
+            db_session, user_id, target_org_id
+        )
 
 
     # Check if user is the author of the resource for "own" permissions

--- a/apps/api/src/tests/security/test_rbac_cross_org.py
+++ b/apps/api/src/tests/security/test_rbac_cross_org.py
@@ -238,3 +238,41 @@ class TestUsersOnlyIsOrgScoped:
         )
 
         assert allowed is True, "the org's own member must still reach a Users Only course"
+
+
+class TestUserAccountsAreOrgScoped:
+    """A user row carries no org column, so the resource-org resolver answers
+    None for it. That used to fall into the placeholder branch, which loads every
+    role the caller holds anywhere — enough for an admin of one org to update or
+    delete an account belonging only to another."""
+
+    @pytest.mark.asyncio
+    async def test_admin_cannot_touch_a_user_from_another_org(
+        self, db, org, other_org, admin_role, mock_request
+    ):
+        alice = _mk_user(db, uid=51, username="alice_users", email="alice3@test.com")
+        _attach_role(db, user_id=alice.id, org_id=org.id, role_id=admin_role.id)
+
+        victim = _mk_user(db, uid=52, username="victim", email="victim@test.com")
+        _attach_role(db, user_id=victim.id, org_id=other_org.id, role_id=admin_role.id)
+
+        for action in ("update", "delete"):
+            allowed = await authorization_verify_based_on_roles(
+                mock_request, alice.id, action, victim.user_uuid, db
+            )
+            assert allowed is False, f"cross-org user {action} must be denied"
+
+    @pytest.mark.asyncio
+    async def test_admin_can_still_manage_a_user_in_a_shared_org(
+        self, db, org, admin_role, mock_request
+    ):
+        alice = _mk_user(db, uid=53, username="alice_shared", email="alice4@test.com")
+        _attach_role(db, user_id=alice.id, org_id=org.id, role_id=admin_role.id)
+
+        member = _mk_user(db, uid=54, username="member", email="member@test.com")
+        _attach_role(db, user_id=member.id, org_id=org.id, role_id=admin_role.id)
+
+        allowed = await authorization_verify_based_on_roles(
+            mock_request, alice.id, "update", member.user_uuid, db
+        )
+        assert allowed is True

--- a/apps/web/app/orgs/[orgslug]/dash/courses/client.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/courses/client.tsx
@@ -73,7 +73,14 @@ function CoursesHome(params: CourseProps) {
     staleTime: 60_000,
   })
 
-  const mutateCourses = () => queryClient.invalidateQueries({ queryKey: queryKeys.courses.list(orgslug) })
+  // Course count feeds the plan's usage numbers, and those drive the "limit
+  // reached" banner and the disabled New Course button. Refreshing only the list
+  // left an org that had just deleted a course still locked out of creating one
+  // until the usage query happened to go stale.
+  const mutateCourses = () => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.courses.list(orgslug) })
+    if (orgId) queryClient.invalidateQueries({ queryKey: queryKeys.org.usage(orgId) })
+  }
 
   const allCourses = coursesData ?? []
 

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -446,18 +446,43 @@ export default async function proxy(req: NextRequest) {
   // 8. Auth redirect bridge (cross-domain return path)
   // -------------------------------------------------------------------------
   if (pathname === '/redirect_from_auth') {
-    const queryString = req.nextUrl.searchParams.toString()
-    const customDomain = req.cookies.get('LH_custom_domain')?.value
+    const params = new URLSearchParams(req.nextUrl.searchParams)
 
-    let redirectUrl: URL
-    if (customDomain) {
-      const protocol = req.nextUrl.protocol + '//'
-      redirectUrl = new URL(`${protocol}${customDomain}/`)
-    } else {
-      redirectUrl = new URL('/', req.url)
+    const rawNext = params.get('next')
+    params.delete('next')
+
+    const customDomain = req.cookies.get('LH_custom_domain')?.value
+    const base = customDomain
+      ? `${req.nextUrl.protocol}//${customDomain}`
+      : req.url
+    const baseOrigin = new URL(base).origin
+
+    // Every auth flow forwards where the user was headed as ?next. Landing them
+    // on "/" instead threw that away, so a deep link that prompted a sign-in
+    // always returned to the org picker.
+    //
+    // Resolve the candidate and compare origins rather than pattern-matching the
+    // raw string: this is an open-redirect sink, and a prefix test lets through
+    // anything the URL parser later normalises into another origin ("//evil",
+    // "/\evil", encoded control characters). Only the path survives.
+    let dest = '/'
+    if (rawNext) {
+      try {
+        const candidate = new URL(rawNext, baseOrigin)
+        if (candidate.origin === baseOrigin) {
+          dest = `${candidate.pathname}${candidate.search}${candidate.hash}`
+        }
+      } catch {
+        // Unparseable — fall back to the root.
+      }
     }
-    if (queryString) {
-      redirectUrl.search = queryString
+
+    const redirectUrl = new URL(dest, base)
+    const remaining = params.toString()
+    if (remaining) {
+      redirectUrl.search = redirectUrl.search
+        ? `${redirectUrl.search}&${remaining}`
+        : remaining
     }
     return NextResponse.redirect(redirectUrl)
   }


### PR DESCRIPTION
Fixes three issues from a follow-up bug sweep. The rest of the sweep's findings are still being triaged and aren't in this PR.

**Cross-org user authorization bypass (the important one)**
User rows don't carry an org column, so role resolution for a user-scoped action couldn't determine the target's org and fell back to a placeholder path that returns every role the caller holds across every org they belong to. An admin in one org could use that to update or delete a user account in a different org just by knowing its UUID. Role loading for real user targets is now scoped to organizations the caller and target actually share, and a request with no shared org gets refused.

**Post-login deep links**
`/redirect_from_auth` always sent users to `/` after the cross-domain login hop, dropping the `?next` param every auth flow depends on. It now redirects to a same-origin `next` and forwards the rest of the query string. The destination is resolved and compared by origin rather than pattern-matched, so anything that normalises into another origin (`//host`, `/\host`, an absolute URL) falls back to the root.

**Course limit banner stuck after delete**
Deleting a course invalidated the course list but not the org usage query, so the "limit reached" banner and disabled New Course button stayed stuck at orgs that were previously at their plan cap. Usage is now invalidated alongside the list.

Testing: API suites pass (1886 tests, including 2 new cross-org checks), eslint clean on changed web files. Not checked in a browser.