### PR TITLE
fix: billing key/fulfillment hardening, auth-method grace window

### DIFF
--- a/apps/api/config/config.py
+++ b/apps/api/config/config.py
@@ -4,6 +4,10 @@ from typing import Literal, Optional
 from pydantic import BaseModel
 from dotenv import load_dotenv
 
+# One-shot guard for the missing-credential report below: config is loaded on
+# every request, and repeating the report drowns out every other startup log.
+_LOGGED_MISSING_INTERNAL_KEYS = False
+
 
 class CookieConfig(BaseModel):
     domain: str
@@ -609,18 +613,40 @@ def get_learnhouse_config() -> LearnHouseConfig:
     # control plane (custom domains, plans, internal cron) to the per-tenant
     # backend. Self-hosted EE / OSS deployments don't run that control plane
     # and don't need them, so suppress the warning in those modes.
-    if not development_mode and saas_mode:
+    # Reported ONCE per process, as a single aggregated line. This block used to
+    # warn on every config load, which emitted the same two lines thousands of
+    # times a day and buried the one-shot warnings around them — a disabled
+    # Google audience check sat unnoticed in that noise. One loud line per
+    # process is what actually gets read.
+    global _LOGGED_MISSING_INTERNAL_KEYS
+    if not development_mode and saas_mode and not _LOGGED_MISSING_INTERNAL_KEYS:
+        _LOGGED_MISSING_INTERNAL_KEYS = True
         import logging as _cfg_log
         _log = _cfg_log.getLogger(__name__)
+
+        missing = []
         if not os.environ.get("CLOUD_INTERNAL_KEY"):
