### PR TITLE
Fix media content-type mismatch and preview iframe sandboxing

### DIFF
--- a/apps/api/src/services/media/media.py
+++ b/apps/api/src/services/media/media.py
@@ -23,6 +23,7 @@ from src.db.resource_authors import (
 )
 from src.db.media.media_share_token import MediaShareToken
 from src.security.auth import resolve_acting_user_id
+from src.security.file_validation import EXT_TO_CANONICAL_MIME
 from src.security.rbac import check_resource_access, AccessAction
 from src.services.media.media_access import media_in_any_private_folder
 from src.services.utils.upload_content import upload_file
@@ -96,7 +97,11 @@ async def create_media(
         # Server-only key (under content/), never returned to clients.
         media.storage_key = f"orgs/{org_uuid}/{directory}/{filename}"
         media.file_format = parts[1] if len(parts) > 1 else ""
-        media.file_mime = file.content_type or ""
+        # Derive the MIME from the STORED extension, which `upload_file` built
+        # from the validated (magic-byte checked) content type. The client's
+        # own `file.content_type` header is not persisted: this value becomes a
+        # response header when the file is served, so it stays server-decided.
+        media.file_mime = EXT_TO_CANONICAL_MIME.get(f".{media.file_format}".lower(), "")
         try:
             file.file.seek(0)
             media.file_size = len(await file.read())

--- a/apps/api/src/services/media/media_serve.py
+++ b/apps/api/src/services/media/media_serve.py
@@ -42,6 +42,26 @@ def _mime_for(key: str) -> str:
     return _MIME_TYPES.get(Path(key).suffix.lower(), 'application/octet-stream')
 
 
+# Every MIME type this endpoint is ever allowed to emit. The stored
+# `media.file_mime` is only usable as a fallback if it is one of these.
+_SERVABLE_MIMES = frozenset(_MIME_TYPES.values())
+
+
+def _serve_mime(media: Media, rel_key: str) -> str:
+    """Decide the Content-Type from server-controlled state only.
+
+    The stored extension is server-derived (`get_safe_filename` builds it from
+    the validated content type), so it is the authoritative signal.
+    `media.file_mime` is consulted only when the extension is unknown — legacy
+    rows, mostly — and even then only if it names a type on the servable list.
+    """
+    by_extension = _mime_for(rel_key)
+    if by_extension != 'application/octet-stream':
+        return by_extension
+    stored = (media.file_mime or '').split(';')[0].strip().lower()
+    return stored if stored in _SERVABLE_MIMES else 'application/octet-stream'
+
+
 async def _resolve_storage_key(db_session: AsyncSession, media: Media) -> str:
     """Return the relative storage key (under `content/`), randomized for new
     uploads (`media.storage_key`), or reconstructed for legacy rows."""
@@ -123,7 +143,7 @@ async def serve_media_file(
         raise HTTPException(status_code=404, detail="This media has no file")
 
     rel_key = await _resolve_storage_key(db_session, media)
-    mime = media.file_mime or _mime_for(rel_key)
+    mime = _serve_mime(media, rel_key)
     headers = _headers(mime, is_public, _download_filename(media, rel_key), download)
     range_header = request.headers.get("range")
 

--- a/apps/api/src/tests/routers/test_media_serve_router.py
+++ b/apps/api/src/tests/routers/test_media_serve_router.py
@@ -46,6 +46,17 @@ def _bypass_rbac():
 
 
 @pytest.fixture
+def fs_file_unknown_ext():
+    """A stored file whose extension carries no MIME of its own."""
+    rel = "orgs/org_test/media/randdir/legacyfile.xyz"
+    path = Path("content") / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(PDF_BYTES)
+    yield rel
+    shutil.rmtree(Path("content") / "orgs" / "org_test", ignore_errors=True)
+
+
+@pytest.fixture
 def fs_file():
     """Create a real file under content/ for filesystem serving; clean up after."""
     rel = "orgs/org_test/media/randdir/testfile.pdf"
@@ -58,12 +69,12 @@ def fs_file():
 
 async def _mk_media(
     db, org, storage_key="", public=True, media_type=MediaTypeEnum.UPLOAD, name="m",
-    file_format="pdf",
+    file_format="pdf", file_mime="application/pdf",
 ):
     m = Media(
         name=name, media_type=media_type, public=public, org_id=org.id,
         media_uuid=f"media_{name}", file_id="testfile.pdf", storage_key=storage_key,
-        file_format=file_format, file_mime="application/pdf",
+        file_format=file_format, file_mime=file_mime,
         creation_date=str(datetime.now()), update_date=str(datetime.now()),
     )
     db.add(m)
@@ -324,3 +335,50 @@ class TestServeS3Errors:
              patch("src.services.media.media_serve.get_s3_bucket_name", return_value="b"):
             res = await client.get(f"/api/v1/media/{m.media_uuid}/file")
         assert res.status_code == 502
+
+
+class TestServedContentTypeIsNotClientControlled:
+    """The Content-Type decides how a browser treats a stored file, so it is
+    derived from server-side state only. Rows written before that — which kept
+    the client's own upload header in `file_mime` — must not influence it.
+    """
+
+    @pytest.mark.parametrize(
+        "poisoned",
+        ["text/html", "text/html; charset=utf-8", "TEXT/HTML", "image/svg+xml",
+         "application/xhtml+xml", "text/javascript"],
+    )
+    async def test_stored_mime_never_overrides_known_extension(
+        self, client, db, org, fs_file, poisoned
+    ):
+        m = await _mk_media(
+            db, org, storage_key=fs_file, name=f"poison{abs(hash(poisoned))}",
+            file_mime=poisoned,
+        )
+        res = await client.get(f"/api/v1/media/{m.media_uuid}/file")
+        assert res.status_code == 200, res.text
+        assert res.headers["content-type"].startswith("application/pdf")
+
+    async def test_unknown_extension_with_poisoned_mime_falls_back_to_octet_stream(
+        self, client, db, org, fs_file_unknown_ext
+    ):
+        m = await _mk_media(
+            db, org, storage_key=fs_file_unknown_ext, name="poisonlegacy",
+            file_format="xyz", file_mime="text/html",
+        )
+        res = await client.get(f"/api/v1/media/{m.media_uuid}/file")
+        assert res.status_code == 200, res.text
+        assert res.headers["content-type"].startswith("application/octet-stream")
+
+    async def test_unknown_extension_keeps_a_servable_stored_mime(
+        self, client, db, org, fs_file_unknown_ext
+    ):
+        # Legacy rows without a recognised extension still serve correctly as
+        # long as the stored type is one this endpoint is allowed to emit.
+        m = await _mk_media(
+            db, org, storage_key=fs_file_unknown_ext, name="legacyok",
+            file_format="xyz", file_mime="application/pdf",
+        )
+        res = await client.get(f"/api/v1/media/{m.media_uuid}/file")
+        assert res.status_code == 200, res.text
+        assert res.headers["content-type"].startswith("application/pdf")

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/playground/[playgrounduuid]/view.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/playground/[playgrounduuid]/view.tsx
@@ -244,7 +244,8 @@ export default function PlaygroundViewClient({
             {playground.html_content ? (
               <iframe
                 srcDoc={playground.html_content}
-                sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+                // srcDoc content runs on an opaque origin (no allow-same-origin)
+                sandbox="allow-scripts allow-forms allow-popups"
                 className="w-full h-full border-0"
                 title={playground.name}
               />

--- a/apps/web/components/Dashboard/Boards/Extensions/PlaygroundBlockComponent.tsx
+++ b/apps/web/components/Dashboard/Boards/Extensions/PlaygroundBlockComponent.tsx
@@ -340,7 +340,8 @@ export default function PlaygroundBlockComponent({
             srcDoc={srcdoc}
             className="w-full h-full bg-white block"
             style={{ border: 'none' }}
-            sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-popups"
+            // srcDoc content runs on an opaque origin (no allow-same-origin)
+            sandbox="allow-scripts allow-forms allow-modals allow-popups"
             title="Playground"
           />
         )}
@@ -495,7 +496,7 @@ function PlaygroundModal({
                     srcDoc={previewSrcdoc}
                     className="w-full h-full bg-white block"
                     style={{ border: 'none' }}
-                    sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-popups"
+                    sandbox="allow-scripts allow-forms allow-modals allow-popups"
                     title="Playground Preview"
                   />
                 </div>

--- a/apps/web/components/Objects/Editor/Extensions/MagicBlocks/MagicBlockPreview.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/MagicBlocks/MagicBlockPreview.tsx
@@ -9,8 +9,11 @@ interface MagicBlockPreviewProps {
 }
 
 /**
- * Sandboxed iframe preview for MagicBlock HTML content
- * Uses blob URLs and sandbox attributes for security
+ * Sandboxed iframe preview for MagicBlock HTML content.
+ *
+ * The document goes in through srcDoc rather than a blob: URL — a blob
+ * document inherits the creating page's origin, whereas a srcDoc frame without
+ * allow-same-origin lands on an opaque one.
  */
 function MagicBlockPreview({
   htmlContent,
@@ -18,15 +21,15 @@ function MagicBlockPreview({
   streamingContent = '',
 }: MagicBlockPreviewProps) {
   const iframeRef = React.useRef<HTMLIFrameElement>(null)
-  const [blobUrl, setBlobUrl] = React.useState<string | null>(null)
+  const [previewHtml, setPreviewHtml] = React.useState<string | null>(null)
 
   // Content to render (prioritize streaming content, then saved content)
   const contentToRender = streamingContent || htmlContent
 
-  // Create blob URL for secure iframe content
+  // Build the document handed to the sandboxed iframe
   React.useEffect(() => {
     if (!contentToRender) {
-      setBlobUrl(null)
+      setPreviewHtml(null)
       return
     }
 
@@ -58,15 +61,7 @@ ${html}
 </html>`
     }
 
-    // Create blob URL
-    const blob = new Blob([wrappedHtml], { type: 'text/html' })
-    const url = URL.createObjectURL(blob)
-    setBlobUrl(url)
-
-    // Cleanup
-    return () => {
-      URL.revokeObjectURL(url)
-    }
+    setPreviewHtml(wrappedHtml)
   }, [contentToRender])
 
   // Show loading state
@@ -82,7 +77,7 @@ ${html}
   }
 
   // Show empty state
-  if (!blobUrl && !isLoading) {
+  if (!previewHtml && !isLoading) {
     return (
       <div className="flex items-center justify-center w-full h-full bg-black/30 border-2 border-dashed border-white/10" style={{ minHeight: '100%' }}>
         <div className="text-center space-y-2 px-4">
@@ -105,10 +100,10 @@ ${html}
       )}
       <iframe
         ref={iframeRef}
-        src={blobUrl || undefined}
+        srcDoc={previewHtml || undefined}
         className="w-full h-full bg-white block"
         style={{ border: 'none', minHeight: '100%' }}
-        sandbox="allow-scripts allow-same-origin"
+        sandbox="allow-scripts"
         title="MagicBlock Preview"
       />
     </div>

--- a/apps/web/components/Playground/PlaygroundPreview.tsx
+++ b/apps/web/components/Playground/PlaygroundPreview.tsx
@@ -20,20 +20,12 @@ export default function PlaygroundPreview({
   const lastRenderedRef = useRef<string | null>(null)
   const writeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // Write HTML directly into the iframe document (no reload, no flicker)
+  // srcdoc, not document.write() — the frame is sandboxed onto an opaque
+  // origin, so its document isn't reachable from here.
   const writeToIframe = useCallback((content: string) => {
     const iframe = iframeRef.current
     if (!iframe) return
-    try {
-      const doc = iframe.contentDocument || iframe.contentWindow?.document
-      if (!doc) return
-      doc.open()
-      doc.write(content)
-      doc.close()
-    } catch {
-      // cross-origin fallback — shouldn't happen with srcdoc
-      iframe.srcdoc = content
-    }
+    iframe.srcdoc = content
   }, [])
 
   useEffect(() => {
@@ -110,7 +102,7 @@ export default function PlaygroundPreview({
       <iframe
         ref={iframeRef}
         className="w-full h-full border-0"
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+        sandbox="allow-scripts allow-forms allow-popups"
         title="Playground Preview"
       />
     </div>


### PR DESCRIPTION
Two code paths disagreed on who decides a file's content type. Upload validation already sniffs the real type from magic bytes and picks the stored extension from it, but the media library saved the client's own content-type header and served that back verbatim. Other upload paths (org logo, thumbnail, OG image) already worked this way.

Separately, a few preview iframes (playgrounds, magic block previews) set `sandbox="allow-scripts allow-same-origin"`. For srcDoc/blob content the two cancel out: the frame inherits the parent's origin, so the sandbox isolates nothing.

- `media.py` stops persisting the client's content-type; `media_serve.py` derives it from the stored extension, falling back to the saved value only for legacy rows with an unrecognized extension, and only if it's servable
- Preview iframes drop `allow-same-origin`. `MagicBlockPreview` now uses `srcDoc`; `PlaygroundPreview` sets `srcdoc` instead of writing into `contentDocument`, since the parent can't reach a cross-origin frame's document
- These frames can no longer reach the parent page's storage or cookies, and previewed content loses same-origin storage of its own
- Added test coverage for the new content-type selection logic

Tested: pytest over media/upload/playground (305 passed, 9 skipped) and the media serve router tests alone (34 passed); eslint clean on the 4 web files. No manual browser pass on the previews.

Thanks to George-Octavian Vieru for reporting both issues.