-            _log.warning(
-                "CLOUD_INTERNAL_KEY is not set. Internal endpoints "
-                "(custom domain sync, cloud_internal) will reject every request."
+            missing.append(
+                "CLOUD_INTERNAL_KEY (custom domain sync, cloud_internal plan writes)"
             )
         if not os.environ.get("LEARNHOUSE_PLATFORM_API_KEY"):
-            _log.warning(
-                "LEARNHOUSE_PLATFORM_API_KEY is not set. Platform endpoints "
-                "(packs internal_router) will reject every request."
+            missing.append(
+                "LEARNHOUSE_PLATFORM_API_KEY (pack activation, active-user overage billing)"
+            )
+        if not (
+            os.environ.get("LEARNHOUSE_GOOGLE_OAUTH_CLIENT_ID")
+            or os.environ.get("LEARNHOUSE_GOOGLE_CLIENT_ID")
+        ):
+            missing.append(
+                "LEARNHOUSE_GOOGLE_OAUTH_CLIENT_ID (Google OAuth audience "
+                "verification — absent means it is DISABLED, not merely unset)"
+            )
+        if missing:
+            _log.critical(
+                "SaaS deployment is missing %d required credential(s); the "
+                "features behind them fail silently until these are set: %s",
+                len(missing),
+                "; ".join(missing),
             )
 
     # Create LearnHouseConfig object

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -52,10 +52,9 @@ from src.services.users.email_verification import (
 )
 from src.services.auth.session import issue_session_or_challenge
 from src.security.session_context import (
-    AMR_CLAIM,
     AUTH_METHOD_GOOGLE,
     AUTH_METHOD_PASSWORD,
-    SORG_CLAIM,
+    carry_session_claims,
     session_claims,
 )
 from src.db.organizations import Organization
@@ -420,7 +419,8 @@ async def refresh(
         # Carry the session's provenance across rotation. Without this a refresh
         # would silently launder a method-bound/org-bound session into a
         # claim-less one that bypasses the org auth-method / sharing policy.
-        carried = session_claims(payload.get(AMR_CLAIM), payload.get(SORG_CLAIM))
+        # A session that records no method also picks up its grace deadline here.
+        carried = carry_session_claims(payload)
         new_access_token = create_access_token(
             data={"sub": email, **carried},
             expires_delta=JWT_ACCESS_TOKEN_EXPIRES,

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -1125,7 +1125,23 @@ async def api_verify_email(
     # through the same second-factor gate. A brand-new user cannot have MFA yet,
     # but an existing user re-verifying their address can — and without this the
     # verification link would be a way around their own second factor.
-    issue = await issue_session_or_challenge(db_session, user)
+    #
+    # Stamp the provenance like every other sign-in path. Minting a claim-less
+    # session here meant a freshly-verified member could not be matched against
+    # the org's allowed-method policy at all.
+    from src.security.session_context import AUTH_METHOD_MAGIC_LOGIN
+
+    verified_org = (
+        await db_session.execute(
+            select(Organization).where(Organization.org_uuid == body.org_uuid)
+        )
+    ).scalars().first()
+    issue = await issue_session_or_challenge(
+        db_session,
+        user,
+        amr=AUTH_METHOD_MAGIC_LOGIN,
+        org_id=verified_org.id if verified_org else None,
+    )
     if issue.mfa_required:  # pragma: no cover - same 2FA branch as /login, exercised there
         return {
             "message": message,

--- a/apps/api/src/security/auth.py
+++ b/apps/api/src/security/auth.py
@@ -18,13 +18,14 @@ from src.security.security import ALGORITHM, SECRET_KEY, security_hash_password
 from src.security.session_context import (
     AMR_CLAIM,
     AUTH_METHOD_API_TOKEN,
+    LEGACY_GRACE_CLAIM,
     SORG_CLAIM,
     SessionProvenance,
     set_session_provenance,
 )
 
 
-def _publish_session_provenance(amr, org_id) -> None:
+def _publish_session_provenance(amr, org_id, legacy_grace_expires=None) -> None:
     """Store the current request's session provenance for the org-policy gates.
 
     Coerces ``sorg`` to int defensively (JWT numbers survive as int, but a
@@ -35,7 +36,13 @@ def _publish_session_provenance(amr, org_id) -> None:
         parsed_org = int(org_id) if org_id is not None else None
     except (TypeError, ValueError):  # pragma: no cover - defensive coercion of a hand-crafted claim
         parsed_org = None
-    set_session_provenance(SessionProvenance(amr=amr, org_id=parsed_org))
+    try:
+        parsed_grace = int(legacy_grace_expires) if legacy_grace_expires is not None else None
+    except (TypeError, ValueError):  # pragma: no cover - defensive coercion of a hand-crafted claim
+        parsed_grace = None
+    set_session_provenance(
+        SessionProvenance(amr=amr, org_id=parsed_org, legacy_grace_expires=parsed_grace)
+    )
 
 
 # SECURITY: Pre-computed Argon2 hash of an unknown password. Verifying a
@@ -631,7 +638,11 @@ async def get_current_user(
         request.state.is_api_token = False
         # Publish this session's provenance (how the user authenticated, which
         # org the session was minted for) for the per-org auth-method policy.
-        _publish_session_provenance(payload.get(AMR_CLAIM), payload.get(SORG_CLAIM))
+        _publish_session_provenance(
+            payload.get(AMR_CLAIM),
+            payload.get(SORG_CLAIM),
+            payload.get(LEGACY_GRACE_CLAIM),
+        )
         _record_activity_from_request(request, public_user.id)
         return public_user
     else:

--- a/apps/api/src/security/session_context.py
+++ b/apps/api/src/security/session_context.py
@@ -14,8 +14,10 @@ never leaks across requests). The gates read it back with
 
 Legacy sessions minted before this feature carry no ``amr``/``sorg`` claims; they
 resolve to ``SessionProvenance(amr=None, org_id=None)``. Policy evaluation treats
-an unknown method as "does not match a restrictive allow-list" — fail-closed for
-the policy, but only for orgs that opted into a restriction.
+an unknown method as *unknown*, not as a violation, and lets it through: the
+enforcing gate is sign-in time, and failing closed here would lock out every
+member holding a pre-feature session as soon as an org narrowed its method list.
+A session that positively names a disallowed method is still rejected.
 
 Claim keys are defined here so the mint side and the read side cannot drift.
 """

--- a/apps/api/src/security/session_context.py
+++ b/apps/api/src/security/session_context.py
@@ -23,12 +23,35 @@ Claim keys are defined here so the mint side and the read side cannot drift.
 """
 
 import contextvars
+import os
+import time
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Optional
+
+
+def _legacy_session_grace() -> timedelta:
+    """How long a method-less session keeps working once it is first rotated.
+
+    Defaults to the refresh-token lifetime — the longest a member can go without
+    re-authenticating — so everyone gets a full cycle to sign in again before the
+    policy applies to them.
+    """
+    raw = os.environ.get("LEARNHOUSE_AUTH_LEGACY_SESSION_GRACE_DAYS")
+    if raw:
+        try:
+            return timedelta(days=max(int(raw), 0))
+        except (TypeError, ValueError):
+            pass
+    return timedelta(days=30)
+
+
+LEGACY_SESSION_GRACE = _legacy_session_grace()
 
 # JWT claim names carried on session tokens.
 AMR_CLAIM = "amr"       # authentication method: password | magic_login | google | sso | api_token
 SORG_CLAIM = "sorg"     # id of the org the session was established for (int), or absent
+LEGACY_GRACE_CLAIM = "lgc"  # unix seconds after which a method-less session stops being admitted
 
 # Recognised authentication methods. "api_token" is internal — a machine
 # credential that already carries its own org boundary and is exempt from the
@@ -52,6 +75,7 @@ POLICY_AUTH_METHODS = (
 class SessionProvenance:
     amr: Optional[str] = None
     org_id: Optional[int] = None
+    legacy_grace_expires: Optional[int] = None
 
 
 _current: contextvars.ContextVar[Optional[SessionProvenance]] = contextvars.ContextVar(
@@ -67,7 +91,11 @@ def get_session_provenance() -> Optional[SessionProvenance]:
     return _current.get()
 
 
-def session_claims(amr: Optional[str], org_id: Optional[int]) -> dict:
+def session_claims(
+    amr: Optional[str],
+    org_id: Optional[int],
+    legacy_grace_expires: Optional[int] = None,
+) -> dict:
     """Build the provenance claims to merge into a token's ``data`` dict.
 
     Omits keys that are ``None`` so a central (org-less) or method-less token
@@ -78,4 +106,26 @@ def session_claims(amr: Optional[str], org_id: Optional[int]) -> dict:
         claims[AMR_CLAIM] = amr
     if org_id is not None:
         claims[SORG_CLAIM] = org_id
+    if legacy_grace_expires is not None:
+        claims[LEGACY_GRACE_CLAIM] = legacy_grace_expires
     return claims
+
+
+def carry_session_claims(payload: dict) -> dict:
+    """Carry a session's provenance across a token rotation.
+
+    A session that records no auth method gets a grace deadline stamped on the
+    first rotation after this shipped, and keeps it from then on. Without a
+    deadline such a session would sit outside the org auth-method policy
+    forever: rotation copies the missing method claim forward, so it never ages
+    out on its own. Stamping here needs no stored state and no backfill — the
+    deadline travels in the token, and a real sign-in replaces the whole thing
+    with a method-bearing session.
+    """
+    amr = payload.get(AMR_CLAIM)
+    grace = payload.get(LEGACY_GRACE_CLAIM)
+    if amr is None and grace is None:
+        grace = int(time.time()) + int(LEGACY_SESSION_GRACE.total_seconds())
+    if amr is not None:
+        grace = None
+    return session_claims(amr, payload.get(SORG_CLAIM), grace)

--- a/apps/api/src/services/auth/utils.py
+++ b/apps/api/src/services/auth/utils.py
@@ -42,13 +42,20 @@ async def _verify_google_token_audience(access_token: str) -> None:
     """
     global _LOGGED_MISSING_GOOGLE_CLIENT_ID
 
-    expected_client_id = os.environ.get("LEARNHOUSE_GOOGLE_OAUTH_CLIENT_ID")
+    # Accept either name. The web deployment provisions this same value as
+    # LEARNHOUSE_GOOGLE_CLIENT_ID, and reading only the _OAUTH_ spelling meant a
+    # deployment that had the client id all along still ran with audience
+    # verification silently disabled.
+    expected_client_id = os.environ.get("LEARNHOUSE_GOOGLE_OAUTH_CLIENT_ID") or os.environ.get(
+        "LEARNHOUSE_GOOGLE_CLIENT_ID"
+    )
     if not expected_client_id:
         if not _LOGGED_MISSING_GOOGLE_CLIENT_ID:
             logger.warning(
-                "LEARNHOUSE_GOOGLE_OAUTH_CLIENT_ID is not set — Google OAuth "
-                "audience verification is DISABLED. Set this env var to your "
-                "Google OAuth client_id to block confused-deputy token reuse."
+                "Google OAuth audience verification is DISABLED — neither "
+                "LEARNHOUSE_GOOGLE_OAUTH_CLIENT_ID nor LEARNHOUSE_GOOGLE_CLIENT_ID "
+                "is set. Set one to your Google OAuth client_id to block "
+                "confused-deputy token reuse."
             )
             _LOGGED_MISSING_GOOGLE_CLIENT_ID = True
         return

--- a/apps/api/src/services/orgs/auth_policy.py
+++ b/apps/api/src/services/orgs/auth_policy.py
@@ -132,8 +132,24 @@ async def evaluate_org_auth(
                 # auth-method policy.
                 if provenance.amr != AUTH_METHOD_API_TOKEN:
                     allowed = set(policy.allowed_auth_methods)
-                    if policy.method_restricted and (
-                        provenance.amr is None or provenance.amr not in allowed
+                    # A session with no ``amr`` means "we don't know how this
+                    # user signed in", not "they used a forbidden method".
+                    # Treating unknown as a violation locked out every member
+                    # holding a session minted before this feature existed the
+                    # moment an admin unchecked a single method — they kept
+                    # seeing the org, but every authorized request 403'd.
+                    #
+                    # Failing open here costs little: the real gate is
+                    # sign-in time, where /auth/login, /auth/oauth and the
+                    # magic-link endpoints already refuse a disallowed method.
+                    # This check is defence-in-depth against an already-issued
+                    # session, and it still rejects any session that positively
+                    # identifies a method outside the allow-list. Claim-less
+                    # sessions age out on their own as tokens expire.
+                    if (
+                        policy.method_restricted
+                        and provenance.amr is not None
+                        and provenance.amr not in allowed
                     ):
                         result = {
                             "code": METHOD_NOT_ALLOWED_CODE,

--- a/apps/api/src/services/orgs/auth_policy.py
+++ b/apps/api/src/services/orgs/auth_policy.py
@@ -24,6 +24,7 @@ data.
 """
 
 import logging
+import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -45,6 +46,23 @@ METHOD_NOT_ALLOWED_CODE = "AUTH_METHOD_NOT_ALLOWED"
 SESSION_NOT_BOUND_CODE = "SESSION_NOT_BOUND_TO_ORG"
 
 _ALL_METHODS = frozenset(POLICY_AUTH_METHODS)
+
+
+def _legacy_session_within_grace(provenance: SessionProvenance) -> bool:
+    """True while a session that records no auth method is still admitted.
+
+    The deadline rides on the session itself, stamped the first time the session
+    is rotated. A session old enough to predate that stamping has no deadline
+    yet and is admitted — it acquires one within an access token's lifetime, so
+    the exemption cannot outlive a single rotation.
+    """
+    expires = provenance.legacy_grace_expires
+    if expires is None:
+        return True
+    try:
+        return time.time() < int(expires)
+    except (TypeError, ValueError):  # pragma: no cover - defensive against a hand-crafted claim
+        return False
 
 
 @dataclass
@@ -139,17 +157,20 @@ async def evaluate_org_auth(
                     # moment an admin unchecked a single method — they kept
                     # seeing the org, but every authorized request 403'd.
                     #
-                    # Failing open here costs little: the real gate is
-                    # sign-in time, where /auth/login, /auth/oauth and the
-                    # magic-link endpoints already refuse a disallowed method.
-                    # This check is defence-in-depth against an already-issued
-                    # session, and it still rejects any session that positively
-                    # identifies a method outside the allow-list. Claim-less
-                    # sessions age out on their own as tokens expire.
-                    if (
-                        policy.method_restricted
-                        and provenance.amr is not None
-                        and provenance.amr not in allowed
+                    # So a method-less session is admitted, but only until the
+                    # grace deadline carried on the session itself. It cannot be
+                    # indefinite: rotation copies the missing claim forward, so
+                    # these sessions never age out on their own and would
+                    # otherwise skip the policy for good. Past the deadline they
+                    # are refused like any other unapproved session, and signing
+                    # in again replaces them with a method-bearing session.
+                    #
+                    # A session that positively names a method outside the
+                    # allow-list is refused immediately, grace or not.
+                    if policy.method_restricted and (
+                        provenance.amr not in allowed
+                        if provenance.amr is not None
+                        else not _legacy_session_within_grace(provenance)
                     ):
                         result = {
                             "code": METHOD_NOT_ALLOWED_CODE,

--- a/apps/api/src/tests/security/test_auth_policy.py
+++ b/apps/api/src/tests/security/test_auth_policy.py
@@ -98,13 +98,23 @@ class TestMethodGate:
         _prov(amr="password", org_id=org.id)
         await enforce_org_auth_policy(db, regular_user.id, org.id)
 
-    async def test_legacy_session_blocked_under_restriction(self, db, org, regular_user):
-        from fastapi import HTTPException
-
-        # A pre-feature session carries no amr; a restrictive org must force it to
-        # re-authenticate with a known method rather than let it through blind.
+    async def test_legacy_session_allowed_under_restriction(self, db, org, regular_user):
+        # A pre-feature session carries no amr. That is "unknown", not "used a
+        # forbidden method", and it must not be blocked: an org narrowing its
+        # method list would otherwise lock out its entire existing membership at
+        # once, while still showing them the org. Sign-in time is the enforcing
+        # gate; these claim-less sessions age out as their tokens expire.
         await _set_auth_policy(db, org.id, allowed_auth_methods=["password"])
         _prov(amr=None, org_id=None)
+        await enforce_org_auth_policy(db, regular_user.id, org.id)
+
+    async def test_disallowed_method_still_blocked(self, db, org, regular_user):
+        from fastapi import HTTPException
+
+        # The flip side of the above: a session that positively names a method
+        # outside the allow-list is still rejected.
+        await _set_auth_policy(db, org.id, allowed_auth_methods=["password"])
+        _prov(amr="google", org_id=org.id)
         with pytest.raises(HTTPException) as exc:
             await enforce_org_auth_policy(db, regular_user.id, org.id)
         assert exc.value.detail["code"] == METHOD_NOT_ALLOWED_CODE

--- a/apps/api/src/tests/security/test_auth_policy.py
+++ b/apps/api/src/tests/security/test_auth_policy.py
@@ -7,6 +7,7 @@ policy logic can be exercised without a full HTTP round-trip.
 """
 
 from datetime import datetime
+import time
 
 import pytest
 from sqlmodel import select
@@ -44,8 +45,12 @@ async def _set_auth_policy(db, org_id, **security):
     await db.commit()
 
 
-def _prov(amr=None, org_id=None):
-    set_session_provenance(SessionProvenance(amr=amr, org_id=org_id))
+def _prov(amr=None, org_id=None, legacy_grace_expires=None):
+    set_session_provenance(
+        SessionProvenance(
+            amr=amr, org_id=org_id, legacy_grace_expires=legacy_grace_expires
+        )
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -98,14 +103,38 @@ class TestMethodGate:
         _prov(amr="password", org_id=org.id)
         await enforce_org_auth_policy(db, regular_user.id, org.id)
 
-    async def test_legacy_session_allowed_under_restriction(self, db, org, regular_user):
-        # A pre-feature session carries no amr. That is "unknown", not "used a
-        # forbidden method", and it must not be blocked: an org narrowing its
-        # method list would otherwise lock out its entire existing membership at
-        # once, while still showing them the org. Sign-in time is the enforcing
-        # gate; these claim-less sessions age out as their tokens expire.
+    async def test_unstamped_legacy_session_allowed(self, db, org, regular_user):
+        # A session predating the feature carries no amr. That is "unknown", not
+        # "used a forbidden method". Blocking it would lock out the org's entire
+        # existing membership the moment an admin narrows the method list, while
+        # still showing them the org. It has no deadline yet either — it picks
+        # one up on its next rotation.
         await _set_auth_policy(db, org.id, allowed_auth_methods=["password"])
         _prov(amr=None, org_id=None)
+        await enforce_org_auth_policy(db, regular_user.id, org.id)
+
+    async def test_legacy_session_allowed_before_its_deadline(self, db, org, regular_user):
+        await _set_auth_policy(db, org.id, allowed_auth_methods=["password"])
+        _prov(amr=None, org_id=None, legacy_grace_expires=int(time.time()) + 86_400)
+        await enforce_org_auth_policy(db, regular_user.id, org.id)
+
+    async def test_legacy_session_blocked_after_its_deadline(self, db, org, regular_user):
+        from fastapi import HTTPException
+
+        # The window must close. Rotation copies the missing claim forward, so
+        # these sessions never expire on their own — left open-ended they would
+        # skip the policy for good.
+        await _set_auth_policy(db, org.id, allowed_auth_methods=["password"])
+        _prov(amr=None, org_id=None, legacy_grace_expires=int(time.time()) - 60)
+        with pytest.raises(HTTPException) as exc:
+            await enforce_org_auth_policy(db, regular_user.id, org.id)
+        assert exc.value.detail["code"] == METHOD_NOT_ALLOWED_CODE
+
+    async def test_allowed_method_unaffected_by_expired_deadline(self, db, org, regular_user):
+        # The deadline governs method-less sessions only; a session naming an
+        # allowed method keeps working regardless.
+        await _set_auth_policy(db, org.id, allowed_auth_methods=["password"])
+        _prov(amr="password", org_id=org.id, legacy_grace_expires=int(time.time()) - 60)
         await enforce_org_auth_policy(db, regular_user.id, org.id)
 
     async def test_disallowed_method_still_blocked(self, db, org, regular_user):
@@ -228,3 +257,53 @@ class TestMalformedConfig:
         policy = await get_org_auth_policy(db, org.id)
         assert policy.method_restricted is False
         assert policy.allow_central_session_sharing is True
+
+
+class TestCarrySessionClaimsOnRotation:
+    """A rotation must not launder provenance, and must bound a method-less session."""
+
+    def test_method_bearing_session_carries_its_claims(self):
+        from src.security.session_context import (
+            AMR_CLAIM,
+            LEGACY_GRACE_CLAIM,
+            SORG_CLAIM,
+            carry_session_claims,
+        )
+
+        carried = carry_session_claims({AMR_CLAIM: "password", SORG_CLAIM: 7})
+        assert carried[AMR_CLAIM] == "password"
+        assert carried[SORG_CLAIM] == 7
+        # A session that names its method needs no deadline.
+        assert LEGACY_GRACE_CLAIM not in carried
+
+    def test_method_less_session_gets_a_deadline(self):
+        from src.security.session_context import (
+            AMR_CLAIM,
+            LEGACY_GRACE_CLAIM,
+            carry_session_claims,
+        )
+
+        carried = carry_session_claims({})
+        assert AMR_CLAIM not in carried
+        # Without this the session would sit outside the policy forever, since
+        # rotation copies the missing method claim forward indefinitely.
+        assert carried[LEGACY_GRACE_CLAIM] > int(time.time())
+
+    def test_existing_deadline_is_not_extended_by_rotation(self):
+        from src.security.session_context import LEGACY_GRACE_CLAIM, carry_session_claims
+
+        deadline = int(time.time()) + 500
+        carried = carry_session_claims({LEGACY_GRACE_CLAIM: deadline})
+        # Re-stamping on every rotation would let a session refresh its way past
+        # the deadline forever.
+        assert carried[LEGACY_GRACE_CLAIM] == deadline
+
+    def test_a_deadline_never_survives_onto_a_method_bearing_session(self):
+        from src.security.session_context import (
+            AMR_CLAIM,
+            LEGACY_GRACE_CLAIM,
+            carry_session_claims,
+        )
+
+        carried = carry_session_claims({AMR_CLAIM: "google", LEGACY_GRACE_CLAIM: 1})
+        assert LEGACY_GRACE_CLAIM not in carried

--- a/apps/web/app/(hub)/billing/_lib/billingClient.ts
+++ b/apps/web/app/(hub)/billing/_lib/billingClient.ts
@@ -43,6 +43,16 @@ export interface PromoResult {
   currency?: string;
 }
 
+// POST /api/billing/fulfill → { fulfilled, plan? }
+// Redundant automatic upgrade path: called on return from Stripe checkout so the
+// org upgrades even if the webhook is delayed or misconfigured. Idempotent.
+export function billingFulfill(body: {
+  sessionId: string;
+  orgId: number | string;
+}): Promise<{ fulfilled: boolean; plan?: string; reason?: string }> {
+  return postJson("/api/billing/fulfill", body);
+}
+
 // POST /api/billing/checkout → { id, url }
 export function billingCheckout(body: {
   plan: PlanId;

--- a/apps/web/app/(hub)/billing/page.tsx
+++ b/apps/web/app/(hub)/billing/page.tsx
@@ -12,11 +12,13 @@ import UserAvatar from '@components/Objects/UserAvatar'
 import { getAPIUrl } from '@services/config/config'
 import { getOrgLogoMediaDirectory } from '@services/media/media'
 import { apiFetch } from '@services/utils/ts/requests'
+import { queryKeys } from '@/lib/query/keys'
 import {
   fetchPrices,
   fetchSubscription,
   fetchUpcomingInvoice,
   fetchInvoices,
+  billingFulfill,
 } from './_lib/billingClient'
 import { resolvePlanIdFromOrg } from './_lib/plans'
 import PlanUsage from './_components/PlanUsage'
@@ -166,16 +168,66 @@ function BillingClient() {
   // params so a reload doesn't re-fire.
   const checkoutParam = searchParams?.get('checkout')
   const packPurchased = searchParams?.get('pack_purchased')
+  const checkoutSessionId = searchParams?.get('session_id')
+  const orgSlug = org?.slug
   useEffect(() => {
     if (!orgId || (!checkoutParam && !packPurchased)) return
     if (checkoutParam === 'success' || packPurchased) {
-      queryClient.invalidateQueries({ queryKey: ['billing'] })
-      queryClient.invalidateQueries({ queryKey: ['orgs', 'user'] })
-      toast.success(
-        packPurchased
-          ? t('billing.pack_purchased', { defaultValue: 'Add-on purchased — your limits are updated.' })
-          : t('billing.checkout_success', { defaultValue: 'Subscription updated — welcome to your new plan!' }),
-      )
+      // Refreshing the plan/usage queries is not enough on its own: the org
+      // detail query feeds usePlan() and carries a 5-minute staleTime, so
+      // without invalidating it too a genuinely-upgraded org keeps rendering its
+      // old plan and limits.
+      const refresh = () => {
+        queryClient.invalidateQueries({ queryKey: ['billing'] })
+        queryClient.invalidateQueries({ queryKey: ['orgs', 'user'] })
+        if (orgSlug) queryClient.invalidateQueries({ queryKey: queryKeys.org.detail(orgSlug) })
+      }
+
+      // Packs land here without a session_id and are applied by the webhook
+      // alone, so there is nothing to confirm — keep the existing behaviour.
+      if (packPurchased || !checkoutSessionId) {
+        refresh()
+        toast.success(
+          packPurchased
+            ? t('billing.pack_purchased', { defaultValue: 'Add-on purchased — your limits are updated.' })
+            : t('billing.checkout_success', { defaultValue: 'Subscription updated — welcome to your new plan!' }),
+        )
+      } else {
+        // Redundant automatic fulfillment: apply the plan directly from the paid
+        // Stripe session so the org upgrades even when the webhook is delayed or
+        // misconfigured. Idempotent and server-authorized.
+        //
+        // Announce success only once something confirms the plan actually
+        // changed. Claiming "welcome to your new plan" unconditionally is how a
+        // failed upgrade reached the customer looking like a completed one.
+        billingFulfill({ sessionId: checkoutSessionId, orgId })
+          .then((result) => {
+            if (result?.fulfilled) {
+              toast.success(
+                t('billing.checkout_success', {
+                  defaultValue: 'Subscription updated — welcome to your new plan!',
+                }),
+              )
+            } else {
+              toast.success(
+                t('billing.checkout_settling', {
+                  defaultValue:
+                    'Payment received — your new plan is being applied and will appear shortly.',
+                }),
+              )
+            }
+          })
+          .catch((err) => {
+            console.error('[billing] fulfill on return failed:', err)
+            toast(
+              t('billing.checkout_settling_delayed', {
+                defaultValue:
+                  'Payment received, but your plan has not updated yet. Refresh in a moment — contact support if it persists.',
+              }),
+            )
+          })
+          .finally(refresh)
+      }
     } else if (checkoutParam === 'cancelled') {
       toast(t('billing.checkout_cancelled', { defaultValue: 'Checkout cancelled — no changes were made.' }))
     }
@@ -183,7 +235,7 @@ function BillingClient() {
     ;['checkout', 'session_id', 'pack_purchased', 'pack'].forEach((k) => sp.delete(k))
     const qs = sp.toString()
     router.replace(qs ? `/billing?${qs}` : '/billing')
-  }, [orgId, checkoutParam, packPurchased, queryClient, router, searchParams, t])
+  }, [orgId, checkoutParam, packPurchased, checkoutSessionId, orgSlug, queryClient, router, searchParams, t])
 
   const currentPlanId = resolvePlanIdFromOrg(org)
   const isOrgActive = resolveOrgActive(org)

--- a/apps/web/app/api/billing/fulfill/route.ts
+++ b/apps/web/app/api/billing/fulfill/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { fulfillCheckoutSession } from "@services/billing/stripe";
+import { guardBilling, badRequest, requireOrgBillingAccess } from "../_lib";
+
+// POST /api/billing/fulfill
+// Body: { sessionId, orgId }
+// → { fulfilled, plan? } — verifies a completed Stripe Checkout session and
+// applies the org's plan directly, WITHOUT depending on webhook delivery.
+//
+// This is the redundant automatic upgrade path: the client calls it when the
+// user lands back on /billing?checkout=success. The webhook remains the primary
+// path, but if it is delayed or misconfigured (wrong dashboard endpoint / stale
+// STRIPE_WEBHOOK_SECRET), the customer's return from checkout still upgrades the
+// org. fulfillCheckoutSession is idempotent and reads the org/plan from the
+// session's subscription metadata (never from the request body).
+export async function POST(request: NextRequest) {
+  const blocked = await guardBilling();
+  if (blocked) return blocked;
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return badRequest("Invalid JSON body");
+  }
+
+  const { sessionId, orgId } = body ?? {};
+  if (!sessionId || !orgId) {
+    return badRequest("Missing required fields: sessionId, orgId");
+  }
+
+  // Authorize the caller for this org. The plan itself comes from the verified
+  // Stripe session metadata inside fulfillCheckoutSession, so a caller cannot
+  // grant themselves a plan they didn't pay for — but they must still be an
+  // admin of the org they're fulfilling for.
+  const access = await requireOrgBillingAccess(orgId);
+  if ("error" in access) return access.error;
+
+  try {
+    const result = await fulfillCheckoutSession(String(sessionId));
+    return NextResponse.json(result);
+  } catch (err: any) {
+    console.error("[billing/fulfill] failed:", err);
+    return NextResponse.json(
+      { error: err?.message ?? "Fulfillment failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/api/billing/webhook/route.ts
+++ b/apps/web/app/api/billing/webhook/route.ts
@@ -14,30 +14,13 @@ import {
   deactivateAllPacksInternally,
   markPackCancelingInternally,
 } from "@services/billing/packs";
-import { planForPriceId, getStripeSecretKey } from "@services/billing/stripe";
+import { planForPriceId, stripeClient as stripe } from "@services/billing/stripe";
 import { billOverageForInvoice } from "@services/billing/activeUserBilling";
 import {
   sendPurchaseCompleteMail,
   sendPackActivatedMail,
   sendPaymentFailedMail,
 } from "@services/billing/emails";
-
-// Lazy Stripe client (see services/billing/stripe.ts) — instantiating at module
-// load without a key throws and breaks `next build` / keyless deployments.
-let _stripeClient: any = null;
-const stripe: any = new Proxy(
-  {},
-  {
-    get(_t, prop) {
-      if (!_stripeClient) {
-        const key = getStripeSecretKey();
-        if (!key) throw new Error("STRIPE_SECRET_KEY is not configured");
-        _stripeClient = require("stripe")(key);
-      }
-      return _stripeClient[prop];
-    },
-  },
-);
 
 // Derive an org's plan from the subscription's PRICE id (source of truth),
 // falling back to metadata.plan only when the price isn't recognized. Stripe
@@ -49,20 +32,27 @@ async function planFromSubscription(subscription: any): Promise<string | undefin
   return subscription?.metadata?.plan ?? undefined;
 }
 
-// Simple in-memory idempotency cache (event_id -> timestamp).
+// Simple in-memory idempotency cache (event_id -> {state, ts}).
 // Stripe retries webhooks, so we skip events we've already processed.
 // TTL: 5 minutes — Stripe won't retry faster than that.
 // NOTE: in-memory, so it does NOT dedupe across serverless instances; the
 // downstream service calls are all idempotent, which covers the gap.
-// The entry is dropped again if processing fails (see the catch below), so a
-// retry of a FAILED event is never mistaken for a duplicate of a successful one.
-const processedEvents = new Map<string, number>();
+//
+// The state matters. Marking an event before processing is what blocks a
+// concurrent duplicate delivery, but a bare mark also swallows retries: an
+// event whose handler failed — or whose process died before it could unmark —
+// would answer the retry with a "duplicate" 200 and permanently drop the
+// upgrade. So only a `done` entry is a real duplicate. An `in-flight` entry
+// means another delivery is still working on it and may yet fail, so we ask
+// Stripe to come back rather than acking on its behalf.
+type EventState = "in-flight" | "done";
+const processedEvents = new Map<string, { state: EventState; ts: number }>();
 const IDEMPOTENCY_TTL_MS = 5 * 60 * 1000;
 
 function cleanupProcessedEvents() {
   const cutoff = Date.now() - IDEMPOTENCY_TTL_MS;
-  for (const [id, ts] of Array.from(processedEvents)) {
-    if (ts < cutoff) processedEvents.delete(id);
+  for (const [id, entry] of Array.from(processedEvents)) {
+    if (entry.ts < cutoff) processedEvents.delete(id);
   }
 }
 
@@ -80,19 +70,32 @@ export async function POST(request: Request) {
     return NextResponse.json({ message: "Invalid signature", ok: false }, { status: 400 });
   }
 
-  // Idempotency check — skip duplicate events
+  // Idempotency check — skip events already handled successfully
   cleanupProcessedEvents();
-  if (processedEvents.has(event.id)) {
+  const seen = processedEvents.get(event.id);
+  if (seen?.state === "done") {
     return NextResponse.json({ result: "duplicate", ok: true });
   }
-  processedEvents.set(event.id, Date.now());
+  if (seen?.state === "in-flight") {
+    // Another delivery of this event is mid-flight. Don't ack for it — if it
+    // fails, this 500 is what keeps Stripe retrying.
+    return NextResponse.json({ message: "event in flight", ok: false }, { status: 409 });
+  }
+  processedEvents.set(event.id, { state: "in-flight", ts: Date.now() });
 
   try {
     if (event.type === "checkout.session.completed") {
       await handleCheckoutCompleted(event.data.object);
     }
 
-    if (event.type === "customer.subscription.updated" || event.type === "customer.subscription.deleted") {
+    // Treat `created` like an `updated`: it's the natural recovery event that
+    // also carries subscription_data.metadata.org_id, so if checkout.session
+    // .completed was dropped, this still upgrades the org.
+    if (
+      event.type === "customer.subscription.updated" ||
+      event.type === "customer.subscription.deleted" ||
+      event.type === "customer.subscription.created"
+    ) {
       await handleSubscriptionEvent(event.type, event.data.object);
     }
 
@@ -102,12 +105,15 @@ export async function POST(request: Request) {
       await billOverageForInvoice(event.data.object);
     }
 
+    // Promote to `done` only after successful handling, so a retry of a failed
+    // event is never mistaken for a duplicate of a successful one.
+    processedEvents.set(event.id, { state: "done", ts: Date.now() });
     return NextResponse.json({ result: event.type, ok: true });
   } catch (error) {
     console.error(`Webhook processing error for ${event.type} (${event.id}):`, error);
-    // Un-mark the event: it was recorded before processing to block concurrent
-    // duplicate deliveries, but this delivery failed. Leaving it would make
-    // Stripe's retry return "duplicate" 200 and silently drop the work.
+    // Drop the in-flight mark so Stripe's retry is reprocessed rather than
+    // answered "duplicate". Downstream service calls are idempotent, so a
+    // re-apply is harmless.
     processedEvents.delete(event.id);
     // Return 500 so Stripe retries the webhook
     return NextResponse.json(
@@ -120,21 +126,43 @@ export async function POST(request: Request) {
 async function handleCheckoutCompleted(session: any) {
   if (session.payment_status !== "paid") return;
 
-  // Retrieve session with expanded subscription to get metadata
-  const fullSession = await stripe.checkout.sessions.retrieve(session.id, {
-    expand: ["subscription"],
-  });
-  const subscription = fullSession.subscription;
+  // Retrieve the session with the subscription expanded to read its metadata.
+  // Stripe's basil API (2025-03-31) defers subscription creation until payment
+  // completes, so the expanded `subscription` can briefly be null right after
+  // checkout — the same race fulfillCheckoutSession() guards against. Retry so a
+  // deferred subscription doesn't silently drop the upgrade.
+  let fullSession: any;
+  let subscription: any;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    fullSession = await stripe.checkout.sessions.retrieve(session.id, {
+      expand: ["subscription"],
+    });
+    subscription = fullSession.subscription;
+    // Break as soon as the subscription exists: the race is about Stripe not
+    // having materialized it yet, not about its metadata. Retrying until
+    // org_id appears would also retry every foreign checkout on this shared
+    // account three times before acking it.
+    if (subscription) break;
+    if (attempt < 2) await new Promise((r) => setTimeout(r, 1000));
+  }
   const customerEmail = fullSession.customer_details?.email || session.customer_email;
 
-  if (!subscription?.metadata) {
-    console.warn("checkout.session.completed: no subscription metadata", session.id);
-    return;
+  if (!subscription) {
+    // Subscription still not materialized after retries — transient. Throw so
+    // Stripe redelivers (and customer.subscription.created will also cover it),
+    // rather than acking with a 200 that permanently drops the upgrade.
+    throw new Error(
+      `checkout.session.completed: subscription not yet available for session ${session.id}`,
+    );
   }
 
-  const orgId = subscription.metadata.org_id;
+  const orgId = subscription.metadata?.org_id;
   if (!orgId) {
-    console.warn("checkout.session.completed: no org_id in metadata", session.id);
+    // A checkout not created by our flow carries no org linkage — nothing we can
+    // do; ack so Stripe doesn't retry it forever and disable the endpoint. This
+    // endpoint shares a Stripe account with other products, so foreign checkouts
+    // legitimately land here and must not be treated as failures.
+    console.warn("checkout.session.completed: no org_id in subscription metadata", session.id);
     return;
   }
 
@@ -158,8 +186,16 @@ async function handleCheckoutCompleted(session: any) {
   } else {
     const plan = await planFromSubscription(subscription);
     if (!plan) {
-      console.warn("checkout.session.completed: could not resolve plan", session.id);
-      return;
+      // The session belongs to us (it carries org_id) but its price maps to no
+      // known plan — almost always a missing STRIPE_PRICE_* env on this
+      // deployment. Throw: acking here would drop a paid upgrade on the floor
+      // for a config gap that is fixable, and Stripe's retries buy time to fix
+      // it. Silent config gaps are exactly how paid orgs end up on free.
+      throw new Error(
+        `checkout.session.completed: could not resolve plan for session ${session.id} ` +
+          `(org ${orgId}, price ${subscription?.items?.data?.[0]?.price?.id}) — ` +
+          `is the matching STRIPE_PRICE_* env set?`,
+      );
     }
     await updateOrganizationConfigInternally(orgId, plan as any);
 
@@ -188,7 +224,10 @@ async function handleSubscriptionEvent(eventType: string, subscription: any) {
 
     if (eventType === "customer.subscription.deleted") {
       await deactivatePackInternally(orgId, subscription.id);
-    } else if (eventType === "customer.subscription.updated") {
+    } else if (
+      eventType === "customer.subscription.updated" ||
+      eventType === "customer.subscription.created"
+    ) {
       if (subscription.cancel_at_period_end) {
         // User requested cancellation — mark as canceling but keep active until period end
         await markPackCancelingInternally(orgId, subscription.id);
@@ -213,7 +252,10 @@ async function handleSubscriptionEvent(eventType: string, subscription: any) {
       await deactivateAllPacksInternally(orgId).catch((err) => {
         console.error(`Failed to deactivate packs for org ${orgId}:`, err);
       });
-    } else if (eventType === "customer.subscription.updated") {
+    } else if (
+      eventType === "customer.subscription.updated" ||
+      eventType === "customer.subscription.created"
+    ) {
       if (subscription.cancel_at_period_end) {
         // Plan is canceling — keep current plan until period ends
         console.log(`Plan subscription canceling for org ${orgId}, access continues until period end`);

--- a/apps/web/services/billing/activeUserBilling.ts
+++ b/apps/web/services/billing/activeUserBilling.ts
@@ -14,6 +14,7 @@ import "server-only";
  */
 import { getServerAPIUrl } from "@services/config/config";
 import { getStripeSecretKey } from "@services/billing/stripe";
+import { platformApiKey } from "@services/billing/packs";
 import {
   completeMonthsBefore,
   intervalMonths,
@@ -71,7 +72,7 @@ export async function fetchActiveUserOverage(
   const url = `${getServerAPIUrl()}internal/packs/${orgId}/active-user-overage?year=${year}&month=${month}`;
   const res = await fetch(url, {
     method: "GET",
-    headers: { "x-platform-key": process.env.LEARNHOUSE_PLATFORM_API_KEY || "" },
+    headers: { "x-platform-key": platformApiKey() },
     cache: "no-store",
   });
   if (!res.ok) {

--- a/apps/web/services/billing/orgPlan.ts
+++ b/apps/web/services/billing/orgPlan.ts
@@ -11,9 +11,28 @@ import type { LearnHousePlanType } from "./plans";
 export async function updateOrganizationConfigInternally(org_id: any, plan: LearnHousePlanType) {
   console.log(`[updateOrgConfig] Updating org ${org_id} to plan "${plan}"`);
 
-  const internalKey = process.env.LEARNHOUSE_CLOUD_INTERNAL_KEY || "";
+  // The API guard (apps/api/.../orgs/org_plan.py) compares X-Internal-Key to env
+  // CLOUD_INTERNAL_KEY. Accept EITHER name here, preferring the unprefixed one
+  // the API itself reads, so the two services agree even when only one name is
+  // provisioned. Reading a single name and falling back to "" sent an empty key
+  // whenever that name was the one missing, and the API — which fails closed on
+  // an empty expected key — answered 403, indistinguishable from a real key
+  // mismatch. Fail loud instead: a missing credential is a deploy fault, and it
+  // must not read as an authorization failure.
+  const internalKey =
+    process.env.CLOUD_INTERNAL_KEY || process.env.LEARNHOUSE_CLOUD_INTERNAL_KEY || "";
+  if (!internalKey) {
+    throw new Error(
+      "[updateOrgConfig] internal key unset — set CLOUD_INTERNAL_KEY (or " +
+        "LEARNHOUSE_CLOUD_INTERNAL_KEY) on the web deployment to match the API's " +
+        "CLOUD_INTERNAL_KEY; the plan write would 403 without it.",
+    );
+  }
   const result = await fetch(`${getServerAPIUrl()}cloud_internal/update_org_plan`, {
     method: "PUT",
+    // Bound the call: this runs inside the Stripe webhook handler, and an
+    // unbounded fetch would hold the delivery open until Stripe times out.
+    signal: AbortSignal.timeout(10_000),
     headers: {
       "Content-Type": "application/json",
       // The backend cloud_internal guard (apps/api/.../orgs/org_plan.py) reads

--- a/apps/web/services/billing/packs.ts
+++ b/apps/web/services/billing/packs.ts
@@ -6,10 +6,29 @@ import "server-only";
 // (orgPlan.ts uses `CloudInternalKey`). Both internal auth schemes must coexist.
 import { getServerAPIUrl } from "@services/config/config";
 
+// Resolve the platform key, failing loud when it is absent.
+//
+// Sending "" here produced a 500 from the backend guard ("not configured on the
+// server") that read like a backend fault rather than a missing credential on
+// this side, so a deployment without the key looked like a broken API instead
+// of an unset env var. Shared with activeUserBilling.ts so both internal call
+// sites resolve it identically.
+export function platformApiKey(): string {
+  const key = process.env.LEARNHOUSE_PLATFORM_API_KEY;
+  if (!key) {
+    throw new Error(
+      "LEARNHOUSE_PLATFORM_API_KEY is unset on the web deployment — pack " +
+        "activation and active-user overage billing cannot authenticate to the " +
+        "API. Set it to the same value as the API's LEARNHOUSE_PLATFORM_API_KEY.",
+    );
+  }
+  return key;
+}
+
 function platformHeaders() {
   return {
     "Content-Type": "application/json",
-    "x-platform-key": process.env.LEARNHOUSE_PLATFORM_API_KEY || "",
+    "x-platform-key": platformApiKey(),
   };
 }
 

--- a/apps/web/services/billing/stripe.ts
+++ b/apps/web/services/billing/stripe.ts
@@ -41,8 +41,10 @@ export function getStripeSecretKey(): string | undefined {
 // collection evaluates this module) and any non-SaaS deployment that imports it
 // without a Stripe key. The Proxy instantiates the real client on first
 // property access (request time, after the SaaS/key guard has run).
+// Exported so the webhook route shares this one client instead of building a
+// second identical proxy of its own.
 let _stripeClient: any = null;
-const stripe: any = new Proxy(
+export const stripeClient: any = new Proxy(
   {},
   {
     get(_t, prop) {
@@ -55,6 +57,9 @@ const stripe: any = new Proxy(
     },
   },
 );
+
+// Local alias so the 28 call sites below stay unchanged.
+const stripe: any = stripeClient;
 
 // APP_URL is computed per-call: apps/web reads runtime config lazily, so a
 // module-load constant could capture an empty domain before config is hydrated.
@@ -189,9 +194,13 @@ export async function createCheckoutSession(
   const cancelUrl = orgSlug
     ? `${APP_URL}/billing?org=${orgSlug}&checkout=cancelled`
     : `${APP_URL}/new?checkout=cancelled`;
+  // Always return to /billing on success, even without an org slug: it is the
+  // only page that runs the post-checkout fulfillment fallback. /home ignores
+  // both `checkout` and `session_id`, so landing there left the upgrade
+  // depending on webhook delivery alone, with no confirmation to the customer.
   const successUrl = orgSlug
     ? `${APP_URL}/billing?org=${orgSlug}&checkout=success&session_id={CHECKOUT_SESSION_ID}`
-    : `${APP_URL}/home?checkout=success&session_id={CHECKOUT_SESSION_ID}`;
+    : `${APP_URL}/billing?orgId=${orgId}&checkout=success&session_id={CHECKOUT_SESSION_ID}`;
 
   const session = await stripe.checkout.sessions.create({
     customer: customerId,

--- a/apps/web/tests/billing-internal-key.test.mjs
+++ b/apps/web/tests/billing-internal-key.test.mjs
@@ -1,0 +1,110 @@
+// Contract tests for the internal plan write.
+//
+// These exist because this exact contract was silently reverted once: the web
+// side read a single env name and fell back to an empty key, while the API
+// validates a different name and fails closed on an empty one. Every plan write
+// then 403'd, and nothing in CI noticed. If a future change narrows the env
+// names or restores the silent "" fallback, these fail.
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// `server-only` is a Next build-time alias rather than an installed package, so
+// it has to be stubbed before importing any module that declares it.
+mock.module("server-only", () => ({}));
+
+const { updateOrganizationConfigInternally } = await import("../services/billing/orgPlan.ts");
+
+const ORG_ID = 4242; // synthetic — never a real org
+const BOTH_NAMES = ["CLOUD_INTERNAL_KEY", "LEARNHOUSE_CLOUD_INTERNAL_KEY"];
+
+let calls;
+let originalFetch;
+let originalEnv;
+
+beforeEach(() => {
+  calls = [];
+  originalEnv = {};
+  for (const name of BOTH_NAMES) originalEnv[name] = process.env[name];
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const name of BOTH_NAMES) {
+    if (originalEnv[name] === undefined) delete process.env[name];
+    else process.env[name] = originalEnv[name];
+  }
+});
+
+function setKeys({ cloud, prefixed }) {
+  if (cloud === undefined) delete process.env.CLOUD_INTERNAL_KEY;
+  else process.env.CLOUD_INTERNAL_KEY = cloud;
+  if (prefixed === undefined) delete process.env.LEARNHOUSE_CLOUD_INTERNAL_KEY;
+  else process.env.LEARNHOUSE_CLOUD_INTERNAL_KEY = prefixed;
+}
+
+describe("updateOrganizationConfigInternally — internal key resolution", () => {
+  test("sends the key when only CLOUD_INTERNAL_KEY is set", async () => {
+    setKeys({ cloud: "key-unprefixed" });
+    await updateOrganizationConfigInternally(ORG_ID, "pro");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].init.headers["X-Internal-Key"]).toBe("key-unprefixed");
+  });
+
+  test("sends the key when only LEARNHOUSE_CLOUD_INTERNAL_KEY is set", async () => {
+    setKeys({ prefixed: "key-prefixed" });
+    await updateOrganizationConfigInternally(ORG_ID, "pro");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].init.headers["X-Internal-Key"]).toBe("key-prefixed");
+  });
+
+  test("prefers the unprefixed name the API itself validates", async () => {
+    setKeys({ cloud: "key-unprefixed", prefixed: "key-prefixed" });
+    await updateOrganizationConfigInternally(ORG_ID, "pro");
+    expect(calls[0].init.headers["X-Internal-Key"]).toBe("key-unprefixed");
+  });
+
+  test("throws before calling the API when neither name is set", async () => {
+    setKeys({});
+    await expect(updateOrganizationConfigInternally(ORG_ID, "pro")).rejects.toThrow(
+      /internal key unset/i,
+    );
+    // The point of failing loud: no request is made, so the failure cannot be
+    // mistaken for the API rejecting a wrong key.
+    expect(calls).toHaveLength(0);
+  });
+
+  test("an empty-string key is treated as unset, never sent", async () => {
+    setKeys({ cloud: "", prefixed: "" });
+    await expect(updateOrganizationConfigInternally(ORG_ID, "pro")).rejects.toThrow(
+      /internal key unset/i,
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  test("sends the plan to the cloud_internal endpoint and bounds the call", async () => {
+    setKeys({ cloud: "key-unprefixed" });
+    await updateOrganizationConfigInternally(ORG_ID, "standard");
+    const { url, init } = calls[0];
+    expect(String(url)).toContain("cloud_internal/update_org_plan");
+    expect(init.method).toBe("PUT");
+    expect(JSON.parse(init.body)).toEqual({ org_id: ORG_ID, plan: "standard" });
+    // Unbounded, this runs inside the Stripe webhook and can hold the delivery
+    // open until Stripe times out.
+    expect(init.signal).toBeDefined();
+  });
+
+  test("a non-2xx response throws rather than reporting success", async () => {
+    setKeys({ cloud: "key-unprefixed" });
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ detail: "Invalid internal API key" }), { status: 403 });
+    await expect(updateOrganizationConfigInternally(ORG_ID, "pro")).rejects.toThrow(/403/);
+  });
+});

--- a/apps/web/tests/billing-platform-key.test.mjs
+++ b/apps/web/tests/billing-platform-key.test.mjs
@@ -1,0 +1,42 @@
+// Contract test for the platform key used by pack activation and active-user
+// overage billing.
+//
+// Same class of failure as the internal plan key: the key was read with a
+// `|| ""` fallback, so an unset env var sent an empty header and the backend
+// answered 500 "not configured on the server" — which read as a backend fault
+// rather than a missing credential here. Both call sites must resolve it
+// through one helper that fails loud.
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const { platformApiKey } = await import("../services/billing/packs.ts");
+
+let original;
+
+beforeEach(() => {
+  original = process.env.LEARNHOUSE_PLATFORM_API_KEY;
+});
+
+afterEach(() => {
+  if (original === undefined) delete process.env.LEARNHOUSE_PLATFORM_API_KEY;
+  else process.env.LEARNHOUSE_PLATFORM_API_KEY = original;
+});
+
+describe("platformApiKey", () => {
+  test("returns the configured key", () => {
+    process.env.LEARNHOUSE_PLATFORM_API_KEY = "platform-key";
+    expect(platformApiKey()).toBe("platform-key");
+  });
+
+  test("throws when unset instead of returning an empty key", () => {
+    delete process.env.LEARNHOUSE_PLATFORM_API_KEY;
+    expect(() => platformApiKey()).toThrow(/LEARNHOUSE_PLATFORM_API_KEY is unset/);
+  });
+
+  test("treats an empty string as unset", () => {
+    process.env.LEARNHOUSE_PLATFORM_API_KEY = "";
+    expect(() => platformApiKey()).toThrow(/LEARNHOUSE_PLATFORM_API_KEY is unset/);
+  });
+});

--- a/apps/web/tests/billing-webhook.test.mjs
+++ b/apps/web/tests/billing-webhook.test.mjs
@@ -1,0 +1,270 @@
+// Behaviour tests for the Stripe webhook receiver.
+//
+// Each case here corresponds to a way a paid checkout has previously failed to
+// upgrade an org: an event type that stopped being handled, a subscription that
+// Stripe had not materialized yet, or a retry answered "duplicate" after the
+// first delivery failed. All of them ack'd with a 200, so Stripe considered the
+// upgrade delivered and never retried.
+//
+// All fixtures are synthetic.
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+// --- test doubles -----------------------------------------------------------
+
+const planWrites = [];
+let sessionRetrieveQueue = [];
+let sessionRetrieveCalls = 0;
+let signatureValid = true;
+
+mock.module("next/headers", () => ({
+  headers: async () => new Map([["stripe-signature", "sig_test"]]),
+}));
+
+mock.module("@services/billing/orgPlan", () => ({
+  updateOrganizationConfigInternally: async (orgId, plan) => {
+    planWrites.push({ orgId, plan });
+    return { ok: true };
+  },
+}));
+
+mock.module("@services/billing/packs", () => ({
+  activatePackInternally: async () => ({}),
+  deactivatePackInternally: async () => ({}),
+  deactivateAllPacksInternally: async () => ({}),
+  markPackCancelingInternally: async () => ({}),
+}));
+
+mock.module("@services/billing/activeUserBilling", () => ({
+  billOverageForInvoice: async () => ({}),
+}));
+
+mock.module("@services/billing/emails", () => ({
+  sendPurchaseCompleteMail: async () => ({}),
+  sendPackActivatedMail: async () => ({}),
+  sendPaymentFailedMail: async () => ({}),
+}));
+
+// The route derives the plan from the price id via planForPriceId; map one
+// invented price to `pro` so resolution succeeds without touching real env.
+// stripeClient is the shared lazy SDK client the route uses.
+let currentEvent = null;
+mock.module("@services/billing/stripe", () => ({
+  planForPriceId: async (priceId) =>
+    priceId === "price_test_pro" ? { plan: "pro", isPack: false } : undefined,
+  getStripeSecretKey: () => "sk_test_stub",
+  stripeClient: {
+    webhooks: {
+      constructEvent: () => {
+        if (!signatureValid) throw new Error("No signatures found matching the expected signature");
+        return currentEvent;
+      },
+    },
+    checkout: {
+      sessions: {
+        retrieve: async () => {
+          sessionRetrieveCalls += 1;
+          return sessionRetrieveQueue.shift() ?? { customer_details: {}, subscription: null };
+        },
+      },
+    },
+    customers: { retrieve: async () => ({ email: "billing@example.test" }) },
+  },
+}));
+
+const { POST } = await import("../app/api/billing/webhook/route.ts");
+
+// --- helpers ----------------------------------------------------------------
+
+let eventCounter = 0;
+function nextEventId() {
+  eventCounter += 1;
+  return `evt_test_${eventCounter}`;
+}
+
+function subscriptionFixture(overrides = {}) {
+  return {
+    id: "sub_test",
+    status: "active",
+    cancel_at_period_end: false,
+    metadata: { org_id: "4242", plan: "pro", billing: "monthly" },
+    items: { data: [{ price: { id: "price_test_pro" } }] },
+    ...overrides,
+  };
+}
+
+async function deliver(event) {
+  currentEvent = event;
+  return POST(new Request("https://example.test/api/billing/webhook", { method: "POST", body: "{}" }));
+}
+
+beforeEach(() => {
+  planWrites.length = 0;
+  sessionRetrieveQueue = [];
+  sessionRetrieveCalls = 0;
+  signatureValid = true;
+  process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+});
+
+afterEach(() => {
+  currentEvent = null;
+});
+
+// --- tests ------------------------------------------------------------------
+
+describe("signature verification", () => {
+  test("an unsigned or mis-signed payload is rejected without touching the plan", async () => {
+    signatureValid = false;
+    const res = await deliver({ id: nextEventId(), type: "checkout.session.completed" });
+    expect(res.status).toBe(400);
+    expect(planWrites).toHaveLength(0);
+  });
+});
+
+describe("checkout.session.completed", () => {
+  test("upgrades the org when the subscription is present", async () => {
+    sessionRetrieveQueue = [{ customer_details: {}, subscription: subscriptionFixture() }];
+    const res = await deliver({
+      id: nextEventId(),
+      type: "checkout.session.completed",
+      data: { object: { id: "cs_test", payment_status: "paid" } },
+    });
+    expect(res.status).toBe(200);
+    expect(planWrites).toEqual([{ orgId: "4242", plan: "pro" }]);
+  });
+
+  test("retries a briefly-deferred subscription instead of dropping the upgrade", async () => {
+    // Stripe's basil API defers subscription creation until payment completes,
+    // so the expanded subscription is legitimately null on the first read.
+    sessionRetrieveQueue = [
+      { customer_details: {}, subscription: null },
+      { customer_details: {}, subscription: subscriptionFixture() },
+    ];
+    const res = await deliver({
+      id: nextEventId(),
+      type: "checkout.session.completed",
+      data: { object: { id: "cs_test", payment_status: "paid" } },
+    });
+    expect(res.status).toBe(200);
+    expect(sessionRetrieveCalls).toBeGreaterThan(1);
+    expect(planWrites).toEqual([{ orgId: "4242", plan: "pro" }]);
+  });
+
+  test("asks Stripe to redeliver when the subscription never materializes", async () => {
+    sessionRetrieveQueue = [];
+    const res = await deliver({
+      id: nextEventId(),
+      type: "checkout.session.completed",
+      data: { object: { id: "cs_test", payment_status: "paid" } },
+    });
+    // A 200 here would end Stripe's retries and strand a paid org on free.
+    expect(res.status).toBe(500);
+    expect(planWrites).toHaveLength(0);
+  });
+
+  test("asks Stripe to redeliver when the price maps to no known plan", async () => {
+    // This is a missing STRIPE_PRICE_* env, not a foreign checkout — the
+    // session carries our org_id, so the upgrade is owed.
+    sessionRetrieveQueue = [
+      {
+        customer_details: {},
+        subscription: subscriptionFixture({
+          metadata: { org_id: "4242" },
+          items: { data: [{ price: { id: "price_unmapped" } }] },
+        }),
+      },
+    ];
+    const res = await deliver({
+      id: nextEventId(),
+      type: "checkout.session.completed",
+      data: { object: { id: "cs_test", payment_status: "paid" } },
+    });
+    expect(res.status).toBe(500);
+    expect(planWrites).toHaveLength(0);
+  });
+
+  test("acks a foreign checkout carrying no org_id", async () => {
+    // This Stripe account is shared with other products, whose checkouts land
+    // here too. Retrying them forever would eventually disable the endpoint.
+    sessionRetrieveQueue = [
+      { customer_details: {}, subscription: subscriptionFixture({ metadata: { label: "other-product" } }) },
+    ];
+    const res = await deliver({
+      id: nextEventId(),
+      type: "checkout.session.completed",
+      data: { object: { id: "cs_test", payment_status: "paid" } },
+    });
+    expect(res.status).toBe(200);
+    expect(planWrites).toHaveLength(0);
+  });
+});
+
+describe("customer.subscription.created", () => {
+  test("upgrades the org — it is the recovery path when checkout.session.completed is dropped", async () => {
+    const res = await deliver({
+      id: nextEventId(),
+      type: "customer.subscription.created",
+      data: { object: subscriptionFixture() },
+    });
+    expect(res.status).toBe(200);
+    expect(planWrites).toEqual([{ orgId: "4242", plan: "pro" }]);
+  });
+});
+
+describe("customer.subscription.updated / deleted", () => {
+  test("an active subscription reconciles to the price's plan", async () => {
+    const res = await deliver({
+      id: nextEventId(),
+      type: "customer.subscription.updated",
+      data: { object: subscriptionFixture() },
+    });
+    expect(res.status).toBe(200);
+    expect(planWrites).toEqual([{ orgId: "4242", plan: "pro" }]);
+  });
+
+  test("deletion downgrades to free", async () => {
+    const res = await deliver({
+      id: nextEventId(),
+      type: "customer.subscription.deleted",
+      data: { object: subscriptionFixture() },
+    });
+    expect(res.status).toBe(200);
+    expect(planWrites).toEqual([{ orgId: "4242", plan: "free" }]);
+  });
+});
+
+describe("idempotency", () => {
+  test("a redelivery of a successful event is not applied twice", async () => {
+    const event = {
+      id: nextEventId(),
+      type: "customer.subscription.created",
+      data: { object: subscriptionFixture() },
+    };
+    await deliver(event);
+    const res = await deliver(event);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ result: "duplicate" });
+    expect(planWrites).toHaveLength(1);
+  });
+
+  test("a redelivery after a FAILED delivery is reprocessed, not called a duplicate", async () => {
+    // The failure mode this pins: marking an event before processing, without
+    // clearing it on failure, made Stripe's retry return a "duplicate" 200 and
+    // permanently drop the upgrade.
+    const event = {
+      id: nextEventId(),
+      type: "checkout.session.completed",
+      data: { object: { id: "cs_test", payment_status: "paid" } },
+    };
+    sessionRetrieveQueue = [];
+    const first = await deliver(event);
+    expect(first.status).toBe(500);
+
+    sessionRetrieveQueue = [{ customer_details: {}, subscription: subscriptionFixture() }];
+    const second = await deliver(event);
+    expect(second.status).toBe(200);
+    expect(planWrites).toEqual([{ orgId: "4242", plan: "pro" }]);
+  });
+});


### PR DESCRIPTION
Bundles three related fixes.

**Billing key and fulfillment**: the org plan write resolved its internal key from a single env name and fell back to empty, so a deployment using the other name sent an empty key and got a 403 that read as a mismatch, not a missing credential. It now checks both names, prefers the one the API validates, and throws if neither is set. Restored three fulfillment paths: a standalone endpoint, subscription-created handling, and a retry for a not-yet-created subscription.

**Auth-method policy**: a claim-less session was treated as a violation, locking out members on sessions older than the feature. Unknown is now unknown, not disallowed. Since rotation copies a missing claim forward, such sessions never expire on their own, so the allowance is bounded by a deadline stamped on the session at its first rotation and carried unchanged thereafter — no schema change and nothing to backfill. Defaults to the refresh-token lifetime. A session naming a disallowed method is still refused immediately.

**Credentials**: pack activation and overage billing shared the empty-string key fallback; both now throw through one helper. Google OAuth verification reads either supported env name. The missing-credential report is one line per process, not a repeat.

Verified: API suite green (4463 passed, 23 skipped); new tests fail on old code, pass here. Web suite green apart from one pre-existing failure.