### PR TITLE
Add lifecycle nudge emails and unsubscribe infrastructure

### DIFF
--- a/apps/api/cli.py
+++ b/apps/api/cli.py
@@ -358,6 +358,136 @@ async def _compute_active_user_overage(year: int, month: int) -> None:
 
 
 @cli.command()
+def nudges_run(
+    dry_run: Annotated[bool, typer.Option(help="Render and log, but send nothing")] = False,
+    seed: Annotated[
+        bool,
+        typer.Option(
+            help="Write suppressed ledger rows instead of sending. Run once "
+            "before enabling, so switching on doesn't fire a backlog."
+        ),
+    ] = False,
+    max_sends: Annotated[int, typer.Option(help="Hard ceiling for this run")] = 0,
+    only: Annotated[str, typer.Option(help="Restrict to a single nudge id")] = "",
+    org_id: Annotated[int, typer.Option(help="Restrict to a single org id")] = 0,
+    force: Annotated[
+        bool, typer.Option(help="Bypass the SaaS and kill-switch gates (staging)")
+    ] = False,
+):
+    """
+    Daily: send lifecycle nudges to organization admins.
+
+    Cron-invoked. Sends nothing unless LEARNHOUSE_NUDGES_ENABLED is set and the
+    deployment is SaaS — so deploying this command is not the same as arming
+    it. Start with --dry-run, then --seed, then a small --max-sends.
+    """
+    asyncio.run(
+        _run_nudges(
+            dry_run=dry_run,
+            seed=seed,
+            max_sends=max_sends or None,
+            only=only or None,
+            org_id=org_id or None,
+            force=force,
+        )
+    )
+
+
+async def _run_nudges(
+    *,
+    dry_run: bool,
+    seed: bool,
+    max_sends,
+    only,
+    org_id,
+    force: bool,
+) -> None:
+    from src.services.nudges.runner import run_nudges
+
+    learnhouse_config = get_learnhouse_config()
+    sql_url = learnhouse_config.database_config.sql_connection_string  # type: ignore
+    async_engine = create_async_engine(_to_async_url(sql_url), echo=False, pool_pre_ping=True)
+
+    try:
+        async with AsyncSession(async_engine, expire_on_commit=False) as db_session:
+            stats = await run_nudges(
+                db_session,
+                dry_run=dry_run,
+                seed=seed,
+                max_sends=max_sends,
+                only=only,
+                org_id=org_id,
+                force=force,
+            )
+    finally:
+        await async_engine.dispose()
+
+    mode = "seed" if seed else ("dry-run" if dry_run else "live")
+    result = stats.as_dict()
+    print(f"Nudge run ({mode}): sent={result['sent']} failed={result['failed']}")
+    print(
+        "  skipped: "
+        f"dedupe={result['skipped_dedupe']} "
+        f"cap={result['skipped_cap']} "
+        f"optout={result['skipped_optout']} "
+        f"backfill={result['skipped_backfill']} "
+        f"inactive_org={result['skipped_inactive_org']}"
+    )
+    if result["budget_exhausted"]:
+        print("  budget exhausted — remaining candidates deferred to the next run")
+    for nudge_id, count in result["by_nudge"].items():
+        print(f"    {nudge_id}: {count}")
+
+
+@cli.command()
+def nudges_stats(
+    days: Annotated[int, typer.Option(help="Window to report on")] = 30,
+):
+    """Report what the nudge ledger has recorded. Sends nothing."""
+    asyncio.run(_nudges_stats(days))
+
+
+async def _nudges_stats(days: int) -> None:
+    from datetime import datetime, timedelta, timezone
+
+    from sqlalchemy import func
+    from sqlmodel import select
+
+    from src.db.nudges import NudgeSend
+
+    learnhouse_config = get_learnhouse_config()
+    sql_url = learnhouse_config.database_config.sql_connection_string  # type: ignore
+    async_engine = create_async_engine(_to_async_url(sql_url), echo=False, pool_pre_ping=True)
+    since = datetime.now(timezone.utc) - timedelta(days=days)
+
+    try:
+        async with AsyncSession(async_engine, expire_on_commit=False) as db_session:
+            rows = (
+                await db_session.execute(
+                    select(NudgeSend.nudge_id, NudgeSend.status, func.count())
+                    .where(NudgeSend.claimed_at >= since)
+                    .group_by(NudgeSend.nudge_id, NudgeSend.status)
+                    .order_by(NudgeSend.nudge_id)
+                )
+            ).all()
+    finally:
+        await async_engine.dispose()
+
+    if not rows:
+        print(f"No nudge activity in the last {days} days.")
+        return
+
+    print(f"Nudge activity, last {days} days:")
+    for nudge_id, status, count in rows:
+        print(f"  {nudge_id:45} {status:10} {count}")
+    # A row still in "claimed" means a process died between the ledger write
+    # and the provider call — worth knowing about, never auto-retried.
+    stuck = sum(count for _n, status, count in rows if status == "claimed")
+    if stuck:
+        print(f"\n  {stuck} row(s) stuck in 'claimed' — a run died mid-send.")
+
+
+@cli.command()
 def main():
     cli()
 

--- a/apps/api/config/config.yaml
+++ b/apps/api/config/config.yaml
@@ -1,6 +1,6 @@
 site_name: LearnHouse
 site_description: LearnHouse is an open-source platform tailored for learning experiences.
-contact_email: hi@learnhouse.app
+contact_email: hello@learnhouse.app
 
 # This config is optimized for local development. You can change the values according to your needs.
 

--- a/apps/api/migrations/versions/b1n2u3d4g5e6_add_nudge_tables.py
+++ b/apps/api/migrations/versions/b1n2u3d4g5e6_add_nudge_tables.py
@@ -65,6 +65,10 @@ def upgrade() -> None:
         ),
         sa.Column('unsubscribed_at', sa.DateTime(timezone=True), nullable=True),
         sa.Column('source', sa.String(length=32), nullable=True),
+        sa.Column(
+            'suppressed', sa.Boolean(), nullable=False, server_default=sa.false()
+        ),
+        sa.Column('suppressed_reason', sa.String(length=32), nullable=True),
         sa.UniqueConstraint('user_id', name='uq_email_preference_user'),
     )
     op.create_index('ix_email_preference_user_id', 'email_preference', ['user_id'])

--- a/apps/api/migrations/versions/b1n2u3d4g5e6_add_nudge_tables.py
+++ b/apps/api/migrations/versions/b1n2u3d4g5e6_add_nudge_tables.py
@@ -42,11 +42,18 @@ def upgrade() -> None:
         sa.Column('sent_at', sa.DateTime(timezone=True), nullable=True),
         sa.Column('error', sa.String(length=255), nullable=True),
         sa.Column('meta', sa.JSON(), nullable=True),
+        sa.Column('provider_id', sa.String(length=64), nullable=True),
+        sa.Column(
+            'delivery_checked', sa.Boolean(), nullable=False, server_default=sa.false()
+        ),
         sa.UniqueConstraint('dedupe_key', name='uq_nudge_send_dedupe'),
     )
     op.create_index('ix_nudge_send_user_sent', 'nudge_send', ['user_id', 'sent_at'])
     op.create_index('ix_nudge_send_org_nudge', 'nudge_send', ['org_id', 'nudge_id'])
     op.create_index('ix_nudge_send_nudge_sent', 'nudge_send', ['nudge_id', 'sent_at'])
+    op.create_index(
+        'ix_nudge_send_unchecked', 'nudge_send', ['delivery_checked', 'sent_at']
+    )
 
     op.create_table(
         'email_preference',
@@ -77,6 +84,7 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_index('ix_email_preference_user_id', table_name='email_preference')
     op.drop_table('email_preference')
+    op.drop_index('ix_nudge_send_unchecked', table_name='nudge_send')
     op.drop_index('ix_nudge_send_nudge_sent', table_name='nudge_send')
     op.drop_index('ix_nudge_send_org_nudge', table_name='nudge_send')
     op.drop_index('ix_nudge_send_user_sent', table_name='nudge_send')

--- a/apps/api/migrations/versions/b1n2u3d4g5e6_add_nudge_tables.py
+++ b/apps/api/migrations/versions/b1n2u3d4g5e6_add_nudge_tables.py
@@ -1,0 +1,79 @@
+"""Add nudge_send ledger and email_preference tables
+
+nudge_send is the send ledger for lifecycle email; its unique dedupe_key is
+what makes a re-run (including a backfill across every existing org) safe.
+email_preference holds per-user opt-out state for non-transactional mail.
+
+Revision ID: b1n2u3d4g5e6
+Revises: t6u7v8w9x0y1
+Create Date: 2026-07-28 09:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa  # noqa: F401
+import sqlmodel  # noqa: F401
+
+# revision identifiers, used by Alembic.
+revision: str = 'b1n2u3d4g5e6'
+down_revision: Union[str, Sequence[str], None] = 't6u7v8w9x0y1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'nudge_send',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('nudge_id', sa.String(length=64), nullable=False),
+        sa.Column('dedupe_key', sa.String(length=160), nullable=False),
+        sa.Column(
+            'org_id', sa.BigInteger(),
+            sa.ForeignKey('organization.id', ondelete='CASCADE'), nullable=False,
+        ),
+        sa.Column(
+            'user_id', sa.Integer(),
+            sa.ForeignKey('user.id', ondelete='CASCADE'), nullable=False,
+        ),
+        sa.Column('status', sa.String(length=16), nullable=False, server_default='claimed'),
+        sa.Column('lang', sa.String(length=8), nullable=False, server_default='en'),
+        sa.Column('claimed_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('sent_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('error', sa.String(length=255), nullable=True),
+        sa.Column('meta', sa.JSON(), nullable=True),
+        sa.UniqueConstraint('dedupe_key', name='uq_nudge_send_dedupe'),
+    )
+    op.create_index('ix_nudge_send_user_sent', 'nudge_send', ['user_id', 'sent_at'])
+    op.create_index('ix_nudge_send_org_nudge', 'nudge_send', ['org_id', 'nudge_id'])
+    op.create_index('ix_nudge_send_nudge_sent', 'nudge_send', ['nudge_id', 'sent_at'])
+
+    op.create_table(
+        'email_preference',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column(
+            'user_id', sa.Integer(),
+            sa.ForeignKey('user.id', ondelete='CASCADE'), nullable=False,
+        ),
+        sa.Column(
+            'lifecycle_opt_out', sa.Boolean(), nullable=False,
+            server_default=sa.false(),
+        ),
+        sa.Column(
+            'product_updates_opt_out', sa.Boolean(), nullable=False,
+            server_default=sa.false(),
+        ),
+        sa.Column('unsubscribed_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('source', sa.String(length=32), nullable=True),
+        sa.UniqueConstraint('user_id', name='uq_email_preference_user'),
+    )
+    op.create_index('ix_email_preference_user_id', 'email_preference', ['user_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_email_preference_user_id', table_name='email_preference')
+    op.drop_table('email_preference')
+    op.drop_index('ix_nudge_send_nudge_sent', table_name='nudge_send')
+    op.drop_index('ix_nudge_send_org_nudge', table_name='nudge_send')
+    op.drop_index('ix_nudge_send_user_sent', table_name='nudge_send')
+    op.drop_table('nudge_send')

--- a/apps/api/src/core/events/events.py
+++ b/apps/api/src/core/events/events.py
@@ -65,12 +65,9 @@ def startup_app(app: FastAPI) -> Callable:
         _cleanup_task = asyncio.create_task(_periodic_migration_cleanup())
 
         # Lifecycle nudges run on their own daily tick so the feature needs no
-        # external scheduler. No-op unless enabled.
-        try:
-            from src.services.nudges.scheduler import start_scheduler
-            start_scheduler()
-        except Exception as e:
-            logger.warning("Nudge scheduler not started: %s", e)
+        # external scheduler. No-op unless enabled; never raises.
+        from src.services.nudges.scheduler import start_scheduler
+        start_scheduler()
 
         # Start the in-app HLS transcoding consumer (drains the Redis queue as a
         # background task; no separate worker). No-op unless LEARNHOUSE_HLS_ENABLED.
@@ -108,11 +105,8 @@ def shutdown_app(app: FastAPI) -> Callable:
             await asyncio.gather(*list(_webhook_tasks), return_exceptions=True)
         await close_webhook_client()
         # Stop the daily nudge tick.
-        try:
-            from src.services.nudges.scheduler import stop_scheduler
-            await stop_scheduler()
-        except Exception:
-            pass
+        from src.services.nudges.scheduler import stop_scheduler
+        await stop_scheduler()
         await close_database(app)
 
     return close_app

--- a/apps/api/src/core/events/events.py
+++ b/apps/api/src/core/events/events.py
@@ -64,6 +64,14 @@ def startup_app(app: FastAPI) -> Callable:
         global _cleanup_task
         _cleanup_task = asyncio.create_task(_periodic_migration_cleanup())
 
+        # Lifecycle nudges run on their own daily tick so the feature needs no
+        # external scheduler. No-op unless enabled.
+        try:
+            from src.services.nudges.scheduler import start_scheduler
+            start_scheduler()
+        except Exception as e:
+            logger.warning("Nudge scheduler not started: %s", e)
+
         # Start the in-app HLS transcoding consumer (drains the Redis queue as a
         # background task; no separate worker). No-op unless LEARNHOUSE_HLS_ENABLED.
         from src.services.utils.hls_jobs import start_consumer
@@ -99,6 +107,12 @@ def shutdown_app(app: FastAPI) -> Callable:
         if _webhook_tasks:  # pragma: no cover
             await asyncio.gather(*list(_webhook_tasks), return_exceptions=True)
         await close_webhook_client()
+        # Stop the daily nudge tick.
+        try:
+            from src.services.nudges.scheduler import stop_scheduler
+            await stop_scheduler()
+        except Exception:
+            pass
         await close_database(app)
 
     return close_app

--- a/apps/api/src/db/nudges.py
+++ b/apps/api/src/db/nudges.py
@@ -128,5 +128,15 @@ class EmailPreference(SQLModel, table=True):
     unsubscribed_at: Optional[datetime] = Field(
         default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
     )
-    # "email_link" | "dashboard" | "admin"
+    # "email_link" | "dashboard" | "admin" | "bounce" | "complaint"
     source: Optional[str] = Field(default=None, sa_column=Column(String(32), nullable=True))
+    # Set by a hard bounce or a spam complaint. Unlike lifecycle_opt_out this is
+    # not the reader's preference — it is a delivery fact, and it must survive
+    # any later re-subscribe, because continuing to mail a dead address or a
+    # complainant is what actually costs a sending domain its reputation.
+    suppressed: bool = Field(
+        default=False, sa_column=Column(Boolean, nullable=False, default=False)
+    )
+    suppressed_reason: Optional[str] = Field(
+        default=None, sa_column=Column(String(32), nullable=True)
+    )

--- a/apps/api/src/db/nudges.py
+++ b/apps/api/src/db/nudges.py
@@ -1,0 +1,132 @@
+from typing import Optional
+from datetime import datetime, timezone
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    BigInteger,
+    Integer,
+    String,
+    Boolean,
+    DateTime,
+    JSON,
+    UniqueConstraint,
+    Index,
+)
+from sqlmodel import Field, SQLModel
+
+
+class NudgeSendStatus:
+    """Lifecycle of one ledger row.
+
+    ``CLAIMED`` exists because the row is written *before* the send is
+    attempted — a row stuck in this state means a process died mid-send, which
+    is visible for reconciliation rather than silently retried.
+    """
+
+    CLAIMED = "claimed"
+    SENT = "sent"
+    FAILED = "failed"
+    DRY_RUN = "dry_run"
+    SUPPRESSED = "suppressed"
+
+
+class NudgeSend(SQLModel, table=True):
+    """
+    One row per (nudge, org, admin, period) — the send ledger.
+
+    ``dedupe_key`` is the idempotency boundary and the reason a backfill over
+    every historical org is safe to re-run: the row is inserted before the
+    provider is called, so a crash mid-send can never produce a duplicate, and
+    two concurrent runs collide on the unique constraint in the database rather
+    than in someone's inbox.
+    """
+
+    __tablename__ = "nudge_send"
+    __table_args__ = (
+        UniqueConstraint("dedupe_key", name="uq_nudge_send_dedupe"),
+        # Serves the per-admin frequency cap (n sends in the trailing 7 days).
+        Index("ix_nudge_send_user_sent", "user_id", "sent_at"),
+        Index("ix_nudge_send_org_nudge", "org_id", "nudge_id"),
+        Index("ix_nudge_send_nudge_sent", "nudge_id", "sent_at"),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    nudge_id: str = Field(sa_column=Column(String(64), nullable=False))
+    # "<nudge_id>:<org_id>:<user_id>" for once-forever nudges, with a trailing
+    # ":<period>" for repeatable ones, and a "dryrun:" prefix for dry runs so a
+    # rehearsal never consumes the key a real send needs.
+    dedupe_key: str = Field(sa_column=Column(String(160), nullable=False))
+    org_id: int = Field(
+        sa_column=Column(
+            BigInteger,
+            ForeignKey("organization.id", ondelete="CASCADE"),
+            nullable=False,
+        )
+    )
+    user_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("user.id", ondelete="CASCADE"),
+            nullable=False,
+        )
+    )
+    status: str = Field(
+        default=NudgeSendStatus.CLAIMED,
+        sa_column=Column(String(16), nullable=False, default=NudgeSendStatus.CLAIMED),
+    )
+    lang: str = Field(default="en", sa_column=Column(String(8), nullable=False, default="en"))
+    claimed_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    # Set only on a successful send, so the frequency cap counts delivered mail
+    # rather than attempts.
+    sent_at: Optional[datetime] = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )
+    error: Optional[str] = Field(default=None, sa_column=Column(String(255), nullable=True))
+    # Snapshot of the segment values that made this nudge fire, for debugging a
+    # send after the underlying org state has moved on. JSON (not JSONB): the
+    # test suite runs on SQLite.
+    meta: Optional[dict] = Field(default=None, sa_column=Column(JSON, nullable=True))
+
+
+class EmailPreference(SQLModel, table=True):
+    """
+    Per-user opt-out state for non-transactional email.
+
+    Created lazily — the absence of a row means "opted in, never asked", which
+    is why this is a table rather than a column on ``user``: it needs a
+    tri-state, and adding a column to the hottest table in the schema for it
+    would be a poor trade.
+
+    Transactional mail (password reset, invitation, address verification)
+    ignores this table entirely.
+    """
+
+    __tablename__ = "email_preference"
+    __table_args__ = (
+        UniqueConstraint("user_id", name="uq_email_preference_user"),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("user.id", ondelete="CASCADE"),
+            nullable=False,
+        )
+    )
+    lifecycle_opt_out: bool = Field(
+        default=False, sa_column=Column(Boolean, nullable=False, default=False)
+    )
+    # Reserved for a future "product updates" category; a separate flag now
+    # avoids a migration when that category ships.
+    product_updates_opt_out: bool = Field(
+        default=False, sa_column=Column(Boolean, nullable=False, default=False)
+    )
+    unsubscribed_at: Optional[datetime] = Field(
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
+    )
+    # "email_link" | "dashboard" | "admin"
+    source: Optional[str] = Field(default=None, sa_column=Column(String(32), nullable=True))

--- a/apps/api/src/db/nudges.py
+++ b/apps/api/src/db/nudges.py
@@ -48,6 +48,8 @@ class NudgeSend(SQLModel, table=True):
         Index("ix_nudge_send_user_sent", "user_id", "sent_at"),
         Index("ix_nudge_send_org_nudge", "org_id", "nudge_id"),
         Index("ix_nudge_send_nudge_sent", "nudge_id", "sent_at"),
+        # Finds the handful of messages awaiting a delivery check.
+        Index("ix_nudge_send_unchecked", "delivery_checked", "sent_at"),
     )
 
     id: Optional[int] = Field(default=None, primary_key=True)
@@ -85,6 +87,15 @@ class NudgeSend(SQLModel, table=True):
         default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
     )
     error: Optional[str] = Field(default=None, sa_column=Column(String(255), nullable=True))
+    # The provider's id for this message, so its delivery outcome can be read
+    # back later. Polling this is what removes the need to configure a webhook.
+    provider_id: Optional[str] = Field(
+        default=None, sa_column=Column(String(64), nullable=True)
+    )
+    # Set once the outcome has been read, so each message is polled at most once.
+    delivery_checked: bool = Field(
+        default=False, sa_column=Column(Boolean, nullable=False, default=False)
+    )
     # Snapshot of the segment values that made this nudge fire, for debugging a
     # send after the underlying org state has moved on. JSON (not JSONB): the
     # test suite runs on SQLite.

--- a/apps/api/src/router.py
+++ b/apps/api/src/router.py
@@ -144,6 +144,13 @@ v1_router.include_router(
     prefix="/emails",
     tags=["emails"],
 )
+# Email delivery feedback from the provider (protected by a shared secret).
+# Bounces and complaints have to reach us or a dead address is mailed forever.
+v1_router.include_router(
+    nudges_router_module.internal_router,
+    prefix="/internal/emails",
+    tags=["emails-internal"],
+)
 # Internal domain listing endpoint (protected by internal key)
 v1_router.include_router(
     custom_domains.internal_router,

--- a/apps/api/src/router.py
+++ b/apps/api/src/router.py
@@ -11,6 +11,7 @@ from src.routers import usergroups
 from src.routers import dev, trail, users, auth, orgs, roles, search
 from src.routers import mfa as mfa_router_module
 from src.routers import monitoring
+from src.routers import nudges as nudges_router_module
 from src.routers import stream
 from src.routers import api_tokens
 from src.routers import webhooks
@@ -135,6 +136,13 @@ v1_router.include_router(
     custom_domains.public_router,
     prefix="/orgs",
     tags=["custom-domains"],
+)
+# Public unsubscribe endpoints (no auth — the HMAC token in the link is the
+# authorisation; a nudge recipient may have no session at all)
+v1_router.include_router(
+    nudges_router_module.public_router,
+    prefix="/emails",
+    tags=["emails"],
 )
 # Internal domain listing endpoint (protected by internal key)
 v1_router.include_router(

--- a/apps/api/src/routers/nudges.py
+++ b/apps/api/src/routers/nudges.py
@@ -1,0 +1,134 @@
+"""
+Public unsubscribe endpoints for lifecycle email.
+
+Unauthenticated by design: the recipient of a nudge may not have a live session
+(and if they are unsubscribing, quite likely does not want to make one). The
+HMAC token in the link is the authorisation.
+"""
+
+import html
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Form, Query, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.events.database import get_db_session
+from src.services.nudges.preferences import (
+    get_user_by_uuid,
+    set_lifecycle_opt_out,
+)
+from src.services.nudges.tokens import verify_unsubscribe_token
+
+logger = logging.getLogger(__name__)
+
+public_router = APIRouter()
+
+
+_PAGE_STYLE = (
+    "font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; "
+    "max-width: 460px; margin: 80px auto; padding: 0 24px; text-align: center; "
+    "color: #000;"
+)
+_H1_STYLE = "font-size: 20px; font-weight: 800; margin: 0 0 12px 0;"
+_P_STYLE = "font-size: 14px; color: rgba(0,0,0,0.5); line-height: 1.7; margin: 0 0 24px 0;"
+_BUTTON_STYLE = (
+    "display: inline-block; padding: 12px 28px; background: #000; color: #fff; "
+    "border: none; border-radius: 10px; font-size: 14px; font-weight: 700; cursor: pointer;"
+)
+
+
+def _page(title: str, message: str, form_html: str = "") -> HTMLResponse:
+    return HTMLResponse(
+        f"""<!DOCTYPE html>
+<html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{html.escape(title)}</title></head>
+<body style="{_PAGE_STYLE}">
+<h1 style="{_H1_STYLE}">{html.escape(title)}</h1>
+<p style="{_P_STYLE}">{message}</p>
+{form_html}
+</body></html>"""
+    )
+
+
+def _expired_page() -> HTMLResponse:
+    """Shown for any token we can't verify.
+
+    Tampering, a mangled URL and a rotated signing secret are indistinguishable
+    from here, and all three land on someone who is trying to opt out. A 403
+    would read as stonewalling, so point them at a route that still works.
+    """
+    return _page(
+        "This link has expired",
+        "We couldn't confirm this unsubscribe link. You can manage email "
+        "preferences from your account settings, or reply to any of our emails "
+        "and we'll take care of it.",
+    )
+
+
+@public_router.get("/unsubscribe", response_class=HTMLResponse)
+async def unsubscribe_page(
+    request: Request,
+    token: str = Query(..., description="Unsubscribe token from the email link"),
+    db_session: AsyncSession = Depends(get_db_session),
+) -> HTMLResponse:
+    """Render a confirmation page. Deliberately free of side effects.
+
+    Corporate mail scanners (Outlook Safe Links, Proofpoint and friends)
+    prefetch every href in a message. If this GET unsubscribed people, those
+    scanners would silently opt out users who never clicked anything.
+    """
+    user_uuid = verify_unsubscribe_token(token)
+    if not user_uuid:
+        return _expired_page()
+
+    user = await get_user_by_uuid(db_session, user_uuid)
+    if user is None:
+        return _expired_page()
+
+    escaped_token = html.escape(token)
+    form_html = f"""<form method="post" action="unsubscribe">
+<input type="hidden" name="token" value="{escaped_token}" />
+<button type="submit" style="{_BUTTON_STYLE}">Confirm unsubscribe</button>
+</form>"""
+    return _page(
+        "Unsubscribe from these emails?",
+        f"You'll stop receiving tips and reminders at "
+        f"<strong>{html.escape(str(user.email))}</strong>. Account emails like "
+        "password resets and invitations will still reach you.",
+        form_html,
+    )
+
+
+@public_router.post("/unsubscribe", response_class=HTMLResponse)
+async def unsubscribe_confirm(
+    request: Request,
+    token: Optional[str] = Form(default=None),
+    token_query: Optional[str] = Query(default=None, alias="token"),
+    db_session: AsyncSession = Depends(get_db_session),
+) -> HTMLResponse:
+    """Apply the opt-out. Idempotent.
+
+    This is also the RFC 8058 one-click target named by the
+    ``List-Unsubscribe-Post`` header, which posts without a form body — hence
+    accepting the token from either the body or the query string.
+    """
+    supplied = token or token_query
+    user_uuid = verify_unsubscribe_token(supplied or "")
+    if not user_uuid:
+        return _expired_page()
+
+    user = await get_user_by_uuid(db_session, user_uuid)
+    if user is None or user.id is None:
+        return _expired_page()
+
+    await set_lifecycle_opt_out(db_session, user.id, opted_out=True, source="email_link")
+    logger.info("Lifecycle email opt-out recorded for user %s", user.id)
+
+    return _page(
+        "You're unsubscribed",
+        "You won't receive any more tips or reminders from us. Account emails "
+        "like password resets and invitations will still reach you.",
+    )

--- a/apps/api/src/routers/nudges.py
+++ b/apps/api/src/routers/nudges.py
@@ -9,7 +9,6 @@ HMAC token in the link is the authorisation.
 import html
 import logging
 import os
-import secrets
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Form, Query, Request
@@ -141,27 +140,61 @@ async def unsubscribe_confirm(
 # Delivery feedback
 # --------------------------------------------------------------------------
 
-# Resend's event names for the two things that cost a sending domain its
-# reputation: mail to an address that does not exist, and mail the recipient
-# reported as spam.
-_HARD_BOUNCE_EVENTS = {"email.bounced"}
-_COMPLAINT_EVENTS = {"email.complained"}
+# Resend signs webhooks with Svix, not a shared header we choose: the request
+# carries svix-id / svix-timestamp / svix-signature and is verified against a
+# `whsec_` signing secret. `resend.Webhooks.verify` does the HMAC-SHA256 check
+# and also enforces a timestamp tolerance, so replays are rejected too.
+#
+# Only two events matter for reputation. A bounce whose type is "Permanent"
+# means the address does not exist; "Temporary" is a full mailbox and the
+# address is still good. A complaint means the recipient pressed the spam
+# button, which is the single most expensive signal a sending domain can earn.
+_SUPPRESSING_EVENTS = {
+    "email.bounced": "bounce",
+    "email.complained": "complaint",
+    # Resend refused to send because the address is already on its own
+    # suppression list — mirror that locally so we stop trying.
+    "email.suppressed": "suppressed_by_provider",
+}
+_PERMANENT_BOUNCE_TYPES = {"permanent"}
 
 internal_router = APIRouter()
 
 
-def _verify_webhook_secret(request: Request) -> None:
-    """Shared-secret check for the provider callback.
+def _verified_event(request: Request, raw_body: bytes) -> dict:
+    """Verify a Resend webhook and return its parsed payload.
 
-    Fails closed when unset: an unauthenticated endpoint that suppresses
-    addresses is a denial-of-service on your own mail.
+    Fails closed when the signing secret is unset: an unauthenticated endpoint
+    that suppresses addresses would be a denial of service on your own mail.
     """
     from fastapi import HTTPException
 
-    expected = (os.environ.get("LEARNHOUSE_EMAIL_WEBHOOK_SECRET") or "").strip()
-    supplied = (request.headers.get("x-webhook-secret") or "").strip()
-    if not expected or not secrets.compare_digest(expected, supplied):
-        raise HTTPException(status_code=403, detail="Invalid webhook secret")
+    secret = (os.environ.get("LEARNHOUSE_RESEND_WEBHOOK_SECRET") or "").strip()
+    if not secret:
+        logger.error("Delivery webhook received but no signing secret is configured")
+        raise HTTPException(status_code=403, detail="Webhook verification unavailable")
+
+    try:
+        import resend
+
+        return resend.Webhooks.verify(
+            {
+                # The exact bytes that were signed — re-serialising the parsed
+                # JSON would change the payload and fail verification.
+                "payload": raw_body.decode("utf-8"),
+                "headers": {
+                    "id": request.headers.get("svix-id", ""),
+                    "timestamp": request.headers.get("svix-timestamp", ""),
+                    "signature": request.headers.get("svix-signature", ""),
+                },
+                "webhook_secret": secret,
+            }
+        )
+    except Exception as exc:
+        # Covers a bad signature, a missing header, a stale timestamp and
+        # unparseable JSON. None of them should say which.
+        logger.warning("Rejected delivery webhook: %s", exc)
+        raise HTTPException(status_code=403, detail="Invalid webhook signature")
 
 
 @internal_router.post("/delivery-events")
@@ -169,36 +202,32 @@ async def delivery_events(
     request: Request,
     db_session: AsyncSession = Depends(get_db_session),
 ) -> dict:
-    """Consume bounce and complaint callbacks from the email provider.
+    """Consume bounce and complaint callbacks from Resend.
 
     Without this a dead address is mailed forever and a spam complaint changes
-    nothing — which is precisely how a domain's reputation degrades once
-    volume goes up. Only hard bounces suppress; a soft bounce is a full mailbox
-    or a temporary failure and the address is still good.
+    nothing, which is how a domain's reputation degrades once volume rises.
     """
-    _verify_webhook_secret(request)
-
-    try:
-        payload = await request.json()
-    except Exception:
-        return {"status": "ignored", "reason": "unparseable payload"}
+    raw_body = await request.body()
+    payload = _verified_event(request, raw_body)
 
     event_type = str(payload.get("type") or "")
+    reason = _SUPPRESSING_EVENTS.get(event_type)
+    if reason is None:
+        return {"status": "ignored", "reason": "unhandled event"}
+
     data = payload.get("data") or {}
+
+    if reason == "bounce":
+        bounce_type = str((data.get("bounce") or {}).get("type") or "").lower()
+        if bounce_type not in _PERMANENT_BOUNCE_TYPES:
+            # Transient or undetermined: the mailbox was full or the receiving
+            # server was unhappy today. Suppressing here would throw away good
+            # addresses.
+            return {"status": "ignored", "reason": f"non-permanent bounce ({bounce_type or "unknown"})"}
+
     recipients = data.get("to") or []
     if isinstance(recipients, str):
         recipients = [recipients]
-
-    if event_type in _COMPLAINT_EVENTS:
-        reason = "complaint"
-    elif event_type in _HARD_BOUNCE_EVENTS:
-        bounce_kind = str((data.get("bounce") or {}).get("type") or "").lower()
-        # "soft" is a full mailbox or a transient failure; the address is fine.
-        if bounce_kind and bounce_kind != "hard":
-            return {"status": "ignored", "reason": "soft bounce"}
-        reason = "bounce"
-    else:
-        return {"status": "ignored", "reason": "unhandled event"}
 
     suppressed = 0
     for address in recipients:

--- a/apps/api/src/routers/nudges.py
+++ b/apps/api/src/routers/nudges.py
@@ -8,6 +8,8 @@ HMAC token in the link is the authorisation.
 
 import html
 import logging
+import os
+import secrets
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Form, Query, Request
@@ -18,6 +20,7 @@ from src.core.events.database import get_db_session
 from src.services.nudges.preferences import (
     get_user_by_uuid,
     set_lifecycle_opt_out,
+    suppress_address,
 )
 from src.services.nudges.tokens import verify_unsubscribe_token
 
@@ -132,3 +135,75 @@ async def unsubscribe_confirm(
         "You won't receive any more tips or reminders from us. Account emails "
         "like password resets and invitations will still reach you.",
     )
+
+
+# --------------------------------------------------------------------------
+# Delivery feedback
+# --------------------------------------------------------------------------
+
+# Resend's event names for the two things that cost a sending domain its
+# reputation: mail to an address that does not exist, and mail the recipient
+# reported as spam.
+_HARD_BOUNCE_EVENTS = {"email.bounced"}
+_COMPLAINT_EVENTS = {"email.complained"}
+
+internal_router = APIRouter()
+
+
+def _verify_webhook_secret(request: Request) -> None:
+    """Shared-secret check for the provider callback.
+
+    Fails closed when unset: an unauthenticated endpoint that suppresses
+    addresses is a denial-of-service on your own mail.
+    """
+    from fastapi import HTTPException
+
+    expected = (os.environ.get("LEARNHOUSE_EMAIL_WEBHOOK_SECRET") or "").strip()
+    supplied = (request.headers.get("x-webhook-secret") or "").strip()
+    if not expected or not secrets.compare_digest(expected, supplied):
+        raise HTTPException(status_code=403, detail="Invalid webhook secret")
+
+
+@internal_router.post("/delivery-events")
+async def delivery_events(
+    request: Request,
+    db_session: AsyncSession = Depends(get_db_session),
+) -> dict:
+    """Consume bounce and complaint callbacks from the email provider.
+
+    Without this a dead address is mailed forever and a spam complaint changes
+    nothing — which is precisely how a domain's reputation degrades once
+    volume goes up. Only hard bounces suppress; a soft bounce is a full mailbox
+    or a temporary failure and the address is still good.
+    """
+    _verify_webhook_secret(request)
+
+    try:
+        payload = await request.json()
+    except Exception:
+        return {"status": "ignored", "reason": "unparseable payload"}
+
+    event_type = str(payload.get("type") or "")
+    data = payload.get("data") or {}
+    recipients = data.get("to") or []
+    if isinstance(recipients, str):
+        recipients = [recipients]
+
+    if event_type in _COMPLAINT_EVENTS:
+        reason = "complaint"
+    elif event_type in _HARD_BOUNCE_EVENTS:
+        bounce_kind = str((data.get("bounce") or {}).get("type") or "").lower()
+        # "soft" is a full mailbox or a transient failure; the address is fine.
+        if bounce_kind and bounce_kind != "hard":
+            return {"status": "ignored", "reason": "soft bounce"}
+        reason = "bounce"
+    else:
+        return {"status": "ignored", "reason": "unhandled event"}
+
+    suppressed = 0
+    for address in recipients:
+        if await suppress_address(db_session, str(address).strip(), reason):
+            suppressed += 1
+
+    logger.info("Delivery feedback %s suppressed %s address(es)", reason, suppressed)
+    return {"status": "ok", "reason": reason, "suppressed": suppressed}

--- a/apps/api/src/services/analytics/events.py
+++ b/apps/api/src/services/analytics/events.py
@@ -18,6 +18,10 @@ CERTIFICATE_CLAIMED = "certificate_claimed"
 CERTIFICATE_REVOKED = "certificate_revoked"
 DISCUSSION_POSTED = "discussion_posted"
 
+# Lifecycle email. Recorded per delivered nudge so returns can be attributed
+# to the specific message that prompted them, rather than to "we sent emails".
+NUDGE_SENT = "nudge_sent"
+
 # Allowed frontend event names (whitelist for the proxy endpoint)
 ALLOWED_FRONTEND_EVENTS = {
     PAGE_VIEW,

--- a/apps/api/src/services/email/nudge_translations/__init__.py
+++ b/apps/api/src/services/email/nudge_translations/__init__.py
@@ -1,0 +1,72 @@
+"""Lifecycle nudge email copy, one module per locale.
+
+Split by locale rather than kept in a single dict: thirty nudges across twenty
+languages is a few thousand strings, and a reviewer looking at a translation
+change should see one language's diff, not a wall of unrelated scripts.
+
+The English module is the source text — every other locale translates from it,
+and ``t()`` falls back to English per key, so a locale that lags behind renders
+correct English for the missing entries while keeping its own translations for
+the rest.
+
+Copy conventions, because these go to teachers and trainers rather than funnel
+targets: plain subject lines, no emoji, no manufactured urgency, name the
+reader's own course instead of describing it generically, and never write a
+plan name, limit or price into a string — those arrive as placeholders filled
+from ``plans.py`` at render time.
+
+Placeholders available to every nudge: ``{org_name}``, ``{course_name}``,
+``{plan_name}``, ``{next_plan}``.
+"""
+
+from typing import Final
+
+from src.services.email.nudge_translations import (
+    ar,
+    bn,
+    de,
+    en,
+    es,
+    fr,
+    hi,
+    id as id_locale,
+    it,
+    ja,
+    ko,
+    nl,
+    pl,
+    pt,
+    ru,
+    th,
+    tr,
+    uk,
+    vi,
+    zh,
+)
+
+_LOCALE_MODULES = {
+    "en": en,
+    "fr": fr,
+    "de": de,
+    "es": es,
+    "ar": ar,
+    "ja": ja,
+    "pt": pt,
+    "ru": ru,
+    "zh": zh,
+    "hi": hi,
+    "ko": ko,
+    "it": it,
+    "tr": tr,
+    "vi": vi,
+    "id": id_locale,
+    "pl": pl,
+    "uk": uk,
+    "nl": nl,
+    "th": th,
+    "bn": bn,
+}
+
+NUDGE_TRANSLATIONS: Final[dict[str, dict[str, str]]] = {
+    code: module.STRINGS for code, module in _LOCALE_MODULES.items()
+}

--- a/apps/api/src/services/email/nudge_translations/ar.py
+++ b/apps/api/src/services/email/nudge_translations/ar.py
@@ -1,0 +1,155 @@
+"""Arabic nudge copy."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "إلغاء الاشتراك في هذه الرسائل",
+    "nudge.common.footer": "تصلك هذه الرسالة لأنك مسؤول في {org_name}.",
+
+    "nudge.activation.first_course_d1.subject": "دورتك الأولى في {org_name}",
+    "nudge.activation.first_course_d1.heading": "متى ما كنت مستعدًا",
+    "nudge.activation.first_course_d1.body": "{org_name} جاهزة وتنتظر دورتها الأولى. معظم الناس يبدؤون بشيء صغير: موضوع واحد وبضعة دروس. يمكنك التوسّع لاحقًا.",
+    "nudge.activation.first_course_d1.cta": "أنشئ دورتك الأولى",
+
+    "nudge.activation.come_back_d2.subject": "أكمل من حيث توقفت",
+    "nudge.activation.come_back_d2.heading": "إعداداتك ما زالت في انتظارك",
+    "nudge.activation.come_back_d2.body": "أنشأت {org_name} ولم تعد منذ ذلك الحين. كل شيء ما زال موجودًا، ونشر أول دورة يستغرق نحو عشر دقائق.",
+    "nudge.activation.come_back_d2.cta": "اذهب إلى لوحة التحكم",
+
+    "nudge.activation.ai_course_help_d4.subject": "الصفحة الفارغة هي الجزء الصعب",
+    "nudge.activation.ai_course_help_d4.heading": "دع الذكاء الاصطناعي يكتب المخطط",
+    "nudge.activation.ai_course_help_d4.body": "إن كانت {org_name} ما زالت فارغة لأنك لا تعرف من أين تبدأ، فاكتب موضوعك وسيصوغ الذكاء الاصطناعي الفصول والدروس. التحرير بعد ذلك لك.",
+    "nudge.activation.ai_course_help_d4.cta": "أنشئ دورة بالذكاء الاصطناعي",
+
+    "nudge.activation.import_existing_d5.subject": "أحضر ما لديك بالفعل",
+    "nudge.activation.import_existing_d5.heading": "لا داعي للبدء من الصفر",
+    "nudge.activation.import_existing_d5.body": "إن كانت موادك موجودة أصلًا كمستندات أو شرائح أو تصدير من منصة أخرى، يمكنك نقلها إلى {org_name} بدل إعادة كتابتها.",
+    "nudge.activation.import_existing_d5.cta": "استورد موادك",
+
+    "nudge.activation.setup_checklist_d7.subject": "خمس عشرة دقيقة إلى أكاديمية جاهزة",
+    "nudge.activation.setup_checklist_d7.heading": "قائمة قصيرة",
+    "nudge.activation.setup_checklist_d7.body": "{org_name} ما زالت تنتظر دورتها الأولى. قائمة الإعداد ترشدك عبر خطوات قصيرة، ومعظم الناس ينتهون خلال ربع ساعة.",
+    "nudge.activation.setup_checklist_d7.cta": "افتح القائمة",
+
+    "nudge.activation.whats_blocking_d14.subject": "ما الذي حال دون ذلك؟",
+    "nudge.activation.whats_blocking_d14.heading": "هل لنا أن نسأل ما الذي أوقفك؟",
+    "nudge.activation.whats_blocking_d14.body": "أنشأت {org_name} قبل أسبوعين ولم تضف دورة بعد. إن كان هناك ما أربكك أو نقص شيء، يهمّنا أن نعرف — يكفي أن ترد على هذه الرسالة، وستصلنا مباشرة.",
+
+    "nudge.activation.last_call_d30.subject": "آخر رسالة بخصوص {org_name}",
+    "nudge.activation.last_call_d30.heading": "هذه الأخيرة",
+    "nudge.activation.last_call_d30.body": "{org_name} هادئة منذ شهر، لذا سنتوقف عن إرسال هذه الرسائل. حسابك وكل ما فيه يبقى كما هو — إن عدت، ستجد كل شيء في مكانه.",
+    "nudge.activation.last_call_d30.cta": "افتح لوحة التحكم",
+
+    "nudge.content.course_no_chapter_d1.subject": "«{course_name}» بحاجة إلى فصلها الأول",
+    "nudge.content.course_no_chapter_d1.heading": "بقي فصل واحد",
+    "nudge.content.course_no_chapter_d1.body": "«{course_name}» موجودة لكن بلا فصول بعد، فلا شيء يمكن فتحه. الفصول مجرد أقسام، وواحد لكل موضوع يعمل جيدًا.",
+    "nudge.content.course_no_chapter_d1.cta": "أضف فصلًا",
+
+    "nudge.content.chapter_no_activity_d1.subject": "أضف درسك الأول إلى «{course_name}»",
+    "nudge.content.chapter_no_activity_d1.heading": "الفصول جاهزة",
+    "nudge.content.chapter_no_activity_d1.body": "«{course_name}» فيها فصول لكنها ما زالت فارغة. الدرس قد يكون صفحة نص أو مقطع فيديو أو اختبارًا قصيرًا — ما يناسب الموضوع.",
+    "nudge.content.chapter_no_activity_d1.cta": "أضف درسًا",
+
+    "nudge.content.activity_unpublished_d2.subject": "دروسك في «{course_name}» غير ظاهرة بعد",
+    "nudge.content.activity_unpublished_d2.heading": "الدروس ما زالت مخفية",
+    "nudge.content.activity_unpublished_d2.body": "كتبت دروسًا في «{course_name}» لكن لم يُنشر أي منها، فيرى المتعلمون دورة فارغة. النشر لا يقفل شيئًا، ويمكنك مواصلة التعديل بعده.",
+    "nudge.content.activity_unpublished_d2.cta": "انشر دروسك",
+
+    "nudge.content.course_draft_d3.subject": "«{course_name}» ما زالت مسودة",
+    "nudge.content.course_draft_d3.heading": "«{course_name}» شارفت على الاكتمال",
+    "nudge.content.course_draft_d3.body": "أضفت دروسًا إلى «{course_name}» لكنها غير منشورة، فلا يستطيع أحد فتحها. لا يلزم أن تكون مكتملة — النشر يجعلها ظاهرة فقط، ويمكنك التعديل بعده.",
+    "nudge.content.course_draft_d3.cta": "انشرها",
+
+    "nudge.content.course_draft_d10.subject": "«{course_name}» مسودة منذ فترة",
+    "nudge.content.course_draft_d10.heading": "على الأرجح جاهزة",
+    "nudge.content.course_draft_d10.body": "«{course_name}» غير منشورة منذ أكثر من أسبوع. نادرًا ما تبدو الدورة مكتملة — النشر يجعلها ظاهرة، ويمكنك تحسينها بينما يقرأها الناس.",
+    "nudge.content.course_draft_d10.cta": "انشرها",
+
+    "nudge.content.thin_course_d5.subject": "«{course_name}» تحتمل المزيد",
+    "nudge.content.thin_course_d5.heading": "درس أو درسان",
+    "nudge.content.thin_course_d5.body": "«{course_name}» فيها درس أو درسان حتى الآن. الدورات تصل أفضل مع بضعة دروس، والذكاء الاصطناعي يستطيع صياغة التالية اعتمادًا على الموجود.",
+    "nudge.content.thin_course_d5.cta": "أضف دروسًا أخرى",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "لا تسليمات بعد في {org_name}",
+    "nudge.content.assignment_no_submissions_d5.heading": "لم يسلّم أحد شيئًا",
+    "nudge.content.assignment_no_submissions_d5.body": "أنشأت واجبًا في {org_name} لكن لم يُسلَّم شيء. يستحق الأمر التأكد من أنه منشور وأن المتعلمين يستطيعون الوصول إلى الدورة التابع لها.",
+    "nudge.content.assignment_no_submissions_d5.cta": "راجع واجباتك",
+
+    "nudge.audience.published_no_members_d1.subject": "«{course_name}» منشورة لكن لا أحد هناك",
+    "nudge.audience.published_no_members_d1.heading": "حان وقت دعوة أحدهم",
+    "nudge.audience.published_no_members_d1.body": "«{course_name}» منشورة وجاهزة للقراءة. {org_name} ليس فيها متعلمون بعد، فالخطوة التالية دعوة من كتبتها لأجلهم.",
+    "nudge.audience.published_no_members_d1.cta": "ادعُ متعلمين",
+
+    "nudge.audience.published_no_members_d7.subject": "«{course_name}» ما زالت بلا متعلمين",
+    "nudge.audience.published_no_members_d7.heading": "أسبوع على النشر ولا أحد يقرأ",
+    "nudge.audience.published_no_members_d7.body": "مضى أسبوع على نشر «{course_name}» و{org_name} ما زالت بلا متعلمين. يمكنك الدعوة فردًا فردًا، أو لصق قائمة، أو مشاركة رابط الانضمام فقط.",
+    "nudge.audience.published_no_members_d7.cta": "ادعُ أشخاصًا",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "متعلموك لم يبدأوا بعد",
+    "nudge.audience.members_no_enrollment_d3.heading": "انضموا لكنهم لم يفتحوا شيئًا",
+    "nudge.audience.members_no_enrollment_d3.body": "انضم أشخاص إلى {org_name} لكن لم يبدأ أحد دورة. رسالة قصيرة مع رابط مباشر تكفي عادة — معظمهم ببساطة لم يجدوا المدخل.",
+    "nudge.audience.members_no_enrollment_d3.cta": "اطّلع على الأعضاء",
+
+    "nudge.audience.share_public_page_d14.subject": "صفحة دورتك عامة — هذا هو الرابط",
+    "nudge.audience.share_public_page_d14.heading": "أي شخص لديه الرابط يستطيع القراءة",
+    "nudge.audience.share_public_page_d14.body": "«{course_name}» عامة، فيمكنك مشاركتها في أي مكان دون حاجة أحد إلى دعوة. الرابط أدناه هو ما ترسله.",
+    "nudge.audience.share_public_page_d14.cta": "اعرض الصفحة العامة",
+
+    "nudge.audience.stalled_learners_d14.subject": "بعض المتعلمين توقفوا في المنتصف",
+    "nudge.audience.stalled_learners_d14.heading": "بضعة أشخاص تعثّروا",
+    "nudge.audience.stalled_learners_d14.body": "بعض المتعلمين في {org_name} بدأوا دورة ولم يعودوا منذ أسبوعين. غالبًا ما تنفع رسالة منك، أو نظرة على الموضع الذي توقفوا عنده.",
+    "nudge.audience.stalled_learners_d14.cta": "تفقّد متعلميك",
+
+    "nudge.monetization.course_limit_d1.subject": "استخدمت كل الدورات في خطة {plan_name}",
+    "nudge.monetization.course_limit_d1.heading": "بلغت حد الدورات",
+    "nudge.monetization.course_limit_d1.body": "{org_name} على خطة {plan_name} واستهلكت كل الدورات المتاحة فيها. الانتقال إلى {next_plan} يرفع هذا الحد إن أردت المواصلة.",
+    "nudge.monetization.course_limit_d1.cta": "اطّلع على الخطط",
+
+    "nudge.monetization.member_limit_near.subject": "أنت قريب من حد الأعضاء في خطة {plan_name}",
+    "nudge.monetization.member_limit_near.heading": "اقتربت من حد الأعضاء",
+    "nudge.monetization.member_limit_near.body": "{org_name} تقترب من عدد الأعضاء الذي تسمح به خطة {plan_name}. الانتقال إلى {next_plan} يرفعه، فلا يُمنع أحد في منتصف التسجيل.",
+    "nudge.monetization.member_limit_near.cta": "اطّلع على الخطط",
+
+    "nudge.monetization.ai_credits_low.subject": "أرصدة الذكاء الاصطناعي شارفت على الانتهاء",
+    "nudge.monetization.ai_credits_low.heading": "تبقّى القليل من أرصدة الذكاء الاصطناعي",
+    "nudge.monetization.ai_credits_low.body": "استهلكت {org_name} معظم أرصدة الذكاء الاصطناعي المتضمنة في خطة {plan_name}. خطة {next_plan} تتضمن المزيد، إن صار الذكاء الاصطناعي جزءًا من طريقتك في بناء الدورات.",
+    "nudge.monetization.ai_credits_low.cta": "اطّلع على الخطط",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "ما ستضيفه {next_plan} إلى {org_name}",
+    "nudge.monetization.upgrade_recap_d21.heading": "بنيت شيئًا حقيقيًا",
+    "nudge.monetization.upgrade_recap_d21.body": "لدى {org_name} دورات منشورة وأشخاص يقرؤونها. خطة {next_plan} تمنح مساحة للنمو وأشياء لا تتضمنها خطة {plan_name} — تستحق النظر إن كنت تنوي التوسّع.",
+    "nudge.monetization.upgrade_recap_d21.cta": "قارن الخطط",
+
+    "nudge.dormancy.no_login_14d.subject": "{org_name} كانت هادئة",
+    "nudge.dormancy.no_login_14d.heading": "مضى أسبوعان",
+    "nudge.dormancy.no_login_14d.body": "لم يتغير شيء في {org_name} منذ زيارتك الأخيرة. إن كنت في منتصف عمل ما، فهو تمامًا حيث تركته.",
+    "nudge.dormancy.no_login_14d.cta": "افتح لوحة التحكم",
+
+    "nudge.dormancy.no_login_30d.subject": "دوراتك في {org_name} ما زالت هنا",
+    "nudge.dormancy.no_login_30d.heading": "مضت بضعة أسابيع",
+    "nudge.dormancy.no_login_30d.body": "لم يتغير شيء أثناء غيابك — {org_name} وكل ما فيها تمامًا حيث تركته. العودة تحتاج نقرة واحدة.",
+    "nudge.dormancy.no_login_30d.cta": "افتح لوحة التحكم",
+
+    "nudge.dormancy.no_login_60d.subject": "آخر تواصل بخصوص {org_name}",
+    "nudge.dormancy.no_login_60d.heading": "سنتركك وشأنك",
+    "nudge.dormancy.no_login_60d.body": "{org_name} هادئة منذ شهرين، لذا هذه آخر رسالة من هذا النوع في الوقت الحالي. كل ما بنيته يبقى كما هو، متى ما احتجته.",
+    "nudge.dormancy.no_login_60d.cta": "افتح لوحة التحكم",
+
+    "nudge.dormancy.winback_q.subject": "ما الجديد منذ آخر زيارة لك إلى {org_name}",
+    "nudge.dormancy.winback_q.heading": "تغيّرت بعض الأمور",
+    "nudge.dormancy.winback_q.body": "مضى وقت منذ آخر مرة دخلت فيها {org_name}. تطوّر المنتج كثيرًا منذ ذلك الحين، وكل ما بنيته ما زال موجودًا.",
+    "nudge.dormancy.winback_q.cta": "ألقِ نظرة",
+
+    "nudge.milestone.first_course_published.subject": "«{course_name}» أصبحت منشورة",
+    "nudge.milestone.first_course_published.heading": "نشرت دورتك الأولى",
+    "nudge.milestone.first_course_published.body": "«{course_name}» منشورة وقابلة للقراءة. ما يصنع الفارق الآن هو وجود من يقرؤها — ولو شخص أو اثنان في البداية.",
+    "nudge.milestone.first_course_published.cta": "ادعُ أول متعلمين لديك",
+
+    "nudge.milestone.first_learner_enrolled.subject": "أحدهم بدأ «{course_name}»",
+    "nudge.milestone.first_learner_enrolled.heading": "وصل أول متعلم لديك",
+    "nudge.milestone.first_learner_enrolled.body": "بدأ أحدهم دورة في {org_name} لأول مرة. يمكنك متابعة تقدمه من لوحة التحكم.",
+    "nudge.milestone.first_learner_enrolled.cta": "اعرض تقدّمه",
+
+    "nudge.milestone.first_completion.subject": "أحدهم أنهى دورة في {org_name}",
+    "nudge.milestone.first_completion.heading": "أول إتمام",
+    "nudge.milestone.first_completion.body": "أنهى متعلم دورة في {org_name} من أولها إلى آخرها. إن أردت توثيق ذلك، يمكنك إضافة شهادة — أو البدء ببناء ما يليها.",
+    "nudge.milestone.first_completion.cta": "افتح لوحة التحكم",
+}

--- a/apps/api/src/services/email/nudge_translations/ar.py
+++ b/apps/api/src/services/email/nudge_translations/ar.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "إلغاء الاشتراك في هذه الرسائل",
     "nudge.common.footer": "تصلك هذه الرسالة لأنك مسؤول في {org_name}.",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "الدورات",
+    "nudge.stat.chapters": "الفصول",
+    "nudge.stat.lessons": "الدروس",
+    "nudge.stat.members": "الأعضاء",
+    "nudge.stat.learners": "المتعلمون",
+    "nudge.stat.completed": "مكتملة",
+
     "nudge.activation.first_course_d1.subject": "دورتك الأولى في {org_name}",
     "nudge.activation.first_course_d1.heading": "متى ما كنت مستعدًا",
     "nudge.activation.first_course_d1.body": "{org_name} جاهزة وتنتظر دورتها الأولى. معظم الناس يبدؤون بشيء صغير: موضوع واحد وبضعة دروس. يمكنك التوسّع لاحقًا.",
@@ -152,4 +161,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "أول إتمام",
     "nudge.milestone.first_completion.body": "أنهى متعلم دورة في {org_name} من أولها إلى آخرها. إن أردت توثيق ذلك، يمكنك إضافة شهادة — أو البدء ببناء ما يليها.",
     "nudge.milestone.first_completion.cta": "افتح لوحة التحكم",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "أكاديميتك على {org_name} ما زالت هنا",
+    "nudge.reactivation.opener.heading": "ما زالت هنا، تمامًا كما تركتها",
+    "nudge.reactivation.opener.body": "لم يمسّ أحد {org_name} منذ زيارتك الأخيرة — كل دورة وفصل ودرس في مكانه. للعودة يكفي نقرة واحدة.",
+    "nudge.reactivation.opener.cta": "افتح لوحة التحكم",
+    "nudge.reactivation.whats_changed.subject": "تغيّرت بعض الأمور في LearnHouse",
+    "nudge.reactivation.whats_changed.heading": "منذ آخر زيارة لك",
+    "nudge.reactivation.whats_changed.body": "تطوّر المنتج كثيرًا بينما كانت {org_name} هادئة: المحرّر وأدوات الدورات ومسار المتعلمين نالت جميعها عملًا حقيقيًا. كل ما بنيته يعمل كما كان.",
+    "nudge.reactivation.whats_changed.cta": "اطّلع على الجديد",
+    "nudge.reactivation.need_a_hand.subject": "هل تحتاج مساعدة للعودة إلى {org_name}؟",
+    "nudge.reactivation.need_a_hand.heading": "هل اعترض شيء طريقك؟",
+    "nudge.reactivation.need_a_hand.body": "إن كان هناك سبب لتوقّف {org_name} — شيء مربك أو ناقص أو ببساطة ضيق الوقت — فنحن نودّ سماعه. ردّ على هذه الرسالة وستصلنا مباشرة.",
+    "nudge.reactivation.closing.subject": "آخر رسالة بخصوص {org_name}",
+    "nudge.reactivation.closing.heading": "سنتوقف هنا",
+    "nudge.reactivation.closing.body": "هذه آخر رسالة من هذا النوع. تبقى {org_name} كما هي ولا ينتهي شيء — إن أردت العودة يومًا، سيكون كل شيء في انتظارك.",
+    "nudge.reactivation.closing.cta": "افتح لوحة التحكم",
 }

--- a/apps/api/src/services/email/nudge_translations/bn.py
+++ b/apps/api/src/services/email/nudge_translations/bn.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "এই ইমেলগুলি থেকে আনসাবস্ক্রাইব করুন",
     "nudge.common.footer": "আপনি এই ইমেলটি পাচ্ছেন কারণ আপনি {org_name}-এর একজন অ্যাডমিন।",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "কোর্স",
+    "nudge.stat.chapters": "অধ্যায়",
+    "nudge.stat.lessons": "পাঠ",
+    "nudge.stat.members": "সদস্য",
+    "nudge.stat.learners": "শিক্ষার্থী",
+    "nudge.stat.completed": "সম্পন্ন",
+
     "nudge.activation.first_course_d1.subject": "{org_name}-এ আপনার প্রথম কোর্স",
     "nudge.activation.first_course_d1.heading": "যখন আপনি প্রস্তুত",
     "nudge.activation.first_course_d1.body": "{org_name} তৈরি হয়ে গেছে এবং প্রথম কোর্সের অপেক্ষায় আছে। বেশিরভাগ মানুষ ছোট থেকে শুরু করেন: একটি বিষয়, কয়েকটি পাঠ। পরে যোগ করা সবসময়ই সম্ভব।",
@@ -152,4 +161,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "প্রথম সমাপ্তি",
     "nudge.milestone.first_completion.body": "একজন শিক্ষার্থী {org_name}-এর একটি কোর্স শুরু থেকে শেষ পর্যন্ত সম্পূর্ণ করেছেন। ঠিকভাবে চিহ্নিত করতে চাইলে একটি সার্টিফিকেট যোগ করতে পারেন — বা পরেরটি বানানো শুরু করতে পারেন।",
     "nudge.milestone.first_completion.cta": "আপনার ড্যাশবোর্ড খুলুন",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "{org_name}-এ আপনার অ্যাকাডেমি এখনও আছে",
+    "nudge.reactivation.opener.heading": "এখনও এখানে, যেমন রেখে গিয়েছিলেন",
+    "nudge.reactivation.opener.body": "আপনার শেষবার আসার পর {org_name}-এ কেউ হাত দেয়নি — প্রতিটি কোর্স, অধ্যায় আর পাঠ ঠিক জায়গাতেই আছে। আবার শুরু করতে একটি ক্লিকই যথেষ্ট।",
+    "nudge.reactivation.opener.cta": "আপনার ড্যাশবোর্ড খুলুন",
+    "nudge.reactivation.whats_changed.subject": "LearnHouse-এ কিছু বদলেছে",
+    "nudge.reactivation.whats_changed.heading": "আপনার শেষবার আসার পর",
+    "nudge.reactivation.whats_changed.body": "{org_name} চুপচাপ থাকার সময় পণ্যটি বেশ এগিয়েছে: এডিটর, কোর্স তৈরির সরঞ্জাম আর শিক্ষার্থীদের এগিয়ে চলার পথ — সবেতেই সত্যিকারের কাজ হয়েছে। আপনার গড়া সবকিছু আগের মতোই চলে।",
+    "nudge.reactivation.whats_changed.cta": "কী নতুন হয়েছে দেখুন",
+    "nudge.reactivation.need_a_hand.subject": "{org_name}-এ ফিরতে সাহায্য লাগবে?",
+    "nudge.reactivation.need_a_hand.heading": "কিছু কি বাধা হয়ে দাঁড়িয়েছিল?",
+    "nudge.reactivation.need_a_hand.body": "{org_name} থেমে যাওয়ার কোনো কারণ থাকলে — বিভ্রান্তিকর কিছু, কিছুর অভাব, কিংবা কেবল সময় না পাওয়া — আমরা সত্যিই জানতে চাই। এই ইমেলের উত্তর দিন, সেটি সরাসরি আমাদের কাছে পৌঁছবে।",
+    "nudge.reactivation.closing.subject": "{org_name} নিয়ে শেষ কথা",
+    "nudge.reactivation.closing.heading": "আমরা এখানেই থামছি",
+    "nudge.reactivation.closing.body": "এ ধরনের ইমেলের মধ্যে এটিই শেষ। {org_name} যেমন আছে তেমনই থাকবে, কিছুই মেয়াদোত্তীর্ণ হয় না — কখনও ফিরতে চাইলে সবকিছু অপেক্ষায় থাকবে।",
+    "nudge.reactivation.closing.cta": "আপনার ড্যাশবোর্ড খুলুন",
 }

--- a/apps/api/src/services/email/nudge_translations/bn.py
+++ b/apps/api/src/services/email/nudge_translations/bn.py
@@ -1,0 +1,155 @@
+"""Bengali nudge copy."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "এই ইমেলগুলি থেকে আনসাবস্ক্রাইব করুন",
+    "nudge.common.footer": "আপনি এই ইমেলটি পাচ্ছেন কারণ আপনি {org_name}-এর একজন অ্যাডমিন।",
+
+    "nudge.activation.first_course_d1.subject": "{org_name}-এ আপনার প্রথম কোর্স",
+    "nudge.activation.first_course_d1.heading": "যখন আপনি প্রস্তুত",
+    "nudge.activation.first_course_d1.body": "{org_name} তৈরি হয়ে গেছে এবং প্রথম কোর্সের অপেক্ষায় আছে। বেশিরভাগ মানুষ ছোট থেকে শুরু করেন: একটি বিষয়, কয়েকটি পাঠ। পরে যোগ করা সবসময়ই সম্ভব।",
+    "nudge.activation.first_course_d1.cta": "আপনার প্রথম কোর্স তৈরি করুন",
+
+    "nudge.activation.come_back_d2.subject": "যেখানে থেমেছিলেন সেখান থেকে শুরু করুন",
+    "nudge.activation.come_back_d2.heading": "আপনার সেটআপ এখনও অপেক্ষা করছে",
+    "nudge.activation.come_back_d2.body": "আপনি {org_name} তৈরি করেছিলেন, তারপর আর ফেরেননি। সবকিছু ঠিক আগের মতোই আছে, আর প্রথম কোর্স প্রকাশ করতে মিনিট দশেক লাগে।",
+    "nudge.activation.come_back_d2.cta": "ড্যাশবোর্ডে যান",
+
+    "nudge.activation.ai_course_help_d4.subject": "ফাঁকা পাতাই সবচেয়ে কঠিন",
+    "nudge.activation.ai_course_help_d4.heading": "রূপরেখাটা AI-কে লিখতে দিন",
+    "nudge.activation.ai_course_help_d4.body": "কোথা থেকে শুরু করবেন বুঝতে না পারায় {org_name} যদি এখনও ফাঁকা থাকে, তাহলে শুধু বিষয়টা লিখুন — AI অধ্যায় ও পাঠের খসড়া করে দেবে। সম্পাদনা আপনার হাতে।",
+    "nudge.activation.ai_course_help_d4.cta": "AI দিয়ে কোর্স তৈরি করুন",
+
+    "nudge.activation.import_existing_d5.subject": "যা আছে তা-ই নিয়ে আসুন",
+    "nudge.activation.import_existing_d5.heading": "শূন্য থেকে শুরু করতে হবে না",
+    "nudge.activation.import_existing_d5.body": "আপনার উপকরণ যদি আগে থেকেই নথি, স্লাইড বা অন্য প্ল্যাটফর্মের এক্সপোর্ট হিসেবে থাকে, নতুন করে টাইপ না করে সেগুলো {org_name}-এ নিয়ে আসতে পারেন।",
+    "nudge.activation.import_existing_d5.cta": "আপনার উপকরণ আমদানি করুন",
+
+    "nudge.activation.setup_checklist_d7.subject": "পনেরো মিনিটে চালু একটি অ্যাকাডেমি",
+    "nudge.activation.setup_checklist_d7.heading": "ছোট একটি তালিকা",
+    "nudge.activation.setup_checklist_d7.body": "{org_name} এখনও প্রথম কোর্সের অপেক্ষায়। সেটআপ তালিকা কয়েকটি ছোট ধাপে পথ দেখিয়ে দেয় — বেশিরভাগ মানুষ পনেরো মিনিটের মধ্যেই শেষ করেন।",
+    "nudge.activation.setup_checklist_d7.cta": "তালিকাটি খুলুন",
+
+    "nudge.activation.whats_blocking_d14.subject": "মাঝখানে কী এসে দাঁড়াল?",
+    "nudge.activation.whats_blocking_d14.heading": "জিজ্ঞেস করতে পারি, কী আপনাকে থামাল?",
+    "nudge.activation.whats_blocking_d14.body": "সপ্তাহ দুয়েক আগে আপনি {org_name} তৈরি করেছিলেন, এখনও কোনো কোর্স যোগ করেননি। কিছু বিভ্রান্তিকর লেগে থাকলে বা কিছু কম পড়ে থাকলে আমরা জানতে চাই — এই ইমেলের উত্তর দিলেই সরাসরি আমাদের কাছে পৌঁছবে।",
+
+    "nudge.activation.last_call_d30.subject": "{org_name} নিয়ে শেষ ইমেল",
+    "nudge.activation.last_call_d30.heading": "এটাই শেষ",
+    "nudge.activation.last_call_d30.body": "{org_name} এক মাস ধরে নিঃশব্দ, তাই আমরা এই ধরনের ইমেল পাঠানো বন্ধ করছি। আপনার অ্যাকাউন্ট ও ভেতরের সবকিছু থেকে যাবে — ফিরে এলে সব যেমন রেখে গিয়েছিলেন তেমনই পাবেন।",
+    "nudge.activation.last_call_d30.cta": "আপনার ড্যাশবোর্ড খুলুন",
+
+    "nudge.content.course_no_chapter_d1.subject": "«{course_name}»-এর প্রথম অধ্যায় দরকার",
+    "nudge.content.course_no_chapter_d1.heading": "আর একটি অধ্যায় বাকি",
+    "nudge.content.course_no_chapter_d1.body": "«{course_name}» তৈরি হয়েছে, কিন্তু এখনও কোনো অধ্যায় নেই, তাই খোলার মতো কিছু নেই। অধ্যায় আসলে শুধু ভাগ — বিষয়প্রতি একটি করে ভালো কাজ করে।",
+    "nudge.content.course_no_chapter_d1.cta": "অধ্যায় যোগ করুন",
+
+    "nudge.content.chapter_no_activity_d1.subject": "«{course_name}»-এ প্রথম পাঠ যোগ করুন",
+    "nudge.content.chapter_no_activity_d1.heading": "অধ্যায়গুলো প্রস্তুত",
+    "nudge.content.chapter_no_activity_d1.body": "«{course_name}»-এ অধ্যায় আছে, কিন্তু ভেতরটা এখনও ফাঁকা। একটি পাঠ হতে পারে এক পৃষ্ঠার লেখা, একটি ভিডিও বা একটি কুইজ — বিষয়ের সঙ্গে যা মানায়।",
+    "nudge.content.chapter_no_activity_d1.cta": "পাঠ যোগ করুন",
+
+    "nudge.content.activity_unpublished_d2.subject": "«{course_name}»-এর পাঠগুলো এখনও দেখা যাচ্ছে না",
+    "nudge.content.activity_unpublished_d2.heading": "পাঠগুলো এখনও লুকানো",
+    "nudge.content.activity_unpublished_d2.body": "আপনি «{course_name}»-এ পাঠ লিখেছেন, কিন্তু একটিও প্রকাশিত নয়, তাই শিক্ষার্থীরা একটি ফাঁকা কোর্স দেখছেন। প্রকাশ করলে কিছু আটকে যায় না — পরেও সম্পাদনা করা যায়।",
+    "nudge.content.activity_unpublished_d2.cta": "আপনার পাঠ প্রকাশ করুন",
+
+    "nudge.content.course_draft_d3.subject": "«{course_name}» এখনও খসড়া",
+    "nudge.content.course_draft_d3.heading": "«{course_name}» প্রায় তৈরি",
+    "nudge.content.course_draft_d3.body": "আপনি «{course_name}»-এ পাঠ যোগ করেছেন, কিন্তু এটি প্রকাশিত নয়, তাই কেউ খুলতে পারছে না। সম্পূর্ণ হওয়ার দরকার নেই — প্রকাশ করলে কেবল দৃশ্যমান হয়, পরেও সম্পাদনা চালিয়ে যেতে পারেন।",
+    "nudge.content.course_draft_d3.cta": "প্রকাশ করুন",
+
+    "nudge.content.course_draft_d10.subject": "«{course_name}» বেশ কিছুদিন ধরে খসড়া",
+    "nudge.content.course_draft_d10.heading": "সম্ভবত এটি তৈরি",
+    "nudge.content.course_draft_d10.body": "«{course_name}» এক সপ্তাহেরও বেশি সময় ধরে অপ্রকাশিত। কোর্স খুব কমই সম্পূর্ণ মনে হয় — প্রকাশ করলে দেখা যায়, আর পাঠক থাকা অবস্থাতেও উন্নত করা যায়।",
+    "nudge.content.course_draft_d10.cta": "প্রকাশ করুন",
+
+    "nudge.content.thin_course_d5.subject": "«{course_name}»-এ আরেকটু যোগ করা যায়",
+    "nudge.content.thin_course_d5.heading": "এক-দুটি পাঠ",
+    "nudge.content.thin_course_d5.body": "«{course_name}»-এ এখন পর্যন্ত এক-দুটি পাঠ আছে। কয়েকটি পাঠ থাকলে কোর্স সাধারণত বেশি কাজে দেয়, আর যা আছে তা থেকেই AI পরের পাঠগুলোর খসড়া করতে পারে।",
+    "nudge.content.thin_course_d5.cta": "আরও পাঠ যোগ করুন",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "{org_name}-এ এখনও কোনো জমা পড়েনি",
+    "nudge.content.assignment_no_submissions_d5.heading": "কেউ কিছু জমা দেয়নি",
+    "nudge.content.assignment_no_submissions_d5.body": "আপনি {org_name}-এ একটি অ্যাসাইনমেন্ট তৈরি করেছিলেন, কিন্তু কিছু জমা পড়েনি। দেখে নেওয়া ভালো যে এটি প্রকাশিত কি না এবং শিক্ষার্থীরা সংশ্লিষ্ট কোর্সে পৌঁছাতে পারছেন কি না।",
+    "nudge.content.assignment_no_submissions_d5.cta": "অ্যাসাইনমেন্ট দেখুন",
+
+    "nudge.audience.published_no_members_d1.subject": "«{course_name}» প্রকাশিত, কিন্তু কেউ নেই",
+    "nudge.audience.published_no_members_d1.heading": "কাউকে আমন্ত্রণ জানানোর সময়",
+    "nudge.audience.published_no_members_d1.body": "«{course_name}» প্রকাশিত এবং পড়ার জন্য প্রস্তুত। {org_name}-এ এখনও কোনো শিক্ষার্থী নেই, তাই পরের ধাপ হলো যাদের জন্য লিখেছিলেন তাদের আমন্ত্রণ জানানো।",
+    "nudge.audience.published_no_members_d1.cta": "শিক্ষার্থীদের আমন্ত্রণ জানান",
+
+    "nudge.audience.published_no_members_d7.subject": "«{course_name}»-এ এখনও কোনো শিক্ষার্থী নেই",
+    "nudge.audience.published_no_members_d7.heading": "এক সপ্তাহ প্রকাশিত, কেউ পড়ছে না",
+    "nudge.audience.published_no_members_d7.body": "«{course_name}» এক সপ্তাহ ধরে প্রকাশিত, তবু {org_name}-এ কোনো শিক্ষার্থী নেই। একজন একজন করে আমন্ত্রণ জানাতে পারেন, তালিকা পেস্ট করতে পারেন, কিংবা কেবল যোগদানের লিংক ভাগ করে নিতে পারেন।",
+    "nudge.audience.published_no_members_d7.cta": "মানুষজনকে আমন্ত্রণ জানান",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "আপনার শিক্ষার্থীরা এখনও শুরু করেননি",
+    "nudge.audience.members_no_enrollment_d3.heading": "যোগ দিয়েছেন, কিন্তু কিছু খোলেননি",
+    "nudge.audience.members_no_enrollment_d3.body": "কিছু মানুষ {org_name}-এ যোগ দিয়েছেন, কিন্তু কেউ কোর্স শুরু করেননি। সরাসরি লিংকসহ একটি ছোট বার্তা সাধারণত যথেষ্ট — বেশিরভাগই কেবল ঢোকার পথটা খুঁজে পাননি।",
+    "nudge.audience.members_no_enrollment_d3.cta": "আপনার সদস্যদের দেখুন",
+
+    "nudge.audience.share_public_page_d14.subject": "আপনার কোর্স পাতা সর্বজনীন — লিংকটি এখানে",
+    "nudge.audience.share_public_page_d14.heading": "লিংক থাকলেই যে কেউ পড়তে পারবেন",
+    "nudge.audience.share_public_page_d14.body": "«{course_name}» সর্বজনীন, তাই আমন্ত্রণ ছাড়াই যেকোনো জায়গায় ভাগ করে নিতে পারেন। নিচের লিংকটিই পাঠানোর জন্য।",
+    "nudge.audience.share_public_page_d14.cta": "সর্বজনীন পাতা দেখুন",
+
+    "nudge.audience.stalled_learners_d14.subject": "কয়েকজন শিক্ষার্থী মাঝপথে থেমে গেছেন",
+    "nudge.audience.stalled_learners_d14.heading": "কয়েকজন আটকে আছেন",
+    "nudge.audience.stalled_learners_d14.body": "{org_name}-এর কয়েকজন শিক্ষার্থী কোর্স শুরু করে দুই সপ্তাহ ধরে ফেরেননি। আপনার একটি বার্তা প্রায়ই কাজে দেয়, আর তাঁরা কোথায় থেমেছেন সেটা দেখাও।",
+    "nudge.audience.stalled_learners_d14.cta": "শিক্ষার্থীদের দেখুন",
+
+    "nudge.monetization.course_limit_d1.subject": "{plan_name} প্ল্যানের সব কোর্স ব্যবহার হয়ে গেছে",
+    "nudge.monetization.course_limit_d1.heading": "আপনি কোর্সের সীমায় পৌঁছেছেন",
+    "nudge.monetization.course_limit_d1.body": "{org_name} {plan_name} প্ল্যানে আছে এবং এতে থাকা সব কোর্স ব্যবহার করে ফেলেছে। বানিয়ে যেতে চাইলে {next_plan}-এ যাওয়া এই সীমা তুলে দেয়।",
+    "nudge.monetization.course_limit_d1.cta": "প্ল্যানগুলো দেখুন",
+
+    "nudge.monetization.member_limit_near.subject": "{plan_name} প্ল্যানের সদস্যসীমার কাছে চলে এসেছেন",
+    "nudge.monetization.member_limit_near.heading": "সদস্যসীমা প্রায় ছুঁই ছুঁই",
+    "nudge.monetization.member_limit_near.body": "{plan_name} প্ল্যান যত সদস্যের অনুমতি দেয়, {org_name} তার কাছাকাছি পৌঁছাচ্ছে। {next_plan}-এ গেলে সেটা বাড়ে, যাতে সাইন-আপের মাঝপথে কেউ আটকে না যান।",
+    "nudge.monetization.member_limit_near.cta": "প্ল্যানগুলো দেখুন",
+
+    "nudge.monetization.ai_credits_low.subject": "আপনার AI ক্রেডিট প্রায় শেষ",
+    "nudge.monetization.ai_credits_low.heading": "AI ক্রেডিট কমে এসেছে",
+    "nudge.monetization.ai_credits_low.body": "{plan_name} প্ল্যানে থাকা AI ক্রেডিটের বেশিরভাগই {org_name} ব্যবহার করে ফেলেছে। AI যদি আপনার কোর্স বানানোর অংশ হয়ে থাকে, {next_plan} প্ল্যানে আরও বেশি রয়েছে।",
+    "nudge.monetization.ai_credits_low.cta": "প্ল্যানগুলো দেখুন",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "{next_plan} {org_name}-এ কী যোগ করবে",
+    "nudge.monetization.upgrade_recap_d21.heading": "আপনি সত্যিকারের কিছু গড়েছেন",
+    "nudge.monetization.upgrade_recap_d21.body": "{org_name}-এ প্রকাশিত কোর্স আছে এবং তা পড়ার মানুষও আছে। {next_plan} প্ল্যান বাড়ার জায়গা দেয় এবং এতে এমন কিছু আছে যা {plan_name} প্ল্যানে নেই — বাড়ানোর পরিকল্পনা থাকলে দেখার মতো।",
+    "nudge.monetization.upgrade_recap_d21.cta": "প্ল্যান তুলনা করুন",
+
+    "nudge.dormancy.no_login_14d.subject": "{org_name} চুপচাপ ছিল",
+    "nudge.dormancy.no_login_14d.heading": "দুই সপ্তাহ কেটে গেছে",
+    "nudge.dormancy.no_login_14d.body": "আপনার শেষবার আসার পর {org_name}-এ কিছুই বদলায়নি। কোনো কাজের মাঝখানে থাকলে সেটা ঠিক যেখানে রেখেছিলেন সেখানেই আছে।",
+    "nudge.dormancy.no_login_14d.cta": "আপনার ড্যাশবোর্ড খুলুন",
+
+    "nudge.dormancy.no_login_30d.subject": "{org_name}-এ আপনার কোর্সগুলো এখনও আছে",
+    "nudge.dormancy.no_login_30d.heading": "কয়েক সপ্তাহ কেটে গেছে",
+    "nudge.dormancy.no_login_30d.body": "আপনি না থাকাকালে কিছুই বদলায়নি — {org_name} আর তার ভেতরের সবকিছু ঠিক যেখানে রেখেছিলেন সেখানেই। আবার শুরু করতে একটি ক্লিকই যথেষ্ট।",
+    "nudge.dormancy.no_login_30d.cta": "আপনার ড্যাশবোর্ড খুলুন",
+
+    "nudge.dormancy.no_login_60d.subject": "{org_name} নিয়ে শেষ বার্তা",
+    "nudge.dormancy.no_login_60d.heading": "আমরা আর বিরক্ত করব না",
+    "nudge.dormancy.no_login_60d.body": "{org_name} প্রায় দুই মাস ধরে নিঃশব্দ, তাই আপাতত এটাই এ ধরনের শেষ ইমেল। আপনার গড়া সবকিছু যেমন আছে তেমনই থাকবে, যখনই দরকার হয়।",
+    "nudge.dormancy.no_login_60d.cta": "আপনার ড্যাশবোর্ড খুলুন",
+
+    "nudge.dormancy.winback_q.subject": "{org_name}-এ শেষবার আসার পর কী নতুন হলো",
+    "nudge.dormancy.winback_q.heading": "কিছু জিনিস বদলেছে",
+    "nudge.dormancy.winback_q.body": "{org_name}-এ আপনার শেষবার আসার পর অনেকটা সময় গেছে। এর মধ্যে পণ্যটি বেশ এগিয়েছে, আর আপনার গড়া সবকিছু এখনও আছে।",
+    "nudge.dormancy.winback_q.cta": "একবার দেখুন",
+
+    "nudge.milestone.first_course_published.subject": "«{course_name}» প্রকাশিত হয়েছে",
+    "nudge.milestone.first_course_published.heading": "আপনি আপনার প্রথম কোর্স প্রকাশ করেছেন",
+    "nudge.milestone.first_course_published.body": "«{course_name}» প্রকাশিত এবং পড়া যাচ্ছে। এখন যেটা পার্থক্য গড়ে দেয় সেটা হলো কেউ একজন পড়ুক — শুরুতে এক-দুজন হলেও চলে।",
+    "nudge.milestone.first_course_published.cta": "প্রথম শিক্ষার্থীদের আমন্ত্রণ জানান",
+
+    "nudge.milestone.first_learner_enrolled.subject": "কেউ «{course_name}» শুরু করেছেন",
+    "nudge.milestone.first_learner_enrolled.heading": "আপনার প্রথম শিক্ষার্থী এসেছেন",
+    "nudge.milestone.first_learner_enrolled.body": "{org_name}-এ প্রথমবারের মতো কেউ একটি কোর্স শুরু করেছেন। ড্যাশবোর্ড থেকে তাঁর অগ্রগতি দেখতে পারেন।",
+    "nudge.milestone.first_learner_enrolled.cta": "অগ্রগতি দেখুন",
+
+    "nudge.milestone.first_completion.subject": "কেউ {org_name}-এর একটি কোর্স শেষ করেছেন",
+    "nudge.milestone.first_completion.heading": "প্রথম সমাপ্তি",
+    "nudge.milestone.first_completion.body": "একজন শিক্ষার্থী {org_name}-এর একটি কোর্স শুরু থেকে শেষ পর্যন্ত সম্পূর্ণ করেছেন। ঠিকভাবে চিহ্নিত করতে চাইলে একটি সার্টিফিকেট যোগ করতে পারেন — বা পরেরটি বানানো শুরু করতে পারেন।",
+    "nudge.milestone.first_completion.cta": "আপনার ড্যাশবোর্ড খুলুন",
+}

--- a/apps/api/src/services/email/nudge_translations/de.py
+++ b/apps/api/src/services/email/nudge_translations/de.py
@@ -1,0 +1,155 @@
+"""German nudge copy."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "Diese E-Mails abbestellen",
+    "nudge.common.footer": "Sie erhalten diese E-Mail, weil Sie Administrator von {org_name} sind.",
+
+    "nudge.activation.first_course_d1.subject": "Ihr erster Kurs auf {org_name}",
+    "nudge.activation.first_course_d1.heading": "Wann immer Sie möchten",
+    "nudge.activation.first_course_d1.body": "{org_name} ist eingerichtet und wartet auf den ersten Kurs. Die meisten fangen klein an: ein Thema, ein paar Lektionen. Ergänzen können Sie jederzeit.",
+    "nudge.activation.first_course_d1.cta": "Ersten Kurs erstellen",
+
+    "nudge.activation.come_back_d2.subject": "Da weitermachen, wo Sie aufgehört haben",
+    "nudge.activation.come_back_d2.heading": "Ihre Einrichtung wartet noch",
+    "nudge.activation.come_back_d2.body": "Sie haben {org_name} eingerichtet und waren seitdem nicht mehr da. Alles ist noch vorhanden, und ein erster Kurs ist in etwa zehn Minuten online.",
+    "nudge.activation.come_back_d2.cta": "Zum Dashboard",
+
+    "nudge.activation.ai_course_help_d4.subject": "Das leere Blatt ist das Schwierigste",
+    "nudge.activation.ai_course_help_d4.heading": "Lassen Sie die KI die Gliederung schreiben",
+    "nudge.activation.ai_course_help_d4.body": "Wenn {org_name} noch leer ist, weil der Anfang schwerfällt: Beschreiben Sie Ihr Thema, und die KI entwirft Kapitel und Lektionen. Den Rest übernehmen Sie.",
+    "nudge.activation.ai_course_help_d4.cta": "Kurs mit KI entwerfen",
+
+    "nudge.activation.import_existing_d5.subject": "Bringen Sie mit, was Sie schon haben",
+    "nudge.activation.import_existing_d5.heading": "Sie müssen nicht bei null anfangen",
+    "nudge.activation.import_existing_d5.body": "Wenn Ihr Material bereits als Dokument, Präsentation oder Export einer anderen Plattform vorliegt, können Sie es nach {org_name} übernehmen, statt alles neu zu tippen.",
+    "nudge.activation.import_existing_d5.cta": "Material importieren",
+
+    "nudge.activation.setup_checklist_d7.subject": "Fünfzehn Minuten bis zur fertigen Akademie",
+    "nudge.activation.setup_checklist_d7.heading": "Eine kurze Checkliste",
+    "nudge.activation.setup_checklist_d7.body": "{org_name} wartet noch auf den ersten Kurs. Die Checkliste führt Sie in wenigen Schritten hindurch — die meisten sind in einer Viertelstunde fertig.",
+    "nudge.activation.setup_checklist_d7.cta": "Checkliste öffnen",
+
+    "nudge.activation.whats_blocking_d14.subject": "Was ist dazwischengekommen?",
+    "nudge.activation.whats_blocking_d14.heading": "Dürfen wir fragen, woran es lag?",
+    "nudge.activation.whats_blocking_d14.body": "Sie haben {org_name} vor zwei Wochen eingerichtet und noch keinen Kurs angelegt. Wenn etwas unklar war oder gefehlt hat, würden wir das gern wissen — antworten Sie einfach auf diese E-Mail, sie kommt direkt bei uns an.",
+
+    "nudge.activation.last_call_d30.subject": "Letzte E-Mail zu {org_name}",
+    "nudge.activation.last_call_d30.heading": "Das ist die letzte",
+    "nudge.activation.last_call_d30.body": "{org_name} war einen Monat lang still, deshalb hören wir mit diesen E-Mails auf. Ihr Konto und alles darin bleibt bestehen — wenn Sie zurückkommen, ist alles noch da.",
+    "nudge.activation.last_call_d30.cta": "Dashboard öffnen",
+
+    "nudge.content.course_no_chapter_d1.subject": "{course_name} braucht sein erstes Kapitel",
+    "nudge.content.course_no_chapter_d1.heading": "Nur noch ein Kapitel",
+    "nudge.content.course_no_chapter_d1.body": "{course_name} existiert, hat aber noch keine Kapitel — es gibt also nichts zu öffnen. Kapitel sind einfach Abschnitte, eines pro Thema funktioniert gut.",
+    "nudge.content.course_no_chapter_d1.cta": "Kapitel hinzufügen",
+
+    "nudge.content.chapter_no_activity_d1.subject": "Fügen Sie {course_name} die erste Lektion hinzu",
+    "nudge.content.chapter_no_activity_d1.heading": "Die Kapitel stehen",
+    "nudge.content.chapter_no_activity_d1.body": "{course_name} hat Kapitel, aber noch keinen Inhalt darin. Eine Lektion kann eine Textseite sein, ein Video, ein Quiz — was zum Thema passt.",
+    "nudge.content.chapter_no_activity_d1.cta": "Lektion hinzufügen",
+
+    "nudge.content.activity_unpublished_d2.subject": "Ihre Lektionen in {course_name} sind noch nicht sichtbar",
+    "nudge.content.activity_unpublished_d2.heading": "Die Lektionen sind noch verborgen",
+    "nudge.content.activity_unpublished_d2.body": "Sie haben Lektionen in {course_name} geschrieben, aber keine ist veröffentlicht — Lernende sehen einen leeren Kurs. Veröffentlichen sperrt nichts, Sie können weiter bearbeiten.",
+    "nudge.content.activity_unpublished_d2.cta": "Lektionen veröffentlichen",
+
+    "nudge.content.course_draft_d3.subject": "{course_name} ist noch ein Entwurf",
+    "nudge.content.course_draft_d3.heading": "{course_name} ist fast fertig",
+    "nudge.content.course_draft_d3.body": "Sie haben {course_name} Lektionen hinzugefügt, aber der Kurs ist nicht veröffentlicht — niemand kann ihn öffnen. Er muss nicht fertig sein: Veröffentlichen macht ihn nur sichtbar, und Sie können weiter daran arbeiten.",
+    "nudge.content.course_draft_d3.cta": "Jetzt veröffentlichen",
+
+    "nudge.content.course_draft_d10.subject": "{course_name} ist schon eine Weile ein Entwurf",
+    "nudge.content.course_draft_d10.heading": "Wahrscheinlich ist er so weit",
+    "nudge.content.course_draft_d10.body": "{course_name} liegt seit über einer Woche unveröffentlicht da. Ein Kurs fühlt sich selten fertig an — Veröffentlichen macht ihn sichtbar, und Sie können ihn weiter verbessern, während schon jemand liest.",
+    "nudge.content.course_draft_d10.cta": "Jetzt veröffentlichen",
+
+    "nudge.content.thin_course_d5.subject": "{course_name} verträgt noch etwas mehr",
+    "nudge.content.thin_course_d5.heading": "Ein, zwei Lektionen",
+    "nudge.content.thin_course_d5.body": "{course_name} hat bisher ein, zwei Lektionen. Kurse wirken mit einer Handvoll meist besser, und die KI kann die nächsten aus dem Vorhandenen entwerfen.",
+    "nudge.content.thin_course_d5.cta": "Weitere Lektionen hinzufügen",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "Noch keine Abgaben in {org_name}",
+    "nudge.content.assignment_no_submissions_d5.heading": "Niemand hat etwas abgegeben",
+    "nudge.content.assignment_no_submissions_d5.body": "Sie haben in {org_name} eine Aufgabe angelegt, aber es wurde nichts eingereicht. Prüfen Sie, ob sie veröffentlicht ist und ob Ihre Lernenden den zugehörigen Kurs erreichen.",
+    "nudge.content.assignment_no_submissions_d5.cta": "Aufgaben prüfen",
+
+    "nudge.audience.published_no_members_d1.subject": "{course_name} ist online, aber noch ist niemand da",
+    "nudge.audience.published_no_members_d1.heading": "Zeit, jemanden einzuladen",
+    "nudge.audience.published_no_members_d1.body": "{course_name} ist veröffentlicht und bereit. {org_name} hat noch keine Lernenden — der nächste Schritt ist, die Menschen einzuladen, für die Sie ihn geschrieben haben.",
+    "nudge.audience.published_no_members_d1.cta": "Lernende einladen",
+
+    "nudge.audience.published_no_members_d7.subject": "{course_name} hat weiterhin keine Lernenden",
+    "nudge.audience.published_no_members_d7.heading": "Eine Woche online, niemand liest",
+    "nudge.audience.published_no_members_d7.body": "{course_name} ist seit einer Woche veröffentlicht und {org_name} hat immer noch keine Lernenden. Sie können einzeln einladen, eine Liste einfügen oder einfach den Beitrittslink teilen.",
+    "nudge.audience.published_no_members_d7.cta": "Personen einladen",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "Ihre Lernenden haben noch nicht angefangen",
+    "nudge.audience.members_no_enrollment_d3.heading": "Beigetreten, aber nichts geöffnet",
+    "nudge.audience.members_no_enrollment_d3.body": "Es sind Leute {org_name} beigetreten, aber niemand hat einen Kurs begonnen. Eine kurze Nachricht mit einem direkten Link genügt meist — die meisten haben schlicht den Einstieg nicht gefunden.",
+    "nudge.audience.members_no_enrollment_d3.cta": "Mitglieder ansehen",
+
+    "nudge.audience.share_public_page_d14.subject": "Ihre Kursseite ist öffentlich — hier ist der Link",
+    "nudge.audience.share_public_page_d14.heading": "Jeder mit dem Link kann lesen",
+    "nudge.audience.share_public_page_d14.body": "{course_name} ist öffentlich, Sie können ihn also überall teilen, ohne dass jemand eine Einladung braucht. Der Link unten ist der richtige.",
+    "nudge.audience.share_public_page_d14.cta": "Öffentliche Seite ansehen",
+
+    "nudge.audience.stalled_learners_d14.subject": "Einige Lernende sind mittendrin stehen geblieben",
+    "nudge.audience.stalled_learners_d14.heading": "Ein paar sind hängen geblieben",
+    "nudge.audience.stalled_learners_d14.body": "Einige Lernende in {org_name} haben einen Kurs begonnen und sind seit zwei Wochen nicht zurückgekehrt. Oft hilft eine Nachricht von Ihnen — oder ein Blick darauf, wo sie aufgehört haben.",
+    "nudge.audience.stalled_learners_d14.cta": "Lernende ansehen",
+
+    "nudge.monetization.course_limit_d1.subject": "Sie haben alle Kurse im Tarif {plan_name} genutzt",
+    "nudge.monetization.course_limit_d1.heading": "Sie haben das Kurslimit erreicht",
+    "nudge.monetization.course_limit_d1.body": "{org_name} nutzt den Tarif {plan_name} und hat alle darin enthaltenen Kurse verbraucht. Der Wechsel zu {next_plan} hebt dieses Limit auf, wenn Sie weiterbauen möchten.",
+    "nudge.monetization.course_limit_d1.cta": "Tarife ansehen",
+
+    "nudge.monetization.member_limit_near.subject": "Sie nähern sich dem Mitgliederlimit von {plan_name}",
+    "nudge.monetization.member_limit_near.heading": "Fast am Mitgliederlimit",
+    "nudge.monetization.member_limit_near.body": "{org_name} nähert sich der Zahl an Mitgliedern, die der Tarif {plan_name} erlaubt. Ein Wechsel zu {next_plan} erhöht sie, damit niemand mitten in der Anmeldung abgewiesen wird.",
+    "nudge.monetization.member_limit_near.cta": "Tarife ansehen",
+
+    "nudge.monetization.ai_credits_low.subject": "Ihre KI-Credits sind fast aufgebraucht",
+    "nudge.monetization.ai_credits_low.heading": "KI-Credits gehen zur Neige",
+    "nudge.monetization.ai_credits_low.body": "{org_name} hat den Großteil der im Tarif {plan_name} enthaltenen KI-Credits verbraucht. Der Tarif {next_plan} enthält mehr davon, falls KI inzwischen fester Teil Ihrer Kursarbeit ist.",
+    "nudge.monetization.ai_credits_low.cta": "Tarife ansehen",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "Was {next_plan} für {org_name} bringen würde",
+    "nudge.monetization.upgrade_recap_d21.heading": "Sie haben etwas Echtes aufgebaut",
+    "nudge.monetization.upgrade_recap_d21.body": "{org_name} hat veröffentlichte Kurse und Menschen, die sie lesen. Der Tarif {next_plan} bietet Luft zum Wachsen und einiges, was im Tarif {plan_name} fehlt — einen Blick wert, wenn Sie größer werden wollen.",
+    "nudge.monetization.upgrade_recap_d21.cta": "Tarife vergleichen",
+
+    "nudge.dormancy.no_login_14d.subject": "In {org_name} war es still",
+    "nudge.dormancy.no_login_14d.heading": "Es sind zwei Wochen vergangen",
+    "nudge.dormancy.no_login_14d.body": "In {org_name} hat sich seit Ihrem letzten Besuch nichts geändert. Falls Sie mitten in etwas waren: Es liegt noch genau so da, wie Sie es verlassen haben.",
+    "nudge.dormancy.no_login_14d.cta": "Dashboard öffnen",
+
+    "nudge.dormancy.no_login_30d.subject": "Ihre Kurse auf {org_name} sind noch da",
+    "nudge.dormancy.no_login_30d.heading": "Es sind ein paar Wochen vergangen",
+    "nudge.dormancy.no_login_30d.body": "Während Ihrer Abwesenheit hat sich nichts geändert — {org_name} und alles darin ist genau dort, wo Sie es gelassen haben. Ein Klick, und Sie sind wieder drin.",
+    "nudge.dormancy.no_login_30d.cta": "Dashboard öffnen",
+
+    "nudge.dormancy.no_login_60d.subject": "Letzte Nachricht zu {org_name}",
+    "nudge.dormancy.no_login_60d.heading": "Wir lassen Sie in Ruhe",
+    "nudge.dormancy.no_login_60d.body": "In {org_name} war es zwei Monate still, deshalb ist das vorerst die letzte dieser E-Mails. Alles, was Sie aufgebaut haben, bleibt unverändert bestehen — für wann immer Sie es brauchen.",
+    "nudge.dormancy.no_login_60d.cta": "Dashboard öffnen",
+
+    "nudge.dormancy.winback_q.subject": "Was sich seit Ihrem letzten Besuch in {org_name} getan hat",
+    "nudge.dormancy.winback_q.heading": "Einiges ist neu",
+    "nudge.dormancy.winback_q.body": "Es ist eine Weile her, dass Sie in {org_name} waren. Das Produkt hat sich seitdem deutlich weiterentwickelt, und alles, was Sie aufgebaut haben, ist noch da.",
+    "nudge.dormancy.winback_q.cta": "Ansehen",
+
+    "nudge.milestone.first_course_published.subject": "{course_name} ist online",
+    "nudge.milestone.first_course_published.heading": "Ihr erster Kurs ist veröffentlicht",
+    "nudge.milestone.first_course_published.body": "{course_name} ist online und lesbar. Den größten Unterschied macht jetzt jemand, der ihn liest — auch ein, zwei Personen für den Anfang.",
+    "nudge.milestone.first_course_published.cta": "Erste Lernende einladen",
+
+    "nudge.milestone.first_learner_enrolled.subject": "Jemand hat {course_name} begonnen",
+    "nudge.milestone.first_learner_enrolled.heading": "Ihr erster Lernender ist da",
+    "nudge.milestone.first_learner_enrolled.body": "Zum ersten Mal hat jemand einen Kurs in {org_name} begonnen. Den Fortschritt können Sie in Ihrem Dashboard verfolgen.",
+    "nudge.milestone.first_learner_enrolled.cta": "Fortschritt ansehen",
+
+    "nudge.milestone.first_completion.subject": "Jemand hat einen Kurs in {org_name} abgeschlossen",
+    "nudge.milestone.first_completion.heading": "Erster Abschluss",
+    "nudge.milestone.first_completion.body": "Ein Lernender hat einen Kurs in {org_name} von Anfang bis Ende abgeschlossen. Wenn Sie das gebührend festhalten wollen, können Sie ein Zertifikat hinzufügen — oder mit dem Nächsten beginnen.",
+    "nudge.milestone.first_completion.cta": "Dashboard öffnen",
+}

--- a/apps/api/src/services/email/nudge_translations/de.py
+++ b/apps/api/src/services/email/nudge_translations/de.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "Diese E-Mails abbestellen",
     "nudge.common.footer": "Sie erhalten diese E-Mail, weil Sie Administrator von {org_name} sind.",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "Kurse",
+    "nudge.stat.chapters": "Kapitel",
+    "nudge.stat.lessons": "Lektionen",
+    "nudge.stat.members": "Mitglieder",
+    "nudge.stat.learners": "Lernende",
+    "nudge.stat.completed": "Abgeschlossen",
+
     "nudge.activation.first_course_d1.subject": "Ihr erster Kurs auf {org_name}",
     "nudge.activation.first_course_d1.heading": "Wann immer Sie möchten",
     "nudge.activation.first_course_d1.body": "{org_name} ist eingerichtet und wartet auf den ersten Kurs. Die meisten fangen klein an: ein Thema, ein paar Lektionen. Ergänzen können Sie jederzeit.",
@@ -152,4 +161,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "Erster Abschluss",
     "nudge.milestone.first_completion.body": "Ein Lernender hat einen Kurs in {org_name} von Anfang bis Ende abgeschlossen. Wenn Sie das gebührend festhalten wollen, können Sie ein Zertifikat hinzufügen — oder mit dem Nächsten beginnen.",
     "nudge.milestone.first_completion.cta": "Dashboard öffnen",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "Ihre Akademie auf {org_name} ist noch da",
+    "nudge.reactivation.opener.heading": "Noch da, genau wie Sie sie verlassen haben",
+    "nudge.reactivation.opener.body": "Seit Ihrem letzten Besuch hat niemand {org_name} angerührt — jeder Kurs, jedes Kapitel und jede Lektion liegt unverändert da. Ein Klick, und Sie machen weiter.",
+    "nudge.reactivation.opener.cta": "Dashboard öffnen",
+    "nudge.reactivation.whats_changed.subject": "Auf LearnHouse hat sich einiges getan",
+    "nudge.reactivation.whats_changed.heading": "Seit Ihrem letzten Besuch",
+    "nudge.reactivation.whats_changed.body": "Während {org_name} still war, hat sich das Produkt deutlich weiterentwickelt: Editor, Kurswerkzeuge und der Lernweg wurden gründlich überarbeitet. Alles, was Sie aufgebaut haben, funktioniert unverändert.",
+    "nudge.reactivation.whats_changed.cta": "Neuerungen ansehen",
+    "nudge.reactivation.need_a_hand.subject": "Brauchen Sie Hilfe beim Wiedereinstieg in {org_name}?",
+    "nudge.reactivation.need_a_hand.heading": "Stand etwas im Weg?",
+    "nudge.reactivation.need_a_hand.body": "Falls es einen Grund gab, warum {org_name} liegen blieb — etwas Unklares, etwas Fehlendes oder schlicht keine Zeit — würden wir das gern erfahren. Antworten Sie einfach auf diese E-Mail, sie kommt direkt bei uns an.",
+    "nudge.reactivation.closing.subject": "Letzte Nachricht zu {org_name}",
+    "nudge.reactivation.closing.heading": "Hier hören wir auf",
+    "nudge.reactivation.closing.body": "Das ist die letzte dieser E-Mails. {org_name} bleibt genau so bestehen und nichts verfällt — wenn Sie zurückkommen möchten, wartet alles auf Sie.",
+    "nudge.reactivation.closing.cta": "Dashboard öffnen",
 }

--- a/apps/api/src/services/email/nudge_translations/en.py
+++ b/apps/api/src/services/email/nudge_translations/en.py
@@ -1,0 +1,161 @@
+"""English nudge copy — the source text every other locale translates from."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "Unsubscribe from these emails",
+    "nudge.common.footer": "You're receiving this because you're an admin of {org_name}.",
+
+    # -- activation --------------------------------------------------------
+    "nudge.activation.first_course_d1.subject": "Your first course on {org_name}",
+    "nudge.activation.first_course_d1.heading": "Ready when you are",
+    "nudge.activation.first_course_d1.body": "{org_name} is set up and waiting for its first course. Most people start small — one topic, a few lessons. You can always add to it later.",
+    "nudge.activation.first_course_d1.cta": "Create your first course",
+
+    "nudge.activation.come_back_d2.subject": "Picking up where you left off",
+    "nudge.activation.come_back_d2.heading": "Your setup is still waiting",
+    "nudge.activation.come_back_d2.body": "You set up {org_name} and haven't been back since. Everything is still there, and getting a first course in place takes about ten minutes.",
+    "nudge.activation.come_back_d2.cta": "Go to your dashboard",
+
+    "nudge.activation.ai_course_help_d4.subject": "The blank page is the hard part",
+    "nudge.activation.ai_course_help_d4.heading": "Let AI write the outline",
+    "nudge.activation.ai_course_help_d4.body": "If {org_name} is still empty because you're not sure where to start, describe your topic and AI will draft the chapters and lessons. You edit from there.",
+    "nudge.activation.ai_course_help_d4.cta": "Draft a course with AI",
+
+    "nudge.activation.import_existing_d5.subject": "Bring what you already have",
+    "nudge.activation.import_existing_d5.heading": "You don't have to start from scratch",
+    "nudge.activation.import_existing_d5.body": "If your material already exists as documents, slides or an export from another platform, you can bring it into {org_name} instead of retyping it.",
+    "nudge.activation.import_existing_d5.cta": "Import your material",
+
+    "nudge.activation.setup_checklist_d7.subject": "Fifteen minutes to a working academy",
+    "nudge.activation.setup_checklist_d7.heading": "A short checklist",
+    "nudge.activation.setup_checklist_d7.body": "{org_name} is still waiting on its first course. The setup checklist walks through it in a few short steps — most people finish in about fifteen minutes.",
+    "nudge.activation.setup_checklist_d7.cta": "Open the checklist",
+
+    "nudge.activation.whats_blocking_d14.subject": "What got in the way?",
+    "nudge.activation.whats_blocking_d14.heading": "Can we ask what stopped you?",
+    "nudge.activation.whats_blocking_d14.body": "You set up {org_name} a couple of weeks ago and haven't added a course yet. If something was confusing or missing, we'd like to know — reply to this email and it comes straight to us.",
+
+    "nudge.activation.last_call_d30.subject": "Last email about {org_name}",
+    "nudge.activation.last_call_d30.heading": "This is the last one",
+    "nudge.activation.last_call_d30.body": "{org_name} has been quiet for a month, so we'll stop sending these. Your account and everything in it stays put — if you come back, it will all be where you left it.",
+    "nudge.activation.last_call_d30.cta": "Open your dashboard",
+
+    # -- content -----------------------------------------------------------
+    "nudge.content.course_no_chapter_d1.subject": "{course_name} needs its first chapter",
+    "nudge.content.course_no_chapter_d1.heading": "One chapter to go",
+    "nudge.content.course_no_chapter_d1.body": "{course_name} exists but has no chapters yet, so there's nothing for anyone to open. Chapters are just sections — one per topic works well.",
+    "nudge.content.course_no_chapter_d1.cta": "Add a chapter",
+
+    "nudge.content.chapter_no_activity_d1.subject": "Add your first lesson to {course_name}",
+    "nudge.content.chapter_no_activity_d1.heading": "The chapters are ready",
+    "nudge.content.chapter_no_activity_d1.body": "{course_name} has chapters but nothing in them yet. A lesson can be a page of text, a video, a quiz — whatever fits the topic.",
+    "nudge.content.chapter_no_activity_d1.cta": "Add a lesson",
+
+    "nudge.content.activity_unpublished_d2.subject": "Your lessons in {course_name} aren't visible yet",
+    "nudge.content.activity_unpublished_d2.heading": "The lessons are still hidden",
+    "nudge.content.activity_unpublished_d2.body": "You've written lessons in {course_name}, but none are published, so learners see an empty course. Publishing doesn't lock anything — you can keep editing afterwards.",
+    "nudge.content.activity_unpublished_d2.cta": "Publish your lessons",
+
+    "nudge.content.course_draft_d3.subject": "{course_name} is still a draft",
+    "nudge.content.course_draft_d3.heading": "{course_name} is nearly there",
+    "nudge.content.course_draft_d3.body": "You've added lessons to {course_name}, but it isn't published yet, so nobody can open it. It doesn't need to be finished — publishing only makes it visible, and you can keep editing afterwards.",
+    "nudge.content.course_draft_d3.cta": "Publish it",
+
+    "nudge.content.course_draft_d10.subject": "{course_name} has been a draft for a while",
+    "nudge.content.course_draft_d10.heading": "It's probably ready",
+    "nudge.content.course_draft_d10.body": "{course_name} has been sitting unpublished for over a week. A course rarely feels finished — publishing makes it visible, and you can keep improving it with people already reading.",
+    "nudge.content.course_draft_d10.cta": "Publish it",
+
+    "nudge.content.thin_course_d5.subject": "{course_name} could use a little more",
+    "nudge.content.thin_course_d5.heading": "A lesson or two in",
+    "nudge.content.thin_course_d5.body": "{course_name} has a couple of lessons so far. Courses tend to land better with a handful, and AI can draft the next few from what's already there.",
+    "nudge.content.thin_course_d5.cta": "Add more lessons",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "No submissions yet in {org_name}",
+    "nudge.content.assignment_no_submissions_d5.heading": "Nobody has handed anything in",
+    "nudge.content.assignment_no_submissions_d5.body": "You set up an assignment in {org_name} but nothing has been submitted. It's worth checking that it's published and that your learners can reach the course it belongs to.",
+    "nudge.content.assignment_no_submissions_d5.cta": "Check your assignments",
+
+    # -- audience ----------------------------------------------------------
+    "nudge.audience.published_no_members_d1.subject": "{course_name} is live, but nobody's there yet",
+    "nudge.audience.published_no_members_d1.heading": "Time to invite someone",
+    "nudge.audience.published_no_members_d1.body": "{course_name} is published and ready to read. {org_name} doesn't have any learners yet, so the next step is inviting the people you wrote it for.",
+    "nudge.audience.published_no_members_d1.cta": "Invite learners",
+
+    "nudge.audience.published_no_members_d7.subject": "{course_name} still has no learners",
+    "nudge.audience.published_no_members_d7.heading": "A week live, nobody reading",
+    "nudge.audience.published_no_members_d7.body": "{course_name} has been published for a week and {org_name} still has no learners. You can invite people one by one, paste in a list, or just share the join link.",
+    "nudge.audience.published_no_members_d7.cta": "Invite people",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "Your learners haven't started yet",
+    "nudge.audience.members_no_enrollment_d3.heading": "They joined but haven't opened anything",
+    "nudge.audience.members_no_enrollment_d3.body": "People have joined {org_name} but nobody has started a course. A short message with a direct link usually does it — most people simply haven't found their way in.",
+    "nudge.audience.members_no_enrollment_d3.cta": "See your members",
+
+    "nudge.audience.share_public_page_d14.subject": "Your course page is public — here's the link",
+    "nudge.audience.share_public_page_d14.heading": "Anyone with the link can read it",
+    "nudge.audience.share_public_page_d14.body": "{course_name} is public, so you can share it anywhere without people needing an invitation first. The link below is the one to send.",
+    "nudge.audience.share_public_page_d14.cta": "View the public page",
+
+    "nudge.audience.stalled_learners_d14.subject": "Some learners stopped partway through",
+    "nudge.audience.stalled_learners_d14.heading": "A few people stalled",
+    "nudge.audience.stalled_learners_d14.body": "Some learners in {org_name} started a course and haven't come back for a couple of weeks. It's often worth a message from you, or a look at where they stopped.",
+    "nudge.audience.stalled_learners_d14.cta": "Check on your learners",
+
+    # -- monetization ------------------------------------------------------
+    "nudge.monetization.course_limit_d1.subject": "You've used every course on the {plan_name} plan",
+    "nudge.monetization.course_limit_d1.heading": "You've reached the course limit",
+    "nudge.monetization.course_limit_d1.body": "{org_name} is on the {plan_name} plan and has used every course it includes. Moving up to {next_plan} lifts that limit if you want to keep building.",
+    "nudge.monetization.course_limit_d1.cta": "See plans",
+
+    "nudge.monetization.member_limit_near.subject": "You're close to the member limit on {plan_name}",
+    "nudge.monetization.member_limit_near.heading": "Nearly at the member limit",
+    "nudge.monetization.member_limit_near.body": "{org_name} is approaching the number of members the {plan_name} plan allows. Moving to {next_plan} raises it, so nobody gets turned away partway through signing up.",
+    "nudge.monetization.member_limit_near.cta": "See plans",
+
+    "nudge.monetization.ai_credits_low.subject": "Your AI credits are nearly used up",
+    "nudge.monetization.ai_credits_low.heading": "Running low on AI credits",
+    "nudge.monetization.ai_credits_low.body": "{org_name} has used most of the AI credits included with the {plan_name} plan. The {next_plan} plan comes with more, if AI has become part of how you build courses.",
+    "nudge.monetization.ai_credits_low.cta": "See plans",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "What {next_plan} would add for {org_name}",
+    "nudge.monetization.upgrade_recap_d21.heading": "You've built something real",
+    "nudge.monetization.upgrade_recap_d21.body": "{org_name} has published courses and people reading them. The {next_plan} plan adds room to grow and a few things the {plan_name} plan doesn't include — worth a look if you're planning to expand.",
+    "nudge.monetization.upgrade_recap_d21.cta": "Compare plans",
+
+    # -- dormancy ----------------------------------------------------------
+    "nudge.dormancy.no_login_14d.subject": "{org_name} has been quiet",
+    "nudge.dormancy.no_login_14d.heading": "It's been a couple of weeks",
+    "nudge.dormancy.no_login_14d.body": "Nothing has changed in {org_name} since you were last here. If you were in the middle of something, it's still exactly where you left it.",
+    "nudge.dormancy.no_login_14d.cta": "Open your dashboard",
+
+    "nudge.dormancy.no_login_30d.subject": "Your courses on {org_name} are still here",
+    "nudge.dormancy.no_login_30d.heading": "It's been a few weeks",
+    "nudge.dormancy.no_login_30d.body": "Nothing has changed while you were away — {org_name} and everything in it is exactly where you left it. Picking it back up takes one click.",
+    "nudge.dormancy.no_login_30d.cta": "Open your dashboard",
+
+    "nudge.dormancy.no_login_60d.subject": "Last check-in about {org_name}",
+    "nudge.dormancy.no_login_60d.heading": "We'll leave you to it",
+    "nudge.dormancy.no_login_60d.body": "{org_name} has been quiet for a couple of months, so this is the last of these for now. Everything you built stays exactly as it is, for whenever you want it.",
+    "nudge.dormancy.no_login_60d.cta": "Open your dashboard",
+
+    "nudge.dormancy.winback_q.subject": "What's new since you were last in {org_name}",
+    "nudge.dormancy.winback_q.heading": "A few things have changed",
+    "nudge.dormancy.winback_q.body": "It's been a while since you were in {org_name}. The product has moved on a fair bit since then, and everything you built is still there.",
+    "nudge.dormancy.winback_q.cta": "Take a look",
+
+    # -- milestone ---------------------------------------------------------
+    "nudge.milestone.first_course_published.subject": "{course_name} is live",
+    "nudge.milestone.first_course_published.heading": "You published your first course",
+    "nudge.milestone.first_course_published.body": "{course_name} is live and readable. The next thing that makes a difference is having someone to read it — even one or two people to start.",
+    "nudge.milestone.first_course_published.cta": "Invite your first learners",
+
+    "nudge.milestone.first_learner_enrolled.subject": "Someone started {course_name}",
+    "nudge.milestone.first_learner_enrolled.heading": "Your first learner is in",
+    "nudge.milestone.first_learner_enrolled.body": "Someone has started a course in {org_name} for the first time. You can follow how they're getting on from your dashboard.",
+    "nudge.milestone.first_learner_enrolled.cta": "See their progress",
+
+    "nudge.milestone.first_completion.subject": "Someone finished a course in {org_name}",
+    "nudge.milestone.first_completion.heading": "First completion",
+    "nudge.milestone.first_completion.body": "A learner has finished a course in {org_name} end to end. If you want to mark that properly you can add a certificate — or start building what comes next.",
+    "nudge.milestone.first_completion.cta": "Open your dashboard",
+}

--- a/apps/api/src/services/email/nudge_translations/en.py
+++ b/apps/api/src/services/email/nudge_translations/en.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "Unsubscribe from these emails",
     "nudge.common.footer": "You're receiving this because you're an admin of {org_name}.",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "Courses",
+    "nudge.stat.chapters": "Chapters",
+    "nudge.stat.lessons": "Lessons",
+    "nudge.stat.members": "Members",
+    "nudge.stat.learners": "Learners",
+    "nudge.stat.completed": "Completed",
+
     # -- activation --------------------------------------------------------
     "nudge.activation.first_course_d1.subject": "Your first course on {org_name}",
     "nudge.activation.first_course_d1.heading": "Ready when you are",
@@ -158,4 +167,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "First completion",
     "nudge.milestone.first_completion.body": "A learner has finished a course in {org_name} end to end. If you want to mark that properly you can add a certificate — or start building what comes next.",
     "nudge.milestone.first_completion.cta": "Open your dashboard",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "Your academy on {org_name} is still here",
+    "nudge.reactivation.opener.heading": "Still here, exactly as you left it",
+    "nudge.reactivation.opener.body": "Nobody has touched {org_name} since you were last in — every course, chapter and lesson is where you left it. If you want to pick it up again, it takes one click.",
+    "nudge.reactivation.opener.cta": "Open your dashboard",
+    "nudge.reactivation.whats_changed.subject": "A few things have changed on LearnHouse",
+    "nudge.reactivation.whats_changed.heading": "Since you were last here",
+    "nudge.reactivation.whats_changed.body": "The product has moved on a fair bit while {org_name} has been quiet — the editor, the course tools and how learners work through material have all had real work. Everything you built still works exactly as before.",
+    "nudge.reactivation.whats_changed.cta": "See what's new",
+    "nudge.reactivation.need_a_hand.subject": "Need a hand getting back into {org_name}?",
+    "nudge.reactivation.need_a_hand.heading": "Is there something in the way?",
+    "nudge.reactivation.need_a_hand.body": "If there was a reason {org_name} stalled — something confusing, something missing, or just no time — we'd genuinely like to hear it. Reply to this email and it comes straight to us.",
+    "nudge.reactivation.closing.subject": "Last note about {org_name}",
+    "nudge.reactivation.closing.heading": "We'll stop here",
+    "nudge.reactivation.closing.body": "This is the last of these. {org_name} stays exactly as it is, and nothing expires — if you ever want to come back, everything will be waiting.",
+    "nudge.reactivation.closing.cta": "Open your dashboard",
 }

--- a/apps/api/src/services/email/nudge_translations/es.py
+++ b/apps/api/src/services/email/nudge_translations/es.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "Cancelar la suscripción a estos correos",
     "nudge.common.footer": "Recibes este correo porque eres administrador de {org_name}.",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "Cursos",
+    "nudge.stat.chapters": "Capítulos",
+    "nudge.stat.lessons": "Lecciones",
+    "nudge.stat.members": "Miembros",
+    "nudge.stat.learners": "Estudiantes",
+    "nudge.stat.completed": "Completados",
+
     "nudge.activation.first_course_d1.subject": "Tu primer curso en {org_name}",
     "nudge.activation.first_course_d1.heading": "Cuando quieras",
     "nudge.activation.first_course_d1.body": "{org_name} está listo y esperando su primer curso. La mayoría empieza con poco: un tema, unas cuantas lecciones. Siempre puedes ampliarlo después.",
@@ -152,4 +161,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "Primera finalización",
     "nudge.milestone.first_completion.body": "Un estudiante ha terminado un curso de {org_name} de principio a fin. Si quieres dejar constancia, puedes añadir un certificado, o empezar a preparar lo siguiente.",
     "nudge.milestone.first_completion.cta": "Abrir tu panel",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "Tu academia en {org_name} sigue aquí",
+    "nudge.reactivation.opener.heading": "Sigue aquí, tal como la dejaste",
+    "nudge.reactivation.opener.body": "Nadie ha tocado {org_name} desde tu última visita: cada curso, capítulo y lección está donde lo dejaste. Retomarlo es cuestión de un clic.",
+    "nudge.reactivation.opener.cta": "Abrir tu panel",
+    "nudge.reactivation.whats_changed.subject": "Han cambiado algunas cosas en LearnHouse",
+    "nudge.reactivation.whats_changed.heading": "Desde tu última visita",
+    "nudge.reactivation.whats_changed.body": "El producto ha avanzado bastante mientras {org_name} estaba en pausa: el editor, las herramientas de cursos y el recorrido de los estudiantes se han trabajado a fondo. Todo lo que creaste funciona igual que antes.",
+    "nudge.reactivation.whats_changed.cta": "Ver las novedades",
+    "nudge.reactivation.need_a_hand.subject": "¿Te echamos una mano para volver a {org_name}?",
+    "nudge.reactivation.need_a_hand.heading": "¿Hubo algo que se interpuso?",
+    "nudge.reactivation.need_a_hand.body": "Si hubo un motivo por el que {org_name} se detuvo —algo confuso, algo que faltaba o simplemente falta de tiempo— nos gustaría saberlo. Responde a este correo y nos llega directamente.",
+    "nudge.reactivation.closing.subject": "Último mensaje sobre {org_name}",
+    "nudge.reactivation.closing.heading": "Lo dejamos aquí",
+    "nudge.reactivation.closing.body": "Este es el último de estos correos. {org_name} se queda exactamente como está y nada caduca: si algún día quieres volver, todo estará esperándote.",
+    "nudge.reactivation.closing.cta": "Abrir tu panel",
 }

--- a/apps/api/src/services/email/nudge_translations/es.py
+++ b/apps/api/src/services/email/nudge_translations/es.py
@@ -1,0 +1,155 @@
+"""Spanish nudge copy."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "Cancelar la suscripción a estos correos",
+    "nudge.common.footer": "Recibes este correo porque eres administrador de {org_name}.",
+
+    "nudge.activation.first_course_d1.subject": "Tu primer curso en {org_name}",
+    "nudge.activation.first_course_d1.heading": "Cuando quieras",
+    "nudge.activation.first_course_d1.body": "{org_name} está listo y esperando su primer curso. La mayoría empieza con poco: un tema, unas cuantas lecciones. Siempre puedes ampliarlo después.",
+    "nudge.activation.first_course_d1.cta": "Crear tu primer curso",
+
+    "nudge.activation.come_back_d2.subject": "Retomar donde lo dejaste",
+    "nudge.activation.come_back_d2.heading": "Tu espacio sigue esperando",
+    "nudge.activation.come_back_d2.body": "Creaste {org_name} y no has vuelto desde entonces. Todo sigue ahí, y poner un primer curso en marcha lleva unos diez minutos.",
+    "nudge.activation.come_back_d2.cta": "Ir al panel",
+
+    "nudge.activation.ai_course_help_d4.subject": "La página en blanco es lo difícil",
+    "nudge.activation.ai_course_help_d4.heading": "Deja que la IA escriba el esquema",
+    "nudge.activation.ai_course_help_d4.body": "Si {org_name} sigue vacío porque no sabes por dónde empezar, describe tu tema y la IA redactará los capítulos y las lecciones. A partir de ahí, editas tú.",
+    "nudge.activation.ai_course_help_d4.cta": "Crear un curso con IA",
+
+    "nudge.activation.import_existing_d5.subject": "Trae lo que ya tienes",
+    "nudge.activation.import_existing_d5.heading": "No hace falta empezar de cero",
+    "nudge.activation.import_existing_d5.body": "Si tu material ya existe como documentos, diapositivas o una exportación de otra plataforma, puedes traerlo a {org_name} en lugar de volver a escribirlo.",
+    "nudge.activation.import_existing_d5.cta": "Importar tu material",
+
+    "nudge.activation.setup_checklist_d7.subject": "Quince minutos para una academia lista",
+    "nudge.activation.setup_checklist_d7.heading": "Una lista breve",
+    "nudge.activation.setup_checklist_d7.body": "{org_name} sigue esperando su primer curso. La lista de configuración te guía en unos pocos pasos; la mayoría termina en un cuarto de hora.",
+    "nudge.activation.setup_checklist_d7.cta": "Abrir la lista",
+
+    "nudge.activation.whats_blocking_d14.subject": "¿Qué se interpuso?",
+    "nudge.activation.whats_blocking_d14.heading": "¿Podemos preguntarte qué te detuvo?",
+    "nudge.activation.whats_blocking_d14.body": "Creaste {org_name} hace un par de semanas y aún no has añadido un curso. Si algo resultó confuso o faltaba, nos gustaría saberlo: responde a este correo y nos llega directamente.",
+
+    "nudge.activation.last_call_d30.subject": "Último correo sobre {org_name}",
+    "nudge.activation.last_call_d30.heading": "Este es el último",
+    "nudge.activation.last_call_d30.body": "{org_name} lleva un mes en silencio, así que dejaremos de enviar estos correos. Tu cuenta y todo lo que contiene se queda igual: si vuelves, lo encontrarás donde lo dejaste.",
+    "nudge.activation.last_call_d30.cta": "Abrir tu panel",
+
+    "nudge.content.course_no_chapter_d1.subject": "{course_name} necesita su primer capítulo",
+    "nudge.content.course_no_chapter_d1.heading": "Falta un capítulo",
+    "nudge.content.course_no_chapter_d1.body": "{course_name} existe pero aún no tiene capítulos, así que no hay nada que abrir. Los capítulos son simplemente secciones: uno por tema funciona bien.",
+    "nudge.content.course_no_chapter_d1.cta": "Añadir un capítulo",
+
+    "nudge.content.chapter_no_activity_d1.subject": "Añade tu primera lección a {course_name}",
+    "nudge.content.chapter_no_activity_d1.heading": "Los capítulos están listos",
+    "nudge.content.chapter_no_activity_d1.body": "{course_name} tiene capítulos, pero todavía están vacíos. Una lección puede ser una página de texto, un vídeo, un cuestionario: lo que encaje con el tema.",
+    "nudge.content.chapter_no_activity_d1.cta": "Añadir una lección",
+
+    "nudge.content.activity_unpublished_d2.subject": "Tus lecciones en {course_name} aún no se ven",
+    "nudge.content.activity_unpublished_d2.heading": "Las lecciones siguen ocultas",
+    "nudge.content.activity_unpublished_d2.body": "Has escrito lecciones en {course_name}, pero ninguna está publicada, así que quien entre verá un curso vacío. Publicar no bloquea nada: puedes seguir editando.",
+    "nudge.content.activity_unpublished_d2.cta": "Publicar tus lecciones",
+
+    "nudge.content.course_draft_d3.subject": "{course_name} sigue siendo un borrador",
+    "nudge.content.course_draft_d3.heading": "{course_name} está casi listo",
+    "nudge.content.course_draft_d3.body": "Has añadido lecciones a {course_name}, pero no está publicado, así que nadie puede abrirlo. No hace falta que esté terminado: publicar solo lo hace visible, y puedes seguir editándolo.",
+    "nudge.content.course_draft_d3.cta": "Publicarlo",
+
+    "nudge.content.course_draft_d10.subject": "{course_name} lleva tiempo como borrador",
+    "nudge.content.course_draft_d10.heading": "Seguramente ya está",
+    "nudge.content.course_draft_d10.body": "{course_name} lleva más de una semana sin publicar. Un curso rara vez se siente terminado: publicarlo lo hace visible, y puedes seguir mejorándolo mientras alguien ya lo lee.",
+    "nudge.content.course_draft_d10.cta": "Publicarlo",
+
+    "nudge.content.thin_course_d5.subject": "{course_name} pide un poco más",
+    "nudge.content.thin_course_d5.heading": "Una o dos lecciones",
+    "nudge.content.thin_course_d5.body": "{course_name} tiene una o dos lecciones por ahora. Los cursos funcionan mejor con unas cuantas más, y la IA puede redactar las siguientes a partir de lo que ya hay.",
+    "nudge.content.thin_course_d5.cta": "Añadir más lecciones",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "Aún no hay entregas en {org_name}",
+    "nudge.content.assignment_no_submissions_d5.heading": "Nadie ha entregado nada",
+    "nudge.content.assignment_no_submissions_d5.body": "Creaste una tarea en {org_name} pero no se ha entregado nada. Conviene comprobar que está publicada y que tus estudiantes pueden llegar al curso al que pertenece.",
+    "nudge.content.assignment_no_submissions_d5.cta": "Revisar tus tareas",
+
+    "nudge.audience.published_no_members_d1.subject": "{course_name} está publicado, pero no hay nadie",
+    "nudge.audience.published_no_members_d1.heading": "Es momento de invitar a alguien",
+    "nudge.audience.published_no_members_d1.body": "{course_name} está publicado y listo para leer. {org_name} todavía no tiene estudiantes, así que el siguiente paso es invitar a las personas para quienes lo escribiste.",
+    "nudge.audience.published_no_members_d1.cta": "Invitar estudiantes",
+
+    "nudge.audience.published_no_members_d7.subject": "{course_name} sigue sin estudiantes",
+    "nudge.audience.published_no_members_d7.heading": "Una semana publicado y nadie lo lee",
+    "nudge.audience.published_no_members_d7.body": "{course_name} lleva una semana publicado y {org_name} sigue sin estudiantes. Puedes invitar de uno en uno, pegar una lista o simplemente compartir el enlace para unirse.",
+    "nudge.audience.published_no_members_d7.cta": "Invitar personas",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "Tus estudiantes aún no han empezado",
+    "nudge.audience.members_no_enrollment_d3.heading": "Se unieron pero no han abierto nada",
+    "nudge.audience.members_no_enrollment_d3.body": "Hay gente que se ha unido a {org_name} pero nadie ha empezado un curso. Un mensaje corto con un enlace directo suele bastar: la mayoría simplemente no ha encontrado la entrada.",
+    "nudge.audience.members_no_enrollment_d3.cta": "Ver tus miembros",
+
+    "nudge.audience.share_public_page_d14.subject": "Tu página de curso es pública: aquí tienes el enlace",
+    "nudge.audience.share_public_page_d14.heading": "Cualquiera con el enlace puede leerlo",
+    "nudge.audience.share_public_page_d14.body": "{course_name} es público, así que puedes compartirlo donde quieras sin que nadie necesite una invitación. El enlace de abajo es el que hay que enviar.",
+    "nudge.audience.share_public_page_d14.cta": "Ver la página pública",
+
+    "nudge.audience.stalled_learners_d14.subject": "Algunos estudiantes se quedaron a medias",
+    "nudge.audience.stalled_learners_d14.heading": "Unos cuantos se han detenido",
+    "nudge.audience.stalled_learners_d14.body": "Algunos estudiantes de {org_name} empezaron un curso y llevan un par de semanas sin volver. Suele ayudar un mensaje tuyo, o mirar dónde se detuvieron.",
+    "nudge.audience.stalled_learners_d14.cta": "Ver tus estudiantes",
+
+    "nudge.monetization.course_limit_d1.subject": "Has usado todos los cursos del plan {plan_name}",
+    "nudge.monetization.course_limit_d1.heading": "Has alcanzado el límite de cursos",
+    "nudge.monetization.course_limit_d1.body": "{org_name} está en el plan {plan_name} y ha usado todos los cursos que incluye. Pasar a {next_plan} elimina ese límite si quieres seguir creando.",
+    "nudge.monetization.course_limit_d1.cta": "Ver planes",
+
+    "nudge.monetization.member_limit_near.subject": "Estás cerca del límite de miembros del plan {plan_name}",
+    "nudge.monetization.member_limit_near.heading": "Casi en el límite de miembros",
+    "nudge.monetization.member_limit_near.body": "{org_name} se acerca al número de miembros que permite el plan {plan_name}. Pasar a {next_plan} lo amplía, para que nadie se quede fuera a mitad del registro.",
+    "nudge.monetization.member_limit_near.cta": "Ver planes",
+
+    "nudge.monetization.ai_credits_low.subject": "Tus créditos de IA están casi agotados",
+    "nudge.monetization.ai_credits_low.heading": "Quedan pocos créditos de IA",
+    "nudge.monetization.ai_credits_low.body": "{org_name} ha usado la mayoría de los créditos de IA incluidos en el plan {plan_name}. El plan {next_plan} incluye más, si la IA ya forma parte de cómo creas cursos.",
+    "nudge.monetization.ai_credits_low.cta": "Ver planes",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "Lo que {next_plan} aportaría a {org_name}",
+    "nudge.monetization.upgrade_recap_d21.heading": "Has construido algo sólido",
+    "nudge.monetization.upgrade_recap_d21.body": "{org_name} tiene cursos publicados y gente leyéndolos. El plan {next_plan} añade margen para crecer y algunas cosas que el plan {plan_name} no incluye: vale la pena mirarlo si piensas ampliar.",
+    "nudge.monetization.upgrade_recap_d21.cta": "Comparar planes",
+
+    "nudge.dormancy.no_login_14d.subject": "{org_name} ha estado en silencio",
+    "nudge.dormancy.no_login_14d.heading": "Han pasado un par de semanas",
+    "nudge.dormancy.no_login_14d.body": "Nada ha cambiado en {org_name} desde tu última visita. Si estabas a mitad de algo, sigue exactamente donde lo dejaste.",
+    "nudge.dormancy.no_login_14d.cta": "Abrir tu panel",
+
+    "nudge.dormancy.no_login_30d.subject": "Tus cursos en {org_name} siguen aquí",
+    "nudge.dormancy.no_login_30d.heading": "Han pasado unas semanas",
+    "nudge.dormancy.no_login_30d.body": "Nada ha cambiado mientras no estabas: {org_name} y todo lo que contiene está exactamente donde lo dejaste. Retomarlo es cuestión de un clic.",
+    "nudge.dormancy.no_login_30d.cta": "Abrir tu panel",
+
+    "nudge.dormancy.no_login_60d.subject": "Último mensaje sobre {org_name}",
+    "nudge.dormancy.no_login_60d.heading": "Te dejamos tranquilo",
+    "nudge.dormancy.no_login_60d.body": "{org_name} lleva un par de meses en silencio, así que este es el último de estos correos por ahora. Todo lo que construiste se queda tal cual, para cuando lo necesites.",
+    "nudge.dormancy.no_login_60d.cta": "Abrir tu panel",
+
+    "nudge.dormancy.winback_q.subject": "Qué hay de nuevo desde tu última visita a {org_name}",
+    "nudge.dormancy.winback_q.heading": "Han cambiado algunas cosas",
+    "nudge.dormancy.winback_q.body": "Hace tiempo que no pasas por {org_name}. El producto ha avanzado bastante desde entonces, y todo lo que construiste sigue ahí.",
+    "nudge.dormancy.winback_q.cta": "Echar un vistazo",
+
+    "nudge.milestone.first_course_published.subject": "{course_name} está publicado",
+    "nudge.milestone.first_course_published.heading": "Has publicado tu primer curso",
+    "nudge.milestone.first_course_published.body": "{course_name} está publicado y se puede leer. Lo siguiente que marca la diferencia es tener a alguien que lo lea, aunque sean una o dos personas para empezar.",
+    "nudge.milestone.first_course_published.cta": "Invitar a tus primeros estudiantes",
+
+    "nudge.milestone.first_learner_enrolled.subject": "Alguien ha empezado {course_name}",
+    "nudge.milestone.first_learner_enrolled.heading": "Tu primer estudiante ya está dentro",
+    "nudge.milestone.first_learner_enrolled.body": "Por primera vez alguien ha empezado un curso en {org_name}. Puedes seguir cómo le va desde tu panel.",
+    "nudge.milestone.first_learner_enrolled.cta": "Ver su progreso",
+
+    "nudge.milestone.first_completion.subject": "Alguien ha terminado un curso en {org_name}",
+    "nudge.milestone.first_completion.heading": "Primera finalización",
+    "nudge.milestone.first_completion.body": "Un estudiante ha terminado un curso de {org_name} de principio a fin. Si quieres dejar constancia, puedes añadir un certificado, o empezar a preparar lo siguiente.",
+    "nudge.milestone.first_completion.cta": "Abrir tu panel",
+}

--- a/apps/api/src/services/email/nudge_translations/fr.py
+++ b/apps/api/src/services/email/nudge_translations/fr.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "Se désabonner de ces e-mails",
     "nudge.common.footer": "Vous recevez cet e-mail car vous êtes administrateur de {org_name}.",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "Cours",
+    "nudge.stat.chapters": "Chapitres",
+    "nudge.stat.lessons": "Leçons",
+    "nudge.stat.members": "Membres",
+    "nudge.stat.learners": "Apprenants",
+    "nudge.stat.completed": "Terminés",
+
     "nudge.activation.first_course_d1.subject": "Votre premier cours sur {org_name}",
     "nudge.activation.first_course_d1.heading": "Quand vous voulez",
     "nudge.activation.first_course_d1.body": "{org_name} est prêt et attend son premier cours. La plupart des gens commencent petit : un sujet, quelques leçons. Vous pourrez toujours compléter plus tard.",
@@ -152,4 +161,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "Première réussite",
     "nudge.milestone.first_completion.body": "Un apprenant a terminé un cours de {org_name} du début à la fin. Pour le marquer comme il se doit, vous pouvez ajouter un certificat — ou commencer à préparer la suite.",
     "nudge.milestone.first_completion.cta": "Ouvrir votre tableau de bord",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "Votre académie sur {org_name} est toujours là",
+    "nudge.reactivation.opener.heading": "Toujours là, exactement comme vous l'avez laissée",
+    "nudge.reactivation.opener.body": "Personne n'a touché à {org_name} depuis votre dernière visite : chaque cours, chapitre et leçon est resté en place. Pour reprendre, il suffit d'un clic.",
+    "nudge.reactivation.opener.cta": "Ouvrir le tableau de bord",
+    "nudge.reactivation.whats_changed.subject": "Quelques nouveautés sur LearnHouse",
+    "nudge.reactivation.whats_changed.heading": "Depuis votre dernier passage",
+    "nudge.reactivation.whats_changed.body": "Le produit a bien avancé pendant que {org_name} était en pause : l'éditeur, les outils de cours et le parcours des apprenants ont tous été retravaillés. Tout ce que vous aviez créé fonctionne comme avant.",
+    "nudge.reactivation.whats_changed.cta": "Voir les nouveautés",
+    "nudge.reactivation.need_a_hand.subject": "Besoin d'aide pour revenir sur {org_name} ?",
+    "nudge.reactivation.need_a_hand.heading": "Quelque chose vous a bloqué ?",
+    "nudge.reactivation.need_a_hand.body": "S'il y avait une raison à l'arrêt de {org_name} — quelque chose de confus, de manquant, ou simplement le manque de temps — nous aimerions vraiment le savoir. Répondez à cet e-mail, il nous parvient directement.",
+    "nudge.reactivation.closing.subject": "Dernier message au sujet de {org_name}",
+    "nudge.reactivation.closing.heading": "Nous nous arrêtons là",
+    "nudge.reactivation.closing.body": "C'est le dernier de ces e-mails. {org_name} reste exactement en l'état et rien n'expire : si vous souhaitez revenir un jour, tout vous attendra.",
+    "nudge.reactivation.closing.cta": "Ouvrir le tableau de bord",
 }

--- a/apps/api/src/services/email/nudge_translations/fr.py
+++ b/apps/api/src/services/email/nudge_translations/fr.py
@@ -1,0 +1,155 @@
+"""French nudge copy."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "Se désabonner de ces e-mails",
+    "nudge.common.footer": "Vous recevez cet e-mail car vous êtes administrateur de {org_name}.",
+
+    "nudge.activation.first_course_d1.subject": "Votre premier cours sur {org_name}",
+    "nudge.activation.first_course_d1.heading": "Quand vous voulez",
+    "nudge.activation.first_course_d1.body": "{org_name} est prêt et attend son premier cours. La plupart des gens commencent petit : un sujet, quelques leçons. Vous pourrez toujours compléter plus tard.",
+    "nudge.activation.first_course_d1.cta": "Créer votre premier cours",
+
+    "nudge.activation.come_back_d2.subject": "Reprendre là où vous en étiez",
+    "nudge.activation.come_back_d2.heading": "Votre espace vous attend",
+    "nudge.activation.come_back_d2.body": "Vous avez créé {org_name} et n'y êtes pas revenu depuis. Tout est resté en place, et mettre un premier cours en ligne prend une dizaine de minutes.",
+    "nudge.activation.come_back_d2.cta": "Aller au tableau de bord",
+
+    "nudge.activation.ai_course_help_d4.subject": "La page blanche, c'est le plus dur",
+    "nudge.activation.ai_course_help_d4.heading": "Laissez l'IA écrire le plan",
+    "nudge.activation.ai_course_help_d4.body": "Si {org_name} est encore vide parce que vous ne savez pas par où commencer, décrivez votre sujet et l'IA rédigera les chapitres et les leçons. Vous reprenez ensuite la main.",
+    "nudge.activation.ai_course_help_d4.cta": "Créer un cours avec l'IA",
+
+    "nudge.activation.import_existing_d5.subject": "Apportez ce que vous avez déjà",
+    "nudge.activation.import_existing_d5.heading": "Pas besoin de repartir de zéro",
+    "nudge.activation.import_existing_d5.body": "Si vos contenus existent déjà sous forme de documents, de diapositives ou d'un export d'une autre plateforme, vous pouvez les importer dans {org_name} plutôt que de tout ressaisir.",
+    "nudge.activation.import_existing_d5.cta": "Importer vos contenus",
+
+    "nudge.activation.setup_checklist_d7.subject": "Quinze minutes pour une académie fonctionnelle",
+    "nudge.activation.setup_checklist_d7.heading": "Une courte liste d'étapes",
+    "nudge.activation.setup_checklist_d7.body": "{org_name} attend toujours son premier cours. La liste de configuration vous guide en quelques étapes — la plupart des gens terminent en un quart d'heure.",
+    "nudge.activation.setup_checklist_d7.cta": "Ouvrir la liste",
+
+    "nudge.activation.whats_blocking_d14.subject": "Qu'est-ce qui vous a bloqué ?",
+    "nudge.activation.whats_blocking_d14.heading": "Pouvons-nous vous demander ce qui vous a arrêté ?",
+    "nudge.activation.whats_blocking_d14.body": "Vous avez créé {org_name} il y a deux semaines et n'avez pas encore ajouté de cours. Si quelque chose n'était pas clair ou manquait, nous aimerions le savoir — répondez simplement à cet e-mail, il nous parvient directement.",
+
+    "nudge.activation.last_call_d30.subject": "Dernier e-mail au sujet de {org_name}",
+    "nudge.activation.last_call_d30.heading": "C'est le dernier",
+    "nudge.activation.last_call_d30.body": "{org_name} est resté silencieux pendant un mois, nous arrêtons donc ces e-mails. Votre compte et tout ce qu'il contient restent en place — si vous revenez, vous retrouverez tout tel quel.",
+    "nudge.activation.last_call_d30.cta": "Ouvrir votre tableau de bord",
+
+    "nudge.content.course_no_chapter_d1.subject": "{course_name} attend son premier chapitre",
+    "nudge.content.course_no_chapter_d1.heading": "Plus qu'un chapitre",
+    "nudge.content.course_no_chapter_d1.body": "{course_name} existe mais n'a pas encore de chapitre, il n'y a donc rien à ouvrir. Les chapitres ne sont que des sections — un par thème fonctionne bien.",
+    "nudge.content.course_no_chapter_d1.cta": "Ajouter un chapitre",
+
+    "nudge.content.chapter_no_activity_d1.subject": "Ajoutez votre première leçon à {course_name}",
+    "nudge.content.chapter_no_activity_d1.heading": "Les chapitres sont prêts",
+    "nudge.content.chapter_no_activity_d1.body": "{course_name} a des chapitres, mais ils sont encore vides. Une leçon peut être une page de texte, une vidéo, un quiz — ce qui convient au sujet.",
+    "nudge.content.chapter_no_activity_d1.cta": "Ajouter une leçon",
+
+    "nudge.content.activity_unpublished_d2.subject": "Vos leçons dans {course_name} ne sont pas encore visibles",
+    "nudge.content.activity_unpublished_d2.heading": "Les leçons sont encore masquées",
+    "nudge.content.activity_unpublished_d2.body": "Vous avez rédigé des leçons dans {course_name}, mais aucune n'est publiée : les apprenants voient un cours vide. Publier ne fige rien — vous pourrez continuer à modifier.",
+    "nudge.content.activity_unpublished_d2.cta": "Publier vos leçons",
+
+    "nudge.content.course_draft_d3.subject": "{course_name} est encore un brouillon",
+    "nudge.content.course_draft_d3.heading": "{course_name} y est presque",
+    "nudge.content.course_draft_d3.body": "Vous avez ajouté des leçons à {course_name}, mais il n'est pas publié : personne ne peut l'ouvrir. Il n'a pas besoin d'être terminé — publier le rend simplement visible, et vous pourrez continuer à le modifier.",
+    "nudge.content.course_draft_d3.cta": "Le publier",
+
+    "nudge.content.course_draft_d10.subject": "{course_name} est un brouillon depuis un moment",
+    "nudge.content.course_draft_d10.heading": "Il est sans doute prêt",
+    "nudge.content.course_draft_d10.body": "{course_name} n'est pas publié depuis plus d'une semaine. Un cours semble rarement terminé — le publier le rend visible, et vous pouvez continuer à l'améliorer pendant que des gens le lisent.",
+    "nudge.content.course_draft_d10.cta": "Le publier",
+
+    "nudge.content.thin_course_d5.subject": "{course_name} mériterait un peu plus",
+    "nudge.content.thin_course_d5.heading": "Une ou deux leçons",
+    "nudge.content.thin_course_d5.body": "{course_name} compte pour l'instant une ou deux leçons. Les cours fonctionnent mieux avec quelques-unes de plus, et l'IA peut rédiger les suivantes à partir de l'existant.",
+    "nudge.content.thin_course_d5.cta": "Ajouter des leçons",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "Aucun rendu pour l'instant dans {org_name}",
+    "nudge.content.assignment_no_submissions_d5.heading": "Personne n'a rien rendu",
+    "nudge.content.assignment_no_submissions_d5.body": "Vous avez créé un devoir dans {org_name} mais rien n'a été rendu. Vérifiez qu'il est bien publié et que vos apprenants ont accès au cours auquel il appartient.",
+    "nudge.content.assignment_no_submissions_d5.cta": "Vérifier vos devoirs",
+
+    "nudge.audience.published_no_members_d1.subject": "{course_name} est en ligne, mais personne n'est là",
+    "nudge.audience.published_no_members_d1.heading": "Il est temps d'inviter quelqu'un",
+    "nudge.audience.published_no_members_d1.body": "{course_name} est publié et prêt à être lu. {org_name} n'a encore aucun apprenant : l'étape suivante est d'inviter les personnes pour qui vous l'avez écrit.",
+    "nudge.audience.published_no_members_d1.cta": "Inviter des apprenants",
+
+    "nudge.audience.published_no_members_d7.subject": "{course_name} n'a toujours aucun apprenant",
+    "nudge.audience.published_no_members_d7.heading": "Une semaine en ligne, personne pour le lire",
+    "nudge.audience.published_no_members_d7.body": "{course_name} est publié depuis une semaine et {org_name} n'a toujours aucun apprenant. Vous pouvez inviter les gens un par un, coller une liste, ou simplement partager le lien d'inscription.",
+    "nudge.audience.published_no_members_d7.cta": "Inviter des personnes",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "Vos apprenants n'ont pas encore commencé",
+    "nudge.audience.members_no_enrollment_d3.heading": "Ils ont rejoint mais n'ont rien ouvert",
+    "nudge.audience.members_no_enrollment_d3.body": "Des personnes ont rejoint {org_name} mais personne n'a commencé de cours. Un court message avec un lien direct suffit généralement — la plupart n'ont simplement pas trouvé l'entrée.",
+    "nudge.audience.members_no_enrollment_d3.cta": "Voir vos membres",
+
+    "nudge.audience.share_public_page_d14.subject": "Votre page de cours est publique — voici le lien",
+    "nudge.audience.share_public_page_d14.heading": "Toute personne avec le lien peut lire",
+    "nudge.audience.share_public_page_d14.body": "{course_name} est public : vous pouvez le partager partout sans que personne ait besoin d'une invitation. Le lien ci-dessous est celui à envoyer.",
+    "nudge.audience.share_public_page_d14.cta": "Voir la page publique",
+
+    "nudge.audience.stalled_learners_d14.subject": "Des apprenants se sont arrêtés en chemin",
+    "nudge.audience.stalled_learners_d14.heading": "Quelques personnes sont bloquées",
+    "nudge.audience.stalled_learners_d14.body": "Des apprenants de {org_name} ont commencé un cours et ne sont pas revenus depuis deux semaines. Un message de votre part aide souvent, tout comme regarder où ils se sont arrêtés.",
+    "nudge.audience.stalled_learners_d14.cta": "Voir vos apprenants",
+
+    "nudge.monetization.course_limit_d1.subject": "Vous avez utilisé tous les cours du forfait {plan_name}",
+    "nudge.monetization.course_limit_d1.heading": "Vous avez atteint la limite de cours",
+    "nudge.monetization.course_limit_d1.body": "{org_name} est sur le forfait {plan_name} et a utilisé tous les cours qu'il comprend. Passer à {next_plan} lève cette limite si vous voulez continuer.",
+    "nudge.monetization.course_limit_d1.cta": "Voir les forfaits",
+
+    "nudge.monetization.member_limit_near.subject": "Vous approchez la limite de membres du forfait {plan_name}",
+    "nudge.monetization.member_limit_near.heading": "Bientôt à la limite de membres",
+    "nudge.monetization.member_limit_near.body": "{org_name} approche du nombre de membres autorisé par le forfait {plan_name}. Passer à {next_plan} l'augmente, pour que personne ne soit bloqué en pleine inscription.",
+    "nudge.monetization.member_limit_near.cta": "Voir les forfaits",
+
+    "nudge.monetization.ai_credits_low.subject": "Vos crédits IA sont presque épuisés",
+    "nudge.monetization.ai_credits_low.heading": "Crédits IA bientôt épuisés",
+    "nudge.monetization.ai_credits_low.body": "{org_name} a utilisé la majeure partie des crédits IA inclus dans le forfait {plan_name}. Le forfait {next_plan} en contient davantage, si l'IA fait désormais partie de votre façon de créer des cours.",
+    "nudge.monetization.ai_credits_low.cta": "Voir les forfaits",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "Ce que {next_plan} apporterait à {org_name}",
+    "nudge.monetization.upgrade_recap_d21.heading": "Vous avez construit quelque chose de solide",
+    "nudge.monetization.upgrade_recap_d21.body": "{org_name} a des cours publiés et des personnes qui les lisent. Le forfait {next_plan} offre de la marge et quelques fonctionnalités absentes du forfait {plan_name} — à regarder si vous comptez grandir.",
+    "nudge.monetization.upgrade_recap_d21.cta": "Comparer les forfaits",
+
+    "nudge.dormancy.no_login_14d.subject": "{org_name} est resté silencieux",
+    "nudge.dormancy.no_login_14d.heading": "Cela fait deux semaines",
+    "nudge.dormancy.no_login_14d.body": "Rien n'a changé dans {org_name} depuis votre dernière visite. Si vous étiez en train de faire quelque chose, tout est resté exactement là où vous l'avez laissé.",
+    "nudge.dormancy.no_login_14d.cta": "Ouvrir votre tableau de bord",
+
+    "nudge.dormancy.no_login_30d.subject": "Vos cours sur {org_name} sont toujours là",
+    "nudge.dormancy.no_login_30d.heading": "Cela fait quelques semaines",
+    "nudge.dormancy.no_login_30d.body": "Rien n'a changé pendant votre absence — {org_name} et tout ce qu'il contient sont exactement là où vous les avez laissés. Reprendre ne prend qu'un clic.",
+    "nudge.dormancy.no_login_30d.cta": "Ouvrir votre tableau de bord",
+
+    "nudge.dormancy.no_login_60d.subject": "Dernier message au sujet de {org_name}",
+    "nudge.dormancy.no_login_60d.heading": "Nous vous laissons tranquille",
+    "nudge.dormancy.no_login_60d.body": "{org_name} est silencieux depuis deux mois, c'est donc le dernier de ces e-mails pour l'instant. Tout ce que vous avez construit reste en l'état, pour le jour où vous en aurez besoin.",
+    "nudge.dormancy.no_login_60d.cta": "Ouvrir votre tableau de bord",
+
+    "nudge.dormancy.winback_q.subject": "Ce qui a changé depuis votre dernière visite sur {org_name}",
+    "nudge.dormancy.winback_q.heading": "Quelques nouveautés",
+    "nudge.dormancy.winback_q.body": "Cela fait un moment que vous n'êtes pas passé sur {org_name}. Le produit a pas mal évolué depuis, et tout ce que vous aviez construit est toujours là.",
+    "nudge.dormancy.winback_q.cta": "Y jeter un œil",
+
+    "nudge.milestone.first_course_published.subject": "{course_name} est en ligne",
+    "nudge.milestone.first_course_published.heading": "Vous avez publié votre premier cours",
+    "nudge.milestone.first_course_published.body": "{course_name} est en ligne et lisible. La suite qui change tout, c'est d'avoir quelqu'un pour le lire — même une ou deux personnes pour commencer.",
+    "nudge.milestone.first_course_published.cta": "Inviter vos premiers apprenants",
+
+    "nudge.milestone.first_learner_enrolled.subject": "Quelqu'un a commencé {course_name}",
+    "nudge.milestone.first_learner_enrolled.heading": "Votre premier apprenant est là",
+    "nudge.milestone.first_learner_enrolled.body": "Quelqu'un a commencé un cours dans {org_name} pour la première fois. Vous pouvez suivre sa progression depuis votre tableau de bord.",
+    "nudge.milestone.first_learner_enrolled.cta": "Voir sa progression",
+
+    "nudge.milestone.first_completion.subject": "Quelqu'un a terminé un cours dans {org_name}",
+    "nudge.milestone.first_completion.heading": "Première réussite",
+    "nudge.milestone.first_completion.body": "Un apprenant a terminé un cours de {org_name} du début à la fin. Pour le marquer comme il se doit, vous pouvez ajouter un certificat — ou commencer à préparer la suite.",
+    "nudge.milestone.first_completion.cta": "Ouvrir votre tableau de bord",
+}

--- a/apps/api/src/services/email/nudge_translations/hi.py
+++ b/apps/api/src/services/email/nudge_translations/hi.py
@@ -1,0 +1,155 @@
+"""Hindi nudge copy."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "इन ईमेल की सदस्यता समाप्त करें",
+    "nudge.common.footer": "आपको यह ईमेल इसलिए मिला है क्योंकि आप {org_name} के व्यवस्थापक हैं।",
+
+    "nudge.activation.first_course_d1.subject": "{org_name} पर आपका पहला कोर्स",
+    "nudge.activation.first_course_d1.heading": "जब आप तैयार हों",
+    "nudge.activation.first_course_d1.body": "{org_name} तैयार है और अपने पहले कोर्स का इंतज़ार कर रही है। ज़्यादातर लोग छोटे से शुरू करते हैं: एक विषय, कुछ पाठ। आगे जोड़ते रहना हमेशा संभव है।",
+    "nudge.activation.first_course_d1.cta": "अपना पहला कोर्स बनाएँ",
+
+    "nudge.activation.come_back_d2.subject": "जहाँ छोड़ा था, वहीं से आगे",
+    "nudge.activation.come_back_d2.heading": "आपका सेटअप अब भी तैयार है",
+    "nudge.activation.come_back_d2.body": "आपने {org_name} बनाई और उसके बाद लौटे नहीं। सब कुछ वैसा ही है, और पहला कोर्स प्रकाशित करने में लगभग दस मिनट लगते हैं।",
+    "nudge.activation.come_back_d2.cta": "डैशबोर्ड पर जाएँ",
+
+    "nudge.activation.ai_course_help_d4.subject": "खाली पन्ना ही सबसे मुश्किल है",
+    "nudge.activation.ai_course_help_d4.heading": "रूपरेखा AI को लिखने दें",
+    "nudge.activation.ai_course_help_d4.body": "अगर {org_name} अब भी खाली है क्योंकि शुरुआत कहाँ से करें यह तय नहीं हो रहा, तो बस विषय बताइए और AI अध्याय और पाठ का मसौदा बना देगा। संपादन आपका।",
+    "nudge.activation.ai_course_help_d4.cta": "AI से कोर्स बनाएँ",
+
+    "nudge.activation.import_existing_d5.subject": "जो पहले से है, उसे ले आइए",
+    "nudge.activation.import_existing_d5.heading": "शून्य से शुरू करना ज़रूरी नहीं",
+    "nudge.activation.import_existing_d5.body": "अगर आपकी सामग्री पहले से दस्तावेज़, स्लाइड या किसी और प्लेटफ़ॉर्म के निर्यात के रूप में मौजूद है, तो उसे दोबारा टाइप करने के बजाय {org_name} में ला सकते हैं।",
+    "nudge.activation.import_existing_d5.cta": "अपनी सामग्री आयात करें",
+
+    "nudge.activation.setup_checklist_d7.subject": "पंद्रह मिनट में चलती-फिरती अकादमी",
+    "nudge.activation.setup_checklist_d7.heading": "एक छोटी सूची",
+    "nudge.activation.setup_checklist_d7.body": "{org_name} अब भी पहले कोर्स का इंतज़ार कर रही है। सेटअप सूची कुछ छोटे चरणों में रास्ता दिखाती है — ज़्यादातर लोग पंद्रह मिनट में पूरा कर लेते हैं।",
+    "nudge.activation.setup_checklist_d7.cta": "सूची खोलें",
+
+    "nudge.activation.whats_blocking_d14.subject": "बीच में क्या आ गया?",
+    "nudge.activation.whats_blocking_d14.heading": "पूछ सकते हैं कि किस वजह से रुक गए?",
+    "nudge.activation.whats_blocking_d14.body": "आपने {org_name} दो हफ़्ते पहले बनाई थी और अब तक कोई कोर्स नहीं जोड़ा। अगर कुछ उलझन भरा था या कुछ कमी रह गई, तो हम जानना चाहेंगे — इस ईमेल का जवाब दीजिए, वह सीधे हम तक पहुँचता है।",
+
+    "nudge.activation.last_call_d30.subject": "{org_name} के बारे में आखिरी ईमेल",
+    "nudge.activation.last_call_d30.heading": "यह आखिरी है",
+    "nudge.activation.last_call_d30.body": "{org_name} एक महीने से शांत है, इसलिए हम ये ईमेल भेजना बंद कर रहे हैं। आपका खाता और उसमें सब कुछ वैसा ही रहेगा — लौटेंगे तो सब जहाँ छोड़ा था वहीं मिलेगा।",
+    "nudge.activation.last_call_d30.cta": "अपना डैशबोर्ड खोलें",
+
+    "nudge.content.course_no_chapter_d1.subject": "«{course_name}» को पहला अध्याय चाहिए",
+    "nudge.content.course_no_chapter_d1.heading": "बस एक अध्याय बाकी",
+    "nudge.content.course_no_chapter_d1.body": "«{course_name}» बन चुका है पर अभी कोई अध्याय नहीं है, इसलिए खोलने को कुछ नहीं। अध्याय बस खंड होते हैं — एक विषय पर एक अच्छा रहता है।",
+    "nudge.content.course_no_chapter_d1.cta": "अध्याय जोड़ें",
+
+    "nudge.content.chapter_no_activity_d1.subject": "«{course_name}» में पहला पाठ जोड़ें",
+    "nudge.content.chapter_no_activity_d1.heading": "अध्याय तैयार हैं",
+    "nudge.content.chapter_no_activity_d1.body": "«{course_name}» में अध्याय हैं, पर वे अभी खाली हैं। पाठ एक पन्ना लेख, वीडियो या क्विज़ हो सकता है — जो विषय के अनुकूल हो।",
+    "nudge.content.chapter_no_activity_d1.cta": "पाठ जोड़ें",
+
+    "nudge.content.activity_unpublished_d2.subject": "«{course_name}» के आपके पाठ अभी दिख नहीं रहे",
+    "nudge.content.activity_unpublished_d2.heading": "पाठ अब भी छिपे हैं",
+    "nudge.content.activity_unpublished_d2.body": "आपने «{course_name}» में पाठ लिखे हैं, पर कोई प्रकाशित नहीं है, इसलिए सीखने वालों को खाली कोर्स दिखता है। प्रकाशित करने से कुछ लॉक नहीं होता — बाद में भी संपादन कर सकते हैं।",
+    "nudge.content.activity_unpublished_d2.cta": "अपने पाठ प्रकाशित करें",
+
+    "nudge.content.course_draft_d3.subject": "«{course_name}» अब भी ड्राफ़्ट है",
+    "nudge.content.course_draft_d3.heading": "«{course_name}» लगभग तैयार है",
+    "nudge.content.course_draft_d3.body": "आपने «{course_name}» में पाठ जोड़े हैं, पर वह प्रकाशित नहीं है, इसलिए कोई खोल नहीं सकता। पूरा होना ज़रूरी नहीं — प्रकाशित करना बस उसे दृश्य बनाता है, और उसके बाद भी संपादन चलता रहता है।",
+    "nudge.content.course_draft_d3.cta": "प्रकाशित करें",
+
+    "nudge.content.course_draft_d10.subject": "«{course_name}» काफ़ी समय से ड्राफ़्ट है",
+    "nudge.content.course_draft_d10.heading": "शायद यह तैयार है",
+    "nudge.content.course_draft_d10.body": "«{course_name}» एक हफ़्ते से ज़्यादा से अप्रकाशित पड़ा है। कोर्स शायद ही कभी पूरा लगता है — प्रकाशित करने से वह दिखने लगता है, और पढ़ने वालों के रहते भी आप उसे बेहतर करते रह सकते हैं।",
+    "nudge.content.course_draft_d10.cta": "प्रकाशित करें",
+
+    "nudge.content.thin_course_d5.subject": "«{course_name}» में थोड़ा और जोड़ा जा सकता है",
+    "nudge.content.thin_course_d5.heading": "एक-दो पाठ",
+    "nudge.content.thin_course_d5.body": "«{course_name}» में अभी एक-दो पाठ हैं। कुछ और पाठों के साथ कोर्स बेहतर बैठते हैं, और AI मौजूदा सामग्री से अगले पाठों का मसौदा बना सकता है।",
+    "nudge.content.thin_course_d5.cta": "और पाठ जोड़ें",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "{org_name} में अभी कोई जमा नहीं हुआ",
+    "nudge.content.assignment_no_submissions_d5.heading": "किसी ने कुछ जमा नहीं किया",
+    "nudge.content.assignment_no_submissions_d5.body": "आपने {org_name} में असाइनमेंट बनाया था, पर कुछ जमा नहीं हुआ। देख लीजिए कि वह प्रकाशित है या नहीं और सीखने वाले संबंधित कोर्स तक पहुँच पा रहे हैं या नहीं।",
+    "nudge.content.assignment_no_submissions_d5.cta": "अपने असाइनमेंट देखें",
+
+    "nudge.audience.published_no_members_d1.subject": "«{course_name}» प्रकाशित है, पर वहाँ कोई नहीं",
+    "nudge.audience.published_no_members_d1.heading": "किसी को बुलाने का समय",
+    "nudge.audience.published_no_members_d1.body": "«{course_name}» प्रकाशित है और पढ़ने के लिए तैयार। {org_name} में अभी कोई सीखने वाला नहीं है, इसलिए अगला कदम है उन लोगों को बुलाना जिनके लिए आपने इसे लिखा।",
+    "nudge.audience.published_no_members_d1.cta": "सीखने वालों को आमंत्रित करें",
+
+    "nudge.audience.published_no_members_d7.subject": "«{course_name}» में अब भी कोई सीखने वाला नहीं",
+    "nudge.audience.published_no_members_d7.heading": "एक हफ़्ता हो गया, कोई पढ़ नहीं रहा",
+    "nudge.audience.published_no_members_d7.body": "«{course_name}» को प्रकाशित हुए एक हफ़्ता हो गया और {org_name} में अब भी कोई सीखने वाला नहीं है। एक-एक करके बुला सकते हैं, सूची चिपका सकते हैं, या बस जुड़ने का लिंक साझा कर सकते हैं।",
+    "nudge.audience.published_no_members_d7.cta": "लोगों को आमंत्रित करें",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "आपके सीखने वालों ने अभी शुरुआत नहीं की",
+    "nudge.audience.members_no_enrollment_d3.heading": "जुड़ गए, पर कुछ खोला नहीं",
+    "nudge.audience.members_no_enrollment_d3.body": "लोग {org_name} से जुड़े हैं, पर किसी ने कोर्स शुरू नहीं किया। सीधे लिंक के साथ एक छोटा संदेश आम तौर पर काम कर जाता है — ज़्यादातर को बस रास्ता नहीं मिला।",
+    "nudge.audience.members_no_enrollment_d3.cta": "अपने सदस्य देखें",
+
+    "nudge.audience.share_public_page_d14.subject": "आपका कोर्स पेज सार्वजनिक है — लिंक यह रहा",
+    "nudge.audience.share_public_page_d14.heading": "लिंक वाला कोई भी पढ़ सकता है",
+    "nudge.audience.share_public_page_d14.body": "«{course_name}» सार्वजनिक है, इसलिए आप उसे कहीं भी साझा कर सकते हैं और किसी को आमंत्रण की ज़रूरत नहीं। नीचे दिया लिंक वही है जो भेजना है।",
+    "nudge.audience.share_public_page_d14.cta": "सार्वजनिक पेज देखें",
+
+    "nudge.audience.stalled_learners_d14.subject": "कुछ सीखने वाले बीच में रुक गए",
+    "nudge.audience.stalled_learners_d14.heading": "कुछ लोग अटक गए हैं",
+    "nudge.audience.stalled_learners_d14.body": "{org_name} के कुछ सीखने वालों ने कोर्स शुरू किया था और दो हफ़्ते से लौटे नहीं। आपकी ओर से एक संदेश अक्सर काम करता है, और यह देखना भी कि वे कहाँ रुके।",
+    "nudge.audience.stalled_learners_d14.cta": "अपने सीखने वालों को देखें",
+
+    "nudge.monetization.course_limit_d1.subject": "आपने {plan_name} योजना के सारे कोर्स इस्तेमाल कर लिए",
+    "nudge.monetization.course_limit_d1.heading": "आप कोर्स की सीमा तक पहुँच गए",
+    "nudge.monetization.course_limit_d1.body": "{org_name} {plan_name} योजना पर है और उसमें शामिल सारे कोर्स इस्तेमाल हो चुके हैं। आगे बनाते रहना है तो {next_plan} पर जाने से यह सीमा हट जाती है।",
+    "nudge.monetization.course_limit_d1.cta": "योजनाएँ देखें",
+
+    "nudge.monetization.member_limit_near.subject": "आप {plan_name} योजना की सदस्य सीमा के पास हैं",
+    "nudge.monetization.member_limit_near.heading": "सदस्य सीमा लगभग पूरी",
+    "nudge.monetization.member_limit_near.body": "{org_name} उस सदस्य संख्या के पास पहुँच रही है जिसकी {plan_name} योजना अनुमति देती है। {next_plan} पर जाने से वह बढ़ जाती है, ताकि कोई साइन-अप के बीच में न रुके।",
+    "nudge.monetization.member_limit_near.cta": "योजनाएँ देखें",
+
+    "nudge.monetization.ai_credits_low.subject": "आपके AI क्रेडिट लगभग खत्म हैं",
+    "nudge.monetization.ai_credits_low.heading": "AI क्रेडिट कम बचे हैं",
+    "nudge.monetization.ai_credits_low.body": "{org_name} ने {plan_name} योजना में शामिल AI क्रेडिट का ज़्यादातर हिस्सा इस्तेमाल कर लिया है। अगर AI आपके कोर्स बनाने का हिस्सा बन चुका है, तो {next_plan} योजना में और ज़्यादा मिलते हैं।",
+    "nudge.monetization.ai_credits_low.cta": "योजनाएँ देखें",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "{next_plan} {org_name} में क्या जोड़ेगी",
+    "nudge.monetization.upgrade_recap_d21.heading": "आपने कुछ ठोस बनाया है",
+    "nudge.monetization.upgrade_recap_d21.body": "{org_name} में प्रकाशित कोर्स हैं और उन्हें पढ़ने वाले लोग भी। {next_plan} योजना बढ़ने की गुंजाइश देती है और उसमें कुछ ऐसा है जो {plan_name} योजना में नहीं — विस्तार की सोच रहे हैं तो देखने लायक है।",
+    "nudge.monetization.upgrade_recap_d21.cta": "योजनाओं की तुलना करें",
+
+    "nudge.dormancy.no_login_14d.subject": "{org_name} शांत रही है",
+    "nudge.dormancy.no_login_14d.heading": "दो हफ़्ते बीत गए",
+    "nudge.dormancy.no_login_14d.body": "आपकी पिछली बार आने के बाद से {org_name} में कुछ नहीं बदला। अगर आप किसी काम के बीच में थे, तो वह ठीक वहीं है जहाँ छोड़ा था।",
+    "nudge.dormancy.no_login_14d.cta": "अपना डैशबोर्ड खोलें",
+
+    "nudge.dormancy.no_login_30d.subject": "{org_name} पर आपके कोर्स अब भी यहीं हैं",
+    "nudge.dormancy.no_login_30d.heading": "कुछ हफ़्ते बीत गए",
+    "nudge.dormancy.no_login_30d.body": "आपकी अनुपस्थिति में कुछ नहीं बदला — {org_name} और उसमें सब कुछ ठीक वहीं है जहाँ आपने छोड़ा था। दोबारा शुरू करना एक क्लिक का काम है।",
+    "nudge.dormancy.no_login_30d.cta": "अपना डैशबोर्ड खोलें",
+
+    "nudge.dormancy.no_login_60d.subject": "{org_name} के बारे में आखिरी संदेश",
+    "nudge.dormancy.no_login_60d.heading": "अब हम आपको परेशान नहीं करेंगे",
+    "nudge.dormancy.no_login_60d.body": "{org_name} दो महीने से शांत है, इसलिए फ़िलहाल यह इस तरह का आखिरी ईमेल है। आपने जो बनाया वह वैसा ही रहेगा, जब भी ज़रूरत हो।",
+    "nudge.dormancy.no_login_60d.cta": "अपना डैशबोर्ड खोलें",
+
+    "nudge.dormancy.winback_q.subject": "{org_name} में आपकी पिछली बार के बाद क्या नया है",
+    "nudge.dormancy.winback_q.heading": "कुछ चीज़ें बदली हैं",
+    "nudge.dormancy.winback_q.body": "{org_name} में आए हुए आपको काफ़ी समय हो गया। तब से उत्पाद काफ़ी आगे बढ़ा है, और आपने जो बनाया वह सब अब भी वहीं है।",
+    "nudge.dormancy.winback_q.cta": "एक नज़र डालें",
+
+    "nudge.milestone.first_course_published.subject": "«{course_name}» प्रकाशित हो गया",
+    "nudge.milestone.first_course_published.heading": "आपने अपना पहला कोर्स प्रकाशित किया",
+    "nudge.milestone.first_course_published.body": "«{course_name}» प्रकाशित है और पढ़ा जा सकता है। अब फ़र्क यह पड़ता है कि कोई उसे पढ़े — शुरुआत में एक-दो लोग भी काफ़ी हैं।",
+    "nudge.milestone.first_course_published.cta": "अपने पहले सीखने वालों को बुलाएँ",
+
+    "nudge.milestone.first_learner_enrolled.subject": "किसी ने «{course_name}» शुरू किया",
+    "nudge.milestone.first_learner_enrolled.heading": "आपका पहला सीखने वाला आ गया",
+    "nudge.milestone.first_learner_enrolled.body": "{org_name} में पहली बार किसी ने कोर्स शुरू किया है। उनकी प्रगति आप डैशबोर्ड से देख सकते हैं।",
+    "nudge.milestone.first_learner_enrolled.cta": "प्रगति देखें",
+
+    "nudge.milestone.first_completion.subject": "किसी ने {org_name} का एक कोर्स पूरा किया",
+    "nudge.milestone.first_completion.heading": "पहली बार कोर्स पूरा हुआ",
+    "nudge.milestone.first_completion.body": "एक सीखने वाले ने {org_name} का कोर्स शुरू से अंत तक पूरा किया। इसे ठीक से दर्ज करना हो तो प्रमाणपत्र जोड़ सकते हैं — या अगला कोर्स बनाना शुरू कर सकते हैं।",
+    "nudge.milestone.first_completion.cta": "अपना डैशबोर्ड खोलें",
+}

--- a/apps/api/src/services/email/nudge_translations/hi.py
+++ b/apps/api/src/services/email/nudge_translations/hi.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "इन ईमेल की सदस्यता समाप्त करें",
     "nudge.common.footer": "आपको यह ईमेल इसलिए मिला है क्योंकि आप {org_name} के व्यवस्थापक हैं।",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "कोर्स",
+    "nudge.stat.chapters": "अध्याय",
+    "nudge.stat.lessons": "पाठ",
+    "nudge.stat.members": "सदस्य",
+    "nudge.stat.learners": "शिक्षार्थी",
+    "nudge.stat.completed": "पूर्ण",
+
     "nudge.activation.first_course_d1.subject": "{org_name} पर आपका पहला कोर्स",
     "nudge.activation.first_course_d1.heading": "जब आप तैयार हों",
     "nudge.activation.first_course_d1.body": "{org_name} तैयार है और अपने पहले कोर्स का इंतज़ार कर रही है। ज़्यादातर लोग छोटे से शुरू करते हैं: एक विषय, कुछ पाठ। आगे जोड़ते रहना हमेशा संभव है।",
@@ -152,4 +161,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "पहली बार कोर्स पूरा हुआ",
     "nudge.milestone.first_completion.body": "एक सीखने वाले ने {org_name} का कोर्स शुरू से अंत तक पूरा किया। इसे ठीक से दर्ज करना हो तो प्रमाणपत्र जोड़ सकते हैं — या अगला कोर्स बनाना शुरू कर सकते हैं।",
     "nudge.milestone.first_completion.cta": "अपना डैशबोर्ड खोलें",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "{org_name} पर आपकी अकादमी अब भी यहीं है",
+    "nudge.reactivation.opener.heading": "वैसी ही, जैसी आपने छोड़ी थी",
+    "nudge.reactivation.opener.body": "आपकी पिछली बार के बाद {org_name} को किसी ने नहीं छुआ — हर कोर्स, अध्याय और पाठ वहीं है जहाँ आपने छोड़ा था। दोबारा शुरू करना एक क्लिक का काम है।",
+    "nudge.reactivation.opener.cta": "अपना डैशबोर्ड खोलें",
+    "nudge.reactivation.whats_changed.subject": "LearnHouse में कुछ चीज़ें बदली हैं",
+    "nudge.reactivation.whats_changed.heading": "आपकी पिछली बार के बाद",
+    "nudge.reactivation.whats_changed.body": "{org_name} के शांत रहते हुए उत्पाद काफ़ी आगे बढ़ा है: एडिटर, कोर्स के उपकरण और सीखने वालों का रास्ता — सब पर असली काम हुआ है। आपने जो बनाया वह पहले जैसा ही चलता है।",
+    "nudge.reactivation.whats_changed.cta": "नया क्या है देखें",
+    "nudge.reactivation.need_a_hand.subject": "{org_name} पर लौटने में मदद चाहिए?",
+    "nudge.reactivation.need_a_hand.heading": "कुछ रास्ते में आ गया था?",
+    "nudge.reactivation.need_a_hand.body": "अगर {org_name} के रुकने की कोई वजह थी — कुछ उलझन भरा, कुछ कमी, या बस समय की कमी — तो हम सचमुच जानना चाहेंगे। इस ईमेल का जवाब दीजिए, वह सीधे हम तक पहुँचता है।",
+    "nudge.reactivation.closing.subject": "{org_name} के बारे में आखिरी बात",
+    "nudge.reactivation.closing.heading": "हम यहीं रुकते हैं",
+    "nudge.reactivation.closing.body": "यह इस तरह का आखिरी ईमेल है। {org_name} जस की तस बनी रहेगी और कुछ भी समाप्त नहीं होता — कभी लौटना चाहें, तो सब इंतज़ार में मिलेगा।",
+    "nudge.reactivation.closing.cta": "अपना डैशबोर्ड खोलें",
 }

--- a/apps/api/src/services/email/nudge_translations/id.py
+++ b/apps/api/src/services/email/nudge_translations/id.py
@@ -1,0 +1,155 @@
+"""Indonesian nudge copy."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "Berhenti berlangganan email ini",
+    "nudge.common.footer": "Anda menerima email ini karena Anda admin di {org_name}.",
+
+    "nudge.activation.first_course_d1.subject": "Kursus pertama Anda di {org_name}",
+    "nudge.activation.first_course_d1.heading": "Kapan pun Anda siap",
+    "nudge.activation.first_course_d1.body": "{org_name} sudah siap dan menunggu kursus pertamanya. Kebanyakan orang mulai dari yang kecil: satu topik, beberapa pelajaran. Menambah bisa kapan saja.",
+    "nudge.activation.first_course_d1.cta": "Buat kursus pertama Anda",
+
+    "nudge.activation.come_back_d2.subject": "Lanjutkan dari tempat Anda berhenti",
+    "nudge.activation.come_back_d2.heading": "Pengaturan Anda masih menunggu",
+    "nudge.activation.come_back_d2.body": "Anda membuat {org_name} dan belum kembali sejak itu. Semuanya masih ada, dan menerbitkan kursus pertama butuh sekitar sepuluh menit.",
+    "nudge.activation.come_back_d2.cta": "Buka dasbor",
+
+    "nudge.activation.ai_course_help_d4.subject": "Halaman kosong itu bagian tersulit",
+    "nudge.activation.ai_course_help_d4.heading": "Biarkan AI menulis kerangkanya",
+    "nudge.activation.ai_course_help_d4.body": "Kalau {org_name} masih kosong karena bingung mulai dari mana, cukup jelaskan topiknya dan AI akan menyusun draf bab serta pelajarannya. Penyuntingan tetap di tangan Anda.",
+    "nudge.activation.ai_course_help_d4.cta": "Buat kursus dengan AI",
+
+    "nudge.activation.import_existing_d5.subject": "Bawa yang sudah Anda punya",
+    "nudge.activation.import_existing_d5.heading": "Tak perlu mulai dari nol",
+    "nudge.activation.import_existing_d5.body": "Kalau materi Anda sudah ada dalam bentuk dokumen, slide, atau ekspor dari platform lain, Anda bisa memasukkannya ke {org_name} alih-alih mengetik ulang.",
+    "nudge.activation.import_existing_d5.cta": "Impor materi Anda",
+
+    "nudge.activation.setup_checklist_d7.subject": "Lima belas menit menuju akademi yang jalan",
+    "nudge.activation.setup_checklist_d7.heading": "Daftar singkat",
+    "nudge.activation.setup_checklist_d7.body": "{org_name} masih menunggu kursus pertamanya. Daftar penyiapan memandu Anda dalam beberapa langkah singkat — kebanyakan orang selesai dalam seperempat jam.",
+    "nudge.activation.setup_checklist_d7.cta": "Buka daftarnya",
+
+    "nudge.activation.whats_blocking_d14.subject": "Apa yang menghalangi?",
+    "nudge.activation.whats_blocking_d14.heading": "Boleh kami tanya apa yang membuat Anda berhenti?",
+    "nudge.activation.whats_blocking_d14.body": "Anda membuat {org_name} dua minggu lalu dan belum menambahkan kursus. Kalau ada yang membingungkan atau kurang, kami ingin tahu — balas saja email ini, langsung sampai ke kami.",
+
+    "nudge.activation.last_call_d30.subject": "Email terakhir soal {org_name}",
+    "nudge.activation.last_call_d30.heading": "Ini yang terakhir",
+    "nudge.activation.last_call_d30.body": "{org_name} sudah sebulan sepi, jadi kami berhenti mengirim email seperti ini. Akun dan semua isinya tetap ada — kalau Anda kembali, semuanya masih di tempatnya.",
+    "nudge.activation.last_call_d30.cta": "Buka dasbor Anda",
+
+    "nudge.content.course_no_chapter_d1.subject": "«{course_name}» butuh bab pertamanya",
+    "nudge.content.course_no_chapter_d1.heading": "Tinggal satu bab",
+    "nudge.content.course_no_chapter_d1.body": "«{course_name}» sudah ada tapi belum punya bab, jadi belum ada yang bisa dibuka. Bab hanyalah bagian — satu per topik biasanya pas.",
+    "nudge.content.course_no_chapter_d1.cta": "Tambah bab",
+
+    "nudge.content.chapter_no_activity_d1.subject": "Tambahkan pelajaran pertama ke «{course_name}»",
+    "nudge.content.chapter_no_activity_d1.heading": "Babnya sudah siap",
+    "nudge.content.chapter_no_activity_d1.body": "«{course_name}» punya bab, tapi isinya masih kosong. Pelajaran bisa berupa halaman teks, video, atau kuis — apa pun yang cocok dengan topiknya.",
+    "nudge.content.chapter_no_activity_d1.cta": "Tambah pelajaran",
+
+    "nudge.content.activity_unpublished_d2.subject": "Pelajaran Anda di «{course_name}» belum terlihat",
+    "nudge.content.activity_unpublished_d2.heading": "Pelajarannya masih tersembunyi",
+    "nudge.content.activity_unpublished_d2.body": "Anda sudah menulis pelajaran di «{course_name}», tapi belum ada yang diterbitkan, jadi peserta melihat kursus kosong. Menerbitkan tidak mengunci apa pun — Anda tetap bisa menyunting.",
+    "nudge.content.activity_unpublished_d2.cta": "Terbitkan pelajaran Anda",
+
+    "nudge.content.course_draft_d3.subject": "«{course_name}» masih berupa draf",
+    "nudge.content.course_draft_d3.heading": "«{course_name}» hampir jadi",
+    "nudge.content.course_draft_d3.body": "Anda sudah menambahkan pelajaran ke «{course_name}», tapi belum diterbitkan sehingga tak ada yang bisa membukanya. Tidak harus selesai — menerbitkan hanya membuatnya terlihat, dan Anda tetap bisa menyunting sesudahnya.",
+    "nudge.content.course_draft_d3.cta": "Terbitkan",
+
+    "nudge.content.course_draft_d10.subject": "«{course_name}» sudah lama jadi draf",
+    "nudge.content.course_draft_d10.heading": "Kemungkinan sudah siap",
+    "nudge.content.course_draft_d10.body": "«{course_name}» belum diterbitkan selama lebih dari seminggu. Kursus jarang terasa selesai — menerbitkan membuatnya terlihat, dan Anda bisa terus memperbaiki sambil orang sudah membaca.",
+    "nudge.content.course_draft_d10.cta": "Terbitkan",
+
+    "nudge.content.thin_course_d5.subject": "«{course_name}» bisa ditambah sedikit lagi",
+    "nudge.content.thin_course_d5.heading": "Baru satu dua pelajaran",
+    "nudge.content.thin_course_d5.body": "«{course_name}» baru punya satu dua pelajaran. Kursus biasanya lebih mengena dengan beberapa pelajaran, dan AI bisa menyusun draf berikutnya dari yang sudah ada.",
+    "nudge.content.thin_course_d5.cta": "Tambah pelajaran",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "Belum ada pengumpulan di {org_name}",
+    "nudge.content.assignment_no_submissions_d5.heading": "Belum ada yang mengumpulkan",
+    "nudge.content.assignment_no_submissions_d5.body": "Anda membuat tugas di {org_name} tapi belum ada yang dikumpulkan. Ada baiknya memeriksa apakah tugas itu sudah diterbitkan dan peserta bisa mengakses kursusnya.",
+    "nudge.content.assignment_no_submissions_d5.cta": "Periksa tugas Anda",
+
+    "nudge.audience.published_no_members_d1.subject": "«{course_name}» sudah tayang, tapi belum ada orang",
+    "nudge.audience.published_no_members_d1.heading": "Saatnya mengundang seseorang",
+    "nudge.audience.published_no_members_d1.body": "«{course_name}» sudah diterbitkan dan siap dibaca. {org_name} belum punya peserta, jadi langkah berikutnya adalah mengundang orang-orang yang Anda tuju saat menulisnya.",
+    "nudge.audience.published_no_members_d1.cta": "Undang peserta",
+
+    "nudge.audience.published_no_members_d7.subject": "«{course_name}» masih tanpa peserta",
+    "nudge.audience.published_no_members_d7.heading": "Seminggu tayang, belum ada yang baca",
+    "nudge.audience.published_no_members_d7.body": "«{course_name}» sudah seminggu terbit dan {org_name} masih belum punya peserta. Anda bisa mengundang satu per satu, menempel daftar, atau cukup membagikan tautan gabung.",
+    "nudge.audience.published_no_members_d7.cta": "Undang orang",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "Peserta Anda belum mulai",
+    "nudge.audience.members_no_enrollment_d3.heading": "Sudah bergabung tapi belum membuka apa pun",
+    "nudge.audience.members_no_enrollment_d3.body": "Ada yang sudah bergabung ke {org_name} tapi belum ada yang memulai kursus. Pesan singkat dengan tautan langsung biasanya cukup — kebanyakan hanya belum menemukan pintunya.",
+    "nudge.audience.members_no_enrollment_d3.cta": "Lihat anggota Anda",
+
+    "nudge.audience.share_public_page_d14.subject": "Halaman kursus Anda publik — ini tautannya",
+    "nudge.audience.share_public_page_d14.heading": "Siapa pun dengan tautannya bisa membaca",
+    "nudge.audience.share_public_page_d14.body": "«{course_name}» bersifat publik, jadi bisa Anda bagikan di mana saja tanpa perlu undangan. Tautan di bawah inilah yang perlu dikirim.",
+    "nudge.audience.share_public_page_d14.cta": "Lihat halaman publik",
+
+    "nudge.audience.stalled_learners_d14.subject": "Beberapa peserta berhenti di tengah jalan",
+    "nudge.audience.stalled_learners_d14.heading": "Beberapa orang tersendat",
+    "nudge.audience.stalled_learners_d14.body": "Beberapa peserta di {org_name} memulai kursus dan sudah dua minggu tidak kembali. Pesan dari Anda sering membantu, begitu juga melihat di mana mereka berhenti.",
+    "nudge.audience.stalled_learners_d14.cta": "Periksa peserta Anda",
+
+    "nudge.monetization.course_limit_d1.subject": "Anda sudah memakai semua kursus di paket {plan_name}",
+    "nudge.monetization.course_limit_d1.heading": "Anda mencapai batas kursus",
+    "nudge.monetization.course_limit_d1.body": "{org_name} memakai paket {plan_name} dan sudah menghabiskan semua kursus yang termasuk. Naik ke {next_plan} menghapus batas itu kalau Anda ingin terus membuat.",
+    "nudge.monetization.course_limit_d1.cta": "Lihat paket",
+
+    "nudge.monetization.member_limit_near.subject": "Anda hampir mencapai batas anggota paket {plan_name}",
+    "nudge.monetization.member_limit_near.heading": "Hampir menyentuh batas anggota",
+    "nudge.monetization.member_limit_near.body": "{org_name} mendekati jumlah anggota yang diizinkan paket {plan_name}. Naik ke {next_plan} menaikkan batasnya, supaya tak ada yang tertolak di tengah pendaftaran.",
+    "nudge.monetization.member_limit_near.cta": "Lihat paket",
+
+    "nudge.monetization.ai_credits_low.subject": "Kredit AI Anda hampir habis",
+    "nudge.monetization.ai_credits_low.heading": "Kredit AI tinggal sedikit",
+    "nudge.monetization.ai_credits_low.body": "{org_name} sudah memakai sebagian besar kredit AI yang termasuk dalam paket {plan_name}. Paket {next_plan} memberi lebih banyak, kalau AI sudah jadi bagian dari cara Anda menyusun kursus.",
+    "nudge.monetization.ai_credits_low.cta": "Lihat paket",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "Apa yang {next_plan} tambahkan untuk {org_name}",
+    "nudge.monetization.upgrade_recap_d21.heading": "Anda sudah membangun sesuatu yang nyata",
+    "nudge.monetization.upgrade_recap_d21.body": "{org_name} punya kursus yang terbit dan orang yang membacanya. Paket {next_plan} memberi ruang untuk tumbuh dan beberapa hal yang tidak ada di paket {plan_name} — layak dilihat kalau Anda berencana memperluas.",
+    "nudge.monetization.upgrade_recap_d21.cta": "Bandingkan paket",
+
+    "nudge.dormancy.no_login_14d.subject": "{org_name} sedang sepi",
+    "nudge.dormancy.no_login_14d.heading": "Sudah dua minggu",
+    "nudge.dormancy.no_login_14d.body": "Tidak ada yang berubah di {org_name} sejak kunjungan terakhir Anda. Kalau Anda sedang di tengah sesuatu, semuanya masih persis di tempat Anda tinggalkan.",
+    "nudge.dormancy.no_login_14d.cta": "Buka dasbor Anda",
+
+    "nudge.dormancy.no_login_30d.subject": "Kursus Anda di {org_name} masih ada",
+    "nudge.dormancy.no_login_30d.heading": "Sudah beberapa minggu",
+    "nudge.dormancy.no_login_30d.body": "Tidak ada yang berubah selama Anda pergi — {org_name} dan semua isinya persis di tempat Anda tinggalkan. Melanjutkan hanya butuh satu klik.",
+    "nudge.dormancy.no_login_30d.cta": "Buka dasbor Anda",
+
+    "nudge.dormancy.no_login_60d.subject": "Pesan terakhir soal {org_name}",
+    "nudge.dormancy.no_login_60d.heading": "Kami tidak akan mengganggu lagi",
+    "nudge.dormancy.no_login_60d.body": "{org_name} sudah sekitar dua bulan sepi, jadi ini email terakhir semacam ini untuk sekarang. Semua yang Anda bangun tetap apa adanya, untuk kapan pun Anda membutuhkannya.",
+    "nudge.dormancy.no_login_60d.cta": "Buka dasbor Anda",
+
+    "nudge.dormancy.winback_q.subject": "Apa yang baru sejak terakhir Anda di {org_name}",
+    "nudge.dormancy.winback_q.heading": "Ada beberapa perubahan",
+    "nudge.dormancy.winback_q.body": "Sudah lama sejak Anda terakhir masuk ke {org_name}. Produknya berkembang cukup jauh sejak itu, dan semua yang Anda bangun masih ada.",
+    "nudge.dormancy.winback_q.cta": "Lihat sebentar",
+
+    "nudge.milestone.first_course_published.subject": "«{course_name}» sudah tayang",
+    "nudge.milestone.first_course_published.heading": "Anda menerbitkan kursus pertama",
+    "nudge.milestone.first_course_published.body": "«{course_name}» sudah tayang dan bisa dibaca. Yang membuat perbedaan sekarang adalah ada yang membacanya — satu dua orang untuk awal pun cukup.",
+    "nudge.milestone.first_course_published.cta": "Undang peserta pertama Anda",
+
+    "nudge.milestone.first_learner_enrolled.subject": "Ada yang memulai «{course_name}»",
+    "nudge.milestone.first_learner_enrolled.heading": "Peserta pertama Anda sudah masuk",
+    "nudge.milestone.first_learner_enrolled.body": "Untuk pertama kalinya ada yang memulai kursus di {org_name}. Anda bisa memantau perkembangannya dari dasbor.",
+    "nudge.milestone.first_learner_enrolled.cta": "Lihat perkembangannya",
+
+    "nudge.milestone.first_completion.subject": "Ada yang menyelesaikan kursus di {org_name}",
+    "nudge.milestone.first_completion.heading": "Penyelesaian pertama",
+    "nudge.milestone.first_completion.body": "Seorang peserta menyelesaikan kursus di {org_name} dari awal sampai akhir. Kalau ingin mencatatnya dengan pantas, Anda bisa menambahkan sertifikat — atau mulai menyiapkan kursus berikutnya.",
+    "nudge.milestone.first_completion.cta": "Buka dasbor Anda",
+}

--- a/apps/api/src/services/email/nudge_translations/id.py
+++ b/apps/api/src/services/email/nudge_translations/id.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "Berhenti berlangganan email ini",
     "nudge.common.footer": "Anda menerima email ini karena Anda admin di {org_name}.",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "Kursus",
+    "nudge.stat.chapters": "Bab",
+    "nudge.stat.lessons": "Pelajaran",
+    "nudge.stat.members": "Anggota",
+    "nudge.stat.learners": "Peserta",
+    "nudge.stat.completed": "Selesai",
+
     "nudge.activation.first_course_d1.subject": "Kursus pertama Anda di {org_name}",
     "nudge.activation.first_course_d1.heading": "Kapan pun Anda siap",
     "nudge.activation.first_course_d1.body": "{org_name} sudah siap dan menunggu kursus pertamanya. Kebanyakan orang mulai dari yang kecil: satu topik, beberapa pelajaran. Menambah bisa kapan saja.",
@@ -152,4 +161,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "Penyelesaian pertama",
     "nudge.milestone.first_completion.body": "Seorang peserta menyelesaikan kursus di {org_name} dari awal sampai akhir. Kalau ingin mencatatnya dengan pantas, Anda bisa menambahkan sertifikat — atau mulai menyiapkan kursus berikutnya.",
     "nudge.milestone.first_completion.cta": "Buka dasbor Anda",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "Akademi Anda di {org_name} masih ada",
+    "nudge.reactivation.opener.heading": "Masih di sini, persis seperti Anda tinggalkan",
+    "nudge.reactivation.opener.body": "Tak ada yang menyentuh {org_name} sejak kunjungan terakhir Anda — setiap kursus, bab, dan pelajaran ada di tempatnya. Melanjutkan hanya butuh satu klik.",
+    "nudge.reactivation.opener.cta": "Buka dasbor Anda",
+    "nudge.reactivation.whats_changed.subject": "Ada beberapa perubahan di LearnHouse",
+    "nudge.reactivation.whats_changed.heading": "Sejak terakhir Anda ke sini",
+    "nudge.reactivation.whats_changed.body": "Produknya berkembang cukup jauh selagi {org_name} sepi: editor, perkakas kursus, dan alur peserta semuanya digarap serius. Semua yang Anda bangun tetap berjalan seperti dulu.",
+    "nudge.reactivation.whats_changed.cta": "Lihat apa yang baru",
+    "nudge.reactivation.need_a_hand.subject": "Perlu bantuan untuk kembali ke {org_name}?",
+    "nudge.reactivation.need_a_hand.heading": "Ada yang menghalangi?",
+    "nudge.reactivation.need_a_hand.body": "Kalau ada alasan {org_name} berhenti — sesuatu yang membingungkan, ada yang kurang, atau memang tidak sempat — kami sungguh ingin mendengarnya. Balas email ini, langsung sampai ke kami.",
+    "nudge.reactivation.closing.subject": "Catatan terakhir soal {org_name}",
+    "nudge.reactivation.closing.heading": "Kami berhenti di sini",
+    "nudge.reactivation.closing.body": "Ini yang terakhir dari email semacam ini. {org_name} tetap apa adanya dan tidak ada yang kedaluwarsa — kalau suatu saat ingin kembali, semuanya menunggu.",
+    "nudge.reactivation.closing.cta": "Buka dasbor Anda",
 }

--- a/apps/api/src/services/email/nudge_translations/it.py
+++ b/apps/api/src/services/email/nudge_translations/it.py
@@ -1,0 +1,155 @@
+"""Italian nudge copy."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "Annulla l'iscrizione a queste email",
+    "nudge.common.footer": "Ricevi questa email perché sei amministratore di {org_name}.",
+
+    "nudge.activation.first_course_d1.subject": "Il tuo primo corso su {org_name}",
+    "nudge.activation.first_course_d1.heading": "Quando vuoi",
+    "nudge.activation.first_course_d1.body": "{org_name} è pronta e aspetta il suo primo corso. Quasi tutti iniziano in piccolo: un argomento, qualche lezione. Potrai ampliarlo in seguito.",
+    "nudge.activation.first_course_d1.cta": "Crea il tuo primo corso",
+
+    "nudge.activation.come_back_d2.subject": "Riprendere da dove eri rimasto",
+    "nudge.activation.come_back_d2.heading": "La tua configurazione è ancora lì",
+    "nudge.activation.come_back_d2.body": "Hai creato {org_name} e non sei più tornato. È tutto ancora al suo posto, e mettere online un primo corso richiede una decina di minuti.",
+    "nudge.activation.come_back_d2.cta": "Vai alla dashboard",
+
+    "nudge.activation.ai_course_help_d4.subject": "La pagina bianca è la parte difficile",
+    "nudge.activation.ai_course_help_d4.heading": "Lascia che l'IA scriva la scaletta",
+    "nudge.activation.ai_course_help_d4.body": "Se {org_name} è ancora vuota perché non sai da dove partire, descrivi l'argomento e l'IA preparerà capitoli e lezioni. Poi la modifica è tua.",
+    "nudge.activation.ai_course_help_d4.cta": "Crea un corso con l'IA",
+
+    "nudge.activation.import_existing_d5.subject": "Porta quello che hai già",
+    "nudge.activation.import_existing_d5.heading": "Non devi ripartire da zero",
+    "nudge.activation.import_existing_d5.body": "Se il tuo materiale esiste già come documenti, slide o esportazione da un'altra piattaforma, puoi portarlo in {org_name} invece di riscriverlo.",
+    "nudge.activation.import_existing_d5.cta": "Importa il materiale",
+
+    "nudge.activation.setup_checklist_d7.subject": "Quindici minuti per un'accademia funzionante",
+    "nudge.activation.setup_checklist_d7.heading": "Una breve lista",
+    "nudge.activation.setup_checklist_d7.body": "{org_name} aspetta ancora il primo corso. La lista di configurazione ti guida in pochi passaggi: quasi tutti finiscono in un quarto d'ora.",
+    "nudge.activation.setup_checklist_d7.cta": "Apri la lista",
+
+    "nudge.activation.whats_blocking_d14.subject": "Cosa si è messo di mezzo?",
+    "nudge.activation.whats_blocking_d14.heading": "Possiamo chiederti cosa ti ha fermato?",
+    "nudge.activation.whats_blocking_d14.body": "Hai creato {org_name} un paio di settimane fa e non hai ancora aggiunto un corso. Se qualcosa non era chiaro o mancava, ci farebbe piacere saperlo: rispondi a questa email, arriva direttamente a noi.",
+
+    "nudge.activation.last_call_d30.subject": "Ultima email su {org_name}",
+    "nudge.activation.last_call_d30.heading": "Questa è l'ultima",
+    "nudge.activation.last_call_d30.body": "{org_name} è rimasta ferma per un mese, quindi smettiamo di inviare queste email. Il tuo account e tutto ciò che contiene restano lì: se torni, ritroverai ogni cosa.",
+    "nudge.activation.last_call_d30.cta": "Apri la dashboard",
+
+    "nudge.content.course_no_chapter_d1.subject": "{course_name} ha bisogno del primo capitolo",
+    "nudge.content.course_no_chapter_d1.heading": "Manca un capitolo",
+    "nudge.content.course_no_chapter_d1.body": "{course_name} esiste ma non ha ancora capitoli, quindi non c'è nulla da aprire. I capitoli sono semplici sezioni: uno per argomento funziona bene.",
+    "nudge.content.course_no_chapter_d1.cta": "Aggiungi un capitolo",
+
+    "nudge.content.chapter_no_activity_d1.subject": "Aggiungi la prima lezione a {course_name}",
+    "nudge.content.chapter_no_activity_d1.heading": "I capitoli sono pronti",
+    "nudge.content.chapter_no_activity_d1.body": "{course_name} ha capitoli, ma sono ancora vuoti. Una lezione può essere una pagina di testo, un video, un quiz: quello che si adatta all'argomento.",
+    "nudge.content.chapter_no_activity_d1.cta": "Aggiungi una lezione",
+
+    "nudge.content.activity_unpublished_d2.subject": "Le tue lezioni in {course_name} non si vedono ancora",
+    "nudge.content.activity_unpublished_d2.heading": "Le lezioni sono ancora nascoste",
+    "nudge.content.activity_unpublished_d2.body": "Hai scritto lezioni in {course_name}, ma nessuna è pubblicata: chi entra vede un corso vuoto. Pubblicare non blocca nulla, puoi continuare a modificare.",
+    "nudge.content.activity_unpublished_d2.cta": "Pubblica le lezioni",
+
+    "nudge.content.course_draft_d3.subject": "{course_name} è ancora una bozza",
+    "nudge.content.course_draft_d3.heading": "{course_name} ci siamo quasi",
+    "nudge.content.course_draft_d3.body": "Hai aggiunto lezioni a {course_name}, ma non è pubblicato, quindi nessuno può aprirlo. Non deve essere finito: pubblicare lo rende solo visibile, e puoi continuare a modificarlo.",
+    "nudge.content.course_draft_d3.cta": "Pubblicalo",
+
+    "nudge.content.course_draft_d10.subject": "{course_name} è in bozza da un po'",
+    "nudge.content.course_draft_d10.heading": "Probabilmente è pronto",
+    "nudge.content.course_draft_d10.body": "{course_name} è non pubblicato da oltre una settimana. Un corso raramente sembra finito: pubblicarlo lo rende visibile, e puoi continuare a migliorarlo mentre qualcuno già legge.",
+    "nudge.content.course_draft_d10.cta": "Pubblicalo",
+
+    "nudge.content.thin_course_d5.subject": "{course_name} meriterebbe qualcosa in più",
+    "nudge.content.thin_course_d5.heading": "Una o due lezioni",
+    "nudge.content.thin_course_d5.body": "{course_name} ha una o due lezioni finora. I corsi funzionano meglio con qualcuna in più, e l'IA può preparare le prossime partendo da ciò che c'è già.",
+    "nudge.content.thin_course_d5.cta": "Aggiungi altre lezioni",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "Ancora nessuna consegna in {org_name}",
+    "nudge.content.assignment_no_submissions_d5.heading": "Nessuno ha consegnato nulla",
+    "nudge.content.assignment_no_submissions_d5.body": "Hai creato un compito in {org_name} ma non è stato consegnato niente. Vale la pena controllare che sia pubblicato e che gli studenti riescano a raggiungere il corso a cui appartiene.",
+    "nudge.content.assignment_no_submissions_d5.cta": "Controlla i compiti",
+
+    "nudge.audience.published_no_members_d1.subject": "{course_name} è online, ma non c'è nessuno",
+    "nudge.audience.published_no_members_d1.heading": "È il momento di invitare qualcuno",
+    "nudge.audience.published_no_members_d1.body": "{course_name} è pubblicato e pronto da leggere. {org_name} non ha ancora studenti, quindi il passo successivo è invitare le persone per cui l'hai scritto.",
+    "nudge.audience.published_no_members_d1.cta": "Invita studenti",
+
+    "nudge.audience.published_no_members_d7.subject": "{course_name} non ha ancora studenti",
+    "nudge.audience.published_no_members_d7.heading": "Una settimana online, nessun lettore",
+    "nudge.audience.published_no_members_d7.body": "{course_name} è pubblicato da una settimana e {org_name} non ha ancora studenti. Puoi invitare uno per uno, incollare un elenco o semplicemente condividere il link di accesso.",
+    "nudge.audience.published_no_members_d7.cta": "Invita persone",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "I tuoi studenti non hanno ancora iniziato",
+    "nudge.audience.members_no_enrollment_d3.heading": "Si sono iscritti ma non hanno aperto nulla",
+    "nudge.audience.members_no_enrollment_d3.body": "Alcune persone si sono unite a {org_name} ma nessuno ha iniziato un corso. Di solito basta un messaggio breve con un link diretto: molti semplicemente non hanno trovato l'ingresso.",
+    "nudge.audience.members_no_enrollment_d3.cta": "Vedi i membri",
+
+    "nudge.audience.share_public_page_d14.subject": "La pagina del corso è pubblica: ecco il link",
+    "nudge.audience.share_public_page_d14.heading": "Chiunque abbia il link può leggere",
+    "nudge.audience.share_public_page_d14.body": "{course_name} è pubblico, quindi puoi condividerlo ovunque senza che serva un invito. Il link qui sotto è quello da mandare.",
+    "nudge.audience.share_public_page_d14.cta": "Vedi la pagina pubblica",
+
+    "nudge.audience.stalled_learners_d14.subject": "Alcuni studenti si sono fermati a metà",
+    "nudge.audience.stalled_learners_d14.heading": "Qualcuno si è bloccato",
+    "nudge.audience.stalled_learners_d14.body": "Alcuni studenti di {org_name} hanno iniziato un corso e non tornano da un paio di settimane. Spesso serve un tuo messaggio, o un'occhiata a dove si sono fermati.",
+    "nudge.audience.stalled_learners_d14.cta": "Controlla gli studenti",
+
+    "nudge.monetization.course_limit_d1.subject": "Hai usato tutti i corsi del piano {plan_name}",
+    "nudge.monetization.course_limit_d1.heading": "Hai raggiunto il limite di corsi",
+    "nudge.monetization.course_limit_d1.body": "{org_name} è sul piano {plan_name} e ha usato tutti i corsi inclusi. Passare a {next_plan} elimina quel limite, se vuoi continuare a creare.",
+    "nudge.monetization.course_limit_d1.cta": "Vedi i piani",
+
+    "nudge.monetization.member_limit_near.subject": "Sei vicino al limite di membri del piano {plan_name}",
+    "nudge.monetization.member_limit_near.heading": "Quasi al limite di membri",
+    "nudge.monetization.member_limit_near.body": "{org_name} si sta avvicinando al numero di membri consentito dal piano {plan_name}. Passare a {next_plan} lo alza, così nessuno resta fuori a metà iscrizione.",
+    "nudge.monetization.member_limit_near.cta": "Vedi i piani",
+
+    "nudge.monetization.ai_credits_low.subject": "I tuoi crediti IA stanno finendo",
+    "nudge.monetization.ai_credits_low.heading": "Pochi crediti IA rimasti",
+    "nudge.monetization.ai_credits_low.body": "{org_name} ha usato quasi tutti i crediti IA inclusi nel piano {plan_name}. Il piano {next_plan} ne offre di più, se l'IA è ormai parte di come costruisci i corsi.",
+    "nudge.monetization.ai_credits_low.cta": "Vedi i piani",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "Cosa aggiungerebbe {next_plan} a {org_name}",
+    "nudge.monetization.upgrade_recap_d21.heading": "Hai costruito qualcosa di concreto",
+    "nudge.monetization.upgrade_recap_d21.body": "{org_name} ha corsi pubblicati e persone che li leggono. Il piano {next_plan} dà spazio per crescere e include cose assenti dal piano {plan_name}: vale un'occhiata se pensi di ampliare.",
+    "nudge.monetization.upgrade_recap_d21.cta": "Confronta i piani",
+
+    "nudge.dormancy.no_login_14d.subject": "{org_name} è rimasta ferma",
+    "nudge.dormancy.no_login_14d.heading": "Sono passate un paio di settimane",
+    "nudge.dormancy.no_login_14d.body": "In {org_name} non è cambiato nulla dalla tua ultima visita. Se eri nel mezzo di qualcosa, è esattamente dove l'hai lasciato.",
+    "nudge.dormancy.no_login_14d.cta": "Apri la dashboard",
+
+    "nudge.dormancy.no_login_30d.subject": "I tuoi corsi su {org_name} sono ancora qui",
+    "nudge.dormancy.no_login_30d.heading": "Sono passate alcune settimane",
+    "nudge.dormancy.no_login_30d.body": "Non è cambiato nulla mentre eri via: {org_name} e tutto ciò che contiene è esattamente dove l'hai lasciato. Riprendere è questione di un clic.",
+    "nudge.dormancy.no_login_30d.cta": "Apri la dashboard",
+
+    "nudge.dormancy.no_login_60d.subject": "Ultimo messaggio su {org_name}",
+    "nudge.dormancy.no_login_60d.heading": "Ti lasciamo in pace",
+    "nudge.dormancy.no_login_60d.body": "{org_name} è ferma da un paio di mesi, quindi questa è l'ultima di queste email per ora. Tutto ciò che hai costruito resta com'è, per quando ti servirà.",
+    "nudge.dormancy.no_login_60d.cta": "Apri la dashboard",
+
+    "nudge.dormancy.winback_q.subject": "Cosa è cambiato dalla tua ultima visita a {org_name}",
+    "nudge.dormancy.winback_q.heading": "Qualcosa è cambiato",
+    "nudge.dormancy.winback_q.body": "È passato un po' da quando sei stato in {org_name}. Il prodotto è andato avanti parecchio da allora, e tutto quello che avevi costruito è ancora lì.",
+    "nudge.dormancy.winback_q.cta": "Dai un'occhiata",
+
+    "nudge.milestone.first_course_published.subject": "{course_name} è online",
+    "nudge.milestone.first_course_published.heading": "Hai pubblicato il tuo primo corso",
+    "nudge.milestone.first_course_published.body": "{course_name} è online e leggibile. La cosa che fa davvero la differenza adesso è avere qualcuno che lo legga, anche solo una o due persone per iniziare.",
+    "nudge.milestone.first_course_published.cta": "Invita i primi studenti",
+
+    "nudge.milestone.first_learner_enrolled.subject": "Qualcuno ha iniziato {course_name}",
+    "nudge.milestone.first_learner_enrolled.heading": "Il tuo primo studente è arrivato",
+    "nudge.milestone.first_learner_enrolled.body": "Per la prima volta qualcuno ha iniziato un corso in {org_name}. Puoi seguire i suoi progressi dalla dashboard.",
+    "nudge.milestone.first_learner_enrolled.cta": "Vedi i progressi",
+
+    "nudge.milestone.first_completion.subject": "Qualcuno ha completato un corso in {org_name}",
+    "nudge.milestone.first_completion.heading": "Primo completamento",
+    "nudge.milestone.first_completion.body": "Uno studente ha completato un corso di {org_name} dall'inizio alla fine. Se vuoi darne atto puoi aggiungere un certificato, oppure iniziare a preparare il prossimo.",
+    "nudge.milestone.first_completion.cta": "Apri la dashboard",
+}

--- a/apps/api/src/services/email/nudge_translations/it.py
+++ b/apps/api/src/services/email/nudge_translations/it.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "Annulla l'iscrizione a queste email",
     "nudge.common.footer": "Ricevi questa email perché sei amministratore di {org_name}.",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "Corsi",
+    "nudge.stat.chapters": "Capitoli",
+    "nudge.stat.lessons": "Lezioni",
+    "nudge.stat.members": "Membri",
+    "nudge.stat.learners": "Studenti",
+    "nudge.stat.completed": "Completati",
+
     "nudge.activation.first_course_d1.subject": "Il tuo primo corso su {org_name}",
     "nudge.activation.first_course_d1.heading": "Quando vuoi",
     "nudge.activation.first_course_d1.body": "{org_name} è pronta e aspetta il suo primo corso. Quasi tutti iniziano in piccolo: un argomento, qualche lezione. Potrai ampliarlo in seguito.",
@@ -152,4 +161,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "Primo completamento",
     "nudge.milestone.first_completion.body": "Uno studente ha completato un corso di {org_name} dall'inizio alla fine. Se vuoi darne atto puoi aggiungere un certificato, oppure iniziare a preparare il prossimo.",
     "nudge.milestone.first_completion.cta": "Apri la dashboard",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "La tua accademia su {org_name} è ancora qui",
+    "nudge.reactivation.opener.heading": "Ancora qui, esattamente come l'hai lasciata",
+    "nudge.reactivation.opener.body": "Nessuno ha toccato {org_name} dalla tua ultima visita: ogni corso, capitolo e lezione è dove l'hai lasciato. Riprendere è questione di un clic.",
+    "nudge.reactivation.opener.cta": "Apri la dashboard",
+    "nudge.reactivation.whats_changed.subject": "Qualcosa è cambiato su LearnHouse",
+    "nudge.reactivation.whats_changed.heading": "Dalla tua ultima visita",
+    "nudge.reactivation.whats_changed.body": "Il prodotto è andato avanti parecchio mentre {org_name} era ferma: editor, strumenti dei corsi e percorso degli studenti sono stati rivisti a fondo. Tutto ciò che avevi creato funziona come prima.",
+    "nudge.reactivation.whats_changed.cta": "Vedi le novità",
+    "nudge.reactivation.need_a_hand.subject": "Ti serve una mano per tornare su {org_name}?",
+    "nudge.reactivation.need_a_hand.heading": "C'era qualcosa di mezzo?",
+    "nudge.reactivation.need_a_hand.body": "Se c'è stato un motivo per cui {org_name} si è fermata — qualcosa di poco chiaro, qualcosa che mancava, o semplicemente il tempo — ci farebbe piacere saperlo. Rispondi a questa email, arriva direttamente a noi.",
+    "nudge.reactivation.closing.subject": "Ultimo messaggio su {org_name}",
+    "nudge.reactivation.closing.heading": "Ci fermiamo qui",
+    "nudge.reactivation.closing.body": "Questa è l'ultima di queste email. {org_name} resta esattamente com'è e nulla scade: se un giorno vorrai tornare, troverai tutto ad aspettarti.",
+    "nudge.reactivation.closing.cta": "Apri la dashboard",
 }

--- a/apps/api/src/services/email/nudge_translations/ja.py
+++ b/apps/api/src/services/email/nudge_translations/ja.py
@@ -1,0 +1,155 @@
+"""Japanese nudge copy."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "このメールの配信を停止する",
+    "nudge.common.footer": "{org_name} の管理者であるため、このメールが届いています。",
+
+    "nudge.activation.first_course_d1.subject": "{org_name} での最初のコース",
+    "nudge.activation.first_course_d1.heading": "準備ができたときに",
+    "nudge.activation.first_course_d1.body": "{org_name} の設定は完了し、最初のコースを待っています。多くの方は小さく始めます。テーマを一つ、レッスンを数本。あとから足していけます。",
+    "nudge.activation.first_course_d1.cta": "最初のコースを作る",
+
+    "nudge.activation.come_back_d2.subject": "続きから再開しませんか",
+    "nudge.activation.come_back_d2.heading": "設定はそのまま残っています",
+    "nudge.activation.come_back_d2.body": "{org_name} を作成したあと、まだ戻られていません。設定はすべて残っており、最初のコースを公開するまでは十分ほどです。",
+    "nudge.activation.come_back_d2.cta": "ダッシュボードへ",
+
+    "nudge.activation.ai_course_help_d4.subject": "白紙が一番むずかしい",
+    "nudge.activation.ai_course_help_d4.heading": "構成はAIに任せる",
+    "nudge.activation.ai_course_help_d4.body": "何から始めるか決まらず {org_name} がまだ空のままなら、テーマを書くだけでAIが章とレッスンの下書きを作ります。そこからの編集はご自身で。",
+    "nudge.activation.ai_course_help_d4.cta": "AIでコースを作る",
+
+    "nudge.activation.import_existing_d5.subject": "すでにある教材を持ち込む",
+    "nudge.activation.import_existing_d5.heading": "ゼロから始める必要はありません",
+    "nudge.activation.import_existing_d5.body": "資料やスライド、他サービスからの書き出しがすでにあるなら、打ち直さずそのまま {org_name} に取り込めます。",
+    "nudge.activation.import_existing_d5.cta": "教材をインポートする",
+
+    "nudge.activation.setup_checklist_d7.subject": "15分で使えるアカデミーに",
+    "nudge.activation.setup_checklist_d7.heading": "短いチェックリスト",
+    "nudge.activation.setup_checklist_d7.body": "{org_name} はまだ最初のコースを待っています。セットアップのチェックリストが数ステップで案内します。多くの方は15分ほどで終わります。",
+    "nudge.activation.setup_checklist_d7.cta": "チェックリストを開く",
+
+    "nudge.activation.whats_blocking_d14.subject": "何かつまずきましたか",
+    "nudge.activation.whats_blocking_d14.heading": "何が止めてしまったか、伺えますか",
+    "nudge.activation.whats_blocking_d14.body": "{org_name} を作成されてから2週間ほど経ちますが、まだコースが追加されていません。分かりにくい点や足りない点があれば知りたいので、このメールにそのまま返信してください。私たちに直接届きます。",
+
+    "nudge.activation.last_call_d30.subject": "{org_name} に関する最後のメール",
+    "nudge.activation.last_call_d30.heading": "これが最後です",
+    "nudge.activation.last_call_d30.body": "{org_name} は1か月動きがないため、この種のメールは停止します。アカウントと中身はそのまま残りますので、戻られたときには元のままです。",
+    "nudge.activation.last_call_d30.cta": "ダッシュボードを開く",
+
+    "nudge.content.course_no_chapter_d1.subject": "「{course_name}」に最初の章を",
+    "nudge.content.course_no_chapter_d1.heading": "あと章がひとつ",
+    "nudge.content.course_no_chapter_d1.body": "「{course_name}」はありますが章がまだないため、開くものがありません。章は単なる区切りで、テーマごとに一つが扱いやすいです。",
+    "nudge.content.course_no_chapter_d1.cta": "章を追加する",
+
+    "nudge.content.chapter_no_activity_d1.subject": "「{course_name}」に最初のレッスンを",
+    "nudge.content.chapter_no_activity_d1.heading": "章の準備はできています",
+    "nudge.content.chapter_no_activity_d1.body": "「{course_name}」には章がありますが、中身がまだ空です。レッスンはテキストのページでも、動画でも、小テストでも、テーマに合うもので構いません。",
+    "nudge.content.chapter_no_activity_d1.cta": "レッスンを追加する",
+
+    "nudge.content.activity_unpublished_d2.subject": "「{course_name}」のレッスンがまだ表示されません",
+    "nudge.content.activity_unpublished_d2.heading": "レッスンは非公開のままです",
+    "nudge.content.activity_unpublished_d2.body": "「{course_name}」にレッスンを書かれていますが、どれも公開されていないため、受講者には空のコースが見えています。公開しても固定されるわけではなく、あとから編集できます。",
+    "nudge.content.activity_unpublished_d2.cta": "レッスンを公開する",
+
+    "nudge.content.course_draft_d3.subject": "「{course_name}」はまだ下書きです",
+    "nudge.content.course_draft_d3.heading": "「{course_name}」はもう少しで公開できます",
+    "nudge.content.course_draft_d3.body": "「{course_name}」にレッスンを追加されましたが、まだ公開されていないため誰も開けません。完成している必要はありません。公開は見えるようにするだけで、そのあとも編集できます。",
+    "nudge.content.course_draft_d3.cta": "公開する",
+
+    "nudge.content.course_draft_d10.subject": "「{course_name}」が下書きのままです",
+    "nudge.content.course_draft_d10.heading": "おそらくもう十分です",
+    "nudge.content.course_draft_d10.body": "「{course_name}」は1週間以上、未公開のままです。コースが完成したと感じられることはめったにありません。公開すれば見えるようになり、読まれながら改善していけます。",
+    "nudge.content.course_draft_d10.cta": "公開する",
+
+    "nudge.content.thin_course_d5.subject": "「{course_name}」にもう少し中身を",
+    "nudge.content.thin_course_d5.heading": "レッスンが1、2本",
+    "nudge.content.thin_course_d5.body": "「{course_name}」には今のところレッスンが1、2本です。コースはいくつか揃うと伝わりやすくなります。AIが既存の内容から次のレッスンを下書きできます。",
+    "nudge.content.thin_course_d5.cta": "レッスンを追加する",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "{org_name} でまだ提出がありません",
+    "nudge.content.assignment_no_submissions_d5.heading": "誰も提出していません",
+    "nudge.content.assignment_no_submissions_d5.body": "{org_name} で課題を作成されましたが、提出がまだありません。公開されているか、受講者が該当コースにアクセスできるかを確認してみてください。",
+    "nudge.content.assignment_no_submissions_d5.cta": "課題を確認する",
+
+    "nudge.audience.published_no_members_d1.subject": "「{course_name}」は公開済みですが、まだ誰もいません",
+    "nudge.audience.published_no_members_d1.heading": "誰かを招待するころあいです",
+    "nudge.audience.published_no_members_d1.body": "「{course_name}」は公開され、読める状態です。{org_name} にはまだ受講者がいないので、次は書いた相手を招待することです。",
+    "nudge.audience.published_no_members_d1.cta": "受講者を招待する",
+
+    "nudge.audience.published_no_members_d7.subject": "「{course_name}」にまだ受講者がいません",
+    "nudge.audience.published_no_members_d7.heading": "公開から1週間、読まれていません",
+    "nudge.audience.published_no_members_d7.body": "「{course_name}」を公開して1週間経ちますが、{org_name} にはまだ受講者がいません。個別に招待しても、リストを貼り付けても、参加リンクを共有するだけでも構いません。",
+    "nudge.audience.published_no_members_d7.cta": "招待する",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "受講者がまだ始めていません",
+    "nudge.audience.members_no_enrollment_d3.heading": "参加はしたものの、何も開いていません",
+    "nudge.audience.members_no_enrollment_d3.body": "{org_name} に参加した方はいますが、まだ誰もコースを始めていません。直接のリンクを添えた短いメッセージでたいてい動きます。多くは入口が分からないだけです。",
+    "nudge.audience.members_no_enrollment_d3.cta": "メンバーを見る",
+
+    "nudge.audience.share_public_page_d14.subject": "コースページは公開中です。リンクはこちら",
+    "nudge.audience.share_public_page_d14.heading": "リンクがあれば誰でも読めます",
+    "nudge.audience.share_public_page_d14.body": "「{course_name}」は公開設定なので、招待なしでどこにでも共有できます。下のリンクがそのまま送れるものです。",
+    "nudge.audience.share_public_page_d14.cta": "公開ページを見る",
+
+    "nudge.audience.stalled_learners_d14.subject": "途中で止まっている受講者がいます",
+    "nudge.audience.stalled_learners_d14.heading": "何人か止まっています",
+    "nudge.audience.stalled_learners_d14.body": "{org_name} の受講者の何人かがコースを始めたまま、2週間ほど戻っていません。ひとこと声をかけるか、どこで止まったかを見てみると効果的です。",
+    "nudge.audience.stalled_learners_d14.cta": "受講者を確認する",
+
+    "nudge.monetization.course_limit_d1.subject": "{plan_name} プランのコース枠を使い切りました",
+    "nudge.monetization.course_limit_d1.heading": "コース数の上限に達しました",
+    "nudge.monetization.course_limit_d1.body": "{org_name} は {plan_name} プランで、含まれるコース枠をすべて使い切りました。作り続けるなら、{next_plan} プランに上げるとこの上限がなくなります。",
+    "nudge.monetization.course_limit_d1.cta": "プランを見る",
+
+    "nudge.monetization.member_limit_near.subject": "{plan_name} プランのメンバー上限が近づいています",
+    "nudge.monetization.member_limit_near.heading": "メンバー上限まであとわずか",
+    "nudge.monetization.member_limit_near.body": "{org_name} は {plan_name} プランで認められたメンバー数に近づいています。{next_plan} プランに上げれば枠が増え、登録の途中で断られる方が出ずにすみます。",
+    "nudge.monetization.member_limit_near.cta": "プランを見る",
+
+    "nudge.monetization.ai_credits_low.subject": "AIクレジットが残りわずかです",
+    "nudge.monetization.ai_credits_low.heading": "AIクレジットが少なくなっています",
+    "nudge.monetization.ai_credits_low.body": "{org_name} は {plan_name} プランに含まれるAIクレジットの大半を使いました。AIがコース作りの一部になっているなら、{next_plan} プランにはより多く含まれています。",
+    "nudge.monetization.ai_credits_low.cta": "プランを見る",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "{next_plan} が {org_name} にもたらすもの",
+    "nudge.monetization.upgrade_recap_d21.heading": "確かなものを築かれました",
+    "nudge.monetization.upgrade_recap_d21.body": "{org_name} には公開済みのコースと、それを読む方がいます。{next_plan} プランには広げる余地と、{plan_name} プランにはない機能がいくつかあります。拡大をお考えなら見てみる価値があります。",
+    "nudge.monetization.upgrade_recap_d21.cta": "プランを比較する",
+
+    "nudge.dormancy.no_login_14d.subject": "{org_name} が静かなままです",
+    "nudge.dormancy.no_login_14d.heading": "2週間ほど経ちました",
+    "nudge.dormancy.no_login_14d.body": "前回いらしてから {org_name} に変化はありません。途中だったものがあれば、そのままの状態で残っています。",
+    "nudge.dormancy.no_login_14d.cta": "ダッシュボードを開く",
+
+    "nudge.dormancy.no_login_30d.subject": "{org_name} のコースはそのままあります",
+    "nudge.dormancy.no_login_30d.heading": "数週間が経ちました",
+    "nudge.dormancy.no_login_30d.body": "留守のあいだに変わったことはありません。{org_name} も中身も、置いていかれたそのままです。再開はワンクリックです。",
+    "nudge.dormancy.no_login_30d.cta": "ダッシュボードを開く",
+
+    "nudge.dormancy.no_login_60d.subject": "{org_name} についての最後のご連絡",
+    "nudge.dormancy.no_login_60d.heading": "ここでいったん失礼します",
+    "nudge.dormancy.no_login_60d.body": "{org_name} は2か月ほど動きがないため、この種のご連絡はこれで最後にします。作られたものはそのまま残りますので、必要になったときにお使いください。",
+    "nudge.dormancy.no_login_60d.cta": "ダッシュボードを開く",
+
+    "nudge.dormancy.winback_q.subject": "前回 {org_name} をご覧になってからの変更点",
+    "nudge.dormancy.winback_q.heading": "いくつか変わりました",
+    "nudge.dormancy.winback_q.body": "{org_name} をご覧になってからしばらく経ちました。その間に製品はかなり進み、作られたものはすべてそのまま残っています。",
+    "nudge.dormancy.winback_q.cta": "見てみる",
+
+    "nudge.milestone.first_course_published.subject": "「{course_name}」を公開しました",
+    "nudge.milestone.first_course_published.heading": "最初のコースが公開されました",
+    "nudge.milestone.first_course_published.body": "「{course_name}」は公開され、読める状態です。ここから効いてくるのは読む人がいることです。まずは1人か2人でも構いません。",
+    "nudge.milestone.first_course_published.cta": "最初の受講者を招待する",
+
+    "nudge.milestone.first_learner_enrolled.subject": "「{course_name}」を始めた方がいます",
+    "nudge.milestone.first_learner_enrolled.heading": "最初の受講者が入りました",
+    "nudge.milestone.first_learner_enrolled.body": "{org_name} で初めてコースを始めた方が出ました。進み具合はダッシュボードから追えます。",
+    "nudge.milestone.first_learner_enrolled.cta": "進捗を見る",
+
+    "nudge.milestone.first_completion.subject": "{org_name} でコースを修了した方がいます",
+    "nudge.milestone.first_completion.heading": "はじめての修了",
+    "nudge.milestone.first_completion.body": "受講者が {org_name} のコースを最後まで終えました。きちんと形にするなら修了証を追加できますし、次のコースに取りかかることもできます。",
+    "nudge.milestone.first_completion.cta": "ダッシュボードを開く",
+}

--- a/apps/api/src/services/email/nudge_translations/ja.py
+++ b/apps/api/src/services/email/nudge_translations/ja.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "このメールの配信を停止する",
     "nudge.common.footer": "{org_name} の管理者であるため、このメールが届いています。",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "コース",
+    "nudge.stat.chapters": "章",
+    "nudge.stat.lessons": "レッスン",
+    "nudge.stat.members": "メンバー",
+    "nudge.stat.learners": "受講者",
+    "nudge.stat.completed": "修了",
+
     "nudge.activation.first_course_d1.subject": "{org_name} での最初のコース",
     "nudge.activation.first_course_d1.heading": "準備ができたときに",
     "nudge.activation.first_course_d1.body": "{org_name} の設定は完了し、最初のコースを待っています。多くの方は小さく始めます。テーマを一つ、レッスンを数本。あとから足していけます。",
@@ -152,4 +161,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "はじめての修了",
     "nudge.milestone.first_completion.body": "受講者が {org_name} のコースを最後まで終えました。きちんと形にするなら修了証を追加できますし、次のコースに取りかかることもできます。",
     "nudge.milestone.first_completion.cta": "ダッシュボードを開く",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "{org_name} のアカデミーはそのまま残っています",
+    "nudge.reactivation.opener.heading": "そのまま、置いていかれた状態で",
+    "nudge.reactivation.opener.body": "前回いらしてから {org_name} には誰も手を触れていません。コースも章もレッスンも、すべて残っています。再開はワンクリックです。",
+    "nudge.reactivation.opener.cta": "ダッシュボードを開く",
+    "nudge.reactivation.whats_changed.subject": "LearnHouse でいくつか変わりました",
+    "nudge.reactivation.whats_changed.heading": "前回のご訪問から",
+    "nudge.reactivation.whats_changed.body": "{org_name} が静かなあいだに製品はかなり進みました。エディター、コース作成まわり、受講者の進み方に手が入っています。作られたものはこれまでどおり動きます。",
+    "nudge.reactivation.whats_changed.cta": "変更点を見る",
+    "nudge.reactivation.need_a_hand.subject": "{org_name} に戻るお手伝いをしましょうか",
+    "nudge.reactivation.need_a_hand.heading": "何か引っかかりましたか",
+    "nudge.reactivation.need_a_hand.body": "{org_name} が止まった理由があれば — 分かりにくかった、足りなかった、単に時間がなかった — ぜひ伺いたいです。このメールにそのまま返信してください。私たちに直接届きます。",
+    "nudge.reactivation.closing.subject": "{org_name} についての最後のご連絡",
+    "nudge.reactivation.closing.heading": "ここで失礼します",
+    "nudge.reactivation.closing.body": "この種のご連絡はこれで最後です。{org_name} はそのまま残り、期限もありません。戻りたくなったときには、すべてお待ちしています。",
+    "nudge.reactivation.closing.cta": "ダッシュボードを開く",
 }

--- a/apps/api/src/services/email/nudge_translations/ko.py
+++ b/apps/api/src/services/email/nudge_translations/ko.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "이 이메일 수신 거부",
     "nudge.common.footer": "{org_name}의 관리자이기 때문에 이 이메일을 받았습니다.",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "코스",
+    "nudge.stat.chapters": "챕터",
+    "nudge.stat.lessons": "레슨",
+    "nudge.stat.members": "멤버",
+    "nudge.stat.learners": "학습자",
+    "nudge.stat.completed": "수료",
+
     "nudge.activation.first_course_d1.subject": "{org_name}의 첫 코스",
     "nudge.activation.first_course_d1.heading": "준비되셨을 때",
     "nudge.activation.first_course_d1.body": "{org_name} 설정이 끝나고 첫 코스를 기다리고 있습니다. 대부분 작게 시작합니다. 주제 하나, 레슨 몇 개. 나중에 얼마든지 늘릴 수 있습니다.",
@@ -152,4 +161,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "첫 수료",
     "nudge.milestone.first_completion.body": "한 학습자가 {org_name}의 코스를 처음부터 끝까지 마쳤습니다. 제대로 남기고 싶으시면 수료증을 추가하실 수 있고, 다음 코스를 시작하셔도 좋습니다.",
     "nudge.milestone.first_completion.cta": "대시보드 열기",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "{org_name}의 아카데미는 그대로 있습니다",
+    "nudge.reactivation.opener.heading": "두고 가신 그대로입니다",
+    "nudge.reactivation.opener.body": "마지막으로 다녀가신 뒤 {org_name}은 아무도 건드리지 않았습니다. 코스도 챕터도 레슨도 모두 그 자리에 있습니다. 다시 시작하는 데는 클릭 한 번이면 됩니다.",
+    "nudge.reactivation.opener.cta": "대시보드 열기",
+    "nudge.reactivation.whats_changed.subject": "LearnHouse에 몇 가지가 바뀌었습니다",
+    "nudge.reactivation.whats_changed.heading": "마지막으로 오신 뒤로",
+    "nudge.reactivation.whats_changed.body": "{org_name}이 조용한 사이 제품이 꽤 나아졌습니다. 에디터와 코스 도구, 학습자의 진행 방식에 실질적인 변화가 있었습니다. 만들어 두신 것은 예전 그대로 동작합니다.",
+    "nudge.reactivation.whats_changed.cta": "달라진 점 보기",
+    "nudge.reactivation.need_a_hand.subject": "{org_name}으로 돌아오시는 데 도움이 필요하신가요?",
+    "nudge.reactivation.need_a_hand.heading": "무엇이 걸리셨나요?",
+    "nudge.reactivation.need_a_hand.body": "{org_name}이 멈춘 이유가 있었다면 — 헷갈리는 부분, 빠진 기능, 아니면 그저 시간 — 정말 듣고 싶습니다. 이 메일에 그대로 답장해 주시면 저희에게 바로 전달됩니다.",
+    "nudge.reactivation.closing.subject": "{org_name}에 대한 마지막 안내",
+    "nudge.reactivation.closing.heading": "여기서 멈추겠습니다",
+    "nudge.reactivation.closing.body": "이런 메일은 이번이 마지막입니다. {org_name}은 그대로 남고 만료되는 것도 없습니다. 언제든 돌아오고 싶으시면 모두 그대로 기다리고 있습니다.",
+    "nudge.reactivation.closing.cta": "대시보드 열기",
 }

--- a/apps/api/src/services/email/nudge_translations/ko.py
+++ b/apps/api/src/services/email/nudge_translations/ko.py
@@ -1,0 +1,155 @@
+"""Korean nudge copy."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "이 이메일 수신 거부",
+    "nudge.common.footer": "{org_name}의 관리자이기 때문에 이 이메일을 받았습니다.",
+
+    "nudge.activation.first_course_d1.subject": "{org_name}의 첫 코스",
+    "nudge.activation.first_course_d1.heading": "준비되셨을 때",
+    "nudge.activation.first_course_d1.body": "{org_name} 설정이 끝나고 첫 코스를 기다리고 있습니다. 대부분 작게 시작합니다. 주제 하나, 레슨 몇 개. 나중에 얼마든지 늘릴 수 있습니다.",
+    "nudge.activation.first_course_d1.cta": "첫 코스 만들기",
+
+    "nudge.activation.come_back_d2.subject": "하시던 곳부터 이어서",
+    "nudge.activation.come_back_d2.heading": "설정해 두신 것이 그대로 있습니다",
+    "nudge.activation.come_back_d2.body": "{org_name}을 만드신 뒤로 아직 다시 오지 않으셨습니다. 모두 그대로 있고, 첫 코스를 공개하는 데는 10분쯤 걸립니다.",
+    "nudge.activation.come_back_d2.cta": "대시보드로 가기",
+
+    "nudge.activation.ai_course_help_d4.subject": "빈 화면이 가장 어렵습니다",
+    "nudge.activation.ai_course_help_d4.heading": "개요는 AI에게 맡기세요",
+    "nudge.activation.ai_course_help_d4.body": "어디서 시작할지 정하지 못해 {org_name}이 아직 비어 있다면, 주제만 적어 주시면 AI가 챕터와 레슨의 초안을 만듭니다. 이후 편집은 직접 하시면 됩니다.",
+    "nudge.activation.ai_course_help_d4.cta": "AI로 코스 만들기",
+
+    "nudge.activation.import_existing_d5.subject": "이미 가지고 계신 자료를 가져오세요",
+    "nudge.activation.import_existing_d5.heading": "처음부터 만들 필요는 없습니다",
+    "nudge.activation.import_existing_d5.body": "자료가 이미 문서나 슬라이드, 다른 플랫폼에서 내보낸 파일로 있다면 다시 입력하는 대신 {org_name}으로 가져올 수 있습니다.",
+    "nudge.activation.import_existing_d5.cta": "자료 가져오기",
+
+    "nudge.activation.setup_checklist_d7.subject": "15분이면 쓸 수 있는 아카데미가 됩니다",
+    "nudge.activation.setup_checklist_d7.heading": "짧은 체크리스트",
+    "nudge.activation.setup_checklist_d7.body": "{org_name}은 아직 첫 코스를 기다리고 있습니다. 설정 체크리스트가 몇 단계로 안내해 드리며, 대부분 15분 정도면 끝냅니다.",
+    "nudge.activation.setup_checklist_d7.cta": "체크리스트 열기",
+
+    "nudge.activation.whats_blocking_d14.subject": "무엇이 걸리셨나요?",
+    "nudge.activation.whats_blocking_d14.heading": "무엇 때문에 멈추셨는지 여쭤봐도 될까요?",
+    "nudge.activation.whats_blocking_d14.body": "{org_name}을 만드신 지 2주가 되었는데 아직 코스가 없습니다. 헷갈리거나 부족한 부분이 있었다면 알고 싶습니다. 이 메일에 그대로 답장해 주시면 저희에게 바로 전달됩니다.",
+
+    "nudge.activation.last_call_d30.subject": "{org_name}에 대한 마지막 메일",
+    "nudge.activation.last_call_d30.heading": "이번이 마지막입니다",
+    "nudge.activation.last_call_d30.body": "{org_name}이 한 달째 조용해서 이런 메일은 여기서 멈추겠습니다. 계정과 그 안의 모든 것은 그대로 남으니, 돌아오시면 두고 가신 그대로입니다.",
+    "nudge.activation.last_call_d30.cta": "대시보드 열기",
+
+    "nudge.content.course_no_chapter_d1.subject": "'{course_name}'에 첫 챕터가 필요합니다",
+    "nudge.content.course_no_chapter_d1.heading": "챕터 하나만 더",
+    "nudge.content.course_no_chapter_d1.body": "'{course_name}'은 만들어졌지만 아직 챕터가 없어서 열어 볼 것이 없습니다. 챕터는 그저 구분일 뿐이고, 주제당 하나가 무난합니다.",
+    "nudge.content.course_no_chapter_d1.cta": "챕터 추가하기",
+
+    "nudge.content.chapter_no_activity_d1.subject": "'{course_name}'에 첫 레슨을 추가하세요",
+    "nudge.content.chapter_no_activity_d1.heading": "챕터는 준비되었습니다",
+    "nudge.content.chapter_no_activity_d1.body": "'{course_name}'에 챕터는 있지만 안이 아직 비어 있습니다. 레슨은 글 한 페이지, 영상, 퀴즈 등 주제에 맞는 무엇이든 됩니다.",
+    "nudge.content.chapter_no_activity_d1.cta": "레슨 추가하기",
+
+    "nudge.content.activity_unpublished_d2.subject": "'{course_name}'의 레슨이 아직 보이지 않습니다",
+    "nudge.content.activity_unpublished_d2.heading": "레슨이 아직 숨겨져 있습니다",
+    "nudge.content.activity_unpublished_d2.body": "'{course_name}'에 레슨을 작성하셨지만 공개된 것이 없어서 학습자에게는 빈 코스로 보입니다. 공개해도 잠기지 않으며 이후에도 계속 수정할 수 있습니다.",
+    "nudge.content.activity_unpublished_d2.cta": "레슨 공개하기",
+
+    "nudge.content.course_draft_d3.subject": "'{course_name}'이 아직 초안입니다",
+    "nudge.content.course_draft_d3.heading": "'{course_name}'이 거의 다 되었습니다",
+    "nudge.content.course_draft_d3.body": "'{course_name}'에 레슨을 추가하셨지만 공개되지 않아 아무도 열 수 없습니다. 완성될 필요는 없습니다. 공개는 보이게 할 뿐이고, 이후에도 계속 편집할 수 있습니다.",
+    "nudge.content.course_draft_d3.cta": "공개하기",
+
+    "nudge.content.course_draft_d10.subject": "'{course_name}'이 한동안 초안 상태입니다",
+    "nudge.content.course_draft_d10.heading": "아마 준비되었을 겁니다",
+    "nudge.content.course_draft_d10.body": "'{course_name}'이 일주일 넘게 공개되지 않은 채입니다. 코스가 다 됐다고 느껴지는 일은 드뭅니다. 공개하면 보이게 되고, 읽는 사람이 있는 동안에도 계속 다듬을 수 있습니다.",
+    "nudge.content.course_draft_d10.cta": "공개하기",
+
+    "nudge.content.thin_course_d5.subject": "'{course_name}'에 조금 더 채워 보세요",
+    "nudge.content.thin_course_d5.heading": "레슨이 한두 개",
+    "nudge.content.thin_course_d5.body": "'{course_name}'에는 지금 레슨이 한두 개 있습니다. 코스는 몇 개 더 있을 때 더 잘 전달되고, AI가 기존 내용을 바탕으로 다음 레슨 초안을 만들 수 있습니다.",
+    "nudge.content.thin_course_d5.cta": "레슨 더 추가하기",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "{org_name}에 아직 제출물이 없습니다",
+    "nudge.content.assignment_no_submissions_d5.heading": "아무도 제출하지 않았습니다",
+    "nudge.content.assignment_no_submissions_d5.body": "{org_name}에 과제를 만드셨지만 제출된 것이 없습니다. 과제가 공개되어 있는지, 학습자가 해당 코스에 접근할 수 있는지 확인해 보시면 좋겠습니다.",
+    "nudge.content.assignment_no_submissions_d5.cta": "과제 확인하기",
+
+    "nudge.audience.published_no_members_d1.subject": "'{course_name}'은 공개됐지만 아직 아무도 없습니다",
+    "nudge.audience.published_no_members_d1.heading": "이제 누군가를 초대할 때입니다",
+    "nudge.audience.published_no_members_d1.body": "'{course_name}'이 공개되어 읽을 수 있습니다. {org_name}에는 아직 학습자가 없으니, 다음 단계는 이 코스를 위해 쓰신 그분들을 초대하는 것입니다.",
+    "nudge.audience.published_no_members_d1.cta": "학습자 초대하기",
+
+    "nudge.audience.published_no_members_d7.subject": "'{course_name}'에 아직 학습자가 없습니다",
+    "nudge.audience.published_no_members_d7.heading": "공개한 지 일주일, 아무도 읽지 않았습니다",
+    "nudge.audience.published_no_members_d7.body": "'{course_name}'을 공개한 지 일주일이 지났지만 {org_name}에는 여전히 학습자가 없습니다. 한 명씩 초대해도 되고, 명단을 붙여넣거나 참여 링크를 공유해도 됩니다.",
+    "nudge.audience.published_no_members_d7.cta": "사람들 초대하기",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "학습자들이 아직 시작하지 않았습니다",
+    "nudge.audience.members_no_enrollment_d3.heading": "가입은 했지만 아무것도 열지 않았습니다",
+    "nudge.audience.members_no_enrollment_d3.body": "{org_name}에 가입한 분들은 있지만 아직 아무도 코스를 시작하지 않았습니다. 직접 링크가 담긴 짧은 메시지면 대개 움직입니다. 대부분은 입구를 못 찾았을 뿐입니다.",
+    "nudge.audience.members_no_enrollment_d3.cta": "멤버 보기",
+
+    "nudge.audience.share_public_page_d14.subject": "코스 페이지가 공개 상태입니다 — 링크는 여기 있습니다",
+    "nudge.audience.share_public_page_d14.heading": "링크만 있으면 누구나 읽을 수 있습니다",
+    "nudge.audience.share_public_page_d14.body": "'{course_name}'은 공개 설정이라 초대 없이도 어디에나 공유할 수 있습니다. 아래 링크가 그대로 보내시면 되는 주소입니다.",
+    "nudge.audience.share_public_page_d14.cta": "공개 페이지 보기",
+
+    "nudge.audience.stalled_learners_d14.subject": "중간에 멈춘 학습자가 있습니다",
+    "nudge.audience.stalled_learners_d14.heading": "몇 분이 멈춰 있습니다",
+    "nudge.audience.stalled_learners_d14.body": "{org_name}의 일부 학습자가 코스를 시작한 뒤 2주째 돌아오지 않고 있습니다. 짧은 연락이 도움이 될 때가 많고, 어디서 멈췄는지 살펴보는 것도 좋습니다.",
+    "nudge.audience.stalled_learners_d14.cta": "학습자 확인하기",
+
+    "nudge.monetization.course_limit_d1.subject": "{plan_name} 플랜의 코스를 모두 사용하셨습니다",
+    "nudge.monetization.course_limit_d1.heading": "코스 한도에 도달했습니다",
+    "nudge.monetization.course_limit_d1.body": "{org_name}은 {plan_name} 플랜이며 포함된 코스를 모두 사용했습니다. 계속 만들고 싶으시다면 {next_plan}으로 올리면 이 한도가 사라집니다.",
+    "nudge.monetization.course_limit_d1.cta": "플랜 보기",
+
+    "nudge.monetization.member_limit_near.subject": "{plan_name} 플랜의 멤버 한도에 가까워졌습니다",
+    "nudge.monetization.member_limit_near.heading": "멤버 한도가 얼마 남지 않았습니다",
+    "nudge.monetization.member_limit_near.body": "{org_name}이 {plan_name} 플랜에서 허용하는 멤버 수에 가까워지고 있습니다. {next_plan}으로 올리면 한도가 늘어나 가입 도중에 막히는 분이 생기지 않습니다.",
+    "nudge.monetization.member_limit_near.cta": "플랜 보기",
+
+    "nudge.monetization.ai_credits_low.subject": "AI 크레딧이 거의 소진되었습니다",
+    "nudge.monetization.ai_credits_low.heading": "AI 크레딧이 얼마 남지 않았습니다",
+    "nudge.monetization.ai_credits_low.body": "{org_name}이 {plan_name} 플랜에 포함된 AI 크레딧을 대부분 사용했습니다. AI가 코스를 만드는 방식의 일부가 되었다면 {next_plan} 플랜에는 더 많이 포함되어 있습니다.",
+    "nudge.monetization.ai_credits_low.cta": "플랜 보기",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "{next_plan}이 {org_name}에 더해 줄 것",
+    "nudge.monetization.upgrade_recap_d21.heading": "제대로 된 것을 만드셨습니다",
+    "nudge.monetization.upgrade_recap_d21.body": "{org_name}에는 공개된 코스와 그것을 읽는 사람들이 있습니다. {next_plan} 플랜은 성장할 여유와 {plan_name} 플랜에 없는 몇 가지를 제공합니다. 확장을 생각 중이라면 볼 만합니다.",
+    "nudge.monetization.upgrade_recap_d21.cta": "플랜 비교하기",
+
+    "nudge.dormancy.no_login_14d.subject": "{org_name}이 조용했습니다",
+    "nudge.dormancy.no_login_14d.heading": "2주쯤 지났습니다",
+    "nudge.dormancy.no_login_14d.body": "마지막으로 다녀가신 뒤 {org_name}에는 달라진 것이 없습니다. 하시던 중이었다면 두고 가신 그 자리에 그대로 있습니다.",
+    "nudge.dormancy.no_login_14d.cta": "대시보드 열기",
+
+    "nudge.dormancy.no_login_30d.subject": "{org_name}의 코스는 그대로 있습니다",
+    "nudge.dormancy.no_login_30d.heading": "몇 주가 지났습니다",
+    "nudge.dormancy.no_login_30d.body": "안 계신 동안 달라진 것은 없습니다. {org_name}과 그 안의 모든 것이 두고 가신 그대로입니다. 다시 시작하는 데는 클릭 한 번이면 됩니다.",
+    "nudge.dormancy.no_login_30d.cta": "대시보드 열기",
+
+    "nudge.dormancy.no_login_60d.subject": "{org_name}에 대한 마지막 안부",
+    "nudge.dormancy.no_login_60d.heading": "이만 물러나겠습니다",
+    "nudge.dormancy.no_login_60d.body": "{org_name}이 두 달째 조용해서 당분간 이런 메일은 이번이 마지막입니다. 만들어 두신 것은 그대로 남아 있으니 필요하실 때 쓰시면 됩니다.",
+    "nudge.dormancy.no_login_60d.cta": "대시보드 열기",
+
+    "nudge.dormancy.winback_q.subject": "{org_name}에 마지막으로 오신 뒤 달라진 점",
+    "nudge.dormancy.winback_q.heading": "몇 가지가 바뀌었습니다",
+    "nudge.dormancy.winback_q.body": "{org_name}에 다녀가신 지 꽤 되었습니다. 그동안 제품이 상당히 나아졌고, 만들어 두신 것은 모두 그대로 있습니다.",
+    "nudge.dormancy.winback_q.cta": "둘러보기",
+
+    "nudge.milestone.first_course_published.subject": "'{course_name}'이 공개되었습니다",
+    "nudge.milestone.first_course_published.heading": "첫 코스를 공개하셨습니다",
+    "nudge.milestone.first_course_published.body": "'{course_name}'이 공개되어 읽을 수 있습니다. 이제 차이를 만드는 것은 읽어 줄 사람입니다. 처음에는 한두 명이라도 좋습니다.",
+    "nudge.milestone.first_course_published.cta": "첫 학습자 초대하기",
+
+    "nudge.milestone.first_learner_enrolled.subject": "누군가 '{course_name}'을 시작했습니다",
+    "nudge.milestone.first_learner_enrolled.heading": "첫 학습자가 들어왔습니다",
+    "nudge.milestone.first_learner_enrolled.body": "{org_name}에서 처음으로 누군가 코스를 시작했습니다. 진행 상황은 대시보드에서 확인하실 수 있습니다.",
+    "nudge.milestone.first_learner_enrolled.cta": "진행 상황 보기",
+
+    "nudge.milestone.first_completion.subject": "누군가 {org_name}의 코스를 끝냈습니다",
+    "nudge.milestone.first_completion.heading": "첫 수료",
+    "nudge.milestone.first_completion.body": "한 학습자가 {org_name}의 코스를 처음부터 끝까지 마쳤습니다. 제대로 남기고 싶으시면 수료증을 추가하실 수 있고, 다음 코스를 시작하셔도 좋습니다.",
+    "nudge.milestone.first_completion.cta": "대시보드 열기",
+}

--- a/apps/api/src/services/email/nudge_translations/nl.py
+++ b/apps/api/src/services/email/nudge_translations/nl.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "Afmelden voor deze e-mails",
     "nudge.common.footer": "Je ontvangt deze e-mail omdat je beheerder bent van {org_name}.",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "Cursussen",
+    "nudge.stat.chapters": "Hoofdstukken",
+    "nudge.stat.lessons": "Lessen",
+    "nudge.stat.members": "Leden",
+    "nudge.stat.learners": "Deelnemers",
+    "nudge.stat.completed": "Afgerond",
+
     "nudge.activation.first_course_d1.subject": "Je eerste cursus op {org_name}",
     "nudge.activation.first_course_d1.heading": "Wanneer het jou uitkomt",
     "nudge.activation.first_course_d1.body": "{org_name} staat klaar en wacht op de eerste cursus. De meeste mensen beginnen klein: één onderwerp, een paar lessen. Uitbreiden kan altijd nog.",
@@ -152,4 +161,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "Eerste afronding",
     "nudge.milestone.first_completion.body": "Een deelnemer heeft een cursus in {org_name} van begin tot eind afgerond. Wil je dat vastleggen, dan kun je een certificaat toevoegen — of beginnen aan wat hierna komt.",
     "nudge.milestone.first_completion.cta": "Dashboard openen",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "Je academie op {org_name} staat er nog",
+    "nudge.reactivation.opener.heading": "Nog steeds hier, precies zoals je het achterliet",
+    "nudge.reactivation.opener.body": "Niemand heeft {org_name} aangeraakt sinds je laatste bezoek — elke cursus, elk hoofdstuk en elke les staat waar je het liet. Weer oppakken is één klik.",
+    "nudge.reactivation.opener.cta": "Dashboard openen",
+    "nudge.reactivation.whats_changed.subject": "Er is het een en ander veranderd op LearnHouse",
+    "nudge.reactivation.whats_changed.heading": "Sinds je laatste bezoek",
+    "nudge.reactivation.whats_changed.body": "Het product is flink doorontwikkeld terwijl {org_name} stil lag: de editor, de cursustools en de route die deelnemers volgen zijn allemaal grondig aangepakt. Alles wat je bouwde werkt nog precies zo.",
+    "nudge.reactivation.whats_changed.cta": "Bekijk wat nieuw is",
+    "nudge.reactivation.need_a_hand.subject": "Hulp nodig om weer in {org_name} te komen?",
+    "nudge.reactivation.need_a_hand.heading": "Zat er iets in de weg?",
+    "nudge.reactivation.need_a_hand.body": "Als er een reden was dat {org_name} stil kwam te liggen — iets onduidelijks, iets dat ontbrak, of gewoon geen tijd — horen we dat graag. Beantwoord deze e-mail, hij komt rechtstreeks bij ons binnen.",
+    "nudge.reactivation.closing.subject": "Laatste bericht over {org_name}",
+    "nudge.reactivation.closing.heading": "Hier stoppen we",
+    "nudge.reactivation.closing.body": "Dit is de laatste van deze e-mails. {org_name} blijft precies zoals het is en niets verloopt — wil je ooit terugkomen, dan staat alles klaar.",
+    "nudge.reactivation.closing.cta": "Dashboard openen",
 }

--- a/apps/api/src/services/email/nudge_translations/nl.py
+++ b/apps/api/src/services/email/nudge_translations/nl.py
@@ -1,0 +1,155 @@
+"""Dutch nudge copy."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "Afmelden voor deze e-mails",
+    "nudge.common.footer": "Je ontvangt deze e-mail omdat je beheerder bent van {org_name}.",
+
+    "nudge.activation.first_course_d1.subject": "Je eerste cursus op {org_name}",
+    "nudge.activation.first_course_d1.heading": "Wanneer het jou uitkomt",
+    "nudge.activation.first_course_d1.body": "{org_name} staat klaar en wacht op de eerste cursus. De meeste mensen beginnen klein: één onderwerp, een paar lessen. Uitbreiden kan altijd nog.",
+    "nudge.activation.first_course_d1.cta": "Maak je eerste cursus",
+
+    "nudge.activation.come_back_d2.subject": "Verder waar je gebleven was",
+    "nudge.activation.come_back_d2.heading": "Je opzet staat nog klaar",
+    "nudge.activation.come_back_d2.body": "Je hebt {org_name} opgezet en bent sindsdien niet meer geweest. Alles staat er nog, en een eerste cursus online zetten kost ongeveer tien minuten.",
+    "nudge.activation.come_back_d2.cta": "Naar je dashboard",
+
+    "nudge.activation.ai_course_help_d4.subject": "Het lege blad is het lastigste",
+    "nudge.activation.ai_course_help_d4.heading": "Laat AI de opzet schrijven",
+    "nudge.activation.ai_course_help_d4.body": "Als {org_name} nog leeg is omdat je niet weet waar te beginnen: beschrijf je onderwerp en AI schrijft de hoofdstukken en lessen alvast. Daarna pas jij het aan.",
+    "nudge.activation.ai_course_help_d4.cta": "Cursus opzetten met AI",
+
+    "nudge.activation.import_existing_d5.subject": "Neem mee wat je al hebt",
+    "nudge.activation.import_existing_d5.heading": "Je hoeft niet opnieuw te beginnen",
+    "nudge.activation.import_existing_d5.body": "Als je materiaal al bestaat als documenten, dia's of een export uit een ander platform, kun je het naar {org_name} halen in plaats van alles over te typen.",
+    "nudge.activation.import_existing_d5.cta": "Materiaal importeren",
+
+    "nudge.activation.setup_checklist_d7.subject": "Een kwartier tot een werkende academie",
+    "nudge.activation.setup_checklist_d7.heading": "Een korte checklist",
+    "nudge.activation.setup_checklist_d7.body": "{org_name} wacht nog op de eerste cursus. De checklist loopt het in een paar korte stappen met je door — de meesten zijn binnen een kwartier klaar.",
+    "nudge.activation.setup_checklist_d7.cta": "Checklist openen",
+
+    "nudge.activation.whats_blocking_d14.subject": "Wat kwam ertussen?",
+    "nudge.activation.whats_blocking_d14.heading": "Mogen we vragen wat je tegenhield?",
+    "nudge.activation.whats_blocking_d14.body": "Je hebt {org_name} een paar weken geleden opgezet en nog geen cursus toegevoegd. Als iets onduidelijk was of ontbrak, horen we dat graag — beantwoord deze e-mail, hij komt rechtstreeks bij ons binnen.",
+
+    "nudge.activation.last_call_d30.subject": "Laatste e-mail over {org_name}",
+    "nudge.activation.last_call_d30.heading": "Dit is de laatste",
+    "nudge.activation.last_call_d30.body": "{org_name} is een maand stil geweest, dus we stoppen met deze e-mails. Je account en alles erin blijft staan — kom je terug, dan vind je het precies zoals je het achterliet.",
+    "nudge.activation.last_call_d30.cta": "Dashboard openen",
+
+    "nudge.content.course_no_chapter_d1.subject": "{course_name} heeft een eerste hoofdstuk nodig",
+    "nudge.content.course_no_chapter_d1.heading": "Nog één hoofdstuk",
+    "nudge.content.course_no_chapter_d1.body": "{course_name} bestaat maar heeft nog geen hoofdstukken, dus er valt niets te openen. Hoofdstukken zijn gewoon secties — één per onderwerp werkt prima.",
+    "nudge.content.course_no_chapter_d1.cta": "Hoofdstuk toevoegen",
+
+    "nudge.content.chapter_no_activity_d1.subject": "Voeg je eerste les toe aan {course_name}",
+    "nudge.content.chapter_no_activity_d1.heading": "De hoofdstukken staan klaar",
+    "nudge.content.chapter_no_activity_d1.body": "{course_name} heeft hoofdstukken, maar ze zijn nog leeg. Een les kan een pagina tekst zijn, een video, een quiz — wat bij het onderwerp past.",
+    "nudge.content.chapter_no_activity_d1.cta": "Les toevoegen",
+
+    "nudge.content.activity_unpublished_d2.subject": "Je lessen in {course_name} zijn nog niet zichtbaar",
+    "nudge.content.activity_unpublished_d2.heading": "De lessen staan nog verborgen",
+    "nudge.content.activity_unpublished_d2.body": "Je hebt lessen geschreven in {course_name}, maar geen enkele is gepubliceerd, dus deelnemers zien een lege cursus. Publiceren zet niets vast — je kunt blijven bewerken.",
+    "nudge.content.activity_unpublished_d2.cta": "Lessen publiceren",
+
+    "nudge.content.course_draft_d3.subject": "{course_name} is nog een concept",
+    "nudge.content.course_draft_d3.heading": "{course_name} is er bijna",
+    "nudge.content.course_draft_d3.body": "Je hebt lessen toegevoegd aan {course_name}, maar de cursus is niet gepubliceerd, dus niemand kan hem openen. Hij hoeft niet af te zijn — publiceren maakt hem alleen zichtbaar, en je kunt daarna blijven bewerken.",
+    "nudge.content.course_draft_d3.cta": "Publiceren",
+
+    "nudge.content.course_draft_d10.subject": "{course_name} staat al een tijd als concept",
+    "nudge.content.course_draft_d10.heading": "Waarschijnlijk is hij klaar",
+    "nudge.content.course_draft_d10.body": "{course_name} staat al ruim een week ongepubliceerd. Een cursus voelt zelden af — publiceren maakt hem zichtbaar, en je kunt blijven verbeteren terwijl er al iemand leest.",
+    "nudge.content.course_draft_d10.cta": "Publiceren",
+
+    "nudge.content.thin_course_d5.subject": "{course_name} kan er nog wat bij hebben",
+    "nudge.content.thin_course_d5.heading": "Een of twee lessen",
+    "nudge.content.thin_course_d5.body": "{course_name} heeft tot nu toe een of twee lessen. Cursussen komen beter tot hun recht met een handvol, en AI kan de volgende schrijven op basis van wat er al is.",
+    "nudge.content.thin_course_d5.cta": "Meer lessen toevoegen",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "Nog geen inzendingen in {org_name}",
+    "nudge.content.assignment_no_submissions_d5.heading": "Niemand heeft iets ingeleverd",
+    "nudge.content.assignment_no_submissions_d5.body": "Je hebt een opdracht aangemaakt in {org_name} maar er is niets ingeleverd. Controleer of hij gepubliceerd is en of je deelnemers bij de bijbehorende cursus kunnen.",
+    "nudge.content.assignment_no_submissions_d5.cta": "Opdrachten controleren",
+
+    "nudge.audience.published_no_members_d1.subject": "{course_name} staat live, maar er is nog niemand",
+    "nudge.audience.published_no_members_d1.heading": "Tijd om iemand uit te nodigen",
+    "nudge.audience.published_no_members_d1.body": "{course_name} is gepubliceerd en klaar om gelezen te worden. {org_name} heeft nog geen deelnemers, dus de volgende stap is de mensen uitnodigen voor wie je het schreef.",
+    "nudge.audience.published_no_members_d1.cta": "Deelnemers uitnodigen",
+
+    "nudge.audience.published_no_members_d7.subject": "{course_name} heeft nog steeds geen deelnemers",
+    "nudge.audience.published_no_members_d7.heading": "Een week live, niemand leest mee",
+    "nudge.audience.published_no_members_d7.body": "{course_name} staat een week live en {org_name} heeft nog steeds geen deelnemers. Je kunt mensen één voor één uitnodigen, een lijst plakken of gewoon de deelnamelink delen.",
+    "nudge.audience.published_no_members_d7.cta": "Mensen uitnodigen",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "Je deelnemers zijn nog niet begonnen",
+    "nudge.audience.members_no_enrollment_d3.heading": "Aangemeld maar niets geopend",
+    "nudge.audience.members_no_enrollment_d3.body": "Er hebben zich mensen aangesloten bij {org_name}, maar niemand is aan een cursus begonnen. Een kort bericht met een directe link helpt meestal — de meesten hebben simpelweg de ingang niet gevonden.",
+    "nudge.audience.members_no_enrollment_d3.cta": "Bekijk je leden",
+
+    "nudge.audience.share_public_page_d14.subject": "Je cursuspagina is openbaar — hier is de link",
+    "nudge.audience.share_public_page_d14.heading": "Iedereen met de link kan meelezen",
+    "nudge.audience.share_public_page_d14.body": "{course_name} is openbaar, dus je kunt hem overal delen zonder dat iemand een uitnodiging nodig heeft. De link hieronder is degene om te versturen.",
+    "nudge.audience.share_public_page_d14.cta": "Openbare pagina bekijken",
+
+    "nudge.audience.stalled_learners_d14.subject": "Sommige deelnemers zijn halverwege gestopt",
+    "nudge.audience.stalled_learners_d14.heading": "Een paar mensen zijn blijven steken",
+    "nudge.audience.stalled_learners_d14.body": "Sommige deelnemers in {org_name} zijn aan een cursus begonnen en al twee weken niet teruggekomen. Een bericht van jou helpt vaak, net als kijken waar ze gestopt zijn.",
+    "nudge.audience.stalled_learners_d14.cta": "Deelnemers bekijken",
+
+    "nudge.monetization.course_limit_d1.subject": "Je hebt alle cursussen van het {plan_name}-abonnement gebruikt",
+    "nudge.monetization.course_limit_d1.heading": "Je hebt de cursuslimiet bereikt",
+    "nudge.monetization.course_limit_d1.body": "{org_name} zit op het {plan_name}-abonnement en heeft alle inbegrepen cursussen gebruikt. Overstappen naar {next_plan} haalt die limiet weg als je verder wilt bouwen.",
+    "nudge.monetization.course_limit_d1.cta": "Abonnementen bekijken",
+
+    "nudge.monetization.member_limit_near.subject": "Je nadert de ledenlimiet van {plan_name}",
+    "nudge.monetization.member_limit_near.heading": "Bijna aan de ledenlimiet",
+    "nudge.monetization.member_limit_near.body": "{org_name} nadert het aantal leden dat het {plan_name}-abonnement toestaat. Overstappen naar {next_plan} verhoogt dat, zodat niemand halverwege het aanmelden wordt geweigerd.",
+    "nudge.monetization.member_limit_near.cta": "Abonnementen bekijken",
+
+    "nudge.monetization.ai_credits_low.subject": "Je AI-credits zijn bijna op",
+    "nudge.monetization.ai_credits_low.heading": "Nog weinig AI-credits",
+    "nudge.monetization.ai_credits_low.body": "{org_name} heeft de meeste AI-credits van het {plan_name}-abonnement gebruikt. Het {next_plan}-abonnement bevat er meer, als AI inmiddels onderdeel is van hoe je cursussen maakt.",
+    "nudge.monetization.ai_credits_low.cta": "Abonnementen bekijken",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "Wat {next_plan} zou toevoegen voor {org_name}",
+    "nudge.monetization.upgrade_recap_d21.heading": "Je hebt iets echts opgebouwd",
+    "nudge.monetization.upgrade_recap_d21.body": "{org_name} heeft gepubliceerde cursussen en mensen die ze lezen. Het {next_plan}-abonnement geeft ruimte om te groeien en bevat dingen die in het {plan_name}-abonnement ontbreken — het bekijken waard als je wilt uitbreiden.",
+    "nudge.monetization.upgrade_recap_d21.cta": "Abonnementen vergelijken",
+
+    "nudge.dormancy.no_login_14d.subject": "Het was stil in {org_name}",
+    "nudge.dormancy.no_login_14d.heading": "Het is een paar weken geleden",
+    "nudge.dormancy.no_login_14d.body": "Er is niets veranderd in {org_name} sinds je er voor het laatst was. Was je ergens middenin, dan ligt het nog precies waar je het liet.",
+    "nudge.dormancy.no_login_14d.cta": "Dashboard openen",
+
+    "nudge.dormancy.no_login_30d.subject": "Je cursussen op {org_name} staan er nog",
+    "nudge.dormancy.no_login_30d.heading": "Het is een paar weken geleden",
+    "nudge.dormancy.no_login_30d.body": "Er is niets veranderd terwijl je weg was — {org_name} en alles erin staat precies waar je het liet. Weer oppakken is één klik.",
+    "nudge.dormancy.no_login_30d.cta": "Dashboard openen",
+
+    "nudge.dormancy.no_login_60d.subject": "Laatste bericht over {org_name}",
+    "nudge.dormancy.no_login_60d.heading": "We laten je verder met rust",
+    "nudge.dormancy.no_login_60d.body": "{org_name} is een paar maanden stil geweest, dus dit is voorlopig de laatste van deze e-mails. Alles wat je gebouwd hebt blijft precies zoals het is, voor wanneer je het nodig hebt.",
+    "nudge.dormancy.no_login_60d.cta": "Dashboard openen",
+
+    "nudge.dormancy.winback_q.subject": "Wat er nieuw is sinds je laatst in {org_name} was",
+    "nudge.dormancy.winback_q.heading": "Er is het een en ander veranderd",
+    "nudge.dormancy.winback_q.body": "Het is een tijd geleden dat je in {org_name} was. Het product is sindsdien flink doorontwikkeld, en alles wat je gebouwd hebt staat er nog.",
+    "nudge.dormancy.winback_q.cta": "Even kijken",
+
+    "nudge.milestone.first_course_published.subject": "{course_name} staat live",
+    "nudge.milestone.first_course_published.heading": "Je hebt je eerste cursus gepubliceerd",
+    "nudge.milestone.first_course_published.body": "{course_name} staat live en is te lezen. Wat nu het verschil maakt, is iemand die hem leest — al zijn het maar één of twee mensen om te beginnen.",
+    "nudge.milestone.first_course_published.cta": "Nodig je eerste deelnemers uit",
+
+    "nudge.milestone.first_learner_enrolled.subject": "Iemand is begonnen aan {course_name}",
+    "nudge.milestone.first_learner_enrolled.heading": "Je eerste deelnemer is binnen",
+    "nudge.milestone.first_learner_enrolled.body": "Voor het eerst is iemand begonnen aan een cursus in {org_name}. Je kunt de voortgang volgen vanaf je dashboard.",
+    "nudge.milestone.first_learner_enrolled.cta": "Voortgang bekijken",
+
+    "nudge.milestone.first_completion.subject": "Iemand heeft een cursus in {org_name} afgerond",
+    "nudge.milestone.first_completion.heading": "Eerste afronding",
+    "nudge.milestone.first_completion.body": "Een deelnemer heeft een cursus in {org_name} van begin tot eind afgerond. Wil je dat vastleggen, dan kun je een certificaat toevoegen — of beginnen aan wat hierna komt.",
+    "nudge.milestone.first_completion.cta": "Dashboard openen",
+}

--- a/apps/api/src/services/email/nudge_translations/pl.py
+++ b/apps/api/src/services/email/nudge_translations/pl.py
@@ -1,0 +1,155 @@
+"""Polish nudge copy."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "Zrezygnuj z tych wiadomości",
+    "nudge.common.footer": "Otrzymujesz tę wiadomość, ponieważ jesteś administratorem {org_name}.",
+
+    "nudge.activation.first_course_d1.subject": "Twój pierwszy kurs w {org_name}",
+    "nudge.activation.first_course_d1.heading": "Kiedy tylko zechcesz",
+    "nudge.activation.first_course_d1.body": "{org_name} jest gotowa i czeka na pierwszy kurs. Większość zaczyna od małego: jeden temat, kilka lekcji. Rozbudować możesz później.",
+    "nudge.activation.first_course_d1.cta": "Utwórz pierwszy kurs",
+
+    "nudge.activation.come_back_d2.subject": "Wróć tam, gdzie skończyłeś",
+    "nudge.activation.come_back_d2.heading": "Twoja konfiguracja wciąż czeka",
+    "nudge.activation.come_back_d2.body": "Założyłeś {org_name} i od tamtej pory nie wróciłeś. Wszystko nadal tam jest, a pierwszy kurs da się uruchomić w jakieś dziesięć minut.",
+    "nudge.activation.come_back_d2.cta": "Przejdź do panelu",
+
+    "nudge.activation.ai_course_help_d4.subject": "Pusta strona to najtrudniejsze",
+    "nudge.activation.ai_course_help_d4.heading": "Niech AI napisze konspekt",
+    "nudge.activation.ai_course_help_d4.body": "Jeśli {org_name} wciąż jest pusta, bo nie wiesz, od czego zacząć — opisz temat, a AI przygotuje rozdziały i lekcje. Dalej redagujesz Ty.",
+    "nudge.activation.ai_course_help_d4.cta": "Utwórz kurs z AI",
+
+    "nudge.activation.import_existing_d5.subject": "Przenieś to, co już masz",
+    "nudge.activation.import_existing_d5.heading": "Nie musisz zaczynać od zera",
+    "nudge.activation.import_existing_d5.body": "Jeśli Twoje materiały istnieją już jako dokumenty, slajdy albo eksport z innej platformy, możesz je przenieść do {org_name} zamiast przepisywać.",
+    "nudge.activation.import_existing_d5.cta": "Zaimportuj materiały",
+
+    "nudge.activation.setup_checklist_d7.subject": "Kwadrans do działającej akademii",
+    "nudge.activation.setup_checklist_d7.heading": "Krótka lista kroków",
+    "nudge.activation.setup_checklist_d7.body": "{org_name} wciąż czeka na pierwszy kurs. Lista konfiguracyjna prowadzi przez to w kilku krokach — większość kończy w kwadrans.",
+    "nudge.activation.setup_checklist_d7.cta": "Otwórz listę",
+
+    "nudge.activation.whats_blocking_d14.subject": "Co stanęło na przeszkodzie?",
+    "nudge.activation.whats_blocking_d14.heading": "Możemy zapytać, co Cię zatrzymało?",
+    "nudge.activation.whats_blocking_d14.body": "Założyłeś {org_name} dwa tygodnie temu i nie dodałeś jeszcze kursu. Jeśli coś było niejasne albo czegoś zabrakło, chcielibyśmy o tym wiedzieć — odpowiedz na tę wiadomość, trafi prosto do nas.",
+
+    "nudge.activation.last_call_d30.subject": "Ostatnia wiadomość o {org_name}",
+    "nudge.activation.last_call_d30.heading": "To już ostatnia",
+    "nudge.activation.last_call_d30.body": "{org_name} milczy od miesiąca, więc przestajemy wysyłać te wiadomości. Twoje konto i wszystko w nim zostaje — jeśli wrócisz, znajdziesz to tak, jak zostawiłeś.",
+    "nudge.activation.last_call_d30.cta": "Otwórz panel",
+
+    "nudge.content.course_no_chapter_d1.subject": "{course_name} potrzebuje pierwszego rozdziału",
+    "nudge.content.course_no_chapter_d1.heading": "Został jeden rozdział",
+    "nudge.content.course_no_chapter_d1.body": "{course_name} istnieje, ale nie ma jeszcze rozdziałów, więc nie ma czego otworzyć. Rozdziały to po prostu sekcje — jeden na temat sprawdza się dobrze.",
+    "nudge.content.course_no_chapter_d1.cta": "Dodaj rozdział",
+
+    "nudge.content.chapter_no_activity_d1.subject": "Dodaj pierwszą lekcję do {course_name}",
+    "nudge.content.chapter_no_activity_d1.heading": "Rozdziały są gotowe",
+    "nudge.content.chapter_no_activity_d1.body": "{course_name} ma rozdziały, ale są jeszcze puste. Lekcja może być stroną tekstu, filmem, quizem — czymkolwiek, co pasuje do tematu.",
+    "nudge.content.chapter_no_activity_d1.cta": "Dodaj lekcję",
+
+    "nudge.content.activity_unpublished_d2.subject": "Twoje lekcje w {course_name} nie są jeszcze widoczne",
+    "nudge.content.activity_unpublished_d2.heading": "Lekcje wciąż są ukryte",
+    "nudge.content.activity_unpublished_d2.body": "Napisałeś lekcje w {course_name}, ale żadna nie jest opublikowana, więc uczestnicy widzą pusty kurs. Publikacja niczego nie blokuje — możesz dalej edytować.",
+    "nudge.content.activity_unpublished_d2.cta": "Opublikuj lekcje",
+
+    "nudge.content.course_draft_d3.subject": "{course_name} to wciąż wersja robocza",
+    "nudge.content.course_draft_d3.heading": "{course_name} jest już blisko",
+    "nudge.content.course_draft_d3.body": "Dodałeś lekcje do {course_name}, ale kurs nie jest opublikowany, więc nikt go nie otworzy. Nie musi być skończony — publikacja tylko go uwidacznia, a edytować możesz dalej.",
+    "nudge.content.course_draft_d3.cta": "Opublikuj",
+
+    "nudge.content.course_draft_d10.subject": "{course_name} od dłuższego czasu jest wersją roboczą",
+    "nudge.content.course_draft_d10.heading": "Prawdopodobnie jest gotowy",
+    "nudge.content.course_draft_d10.body": "{course_name} leży nieopublikowany od ponad tygodnia. Kurs rzadko wydaje się skończony — publikacja czyni go widocznym, a ulepszać możesz go dalej, gdy ktoś już czyta.",
+    "nudge.content.course_draft_d10.cta": "Opublikuj",
+
+    "nudge.content.thin_course_d5.subject": "{course_name} przydałoby się nieco więcej",
+    "nudge.content.thin_course_d5.heading": "Jedna, dwie lekcje",
+    "nudge.content.thin_course_d5.body": "{course_name} ma na razie jedną czy dwie lekcje. Kursy zwykle wypadają lepiej przy kilku, a AI potrafi przygotować kolejne na bazie tego, co już jest.",
+    "nudge.content.thin_course_d5.cta": "Dodaj więcej lekcji",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "Wciąż brak prac w {org_name}",
+    "nudge.content.assignment_no_submissions_d5.heading": "Nikt niczego nie oddał",
+    "nudge.content.assignment_no_submissions_d5.body": "Utworzyłeś zadanie w {org_name}, ale nic nie zostało przesłane. Warto sprawdzić, czy jest opublikowane i czy uczestnicy mają dostęp do kursu, do którego należy.",
+    "nudge.content.assignment_no_submissions_d5.cta": "Sprawdź zadania",
+
+    "nudge.audience.published_no_members_d1.subject": "{course_name} jest opublikowany, ale nikogo tam nie ma",
+    "nudge.audience.published_no_members_d1.heading": "Czas kogoś zaprosić",
+    "nudge.audience.published_no_members_d1.body": "{course_name} jest opublikowany i gotowy do czytania. {org_name} nie ma jeszcze uczestników, więc następny krok to zaprosić tych, dla których go napisałeś.",
+    "nudge.audience.published_no_members_d1.cta": "Zaproś uczestników",
+
+    "nudge.audience.published_no_members_d7.subject": "{course_name} wciąż nie ma uczestników",
+    "nudge.audience.published_no_members_d7.heading": "Tydzień online, nikt nie czyta",
+    "nudge.audience.published_no_members_d7.body": "{course_name} jest opublikowany od tygodnia, a {org_name} nadal nie ma uczestników. Możesz zapraszać pojedynczo, wkleić listę albo po prostu udostępnić link.",
+    "nudge.audience.published_no_members_d7.cta": "Zaproś osoby",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "Twoi uczestnicy jeszcze nie zaczęli",
+    "nudge.audience.members_no_enrollment_d3.heading": "Dołączyli, ale nic nie otworzyli",
+    "nudge.audience.members_no_enrollment_d3.body": "Ludzie dołączyli do {org_name}, ale nikt nie zaczął kursu. Zwykle wystarczy krótka wiadomość z bezpośrednim linkiem — większość po prostu nie trafiła do środka.",
+    "nudge.audience.members_no_enrollment_d3.cta": "Zobacz członków",
+
+    "nudge.audience.share_public_page_d14.subject": "Twoja strona kursu jest publiczna — oto link",
+    "nudge.audience.share_public_page_d14.heading": "Każdy z linkiem może czytać",
+    "nudge.audience.share_public_page_d14.body": "{course_name} jest publiczny, więc możesz go udostępniać wszędzie i nikt nie potrzebuje zaproszenia. Link poniżej to ten do wysłania.",
+    "nudge.audience.share_public_page_d14.cta": "Zobacz stronę publiczną",
+
+    "nudge.audience.stalled_learners_d14.subject": "Część uczestników zatrzymała się w połowie",
+    "nudge.audience.stalled_learners_d14.heading": "Kilka osób utknęło",
+    "nudge.audience.stalled_learners_d14.body": "Część uczestników w {org_name} zaczęła kurs i nie wróciła od dwóch tygodni. Często pomaga wiadomość od Ciebie albo sprawdzenie, gdzie się zatrzymali.",
+    "nudge.audience.stalled_learners_d14.cta": "Sprawdź uczestników",
+
+    "nudge.monetization.course_limit_d1.subject": "Wykorzystałeś wszystkie kursy w planie {plan_name}",
+    "nudge.monetization.course_limit_d1.heading": "Osiągnąłeś limit kursów",
+    "nudge.monetization.course_limit_d1.body": "{org_name} korzysta z planu {plan_name} i wykorzystała wszystkie zawarte w nim kursy. Przejście na {next_plan} znosi ten limit, jeśli chcesz tworzyć dalej.",
+    "nudge.monetization.course_limit_d1.cta": "Zobacz plany",
+
+    "nudge.monetization.member_limit_near.subject": "Zbliżasz się do limitu członków w planie {plan_name}",
+    "nudge.monetization.member_limit_near.heading": "Blisko limitu członków",
+    "nudge.monetization.member_limit_near.body": "{org_name} zbliża się do liczby członków, na jaką pozwala plan {plan_name}. Przejście na {next_plan} podnosi ten limit, żeby nikt nie utknął w trakcie rejestracji.",
+    "nudge.monetization.member_limit_near.cta": "Zobacz plany",
+
+    "nudge.monetization.ai_credits_low.subject": "Twoje kredyty AI prawie się skończyły",
+    "nudge.monetization.ai_credits_low.heading": "Zostało mało kredytów AI",
+    "nudge.monetization.ai_credits_low.body": "{org_name} wykorzystała większość kredytów AI zawartych w planie {plan_name}. Plan {next_plan} zawiera ich więcej, jeśli AI stało się częścią tego, jak tworzysz kursy.",
+    "nudge.monetization.ai_credits_low.cta": "Zobacz plany",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "Co {next_plan} dałby {org_name}",
+    "nudge.monetization.upgrade_recap_d21.heading": "Zbudowałeś coś realnego",
+    "nudge.monetization.upgrade_recap_d21.body": "{org_name} ma opublikowane kursy i ludzi, którzy je czytają. Plan {next_plan} daje przestrzeń do wzrostu i kilka rzeczy, których nie ma w planie {plan_name} — warto zerknąć, jeśli planujesz się rozwijać.",
+    "nudge.monetization.upgrade_recap_d21.cta": "Porównaj plany",
+
+    "nudge.dormancy.no_login_14d.subject": "W {org_name} było cicho",
+    "nudge.dormancy.no_login_14d.heading": "Minęły dwa tygodnie",
+    "nudge.dormancy.no_login_14d.body": "W {org_name} nic się nie zmieniło od Twojej ostatniej wizyty. Jeśli byłeś w trakcie czegoś, leży dokładnie tam, gdzie to zostawiłeś.",
+    "nudge.dormancy.no_login_14d.cta": "Otwórz panel",
+
+    "nudge.dormancy.no_login_30d.subject": "Twoje kursy w {org_name} wciąż tu są",
+    "nudge.dormancy.no_login_30d.heading": "Minęło kilka tygodni",
+    "nudge.dormancy.no_login_30d.body": "Podczas Twojej nieobecności nic się nie zmieniło — {org_name} i wszystko w niej jest dokładnie tam, gdzie to zostawiłeś. Powrót to jedno kliknięcie.",
+    "nudge.dormancy.no_login_30d.cta": "Otwórz panel",
+
+    "nudge.dormancy.no_login_60d.subject": "Ostatnia wiadomość o {org_name}",
+    "nudge.dormancy.no_login_60d.heading": "Zostawiamy Cię w spokoju",
+    "nudge.dormancy.no_login_60d.body": "{org_name} milczy od dwóch miesięcy, więc to na razie ostatnia taka wiadomość. Wszystko, co zbudowałeś, zostaje bez zmian — na kiedy tylko zechcesz.",
+    "nudge.dormancy.no_login_60d.cta": "Otwórz panel",
+
+    "nudge.dormancy.winback_q.subject": "Co nowego od Twojej ostatniej wizyty w {org_name}",
+    "nudge.dormancy.winback_q.heading": "Kilka rzeczy się zmieniło",
+    "nudge.dormancy.winback_q.body": "Minęło trochę czasu, odkąd byłeś w {org_name}. Produkt sporo od tego czasu poszedł do przodu, a wszystko, co zbudowałeś, nadal tam jest.",
+    "nudge.dormancy.winback_q.cta": "Rzuć okiem",
+
+    "nudge.milestone.first_course_published.subject": "{course_name} jest opublikowany",
+    "nudge.milestone.first_course_published.heading": "Opublikowałeś swój pierwszy kurs",
+    "nudge.milestone.first_course_published.body": "{course_name} jest dostępny i można go czytać. To, co teraz robi różnicę, to ktoś, kto go przeczyta — nawet jedna czy dwie osoby na start.",
+    "nudge.milestone.first_course_published.cta": "Zaproś pierwszych uczestników",
+
+    "nudge.milestone.first_learner_enrolled.subject": "Ktoś zaczął {course_name}",
+    "nudge.milestone.first_learner_enrolled.heading": "Masz pierwszego uczestnika",
+    "nudge.milestone.first_learner_enrolled.body": "Ktoś po raz pierwszy zaczął kurs w {org_name}. Postępy możesz śledzić w panelu.",
+    "nudge.milestone.first_learner_enrolled.cta": "Zobacz postępy",
+
+    "nudge.milestone.first_completion.subject": "Ktoś ukończył kurs w {org_name}",
+    "nudge.milestone.first_completion.heading": "Pierwsze ukończenie",
+    "nudge.milestone.first_completion.body": "Uczestnik przeszedł kurs w {org_name} od początku do końca. Jeśli chcesz to odpowiednio odnotować, możesz dodać certyfikat — albo zacząć budować kolejny kurs.",
+    "nudge.milestone.first_completion.cta": "Otwórz panel",
+}

--- a/apps/api/src/services/email/nudge_translations/pl.py
+++ b/apps/api/src/services/email/nudge_translations/pl.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "Zrezygnuj z tych wiadomości",
     "nudge.common.footer": "Otrzymujesz tę wiadomość, ponieważ jesteś administratorem {org_name}.",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "Kursy",
+    "nudge.stat.chapters": "Rozdziały",
+    "nudge.stat.lessons": "Lekcje",
+    "nudge.stat.members": "Członkowie",
+    "nudge.stat.learners": "Uczestnicy",
+    "nudge.stat.completed": "Ukończone",
+
     "nudge.activation.first_course_d1.subject": "Twój pierwszy kurs w {org_name}",
     "nudge.activation.first_course_d1.heading": "Kiedy tylko zechcesz",
     "nudge.activation.first_course_d1.body": "{org_name} jest gotowa i czeka na pierwszy kurs. Większość zaczyna od małego: jeden temat, kilka lekcji. Rozbudować możesz później.",
@@ -152,4 +161,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "Pierwsze ukończenie",
     "nudge.milestone.first_completion.body": "Uczestnik przeszedł kurs w {org_name} od początku do końca. Jeśli chcesz to odpowiednio odnotować, możesz dodać certyfikat — albo zacząć budować kolejny kurs.",
     "nudge.milestone.first_completion.cta": "Otwórz panel",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "Twoja akademia w {org_name} wciąż tu jest",
+    "nudge.reactivation.opener.heading": "Wciąż tutaj, dokładnie tak, jak zostawiłeś",
+    "nudge.reactivation.opener.body": "Nikt nie ruszał {org_name} od Twojej ostatniej wizyty — każdy kurs, rozdział i lekcja są tam, gdzie je zostawiłeś. Powrót to jedno kliknięcie.",
+    "nudge.reactivation.opener.cta": "Otwórz panel",
+    "nudge.reactivation.whats_changed.subject": "Kilka rzeczy zmieniło się w LearnHouse",
+    "nudge.reactivation.whats_changed.heading": "Od Twojej ostatniej wizyty",
+    "nudge.reactivation.whats_changed.body": "Produkt sporo poszedł do przodu, gdy {org_name} milczała: edytor, narzędzia kursów i ścieżka uczestników zostały porządnie przepracowane. Wszystko, co zbudowałeś, działa tak samo.",
+    "nudge.reactivation.whats_changed.cta": "Zobacz nowości",
+    "nudge.reactivation.need_a_hand.subject": "Potrzebujesz pomocy z powrotem do {org_name}?",
+    "nudge.reactivation.need_a_hand.heading": "Coś stanęło na przeszkodzie?",
+    "nudge.reactivation.need_a_hand.body": "Jeśli był powód, dla którego {org_name} stanęła — coś niejasnego, czegoś brakowało albo po prostu brakło czasu — chcielibyśmy o tym wiedzieć. Odpowiedz na tę wiadomość, trafi prosto do nas.",
+    "nudge.reactivation.closing.subject": "Ostatnia wiadomość o {org_name}",
+    "nudge.reactivation.closing.heading": "Na tym kończymy",
+    "nudge.reactivation.closing.body": "To ostatnia z takich wiadomości. {org_name} zostaje dokładnie taka, jaka jest, i nic nie wygasa — jeśli kiedyś zechcesz wrócić, wszystko będzie czekać.",
+    "nudge.reactivation.closing.cta": "Otwórz panel",
 }

--- a/apps/api/src/services/email/nudge_translations/pt.py
+++ b/apps/api/src/services/email/nudge_translations/pt.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "Cancelar inscrição nestes e-mails",
     "nudge.common.footer": "Você recebeu este e-mail porque é administrador de {org_name}.",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "Cursos",
+    "nudge.stat.chapters": "Capítulos",
+    "nudge.stat.lessons": "Aulas",
+    "nudge.stat.members": "Membros",
+    "nudge.stat.learners": "Alunos",
+    "nudge.stat.completed": "Concluídos",
+
     "nudge.activation.first_course_d1.subject": "Seu primeiro curso na {org_name}",
     "nudge.activation.first_course_d1.heading": "Quando você quiser",
     "nudge.activation.first_course_d1.body": "A {org_name} está pronta e esperando o primeiro curso. A maioria começa pequeno: um tema, algumas aulas. Você pode ampliar depois.",
@@ -152,4 +161,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "Primeira conclusão",
     "nudge.milestone.first_completion.body": "Um aluno concluiu um curso da {org_name} do início ao fim. Se quiser registrar isso, dá para adicionar um certificado — ou começar a montar o próximo.",
     "nudge.milestone.first_completion.cta": "Abrir seu painel",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "Sua academia na {org_name} continua aqui",
+    "nudge.reactivation.opener.heading": "Continua aqui, do jeito que você deixou",
+    "nudge.reactivation.opener.body": "Ninguém mexeu na {org_name} desde a sua última visita — cada curso, capítulo e aula está onde você deixou. Retomar é um clique.",
+    "nudge.reactivation.opener.cta": "Abrir seu painel",
+    "nudge.reactivation.whats_changed.subject": "Algumas coisas mudaram no LearnHouse",
+    "nudge.reactivation.whats_changed.heading": "Desde a sua última visita",
+    "nudge.reactivation.whats_changed.body": "O produto avançou bastante enquanto a {org_name} esteve parada: o editor, as ferramentas de curso e o percurso dos alunos foram bem trabalhados. Tudo o que você construiu continua funcionando como antes.",
+    "nudge.reactivation.whats_changed.cta": "Ver as novidades",
+    "nudge.reactivation.need_a_hand.subject": "Precisa de ajuda para voltar à {org_name}?",
+    "nudge.reactivation.need_a_hand.heading": "Teve algo atrapalhando?",
+    "nudge.reactivation.need_a_hand.body": "Se houve um motivo para a {org_name} parar — algo confuso, algo faltando ou simplesmente falta de tempo — a gente gostaria muito de saber. Responda a este e-mail, que chega direto para nós.",
+    "nudge.reactivation.closing.subject": "Última mensagem sobre a {org_name}",
+    "nudge.reactivation.closing.heading": "Paramos por aqui",
+    "nudge.reactivation.closing.body": "Este é o último destes e-mails. A {org_name} fica exatamente como está e nada expira — se um dia quiser voltar, tudo estará esperando.",
+    "nudge.reactivation.closing.cta": "Abrir seu painel",
 }

--- a/apps/api/src/services/email/nudge_translations/pt.py
+++ b/apps/api/src/services/email/nudge_translations/pt.py
@@ -1,0 +1,155 @@
+"""Portuguese nudge copy."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "Cancelar inscrição nestes e-mails",
+    "nudge.common.footer": "Você recebeu este e-mail porque é administrador de {org_name}.",
+
+    "nudge.activation.first_course_d1.subject": "Seu primeiro curso na {org_name}",
+    "nudge.activation.first_course_d1.heading": "Quando você quiser",
+    "nudge.activation.first_course_d1.body": "A {org_name} está pronta e esperando o primeiro curso. A maioria começa pequeno: um tema, algumas aulas. Você pode ampliar depois.",
+    "nudge.activation.first_course_d1.cta": "Criar seu primeiro curso",
+
+    "nudge.activation.come_back_d2.subject": "Continuar de onde você parou",
+    "nudge.activation.come_back_d2.heading": "Sua configuração continua esperando",
+    "nudge.activation.come_back_d2.body": "Você criou a {org_name} e não voltou desde então. Está tudo lá, e colocar um primeiro curso no ar leva uns dez minutos.",
+    "nudge.activation.come_back_d2.cta": "Ir para o painel",
+
+    "nudge.activation.ai_course_help_d4.subject": "A página em branco é a parte difícil",
+    "nudge.activation.ai_course_help_d4.heading": "Deixe a IA escrever o roteiro",
+    "nudge.activation.ai_course_help_d4.body": "Se a {org_name} ainda está vazia porque você não sabe por onde começar, descreva o tema e a IA vai esboçar os capítulos e as aulas. A edição fica com você.",
+    "nudge.activation.ai_course_help_d4.cta": "Criar um curso com IA",
+
+    "nudge.activation.import_existing_d5.subject": "Traga o que você já tem",
+    "nudge.activation.import_existing_d5.heading": "Não precisa começar do zero",
+    "nudge.activation.import_existing_d5.body": "Se o seu material já existe como documentos, slides ou uma exportação de outra plataforma, dá para trazer tudo para a {org_name} em vez de digitar de novo.",
+    "nudge.activation.import_existing_d5.cta": "Importar seu material",
+
+    "nudge.activation.setup_checklist_d7.subject": "Quinze minutos para uma academia funcionando",
+    "nudge.activation.setup_checklist_d7.heading": "Uma lista curta",
+    "nudge.activation.setup_checklist_d7.body": "A {org_name} ainda espera o primeiro curso. A lista de configuração guia você em poucos passos — a maioria termina em uns quinze minutos.",
+    "nudge.activation.setup_checklist_d7.cta": "Abrir a lista",
+
+    "nudge.activation.whats_blocking_d14.subject": "O que atrapalhou?",
+    "nudge.activation.whats_blocking_d14.heading": "Podemos perguntar o que travou?",
+    "nudge.activation.whats_blocking_d14.body": "Você criou a {org_name} há duas semanas e ainda não adicionou um curso. Se algo ficou confuso ou faltou, gostaríamos de saber — é só responder a este e-mail, que chega direto para nós.",
+
+    "nudge.activation.last_call_d30.subject": "Último e-mail sobre a {org_name}",
+    "nudge.activation.last_call_d30.heading": "Este é o último",
+    "nudge.activation.last_call_d30.body": "A {org_name} ficou parada por um mês, então vamos parar com estes e-mails. Sua conta e tudo o que está nela continuam ali — se você voltar, vai encontrar tudo como deixou.",
+    "nudge.activation.last_call_d30.cta": "Abrir seu painel",
+
+    "nudge.content.course_no_chapter_d1.subject": "{course_name} precisa do primeiro capítulo",
+    "nudge.content.course_no_chapter_d1.heading": "Falta um capítulo",
+    "nudge.content.course_no_chapter_d1.body": "{course_name} existe mas ainda não tem capítulos, então não há nada para abrir. Capítulos são só seções — um por tema funciona bem.",
+    "nudge.content.course_no_chapter_d1.cta": "Adicionar um capítulo",
+
+    "nudge.content.chapter_no_activity_d1.subject": "Adicione a primeira aula a {course_name}",
+    "nudge.content.chapter_no_activity_d1.heading": "Os capítulos estão prontos",
+    "nudge.content.chapter_no_activity_d1.body": "{course_name} tem capítulos, mas ainda estão vazios. Uma aula pode ser uma página de texto, um vídeo, um quiz — o que combinar com o tema.",
+    "nudge.content.chapter_no_activity_d1.cta": "Adicionar uma aula",
+
+    "nudge.content.activity_unpublished_d2.subject": "Suas aulas em {course_name} ainda não aparecem",
+    "nudge.content.activity_unpublished_d2.heading": "As aulas continuam escondidas",
+    "nudge.content.activity_unpublished_d2.body": "Você escreveu aulas em {course_name}, mas nenhuma está publicada, então quem entra vê um curso vazio. Publicar não trava nada — dá para continuar editando.",
+    "nudge.content.activity_unpublished_d2.cta": "Publicar suas aulas",
+
+    "nudge.content.course_draft_d3.subject": "{course_name} ainda é um rascunho",
+    "nudge.content.course_draft_d3.heading": "{course_name} está quase lá",
+    "nudge.content.course_draft_d3.body": "Você adicionou aulas a {course_name}, mas ele não está publicado, então ninguém consegue abrir. Não precisa estar pronto — publicar só o torna visível, e você pode continuar editando.",
+    "nudge.content.course_draft_d3.cta": "Publicar",
+
+    "nudge.content.course_draft_d10.subject": "{course_name} está como rascunho há um tempo",
+    "nudge.content.course_draft_d10.heading": "Provavelmente já está pronto",
+    "nudge.content.course_draft_d10.body": "{course_name} está sem publicar há mais de uma semana. Curso raramente parece terminado — publicar deixa visível, e você pode seguir melhorando com gente já lendo.",
+    "nudge.content.course_draft_d10.cta": "Publicar",
+
+    "nudge.content.thin_course_d5.subject": "{course_name} pede um pouco mais",
+    "nudge.content.thin_course_d5.heading": "Uma ou duas aulas",
+    "nudge.content.thin_course_d5.body": "{course_name} tem uma ou duas aulas até agora. Cursos costumam funcionar melhor com algumas a mais, e a IA pode esboçar as próximas a partir do que já existe.",
+    "nudge.content.thin_course_d5.cta": "Adicionar mais aulas",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "Ainda sem entregas na {org_name}",
+    "nudge.content.assignment_no_submissions_d5.heading": "Ninguém entregou nada",
+    "nudge.content.assignment_no_submissions_d5.body": "Você criou uma atividade avaliativa na {org_name} mas nada foi entregue. Vale conferir se ela está publicada e se os alunos conseguem chegar ao curso a que ela pertence.",
+    "nudge.content.assignment_no_submissions_d5.cta": "Conferir suas atividades",
+
+    "nudge.audience.published_no_members_d1.subject": "{course_name} está no ar, mas ainda sem ninguém",
+    "nudge.audience.published_no_members_d1.heading": "Hora de convidar alguém",
+    "nudge.audience.published_no_members_d1.body": "{course_name} está publicado e pronto para leitura. A {org_name} ainda não tem alunos, então o próximo passo é convidar as pessoas para quem você escreveu.",
+    "nudge.audience.published_no_members_d1.cta": "Convidar alunos",
+
+    "nudge.audience.published_no_members_d7.subject": "{course_name} continua sem alunos",
+    "nudge.audience.published_no_members_d7.heading": "Uma semana no ar e ninguém lendo",
+    "nudge.audience.published_no_members_d7.body": "{course_name} está publicado há uma semana e a {org_name} continua sem alunos. Dá para convidar um a um, colar uma lista ou simplesmente compartilhar o link de entrada.",
+    "nudge.audience.published_no_members_d7.cta": "Convidar pessoas",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "Seus alunos ainda não começaram",
+    "nudge.audience.members_no_enrollment_d3.heading": "Entraram mas não abriram nada",
+    "nudge.audience.members_no_enrollment_d3.body": "Pessoas entraram na {org_name} mas ninguém começou um curso. Uma mensagem curta com link direto costuma resolver — a maioria só não achou o caminho.",
+    "nudge.audience.members_no_enrollment_d3.cta": "Ver seus membros",
+
+    "nudge.audience.share_public_page_d14.subject": "Sua página de curso é pública — aqui está o link",
+    "nudge.audience.share_public_page_d14.heading": "Qualquer pessoa com o link consegue ler",
+    "nudge.audience.share_public_page_d14.body": "{course_name} é público, então você pode divulgar em qualquer lugar sem que ninguém precise de convite. O link abaixo é o que deve ser enviado.",
+    "nudge.audience.share_public_page_d14.cta": "Ver a página pública",
+
+    "nudge.audience.stalled_learners_d14.subject": "Alguns alunos pararam no meio",
+    "nudge.audience.stalled_learners_d14.heading": "Algumas pessoas travaram",
+    "nudge.audience.stalled_learners_d14.body": "Alguns alunos da {org_name} começaram um curso e não voltam há duas semanas. Costuma valer uma mensagem sua, ou uma olhada em onde eles pararam.",
+    "nudge.audience.stalled_learners_d14.cta": "Ver seus alunos",
+
+    "nudge.monetization.course_limit_d1.subject": "Você usou todos os cursos do plano {plan_name}",
+    "nudge.monetization.course_limit_d1.heading": "Você atingiu o limite de cursos",
+    "nudge.monetization.course_limit_d1.body": "A {org_name} está no plano {plan_name} e usou todos os cursos incluídos. Mudar para {next_plan} remove esse limite, se você quiser continuar criando.",
+    "nudge.monetization.course_limit_d1.cta": "Ver planos",
+
+    "nudge.monetization.member_limit_near.subject": "Você está perto do limite de membros do plano {plan_name}",
+    "nudge.monetization.member_limit_near.heading": "Quase no limite de membros",
+    "nudge.monetization.member_limit_near.body": "A {org_name} está chegando ao número de membros que o plano {plan_name} permite. Mudar para {next_plan} aumenta esse número, para ninguém ficar de fora no meio do cadastro.",
+    "nudge.monetization.member_limit_near.cta": "Ver planos",
+
+    "nudge.monetization.ai_credits_low.subject": "Seus créditos de IA estão quase no fim",
+    "nudge.monetization.ai_credits_low.heading": "Poucos créditos de IA restantes",
+    "nudge.monetization.ai_credits_low.body": "A {org_name} usou a maior parte dos créditos de IA incluídos no plano {plan_name}. O plano {next_plan} vem com mais, se a IA virou parte de como você monta cursos.",
+    "nudge.monetization.ai_credits_low.cta": "Ver planos",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "O que o {next_plan} traria para a {org_name}",
+    "nudge.monetization.upgrade_recap_d21.heading": "Você construiu algo de verdade",
+    "nudge.monetization.upgrade_recap_d21.body": "A {org_name} tem cursos publicados e gente lendo. O plano {next_plan} dá espaço para crescer e inclui coisas que o plano {plan_name} não tem — vale olhar se você pretende expandir.",
+    "nudge.monetization.upgrade_recap_d21.cta": "Comparar planos",
+
+    "nudge.dormancy.no_login_14d.subject": "A {org_name} andou quieta",
+    "nudge.dormancy.no_login_14d.heading": "Já faz duas semanas",
+    "nudge.dormancy.no_login_14d.body": "Nada mudou na {org_name} desde a sua última visita. Se você estava no meio de alguma coisa, está exatamente onde você deixou.",
+    "nudge.dormancy.no_login_14d.cta": "Abrir seu painel",
+
+    "nudge.dormancy.no_login_30d.subject": "Seus cursos na {org_name} continuam aqui",
+    "nudge.dormancy.no_login_30d.heading": "Já faz algumas semanas",
+    "nudge.dormancy.no_login_30d.body": "Nada mudou enquanto você esteve fora — a {org_name} e tudo nela está exatamente onde você deixou. Retomar é um clique.",
+    "nudge.dormancy.no_login_30d.cta": "Abrir seu painel",
+
+    "nudge.dormancy.no_login_60d.subject": "Última mensagem sobre a {org_name}",
+    "nudge.dormancy.no_login_60d.heading": "Vamos deixar você em paz",
+    "nudge.dormancy.no_login_60d.body": "A {org_name} está parada há uns dois meses, então este é o último destes e-mails por ora. Tudo o que você construiu fica exatamente como está, para quando quiser.",
+    "nudge.dormancy.no_login_60d.cta": "Abrir seu painel",
+
+    "nudge.dormancy.winback_q.subject": "O que mudou desde a sua última visita à {org_name}",
+    "nudge.dormancy.winback_q.heading": "Algumas coisas mudaram",
+    "nudge.dormancy.winback_q.body": "Faz um tempo que você não passa pela {org_name}. O produto avançou bastante desde então, e tudo o que você construiu continua lá.",
+    "nudge.dormancy.winback_q.cta": "Dar uma olhada",
+
+    "nudge.milestone.first_course_published.subject": "{course_name} está no ar",
+    "nudge.milestone.first_course_published.heading": "Você publicou seu primeiro curso",
+    "nudge.milestone.first_course_published.body": "{course_name} está no ar e pode ser lido. O que faz diferença agora é ter alguém lendo — mesmo que sejam uma ou duas pessoas para começar.",
+    "nudge.milestone.first_course_published.cta": "Convidar seus primeiros alunos",
+
+    "nudge.milestone.first_learner_enrolled.subject": "Alguém começou {course_name}",
+    "nudge.milestone.first_learner_enrolled.heading": "Seu primeiro aluno chegou",
+    "nudge.milestone.first_learner_enrolled.body": "Pela primeira vez alguém começou um curso na {org_name}. Você pode acompanhar o progresso pelo painel.",
+    "nudge.milestone.first_learner_enrolled.cta": "Ver o progresso",
+
+    "nudge.milestone.first_completion.subject": "Alguém concluiu um curso na {org_name}",
+    "nudge.milestone.first_completion.heading": "Primeira conclusão",
+    "nudge.milestone.first_completion.body": "Um aluno concluiu um curso da {org_name} do início ao fim. Se quiser registrar isso, dá para adicionar um certificado — ou começar a montar o próximo.",
+    "nudge.milestone.first_completion.cta": "Abrir seu painel",
+}

--- a/apps/api/src/services/email/nudge_translations/ru.py
+++ b/apps/api/src/services/email/nudge_translations/ru.py
@@ -1,0 +1,155 @@
+"""Russian nudge copy."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "Отписаться от этих писем",
+    "nudge.common.footer": "Вы получили это письмо, так как являетесь администратором {org_name}.",
+
+    "nudge.activation.first_course_d1.subject": "Ваш первый курс в {org_name}",
+    "nudge.activation.first_course_d1.heading": "Когда будет удобно",
+    "nudge.activation.first_course_d1.body": "{org_name} готова и ждёт первый курс. Большинство начинает с малого: одна тема, несколько уроков. Дополнить можно в любой момент.",
+    "nudge.activation.first_course_d1.cta": "Создать первый курс",
+
+    "nudge.activation.come_back_d2.subject": "Продолжить с того места, где остановились",
+    "nudge.activation.come_back_d2.heading": "Всё настроенное вас ждёт",
+    "nudge.activation.come_back_d2.body": "Вы создали {org_name} и с тех пор не возвращались. Всё на месте, а на публикацию первого курса уходит около десяти минут.",
+    "nudge.activation.come_back_d2.cta": "Перейти в панель",
+
+    "nudge.activation.ai_course_help_d4.subject": "Самое сложное — чистый лист",
+    "nudge.activation.ai_course_help_d4.heading": "Пусть ИИ напишет план",
+    "nudge.activation.ai_course_help_d4.body": "Если {org_name} всё ещё пуста, потому что непонятно, с чего начать, — опишите тему, и ИИ подготовит главы и уроки. Дальше правите вы.",
+    "nudge.activation.ai_course_help_d4.cta": "Создать курс с ИИ",
+
+    "nudge.activation.import_existing_d5.subject": "Перенесите то, что уже есть",
+    "nudge.activation.import_existing_d5.heading": "Не обязательно начинать с нуля",
+    "nudge.activation.import_existing_d5.body": "Если материалы уже существуют в виде документов, презентаций или выгрузки с другой платформы, их можно перенести в {org_name}, а не набирать заново.",
+    "nudge.activation.import_existing_d5.cta": "Импортировать материалы",
+
+    "nudge.activation.setup_checklist_d7.subject": "Пятнадцать минут до работающей академии",
+    "nudge.activation.setup_checklist_d7.heading": "Короткий чек-лист",
+    "nudge.activation.setup_checklist_d7.body": "{org_name} всё ещё ждёт первый курс. Чек-лист проведёт вас за несколько шагов — большинство укладывается в четверть часа.",
+    "nudge.activation.setup_checklist_d7.cta": "Открыть чек-лист",
+
+    "nudge.activation.whats_blocking_d14.subject": "Что помешало?",
+    "nudge.activation.whats_blocking_d14.heading": "Можно спросить, что вас остановило?",
+    "nudge.activation.whats_blocking_d14.body": "Вы создали {org_name} пару недель назад и пока не добавили курс. Если что-то было непонятно или чего-то не хватило, нам важно об этом знать — просто ответьте на это письмо, оно придёт напрямую к нам.",
+
+    "nudge.activation.last_call_d30.subject": "Последнее письмо про {org_name}",
+    "nudge.activation.last_call_d30.heading": "Это последнее",
+    "nudge.activation.last_call_d30.body": "{org_name} молчит уже месяц, поэтому мы перестаём отправлять такие письма. Аккаунт и всё его содержимое остаются на месте — вернётесь, и всё будет там, где вы оставили.",
+    "nudge.activation.last_call_d30.cta": "Открыть панель",
+
+    "nudge.content.course_no_chapter_d1.subject": "Курсу «{course_name}» нужна первая глава",
+    "nudge.content.course_no_chapter_d1.heading": "Осталась одна глава",
+    "nudge.content.course_no_chapter_d1.body": "Курс «{course_name}» создан, но глав в нём пока нет, поэтому открывать нечего. Главы — это просто разделы, по одной на тему работает хорошо.",
+    "nudge.content.course_no_chapter_d1.cta": "Добавить главу",
+
+    "nudge.content.chapter_no_activity_d1.subject": "Добавьте первый урок в «{course_name}»",
+    "nudge.content.chapter_no_activity_d1.heading": "Главы готовы",
+    "nudge.content.chapter_no_activity_d1.body": "В курсе «{course_name}» есть главы, но они пока пустые. Урок может быть страницей текста, видео, тестом — тем, что подходит теме.",
+    "nudge.content.chapter_no_activity_d1.cta": "Добавить урок",
+
+    "nudge.content.activity_unpublished_d2.subject": "Ваши уроки в «{course_name}» пока не видны",
+    "nudge.content.activity_unpublished_d2.heading": "Уроки всё ещё скрыты",
+    "nudge.content.activity_unpublished_d2.body": "Вы написали уроки в курсе «{course_name}», но ни один не опубликован, поэтому участники видят пустой курс. Публикация ничего не фиксирует — редактировать можно и дальше.",
+    "nudge.content.activity_unpublished_d2.cta": "Опубликовать уроки",
+
+    "nudge.content.course_draft_d3.subject": "«{course_name}» всё ещё черновик",
+    "nudge.content.course_draft_d3.heading": "«{course_name}» почти готов",
+    "nudge.content.course_draft_d3.body": "Вы добавили уроки в «{course_name}», но курс не опубликован, поэтому его никто не откроет. Ему не обязательно быть завершённым — публикация лишь делает его видимым, редактировать можно и после.",
+    "nudge.content.course_draft_d3.cta": "Опубликовать",
+
+    "nudge.content.course_draft_d10.subject": "«{course_name}» уже давно в черновиках",
+    "nudge.content.course_draft_d10.heading": "Скорее всего, он готов",
+    "nudge.content.course_draft_d10.body": "«{course_name}» лежит неопубликованным больше недели. Курс редко кажется законченным — публикация делает его видимым, а улучшать можно и когда его уже читают.",
+    "nudge.content.course_draft_d10.cta": "Опубликовать",
+
+    "nudge.content.thin_course_d5.subject": "«{course_name}» не помешает дополнить",
+    "nudge.content.thin_course_d5.heading": "Один-два урока",
+    "nudge.content.thin_course_d5.body": "В курсе «{course_name}» пока один-два урока. Курсы обычно воспринимаются лучше, когда их несколько, и ИИ может подготовить следующие на основе уже написанного.",
+    "nudge.content.thin_course_d5.cta": "Добавить уроки",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "В {org_name} пока нет ни одной работы",
+    "nudge.content.assignment_no_submissions_d5.heading": "Никто ничего не сдал",
+    "nudge.content.assignment_no_submissions_d5.body": "Вы создали задание в {org_name}, но работ пока нет. Стоит проверить, опубликовано ли оно и есть ли у участников доступ к соответствующему курсу.",
+    "nudge.content.assignment_no_submissions_d5.cta": "Проверить задания",
+
+    "nudge.audience.published_no_members_d1.subject": "«{course_name}» опубликован, но там никого нет",
+    "nudge.audience.published_no_members_d1.heading": "Пора кого-нибудь пригласить",
+    "nudge.audience.published_no_members_d1.body": "«{course_name}» опубликован и готов к чтению. В {org_name} пока нет участников, поэтому следующий шаг — пригласить тех, для кого вы его писали.",
+    "nudge.audience.published_no_members_d1.cta": "Пригласить участников",
+
+    "nudge.audience.published_no_members_d7.subject": "У «{course_name}» до сих пор нет участников",
+    "nudge.audience.published_no_members_d7.heading": "Неделя онлайн, никто не читает",
+    "nudge.audience.published_no_members_d7.body": "«{course_name}» опубликован неделю назад, а в {org_name} по-прежнему нет участников. Можно приглашать по одному, вставить список или просто поделиться ссылкой.",
+    "nudge.audience.published_no_members_d7.cta": "Пригласить людей",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "Ваши участники ещё не начали",
+    "nudge.audience.members_no_enrollment_d3.heading": "Присоединились, но ничего не открыли",
+    "nudge.audience.members_no_enrollment_d3.body": "Люди присоединились к {org_name}, но никто не начал курс. Обычно достаточно короткого сообщения с прямой ссылкой — большинство просто не нашли вход.",
+    "nudge.audience.members_no_enrollment_d3.cta": "Посмотреть участников",
+
+    "nudge.audience.share_public_page_d14.subject": "Страница курса публичная — вот ссылка",
+    "nudge.audience.share_public_page_d14.heading": "Прочитать может любой по ссылке",
+    "nudge.audience.share_public_page_d14.body": "«{course_name}» открыт публично, так что делиться им можно где угодно и без приглашений. Ссылка ниже — та самая, которую стоит отправлять.",
+    "nudge.audience.share_public_page_d14.cta": "Открыть публичную страницу",
+
+    "nudge.audience.stalled_learners_d14.subject": "Некоторые участники остановились на середине",
+    "nudge.audience.stalled_learners_d14.heading": "Несколько человек застряли",
+    "nudge.audience.stalled_learners_d14.body": "Некоторые участники {org_name} начали курс и не возвращались уже пару недель. Часто помогает сообщение от вас — или взгляд на то, где именно они остановились.",
+    "nudge.audience.stalled_learners_d14.cta": "Посмотреть участников",
+
+    "nudge.monetization.course_limit_d1.subject": "Вы использовали все курсы тарифа {plan_name}",
+    "nudge.monetization.course_limit_d1.heading": "Достигнут лимит курсов",
+    "nudge.monetization.course_limit_d1.body": "{org_name} на тарифе {plan_name} и использовала все включённые в него курсы. Переход на {next_plan} снимает это ограничение, если хотите продолжать.",
+    "nudge.monetization.course_limit_d1.cta": "Посмотреть тарифы",
+
+    "nudge.monetization.member_limit_near.subject": "Вы близко к лимиту участников на тарифе {plan_name}",
+    "nudge.monetization.member_limit_near.heading": "Почти достигнут лимит участников",
+    "nudge.monetization.member_limit_near.body": "{org_name} приближается к числу участников, которое допускает тариф {plan_name}. Переход на {next_plan} поднимает его, чтобы никто не остановился на полпути к регистрации.",
+    "nudge.monetization.member_limit_near.cta": "Посмотреть тарифы",
+
+    "nudge.monetization.ai_credits_low.subject": "Кредиты ИИ почти закончились",
+    "nudge.monetization.ai_credits_low.heading": "Кредитов ИИ осталось мало",
+    "nudge.monetization.ai_credits_low.body": "{org_name} израсходовала большую часть кредитов ИИ, включённых в тариф {plan_name}. На тарифе {next_plan} их больше — если ИИ стал частью того, как вы готовите курсы.",
+    "nudge.monetization.ai_credits_low.cta": "Посмотреть тарифы",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "Что {next_plan} даст {org_name}",
+    "nudge.monetization.upgrade_recap_d21.heading": "Вы построили что-то настоящее",
+    "nudge.monetization.upgrade_recap_d21.body": "В {org_name} есть опубликованные курсы и люди, которые их читают. Тариф {next_plan} даёт запас для роста и несколько вещей, которых нет в тарифе {plan_name}, — стоит взглянуть, если планируете расширяться.",
+    "nudge.monetization.upgrade_recap_d21.cta": "Сравнить тарифы",
+
+    "nudge.dormancy.no_login_14d.subject": "В {org_name} было тихо",
+    "nudge.dormancy.no_login_14d.heading": "Прошло пару недель",
+    "nudge.dormancy.no_login_14d.body": "С вашего последнего визита в {org_name} ничего не изменилось. Если вы были в процессе, всё лежит ровно там, где вы оставили.",
+    "nudge.dormancy.no_login_14d.cta": "Открыть панель",
+
+    "nudge.dormancy.no_login_30d.subject": "Ваши курсы в {org_name} никуда не делись",
+    "nudge.dormancy.no_login_30d.heading": "Прошло несколько недель",
+    "nudge.dormancy.no_login_30d.body": "Пока вас не было, ничего не изменилось — {org_name} и всё в ней ровно там, где вы оставили. Вернуться — это один клик.",
+    "nudge.dormancy.no_login_30d.cta": "Открыть панель",
+
+    "nudge.dormancy.no_login_60d.subject": "Последнее сообщение про {org_name}",
+    "nudge.dormancy.no_login_60d.heading": "Больше не беспокоим",
+    "nudge.dormancy.no_login_60d.body": "{org_name} молчит уже пару месяцев, так что это последнее такое письмо. Всё, что вы построили, остаётся как есть — на случай, когда понадобится.",
+    "nudge.dormancy.no_login_60d.cta": "Открыть панель",
+
+    "nudge.dormancy.winback_q.subject": "Что нового с вашего последнего визита в {org_name}",
+    "nudge.dormancy.winback_q.heading": "Кое-что изменилось",
+    "nudge.dormancy.winback_q.body": "Вы давно не заходили в {org_name}. Продукт с тех пор заметно продвинулся, а всё, что вы построили, по-прежнему на месте.",
+    "nudge.dormancy.winback_q.cta": "Посмотреть",
+
+    "nudge.milestone.first_course_published.subject": "«{course_name}» опубликован",
+    "nudge.milestone.first_course_published.heading": "Вы опубликовали первый курс",
+    "nudge.milestone.first_course_published.body": "«{course_name}» опубликован, и его можно читать. Дальше главное — чтобы кто-то его прочитал, пусть даже один-два человека для начала.",
+    "nudge.milestone.first_course_published.cta": "Пригласить первых участников",
+
+    "nudge.milestone.first_learner_enrolled.subject": "Кто-то начал «{course_name}»",
+    "nudge.milestone.first_learner_enrolled.heading": "У вас первый участник",
+    "nudge.milestone.first_learner_enrolled.body": "Впервые кто-то начал курс в {org_name}. Следить за прогрессом можно в панели.",
+    "nudge.milestone.first_learner_enrolled.cta": "Посмотреть прогресс",
+
+    "nudge.milestone.first_completion.subject": "Кто-то прошёл курс в {org_name}",
+    "nudge.milestone.first_completion.heading": "Первое завершение",
+    "nudge.milestone.first_completion.body": "Участник прошёл курс в {org_name} от начала до конца. Чтобы отметить это как следует, можно добавить сертификат — или начать готовить следующий курс.",
+    "nudge.milestone.first_completion.cta": "Открыть панель",
+}

--- a/apps/api/src/services/email/nudge_translations/ru.py
+++ b/apps/api/src/services/email/nudge_translations/ru.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "Отписаться от этих писем",
     "nudge.common.footer": "Вы получили это письмо, так как являетесь администратором {org_name}.",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "Курсы",
+    "nudge.stat.chapters": "Главы",
+    "nudge.stat.lessons": "Уроки",
+    "nudge.stat.members": "Участники",
+    "nudge.stat.learners": "Учащиеся",
+    "nudge.stat.completed": "Завершено",
+
     "nudge.activation.first_course_d1.subject": "Ваш первый курс в {org_name}",
     "nudge.activation.first_course_d1.heading": "Когда будет удобно",
     "nudge.activation.first_course_d1.body": "{org_name} готова и ждёт первый курс. Большинство начинает с малого: одна тема, несколько уроков. Дополнить можно в любой момент.",
@@ -152,4 +161,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "Первое завершение",
     "nudge.milestone.first_completion.body": "Участник прошёл курс в {org_name} от начала до конца. Чтобы отметить это как следует, можно добавить сертификат — или начать готовить следующий курс.",
     "nudge.milestone.first_completion.cta": "Открыть панель",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "Ваша академия в {org_name} никуда не делась",
+    "nudge.reactivation.opener.heading": "Всё на месте, ровно как вы оставили",
+    "nudge.reactivation.opener.body": "С вашего последнего визита {org_name} никто не трогал — каждый курс, раздел и урок там, где вы их оставили. Вернуться — один клик.",
+    "nudge.reactivation.opener.cta": "Открыть панель",
+    "nudge.reactivation.whats_changed.subject": "В LearnHouse кое-что изменилось",
+    "nudge.reactivation.whats_changed.heading": "С вашего последнего визита",
+    "nudge.reactivation.whats_changed.body": "Пока {org_name} молчала, продукт заметно продвинулся: редактор, инструменты курсов и путь учащегося серьёзно переработаны. Всё, что вы построили, работает как прежде.",
+    "nudge.reactivation.whats_changed.cta": "Посмотреть новое",
+    "nudge.reactivation.need_a_hand.subject": "Нужна помощь, чтобы вернуться в {org_name}?",
+    "nudge.reactivation.need_a_hand.heading": "Что-то помешало?",
+    "nudge.reactivation.need_a_hand.body": "Если была причина, по которой {org_name} остановилась — что-то непонятное, чего-то не хватило или просто не было времени — нам важно об этом знать. Ответьте на это письмо, оно придёт напрямую к нам.",
+    "nudge.reactivation.closing.subject": "Последнее письмо про {org_name}",
+    "nudge.reactivation.closing.heading": "На этом остановимся",
+    "nudge.reactivation.closing.body": "Это последнее такое письмо. {org_name} остаётся ровно как есть, и ничего не сгорает — захотите вернуться, всё будет ждать вас.",
+    "nudge.reactivation.closing.cta": "Открыть панель",
 }

--- a/apps/api/src/services/email/nudge_translations/th.py
+++ b/apps/api/src/services/email/nudge_translations/th.py
@@ -1,0 +1,155 @@
+"""Thai nudge copy."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "ยกเลิกการรับอีเมลเหล่านี้",
+    "nudge.common.footer": "คุณได้รับอีเมลนี้เพราะคุณเป็นผู้ดูแลของ {org_name}",
+
+    "nudge.activation.first_course_d1.subject": "คอร์สแรกของคุณบน {org_name}",
+    "nudge.activation.first_course_d1.heading": "เมื่อไหร่ที่คุณพร้อม",
+    "nudge.activation.first_course_d1.body": "{org_name} ตั้งค่าเรียบร้อยและรอคอร์สแรกอยู่ ส่วนใหญ่เริ่มจากเล็ก ๆ คือหัวข้อเดียวกับบทเรียนไม่กี่บท เพิ่มทีหลังได้เสมอ",
+    "nudge.activation.first_course_d1.cta": "สร้างคอร์สแรกของคุณ",
+
+    "nudge.activation.come_back_d2.subject": "ทำต่อจากที่ค้างไว้",
+    "nudge.activation.come_back_d2.heading": "สิ่งที่ตั้งค่าไว้ยังรออยู่",
+    "nudge.activation.come_back_d2.body": "คุณสร้าง {org_name} ไว้แล้วยังไม่ได้กลับมาอีกเลย ทุกอย่างยังอยู่ครบ และการเผยแพร่คอร์สแรกใช้เวลาราวสิบนาที",
+    "nudge.activation.come_back_d2.cta": "ไปที่แดชบอร์ด",
+
+    "nudge.activation.ai_course_help_d4.subject": "หน้ากระดาษเปล่าคือส่วนที่ยากที่สุด",
+    "nudge.activation.ai_course_help_d4.heading": "ให้ AI ร่างโครงให้",
+    "nudge.activation.ai_course_help_d4.body": "ถ้า {org_name} ยังว่างเพราะไม่รู้จะเริ่มตรงไหน ลองอธิบายหัวข้อของคุณ แล้ว AI จะร่างบทและบทเรียนให้ จากนั้นคุณค่อยแก้ไข",
+    "nudge.activation.ai_course_help_d4.cta": "สร้างคอร์สด้วย AI",
+
+    "nudge.activation.import_existing_d5.subject": "นำสิ่งที่คุณมีอยู่แล้วมาใช้",
+    "nudge.activation.import_existing_d5.heading": "ไม่ต้องเริ่มจากศูนย์",
+    "nudge.activation.import_existing_d5.body": "ถ้าเนื้อหาของคุณมีอยู่แล้วในรูปเอกสาร สไลด์ หรือไฟล์ส่งออกจากแพลตฟอร์มอื่น คุณนำเข้ามาที่ {org_name} ได้เลย ไม่ต้องพิมพ์ใหม่",
+    "nudge.activation.import_existing_d5.cta": "นำเข้าเนื้อหาของคุณ",
+
+    "nudge.activation.setup_checklist_d7.subject": "สิบห้านาทีสู่สถาบันที่ใช้งานได้",
+    "nudge.activation.setup_checklist_d7.heading": "รายการสั้น ๆ",
+    "nudge.activation.setup_checklist_d7.body": "{org_name} ยังรอคอร์สแรกอยู่ รายการตั้งค่าจะพาคุณผ่านไปทีละขั้นสั้น ๆ ส่วนใหญ่เสร็จภายในราวสิบห้านาที",
+    "nudge.activation.setup_checklist_d7.cta": "เปิดรายการ",
+
+    "nudge.activation.whats_blocking_d14.subject": "มีอะไรมาขวางหรือเปล่า",
+    "nudge.activation.whats_blocking_d14.heading": "ขอถามได้ไหมว่าอะไรทำให้หยุด",
+    "nudge.activation.whats_blocking_d14.body": "คุณสร้าง {org_name} เมื่อสองสัปดาห์ก่อนและยังไม่ได้เพิ่มคอร์ส ถ้ามีอะไรที่สับสนหรือขาดไป เราอยากรู้จริง ๆ ตอบกลับอีเมลฉบับนี้ได้เลย มันจะถึงเราโดยตรง",
+
+    "nudge.activation.last_call_d30.subject": "อีเมลฉบับสุดท้ายเรื่อง {org_name}",
+    "nudge.activation.last_call_d30.heading": "นี่คือฉบับสุดท้าย",
+    "nudge.activation.last_call_d30.body": "{org_name} เงียบมาหนึ่งเดือนแล้ว เราจึงหยุดส่งอีเมลแบบนี้ บัญชีและทุกอย่างข้างในยังอยู่ครบ ถ้าคุณกลับมา ทุกอย่างจะอยู่ตรงที่คุณวางไว้",
+    "nudge.activation.last_call_d30.cta": "เปิดแดชบอร์ดของคุณ",
+
+    "nudge.content.course_no_chapter_d1.subject": "«{course_name}» ยังต้องการบทแรก",
+    "nudge.content.course_no_chapter_d1.heading": "เหลืออีกหนึ่งบท",
+    "nudge.content.course_no_chapter_d1.body": "«{course_name}» มีอยู่แล้วแต่ยังไม่มีบท จึงยังไม่มีอะไรให้เปิด บทก็คือส่วนย่อย หนึ่งหัวข้อต่อหนึ่งบทกำลังดี",
+    "nudge.content.course_no_chapter_d1.cta": "เพิ่มบท",
+
+    "nudge.content.chapter_no_activity_d1.subject": "เพิ่มบทเรียนแรกให้ «{course_name}»",
+    "nudge.content.chapter_no_activity_d1.heading": "บทต่าง ๆ พร้อมแล้ว",
+    "nudge.content.chapter_no_activity_d1.body": "«{course_name}» มีบทแล้วแต่ข้างในยังว่าง บทเรียนจะเป็นหน้าข้อความ วิดีโอ หรือแบบทดสอบก็ได้ แล้วแต่ว่าอะไรเข้ากับหัวข้อ",
+    "nudge.content.chapter_no_activity_d1.cta": "เพิ่มบทเรียน",
+
+    "nudge.content.activity_unpublished_d2.subject": "บทเรียนใน «{course_name}» ยังไม่ปรากฏ",
+    "nudge.content.activity_unpublished_d2.heading": "บทเรียนยังถูกซ่อนอยู่",
+    "nudge.content.activity_unpublished_d2.body": "คุณเขียนบทเรียนใน «{course_name}» แล้ว แต่ยังไม่ได้เผยแพร่สักบท ผู้เรียนจึงเห็นคอร์สว่าง ๆ การเผยแพร่ไม่ได้ล็อกอะไร คุณยังแก้ไขต่อได้",
+    "nudge.content.activity_unpublished_d2.cta": "เผยแพร่บทเรียนของคุณ",
+
+    "nudge.content.course_draft_d3.subject": "«{course_name}» ยังเป็นฉบับร่าง",
+    "nudge.content.course_draft_d3.heading": "«{course_name}» ใกล้เสร็จแล้ว",
+    "nudge.content.course_draft_d3.body": "คุณเพิ่มบทเรียนให้ «{course_name}» แล้ว แต่ยังไม่ได้เผยแพร่ จึงยังไม่มีใครเปิดได้ ไม่จำเป็นต้องเสร็จสมบูรณ์ การเผยแพร่แค่ทำให้มองเห็น และคุณยังแก้ไขต่อได้",
+    "nudge.content.course_draft_d3.cta": "เผยแพร่",
+
+    "nudge.content.course_draft_d10.subject": "«{course_name}» เป็นฉบับร่างมาสักพักแล้ว",
+    "nudge.content.course_draft_d10.heading": "น่าจะพร้อมแล้ว",
+    "nudge.content.course_draft_d10.body": "«{course_name}» ยังไม่ได้เผยแพร่มากว่าหนึ่งสัปดาห์ คอร์สแทบไม่เคยรู้สึกว่าเสร็จ การเผยแพร่ทำให้คนเห็น และคุณยังปรับปรุงต่อได้ระหว่างที่มีคนอ่านอยู่",
+    "nudge.content.course_draft_d10.cta": "เผยแพร่",
+
+    "nudge.content.thin_course_d5.subject": "«{course_name}» เติมได้อีกนิด",
+    "nudge.content.thin_course_d5.heading": "มีแค่หนึ่งถึงสองบทเรียน",
+    "nudge.content.thin_course_d5.body": "ตอนนี้ «{course_name}» มีบทเรียนหนึ่งถึงสองบท คอร์สมักได้ผลดีกว่าเมื่อมีสักสองสามบท และ AI ร่างบทถัดไปจากเนื้อหาที่มีอยู่ได้",
+    "nudge.content.thin_course_d5.cta": "เพิ่มบทเรียน",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "ยังไม่มีการส่งงานใน {org_name}",
+    "nudge.content.assignment_no_submissions_d5.heading": "ยังไม่มีใครส่งงาน",
+    "nudge.content.assignment_no_submissions_d5.body": "คุณสร้างงานที่มอบหมายไว้ใน {org_name} แต่ยังไม่มีใครส่ง ลองตรวจดูว่าเผยแพร่แล้วหรือยัง และผู้เรียนเข้าถึงคอร์สที่งานนั้นสังกัดอยู่ได้หรือไม่",
+    "nudge.content.assignment_no_submissions_d5.cta": "ตรวจงานที่มอบหมาย",
+
+    "nudge.audience.published_no_members_d1.subject": "«{course_name}» เผยแพร่แล้ว แต่ยังไม่มีใครอยู่",
+    "nudge.audience.published_no_members_d1.heading": "ถึงเวลาชวนใครสักคน",
+    "nudge.audience.published_no_members_d1.body": "«{course_name}» เผยแพร่แล้วและพร้อมให้อ่าน {org_name} ยังไม่มีผู้เรียนเลย ขั้นต่อไปคือชวนคนที่คุณเขียนคอร์สนี้ให้",
+    "nudge.audience.published_no_members_d1.cta": "เชิญผู้เรียน",
+
+    "nudge.audience.published_no_members_d7.subject": "«{course_name}» ยังไม่มีผู้เรียน",
+    "nudge.audience.published_no_members_d7.heading": "เผยแพร่มาหนึ่งสัปดาห์ ยังไม่มีใครอ่าน",
+    "nudge.audience.published_no_members_d7.body": "«{course_name}» เผยแพร่มาหนึ่งสัปดาห์แล้วและ {org_name} ยังไม่มีผู้เรียน คุณจะเชิญทีละคน วางรายชื่อทั้งชุด หรือแค่แชร์ลิงก์เข้าร่วมก็ได้",
+    "nudge.audience.published_no_members_d7.cta": "เชิญคนเข้าร่วม",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "ผู้เรียนของคุณยังไม่เริ่ม",
+    "nudge.audience.members_no_enrollment_d3.heading": "เข้าร่วมแล้วแต่ยังไม่ได้เปิดอะไร",
+    "nudge.audience.members_no_enrollment_d3.body": "มีคนเข้าร่วม {org_name} แล้ว แต่ยังไม่มีใครเริ่มคอร์ส ข้อความสั้น ๆ พร้อมลิงก์ตรงมักได้ผล ส่วนใหญ่แค่ยังหาทางเข้าไม่เจอ",
+    "nudge.audience.members_no_enrollment_d3.cta": "ดูสมาชิกของคุณ",
+
+    "nudge.audience.share_public_page_d14.subject": "หน้าคอร์สของคุณเป็นสาธารณะ — ลิงก์อยู่นี่",
+    "nudge.audience.share_public_page_d14.heading": "ใครก็ตามที่มีลิงก์อ่านได้",
+    "nudge.audience.share_public_page_d14.body": "«{course_name}» เป็นสาธารณะ คุณจึงแชร์ที่ไหนก็ได้โดยไม่ต้องให้ใครรอคำเชิญ ลิงก์ด้านล่างคือลิงก์ที่ส่งได้เลย",
+    "nudge.audience.share_public_page_d14.cta": "ดูหน้าสาธารณะ",
+
+    "nudge.audience.stalled_learners_d14.subject": "ผู้เรียนบางคนหยุดกลางทาง",
+    "nudge.audience.stalled_learners_d14.heading": "มีบางคนติดอยู่",
+    "nudge.audience.stalled_learners_d14.body": "ผู้เรียนบางคนใน {org_name} เริ่มคอร์สไว้แล้วไม่กลับมาสองสัปดาห์ ข้อความจากคุณมักช่วยได้ และการดูว่าเขาหยุดตรงไหนก็เช่นกัน",
+    "nudge.audience.stalled_learners_d14.cta": "ดูผู้เรียนของคุณ",
+
+    "nudge.monetization.course_limit_d1.subject": "คุณใช้คอร์สในแพ็กเกจ {plan_name} หมดแล้ว",
+    "nudge.monetization.course_limit_d1.heading": "คุณถึงขีดจำกัดจำนวนคอร์สแล้ว",
+    "nudge.monetization.course_limit_d1.body": "{org_name} อยู่บนแพ็กเกจ {plan_name} และใช้คอร์สที่รวมมาหมดแล้ว ถ้าอยากสร้างต่อ การเปลี่ยนไป {next_plan} จะปลดขีดจำกัดนี้",
+    "nudge.monetization.course_limit_d1.cta": "ดูแพ็กเกจ",
+
+    "nudge.monetization.member_limit_near.subject": "คุณใกล้ถึงขีดจำกัดสมาชิกของแพ็กเกจ {plan_name}",
+    "nudge.monetization.member_limit_near.heading": "เกือบถึงขีดจำกัดสมาชิก",
+    "nudge.monetization.member_limit_near.body": "{org_name} กำลังเข้าใกล้จำนวนสมาชิกที่แพ็กเกจ {plan_name} อนุญาต การเปลี่ยนไป {next_plan} จะเพิ่มจำนวนนั้น เพื่อไม่ให้ใครถูกปฏิเสธกลางคันตอนสมัคร",
+    "nudge.monetization.member_limit_near.cta": "ดูแพ็กเกจ",
+
+    "nudge.monetization.ai_credits_low.subject": "เครดิต AI ของคุณใกล้หมด",
+    "nudge.monetization.ai_credits_low.heading": "เครดิต AI เหลือน้อย",
+    "nudge.monetization.ai_credits_low.body": "{org_name} ใช้เครดิต AI ที่รวมมากับแพ็กเกจ {plan_name} ไปเกือบหมดแล้ว ถ้า AI กลายเป็นส่วนหนึ่งของวิธีสร้างคอร์สของคุณ แพ็กเกจ {next_plan} มีให้มากกว่า",
+    "nudge.monetization.ai_credits_low.cta": "ดูแพ็กเกจ",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "{next_plan} จะเพิ่มอะไรให้ {org_name}",
+    "nudge.monetization.upgrade_recap_d21.heading": "คุณสร้างอะไรที่เป็นรูปเป็นร่างแล้ว",
+    "nudge.monetization.upgrade_recap_d21.body": "{org_name} มีคอร์สที่เผยแพร่แล้วและมีคนอ่าน แพ็กเกจ {next_plan} ให้พื้นที่เติบโตและมีบางอย่างที่แพ็กเกจ {plan_name} ไม่มี น่าดูไว้ถ้าคุณคิดจะขยาย",
+    "nudge.monetization.upgrade_recap_d21.cta": "เปรียบเทียบแพ็กเกจ",
+
+    "nudge.dormancy.no_login_14d.subject": "{org_name} เงียบไปพักหนึ่ง",
+    "nudge.dormancy.no_login_14d.heading": "ผ่านมาสองสัปดาห์แล้ว",
+    "nudge.dormancy.no_login_14d.body": "ไม่มีอะไรเปลี่ยนใน {org_name} นับจากครั้งล่าสุดที่คุณเข้ามา ถ้าคุณกำลังทำอะไรค้างไว้ มันยังอยู่ตรงที่คุณวางไว้",
+    "nudge.dormancy.no_login_14d.cta": "เปิดแดชบอร์ดของคุณ",
+
+    "nudge.dormancy.no_login_30d.subject": "คอร์สของคุณบน {org_name} ยังอยู่ครบ",
+    "nudge.dormancy.no_login_30d.heading": "ผ่านมาหลายสัปดาห์แล้ว",
+    "nudge.dormancy.no_login_30d.body": "ระหว่างที่คุณไม่อยู่ไม่มีอะไรเปลี่ยน {org_name} และทุกอย่างข้างในยังอยู่ตรงที่คุณวางไว้ กลับมาทำต่อแค่คลิกเดียว",
+    "nudge.dormancy.no_login_30d.cta": "เปิดแดชบอร์ดของคุณ",
+
+    "nudge.dormancy.no_login_60d.subject": "ข้อความสุดท้ายเรื่อง {org_name}",
+    "nudge.dormancy.no_login_60d.heading": "เราจะไม่รบกวนแล้ว",
+    "nudge.dormancy.no_login_60d.body": "{org_name} เงียบมาราวสองเดือน นี่จึงเป็นอีเมลแบบนี้ฉบับสุดท้ายไปก่อน ทุกอย่างที่คุณสร้างไว้ยังคงอยู่เหมือนเดิม เมื่อไหร่ที่คุณต้องการ",
+    "nudge.dormancy.no_login_60d.cta": "เปิดแดชบอร์ดของคุณ",
+
+    "nudge.dormancy.winback_q.subject": "มีอะไรใหม่นับจากครั้งล่าสุดที่คุณเข้า {org_name}",
+    "nudge.dormancy.winback_q.heading": "มีบางอย่างเปลี่ยนไป",
+    "nudge.dormancy.winback_q.body": "ผ่านมาสักพักแล้วนับจากที่คุณเข้า {org_name} ครั้งล่าสุด ผลิตภัณฑ์พัฒนาไปพอสมควร และทุกอย่างที่คุณสร้างไว้ยังอยู่",
+    "nudge.dormancy.winback_q.cta": "ลองดูสักหน่อย",
+
+    "nudge.milestone.first_course_published.subject": "«{course_name}» เผยแพร่แล้ว",
+    "nudge.milestone.first_course_published.heading": "คุณเผยแพร่คอร์สแรกแล้ว",
+    "nudge.milestone.first_course_published.body": "«{course_name}» เผยแพร่แล้วและอ่านได้ สิ่งที่ทำให้ต่างจากนี้ไปคือการมีคนอ่าน แค่หนึ่งถึงสองคนตอนเริ่มก็พอ",
+    "nudge.milestone.first_course_published.cta": "เชิญผู้เรียนกลุ่มแรก",
+
+    "nudge.milestone.first_learner_enrolled.subject": "มีคนเริ่มเรียน «{course_name}» แล้ว",
+    "nudge.milestone.first_learner_enrolled.heading": "ผู้เรียนคนแรกของคุณมาแล้ว",
+    "nudge.milestone.first_learner_enrolled.body": "มีคนเริ่มเรียนคอร์สใน {org_name} เป็นครั้งแรก คุณติดตามความคืบหน้าได้จากแดชบอร์ด",
+    "nudge.milestone.first_learner_enrolled.cta": "ดูความคืบหน้า",
+
+    "nudge.milestone.first_completion.subject": "มีคนเรียนจบคอร์สใน {org_name}",
+    "nudge.milestone.first_completion.heading": "การเรียนจบครั้งแรก",
+    "nudge.milestone.first_completion.body": "ผู้เรียนคนหนึ่งเรียนคอร์สใน {org_name} จบตั้งแต่ต้นจนจบ ถ้าอยากบันทึกไว้ให้เป็นเรื่องเป็นราว คุณเพิ่มใบรับรองได้ หรือจะเริ่มสร้างคอร์สถัดไปก็ได้",
+    "nudge.milestone.first_completion.cta": "เปิดแดชบอร์ดของคุณ",
+}

--- a/apps/api/src/services/email/nudge_translations/th.py
+++ b/apps/api/src/services/email/nudge_translations/th.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "ยกเลิกการรับอีเมลเหล่านี้",
     "nudge.common.footer": "คุณได้รับอีเมลนี้เพราะคุณเป็นผู้ดูแลของ {org_name}",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "คอร์ส",
+    "nudge.stat.chapters": "บท",
+    "nudge.stat.lessons": "บทเรียน",
+    "nudge.stat.members": "สมาชิก",
+    "nudge.stat.learners": "ผู้เรียน",
+    "nudge.stat.completed": "เรียนจบ",
+
     "nudge.activation.first_course_d1.subject": "คอร์สแรกของคุณบน {org_name}",
     "nudge.activation.first_course_d1.heading": "เมื่อไหร่ที่คุณพร้อม",
     "nudge.activation.first_course_d1.body": "{org_name} ตั้งค่าเรียบร้อยและรอคอร์สแรกอยู่ ส่วนใหญ่เริ่มจากเล็ก ๆ คือหัวข้อเดียวกับบทเรียนไม่กี่บท เพิ่มทีหลังได้เสมอ",
@@ -152,4 +161,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "การเรียนจบครั้งแรก",
     "nudge.milestone.first_completion.body": "ผู้เรียนคนหนึ่งเรียนคอร์สใน {org_name} จบตั้งแต่ต้นจนจบ ถ้าอยากบันทึกไว้ให้เป็นเรื่องเป็นราว คุณเพิ่มใบรับรองได้ หรือจะเริ่มสร้างคอร์สถัดไปก็ได้",
     "nudge.milestone.first_completion.cta": "เปิดแดชบอร์ดของคุณ",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "สถาบันของคุณบน {org_name} ยังอยู่",
+    "nudge.reactivation.opener.heading": "ยังอยู่ ตรงที่คุณวางไว้",
+    "nudge.reactivation.opener.body": "ไม่มีใครแตะ {org_name} เลยนับจากครั้งล่าสุดที่คุณเข้ามา ทุกคอร์ส ทุกบท ทุกบทเรียนยังอยู่ที่เดิม กลับมาทำต่อแค่คลิกเดียว",
+    "nudge.reactivation.opener.cta": "เปิดแดชบอร์ดของคุณ",
+    "nudge.reactivation.whats_changed.subject": "มีบางอย่างเปลี่ยนไปบน LearnHouse",
+    "nudge.reactivation.whats_changed.heading": "นับจากครั้งล่าสุดที่คุณเข้ามา",
+    "nudge.reactivation.whats_changed.body": "ระหว่างที่ {org_name} เงียบ ผลิตภัณฑ์พัฒนาไปพอสมควร ทั้งตัวแก้ไข เครื่องมือสร้างคอร์ส และเส้นทางของผู้เรียนได้รับการปรับจริงจัง ทุกอย่างที่คุณสร้างไว้ยังทำงานเหมือนเดิม",
+    "nudge.reactivation.whats_changed.cta": "ดูสิ่งที่เปลี่ยนไป",
+    "nudge.reactivation.need_a_hand.subject": "ให้เราช่วยพาคุณกลับเข้า {org_name} ไหม",
+    "nudge.reactivation.need_a_hand.heading": "มีอะไรมาขวางหรือเปล่า",
+    "nudge.reactivation.need_a_hand.body": "ถ้ามีเหตุผลที่ทำให้ {org_name} หยุดไป ไม่ว่าจะสับสนตรงไหน ขาดอะไร หรือแค่ไม่มีเวลา เราอยากรู้จริง ๆ ตอบกลับอีเมลฉบับนี้ได้เลย มันจะถึงเราโดยตรง",
+    "nudge.reactivation.closing.subject": "ข้อความสุดท้ายเรื่อง {org_name}",
+    "nudge.reactivation.closing.heading": "เราขอหยุดไว้เท่านี้",
+    "nudge.reactivation.closing.body": "นี่คืออีเมลแบบนี้ฉบับสุดท้าย {org_name} ยังคงอยู่เหมือนเดิมและไม่มีอะไรหมดอายุ หากวันหนึ่งคุณอยากกลับมา ทุกอย่างจะรออยู่",
+    "nudge.reactivation.closing.cta": "เปิดแดชบอร์ดของคุณ",
 }

--- a/apps/api/src/services/email/nudge_translations/tr.py
+++ b/apps/api/src/services/email/nudge_translations/tr.py
@@ -1,0 +1,155 @@
+"""Turkish nudge copy."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "Bu e-postalardan çık",
+    "nudge.common.footer": "Bu e-postayı {org_name} yöneticisi olduğunuz için alıyorsunuz.",
+
+    "nudge.activation.first_course_d1.subject": "{org_name} üzerindeki ilk kursunuz",
+    "nudge.activation.first_course_d1.heading": "Hazır olduğunuzda",
+    "nudge.activation.first_course_d1.body": "{org_name} kuruldu ve ilk kursunu bekliyor. Çoğu kişi küçük başlıyor: bir konu, birkaç ders. Sonradan her zaman ekleyebilirsiniz.",
+    "nudge.activation.first_course_d1.cta": "İlk kursunuzu oluşturun",
+
+    "nudge.activation.come_back_d2.subject": "Kaldığınız yerden devam edin",
+    "nudge.activation.come_back_d2.heading": "Kurulumunuz sizi bekliyor",
+    "nudge.activation.come_back_d2.body": "{org_name} kurumunu oluşturdunuz ama o günden beri uğramadınız. Her şey yerinde duruyor; ilk kursu yayına almak yaklaşık on dakika sürüyor.",
+    "nudge.activation.come_back_d2.cta": "Panele git",
+
+    "nudge.activation.ai_course_help_d4.subject": "Zor olan kısım boş sayfa",
+    "nudge.activation.ai_course_help_d4.heading": "Taslağı yapay zekâ yazsın",
+    "nudge.activation.ai_course_help_d4.body": "{org_name} nereden başlayacağınızı bilemediğiniz için hâlâ boşsa, konunuzu anlatın; yapay zekâ bölümleri ve dersleri taslak olarak hazırlasın. Düzenleme sizde.",
+    "nudge.activation.ai_course_help_d4.cta": "Yapay zekâ ile kurs oluştur",
+
+    "nudge.activation.import_existing_d5.subject": "Elinizdekini getirin",
+    "nudge.activation.import_existing_d5.heading": "Sıfırdan başlamanıza gerek yok",
+    "nudge.activation.import_existing_d5.body": "Materyalleriniz zaten belge, sunum veya başka bir platformdan dışa aktarım olarak varsa, yeniden yazmak yerine {org_name} içine aktarabilirsiniz.",
+    "nudge.activation.import_existing_d5.cta": "Materyallerinizi içe aktarın",
+
+    "nudge.activation.setup_checklist_d7.subject": "Çalışan bir akademiye on beş dakika",
+    "nudge.activation.setup_checklist_d7.heading": "Kısa bir kontrol listesi",
+    "nudge.activation.setup_checklist_d7.body": "{org_name} hâlâ ilk kursunu bekliyor. Kurulum listesi birkaç kısa adımda yol gösteriyor; çoğu kişi on beş dakikada bitiriyor.",
+    "nudge.activation.setup_checklist_d7.cta": "Listeyi aç",
+
+    "nudge.activation.whats_blocking_d14.subject": "Araya ne girdi?",
+    "nudge.activation.whats_blocking_d14.heading": "Sizi ne durdurdu, sorabilir miyiz?",
+    "nudge.activation.whats_blocking_d14.body": "{org_name} kurumunu iki hafta önce oluşturdunuz ve henüz kurs eklemediniz. Kafa karıştıran ya da eksik bir şey olduysa bilmek isteriz — bu e-postayı yanıtlamanız yeterli, doğrudan bize ulaşıyor.",
+
+    "nudge.activation.last_call_d30.subject": "{org_name} hakkında son e-posta",
+    "nudge.activation.last_call_d30.heading": "Bu sonuncusu",
+    "nudge.activation.last_call_d30.body": "{org_name} bir aydır sessiz, bu yüzden bu e-postaları göndermeyi bırakıyoruz. Hesabınız ve içindeki her şey duruyor — dönerseniz bıraktığınız gibi bulacaksınız.",
+    "nudge.activation.last_call_d30.cta": "Panelinizi açın",
+
+    "nudge.content.course_no_chapter_d1.subject": "{course_name} ilk bölümünü bekliyor",
+    "nudge.content.course_no_chapter_d1.heading": "Bir bölüm kaldı",
+    "nudge.content.course_no_chapter_d1.body": "{course_name} var ama henüz bölümü yok, dolayısıyla açılacak bir şey de yok. Bölümler sadece başlıklar — konu başına bir tane iyi işliyor.",
+    "nudge.content.course_no_chapter_d1.cta": "Bölüm ekle",
+
+    "nudge.content.chapter_no_activity_d1.subject": "{course_name} kursuna ilk dersinizi ekleyin",
+    "nudge.content.chapter_no_activity_d1.heading": "Bölümler hazır",
+    "nudge.content.chapter_no_activity_d1.body": "{course_name} bölümlere sahip ama içleri hâlâ boş. Bir ders metin sayfası, video ya da kısa sınav olabilir — konuya ne uyuyorsa.",
+    "nudge.content.chapter_no_activity_d1.cta": "Ders ekle",
+
+    "nudge.content.activity_unpublished_d2.subject": "{course_name} içindeki dersleriniz henüz görünmüyor",
+    "nudge.content.activity_unpublished_d2.heading": "Dersler hâlâ gizli",
+    "nudge.content.activity_unpublished_d2.body": "{course_name} içinde dersler yazdınız ama hiçbiri yayında değil; katılımcılar boş bir kurs görüyor. Yayınlamak hiçbir şeyi kilitlemez, düzenlemeye devam edebilirsiniz.",
+    "nudge.content.activity_unpublished_d2.cta": "Derslerinizi yayınlayın",
+
+    "nudge.content.course_draft_d3.subject": "{course_name} hâlâ taslak",
+    "nudge.content.course_draft_d3.heading": "{course_name} neredeyse hazır",
+    "nudge.content.course_draft_d3.body": "{course_name} kursuna dersler eklediniz ama yayında değil, bu yüzden kimse açamıyor. Bitmiş olması gerekmiyor — yayınlamak yalnızca görünür kılar, sonrasında düzenlemeye devam edebilirsiniz.",
+    "nudge.content.course_draft_d3.cta": "Yayınla",
+
+    "nudge.content.course_draft_d10.subject": "{course_name} bir süredir taslak halinde",
+    "nudge.content.course_draft_d10.heading": "Muhtemelen hazır",
+    "nudge.content.course_draft_d10.body": "{course_name} bir haftadan uzun süredir yayınlanmadı. Bir kurs nadiren bitmiş hissettirir — yayınlamak görünür kılar, birileri okurken geliştirmeye devam edebilirsiniz.",
+    "nudge.content.course_draft_d10.cta": "Yayınla",
+
+    "nudge.content.thin_course_d5.subject": "{course_name} biraz daha isteyebilir",
+    "nudge.content.thin_course_d5.heading": "Bir iki ders var",
+    "nudge.content.thin_course_d5.body": "{course_name} şimdilik bir iki derse sahip. Kurslar birkaç dersle daha iyi oturuyor ve yapay zekâ mevcut içerikten sonrakileri taslak olarak yazabilir.",
+    "nudge.content.thin_course_d5.cta": "Daha fazla ders ekle",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "{org_name} içinde henüz teslim yok",
+    "nudge.content.assignment_no_submissions_d5.heading": "Kimse bir şey teslim etmedi",
+    "nudge.content.assignment_no_submissions_d5.body": "{org_name} içinde bir ödev oluşturdunuz ama hiçbir şey teslim edilmedi. Yayında olduğunu ve katılımcıların ilgili kursa erişebildiğini kontrol etmekte fayda var.",
+    "nudge.content.assignment_no_submissions_d5.cta": "Ödevlerinizi kontrol edin",
+
+    "nudge.audience.published_no_members_d1.subject": "{course_name} yayında ama henüz kimse yok",
+    "nudge.audience.published_no_members_d1.heading": "Birini davet etme zamanı",
+    "nudge.audience.published_no_members_d1.body": "{course_name} yayında ve okunmaya hazır. {org_name} henüz katılımcıya sahip değil; sıradaki adım, onu kimin için yazdıysanız onları davet etmek.",
+    "nudge.audience.published_no_members_d1.cta": "Katılımcı davet et",
+
+    "nudge.audience.published_no_members_d7.subject": "{course_name} hâlâ katılımcısız",
+    "nudge.audience.published_no_members_d7.heading": "Bir haftadır yayında, okuyan yok",
+    "nudge.audience.published_no_members_d7.body": "{course_name} bir haftadır yayında ve {org_name} hâlâ katılımcıya sahip değil. Tek tek davet edebilir, bir liste yapıştırabilir ya da katılım bağlantısını paylaşabilirsiniz.",
+    "nudge.audience.published_no_members_d7.cta": "Kişileri davet et",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "Katılımcılarınız henüz başlamadı",
+    "nudge.audience.members_no_enrollment_d3.heading": "Katıldılar ama hiçbir şey açmadılar",
+    "nudge.audience.members_no_enrollment_d3.body": "{org_name} kurumuna katılanlar oldu ama kimse kursa başlamadı. Doğrudan bağlantı içeren kısa bir mesaj genelde yeterli oluyor — çoğu kişi sadece girişi bulamıyor.",
+    "nudge.audience.members_no_enrollment_d3.cta": "Üyelerinizi görün",
+
+    "nudge.audience.share_public_page_d14.subject": "Kurs sayfanız herkese açık — bağlantı burada",
+    "nudge.audience.share_public_page_d14.heading": "Bağlantısı olan herkes okuyabilir",
+    "nudge.audience.share_public_page_d14.body": "{course_name} herkese açık; yani kimsenin davete ihtiyacı olmadan istediğiniz yerde paylaşabilirsiniz. Aşağıdaki bağlantı gönderilecek olan.",
+    "nudge.audience.share_public_page_d14.cta": "Herkese açık sayfayı gör",
+
+    "nudge.audience.stalled_learners_d14.subject": "Bazı katılımcılar yarıda kaldı",
+    "nudge.audience.stalled_learners_d14.heading": "Birkaç kişi takıldı",
+    "nudge.audience.stalled_learners_d14.body": "{org_name} içindeki bazı katılımcılar bir kursa başladı ve iki haftadır dönmedi. Sizden gelecek bir mesaj çoğu zaman işe yarar; nerede durduklarına bakmak da öyle.",
+    "nudge.audience.stalled_learners_d14.cta": "Katılımcıları kontrol et",
+
+    "nudge.monetization.course_limit_d1.subject": "{plan_name} planındaki tüm kursları kullandınız",
+    "nudge.monetization.course_limit_d1.heading": "Kurs sınırına ulaştınız",
+    "nudge.monetization.course_limit_d1.body": "{org_name} {plan_name} planında ve dahil olan tüm kursları kullandı. Devam etmek isterseniz {next_plan} planına geçmek bu sınırı kaldırır.",
+    "nudge.monetization.course_limit_d1.cta": "Planları gör",
+
+    "nudge.monetization.member_limit_near.subject": "{plan_name} planının üye sınırına yaklaştınız",
+    "nudge.monetization.member_limit_near.heading": "Üye sınırına az kaldı",
+    "nudge.monetization.member_limit_near.body": "{org_name} {plan_name} planının izin verdiği üye sayısına yaklaşıyor. {next_plan} planına geçmek bu sayıyı artırır; böylece kimse kayıt olurken geri çevrilmez.",
+    "nudge.monetization.member_limit_near.cta": "Planları gör",
+
+    "nudge.monetization.ai_credits_low.subject": "Yapay zekâ krediniz bitmek üzere",
+    "nudge.monetization.ai_credits_low.heading": "Yapay zekâ kredisi azalıyor",
+    "nudge.monetization.ai_credits_low.body": "{org_name} {plan_name} planına dahil yapay zekâ kredilerinin çoğunu kullandı. Yapay zekâ artık kurs hazırlama biçiminizin parçasıysa {next_plan} planı daha fazlasını içeriyor.",
+    "nudge.monetization.ai_credits_low.cta": "Planları gör",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "{next_plan} planının {org_name} için katacakları",
+    "nudge.monetization.upgrade_recap_d21.heading": "Gerçek bir şey kurdunuz",
+    "nudge.monetization.upgrade_recap_d21.body": "{org_name} yayınlanmış kurslara ve onları okuyan kişilere sahip. {next_plan} planı büyümek için alan ve {plan_name} planında bulunmayan birkaç şey sunuyor — genişlemeyi düşünüyorsanız bakmaya değer.",
+    "nudge.monetization.upgrade_recap_d21.cta": "Planları karşılaştır",
+
+    "nudge.dormancy.no_login_14d.subject": "{org_name} sessizdi",
+    "nudge.dormancy.no_login_14d.heading": "Aradan iki hafta geçti",
+    "nudge.dormancy.no_login_14d.body": "Son ziyaretinizden bu yana {org_name} içinde hiçbir şey değişmedi. Bir şeyin ortasındaysanız, tam bıraktığınız yerde duruyor.",
+    "nudge.dormancy.no_login_14d.cta": "Panelinizi açın",
+
+    "nudge.dormancy.no_login_30d.subject": "{org_name} üzerindeki kurslarınız hâlâ burada",
+    "nudge.dormancy.no_login_30d.heading": "Birkaç hafta geçti",
+    "nudge.dormancy.no_login_30d.body": "Siz yokken hiçbir şey değişmedi — {org_name} ve içindeki her şey tam bıraktığınız yerde. Kaldığınız yerden devam etmek tek tık.",
+    "nudge.dormancy.no_login_30d.cta": "Panelinizi açın",
+
+    "nudge.dormancy.no_login_60d.subject": "{org_name} hakkında son mesaj",
+    "nudge.dormancy.no_login_60d.heading": "Sizi rahat bırakıyoruz",
+    "nudge.dormancy.no_login_60d.body": "{org_name} birkaç aydır sessiz, bu yüzden şimdilik bu e-postaların sonuncusu. Kurduğunuz her şey olduğu gibi kalıyor, ihtiyacınız olduğu an için.",
+    "nudge.dormancy.no_login_60d.cta": "Panelinizi açın",
+
+    "nudge.dormancy.winback_q.subject": "{org_name} kurumuna son uğrayışınızdan bu yana yenilikler",
+    "nudge.dormancy.winback_q.heading": "Birkaç şey değişti",
+    "nudge.dormancy.winback_q.body": "{org_name} içinde son bulunuşunuzun üzerinden bir süre geçti. Ürün o zamandan bu yana epey yol aldı ve kurduğunuz her şey hâlâ orada.",
+    "nudge.dormancy.winback_q.cta": "Bir göz atın",
+
+    "nudge.milestone.first_course_published.subject": "{course_name} yayında",
+    "nudge.milestone.first_course_published.heading": "İlk kursunuzu yayınladınız",
+    "nudge.milestone.first_course_published.body": "{course_name} yayında ve okunabilir durumda. Şimdi asıl fark yaratacak olan, onu okuyacak birinin olması — başlangıç için bir iki kişi bile yeter.",
+    "nudge.milestone.first_course_published.cta": "İlk katılımcılarınızı davet edin",
+
+    "nudge.milestone.first_learner_enrolled.subject": "Biri {course_name} kursuna başladı",
+    "nudge.milestone.first_learner_enrolled.heading": "İlk katılımcınız geldi",
+    "nudge.milestone.first_learner_enrolled.body": "İlk kez biri {org_name} içinde bir kursa başladı. Nasıl ilerlediğini panelinizden takip edebilirsiniz.",
+    "nudge.milestone.first_learner_enrolled.cta": "İlerlemeyi gör",
+
+    "nudge.milestone.first_completion.subject": "Biri {org_name} içinde bir kursu tamamladı",
+    "nudge.milestone.first_completion.heading": "İlk tamamlama",
+    "nudge.milestone.first_completion.body": "Bir katılımcı {org_name} içindeki bir kursu baştan sona tamamladı. Bunu düzgün biçimde işaretlemek isterseniz sertifika ekleyebilir ya da sıradakini kurmaya başlayabilirsiniz.",
+    "nudge.milestone.first_completion.cta": "Panelinizi açın",
+}

--- a/apps/api/src/services/email/nudge_translations/tr.py
+++ b/apps/api/src/services/email/nudge_translations/tr.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "Bu e-postalardan çık",
     "nudge.common.footer": "Bu e-postayı {org_name} yöneticisi olduğunuz için alıyorsunuz.",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "Kurslar",
+    "nudge.stat.chapters": "Bölümler",
+    "nudge.stat.lessons": "Dersler",
+    "nudge.stat.members": "Üyeler",
+    "nudge.stat.learners": "Katılımcılar",
+    "nudge.stat.completed": "Tamamlanan",
+
     "nudge.activation.first_course_d1.subject": "{org_name} üzerindeki ilk kursunuz",
     "nudge.activation.first_course_d1.heading": "Hazır olduğunuzda",
     "nudge.activation.first_course_d1.body": "{org_name} kuruldu ve ilk kursunu bekliyor. Çoğu kişi küçük başlıyor: bir konu, birkaç ders. Sonradan her zaman ekleyebilirsiniz.",
@@ -152,4 +161,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "İlk tamamlama",
     "nudge.milestone.first_completion.body": "Bir katılımcı {org_name} içindeki bir kursu baştan sona tamamladı. Bunu düzgün biçimde işaretlemek isterseniz sertifika ekleyebilir ya da sıradakini kurmaya başlayabilirsiniz.",
     "nudge.milestone.first_completion.cta": "Panelinizi açın",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "{org_name} üzerindeki akademiniz hâlâ burada",
+    "nudge.reactivation.opener.heading": "Hâlâ burada, bıraktığınız gibi",
+    "nudge.reactivation.opener.body": "Son ziyaretinizden bu yana {org_name} kuruluşuna kimse dokunmadı — her kurs, bölüm ve ders bıraktığınız yerde. Kaldığınız yerden devam etmek tek tık.",
+    "nudge.reactivation.opener.cta": "Panelinizi açın",
+    "nudge.reactivation.whats_changed.subject": "LearnHouse'ta birkaç şey değişti",
+    "nudge.reactivation.whats_changed.heading": "Son ziyaretinizden bu yana",
+    "nudge.reactivation.whats_changed.body": "{org_name} sessizken ürün epey yol aldı: editör, kurs araçları ve katılımcıların ilerleyişi baştan ele alındı. Kurduğunuz her şey eskisi gibi çalışıyor.",
+    "nudge.reactivation.whats_changed.cta": "Yenilikleri görün",
+    "nudge.reactivation.need_a_hand.subject": "{org_name} kuruluşuna dönmek için yardım ister misiniz?",
+    "nudge.reactivation.need_a_hand.heading": "Araya bir şey mi girdi?",
+    "nudge.reactivation.need_a_hand.body": "{org_name} durduysa bunun bir nedeni varsa — kafa karıştıran bir şey, eksik bir şey ya da sadece zaman — bunu gerçekten bilmek isteriz. Bu e-postayı yanıtlayın, doğrudan bize ulaşır.",
+    "nudge.reactivation.closing.subject": "{org_name} hakkında son not",
+    "nudge.reactivation.closing.heading": "Burada duruyoruz",
+    "nudge.reactivation.closing.body": "Bu, bu e-postaların sonuncusu. {org_name} olduğu gibi kalıyor ve hiçbir şeyin süresi dolmuyor — bir gün dönmek isterseniz her şey sizi bekliyor olacak.",
+    "nudge.reactivation.closing.cta": "Panelinizi açın",
 }

--- a/apps/api/src/services/email/nudge_translations/uk.py
+++ b/apps/api/src/services/email/nudge_translations/uk.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "Відписатися від цих листів",
     "nudge.common.footer": "Ви отримали цей лист, оскільки ви адміністратор {org_name}.",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "Курси",
+    "nudge.stat.chapters": "Розділи",
+    "nudge.stat.lessons": "Уроки",
+    "nudge.stat.members": "Учасники",
+    "nudge.stat.learners": "Слухачі",
+    "nudge.stat.completed": "Завершено",
+
     "nudge.activation.first_course_d1.subject": "Ваш перший курс у {org_name}",
     "nudge.activation.first_course_d1.heading": "Коли вам зручно",
     "nudge.activation.first_course_d1.body": "{org_name} готова й чекає на перший курс. Більшість починає з малого: одна тема, кілька уроків. Доповнити можна будь-коли.",
@@ -152,4 +161,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "Перше завершення",
     "nudge.milestone.first_completion.body": "Учасник пройшов курс у {org_name} від початку до кінця. Щоб відзначити це як належить, можна додати сертифікат — або почати готувати наступний курс.",
     "nudge.milestone.first_completion.cta": "Відкрити панель",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "Ваша академія в {org_name} нікуди не поділася",
+    "nudge.reactivation.opener.heading": "Усе на місці, саме так, як ви залишили",
+    "nudge.reactivation.opener.body": "Від вашого останнього візиту {org_name} ніхто не чіпав — кожен курс, розділ і урок там, де ви їх залишили. Повернутися — один клік.",
+    "nudge.reactivation.opener.cta": "Відкрити панель",
+    "nudge.reactivation.whats_changed.subject": "У LearnHouse дещо змінилося",
+    "nudge.reactivation.whats_changed.heading": "Від вашого останнього візиту",
+    "nudge.reactivation.whats_changed.body": "Поки {org_name} мовчала, продукт помітно просунувся: редактор, інструменти курсів і шлях слухача серйозно перероблено. Усе, що ви побудували, працює як і раніше.",
+    "nudge.reactivation.whats_changed.cta": "Подивитися нове",
+    "nudge.reactivation.need_a_hand.subject": "Потрібна допомога, щоб повернутися в {org_name}?",
+    "nudge.reactivation.need_a_hand.heading": "Щось завадило?",
+    "nudge.reactivation.need_a_hand.body": "Якщо була причина, чому {org_name} спинилася — щось незрозуміле, чогось бракувало або просто не було часу — нам важливо про це знати. Відповідайте на цей лист, він надійде прямо до нас.",
+    "nudge.reactivation.closing.subject": "Останній лист про {org_name}",
+    "nudge.reactivation.closing.heading": "На цьому спинимося",
+    "nudge.reactivation.closing.body": "Це останній такий лист. {org_name} лишається саме такою, як є, і нічого не згорає — захочете повернутися, усе чекатиме на вас.",
+    "nudge.reactivation.closing.cta": "Відкрити панель",
 }

--- a/apps/api/src/services/email/nudge_translations/uk.py
+++ b/apps/api/src/services/email/nudge_translations/uk.py
@@ -1,0 +1,155 @@
+"""Ukrainian nudge copy."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "Відписатися від цих листів",
+    "nudge.common.footer": "Ви отримали цей лист, оскільки ви адміністратор {org_name}.",
+
+    "nudge.activation.first_course_d1.subject": "Ваш перший курс у {org_name}",
+    "nudge.activation.first_course_d1.heading": "Коли вам зручно",
+    "nudge.activation.first_course_d1.body": "{org_name} готова й чекає на перший курс. Більшість починає з малого: одна тема, кілька уроків. Доповнити можна будь-коли.",
+    "nudge.activation.first_course_d1.cta": "Створити перший курс",
+
+    "nudge.activation.come_back_d2.subject": "Продовжити з того місця, де спинилися",
+    "nudge.activation.come_back_d2.heading": "Усе налаштоване вас чекає",
+    "nudge.activation.come_back_d2.body": "Ви створили {org_name} і відтоді не поверталися. Усе на місці, а щоб опублікувати перший курс, потрібно хвилин десять.",
+    "nudge.activation.come_back_d2.cta": "Перейти до панелі",
+
+    "nudge.activation.ai_course_help_d4.subject": "Найважче — чистий аркуш",
+    "nudge.activation.ai_course_help_d4.heading": "Хай ШІ напише план",
+    "nudge.activation.ai_course_help_d4.body": "Якщо {org_name} досі порожня, бо незрозуміло, з чого почати, — опишіть тему, і ШІ підготує розділи та уроки. Далі редагуєте ви.",
+    "nudge.activation.ai_course_help_d4.cta": "Створити курс із ШІ",
+
+    "nudge.activation.import_existing_d5.subject": "Перенесіть те, що вже маєте",
+    "nudge.activation.import_existing_d5.heading": "Не обов'язково починати з нуля",
+    "nudge.activation.import_existing_d5.body": "Якщо ваші матеріали вже існують як документи, презентації чи експорт з іншої платформи, їх можна перенести в {org_name}, а не набирати заново.",
+    "nudge.activation.import_existing_d5.cta": "Імпортувати матеріали",
+
+    "nudge.activation.setup_checklist_d7.subject": "П'ятнадцять хвилин до робочої академії",
+    "nudge.activation.setup_checklist_d7.heading": "Короткий список кроків",
+    "nudge.activation.setup_checklist_d7.body": "{org_name} досі чекає на перший курс. Список налаштування проведе вас за кілька кроків — більшість вкладається у чверть години.",
+    "nudge.activation.setup_checklist_d7.cta": "Відкрити список",
+
+    "nudge.activation.whats_blocking_d14.subject": "Що завадило?",
+    "nudge.activation.whats_blocking_d14.heading": "Можна запитати, що вас спинило?",
+    "nudge.activation.whats_blocking_d14.body": "Ви створили {org_name} два тижні тому й досі не додали курс. Якщо щось було незрозуміло або чогось бракувало, нам важливо про це знати — просто відповідайте на цей лист, він надійде прямо до нас.",
+
+    "nudge.activation.last_call_d30.subject": "Останній лист про {org_name}",
+    "nudge.activation.last_call_d30.heading": "Це останній",
+    "nudge.activation.last_call_d30.body": "{org_name} мовчить уже місяць, тож ми припиняємо надсилати такі листи. Обліковий запис і все в ньому лишається на місці — повернетеся, і все буде там, де ви залишили.",
+    "nudge.activation.last_call_d30.cta": "Відкрити панель",
+
+    "nudge.content.course_no_chapter_d1.subject": "Курсу «{course_name}» потрібен перший розділ",
+    "nudge.content.course_no_chapter_d1.heading": "Лишився один розділ",
+    "nudge.content.course_no_chapter_d1.body": "Курс «{course_name}» створено, але розділів у ньому ще немає, тож відкривати нічого. Розділи — це просто секції, по одному на тему працює добре.",
+    "nudge.content.course_no_chapter_d1.cta": "Додати розділ",
+
+    "nudge.content.chapter_no_activity_d1.subject": "Додайте перший урок до «{course_name}»",
+    "nudge.content.chapter_no_activity_d1.heading": "Розділи готові",
+    "nudge.content.chapter_no_activity_d1.body": "У курсі «{course_name}» є розділи, але вони поки порожні. Урок може бути сторінкою тексту, відео, тестом — тим, що пасує до теми.",
+    "nudge.content.chapter_no_activity_d1.cta": "Додати урок",
+
+    "nudge.content.activity_unpublished_d2.subject": "Ваші уроки в «{course_name}» ще не видно",
+    "nudge.content.activity_unpublished_d2.heading": "Уроки досі приховані",
+    "nudge.content.activity_unpublished_d2.body": "Ви написали уроки в курсі «{course_name}», але жоден не опубліковано, тож учасники бачать порожній курс. Публікація нічого не фіксує — редагувати можна й далі.",
+    "nudge.content.activity_unpublished_d2.cta": "Опублікувати уроки",
+
+    "nudge.content.course_draft_d3.subject": "«{course_name}» досі чернетка",
+    "nudge.content.course_draft_d3.heading": "«{course_name}» майже готовий",
+    "nudge.content.course_draft_d3.body": "Ви додали уроки до «{course_name}», але курс не опубліковано, тож ніхто його не відкриє. Він не мусить бути завершеним — публікація лише робить його видимим, редагувати можна й потім.",
+    "nudge.content.course_draft_d3.cta": "Опублікувати",
+
+    "nudge.content.course_draft_d10.subject": "«{course_name}» вже давно в чернетках",
+    "nudge.content.course_draft_d10.heading": "Найімовірніше, він готовий",
+    "nudge.content.course_draft_d10.body": "«{course_name}» лежить неопублікованим понад тиждень. Курс рідко здається завершеним — публікація робить його видимим, а вдосконалювати можна й тоді, коли його вже читають.",
+    "nudge.content.course_draft_d10.cta": "Опублікувати",
+
+    "nudge.content.thin_course_d5.subject": "«{course_name}» варто трохи доповнити",
+    "nudge.content.thin_course_d5.heading": "Один-два уроки",
+    "nudge.content.thin_course_d5.body": "У курсі «{course_name}» поки один-два уроки. Курси зазвичай сприймаються краще, коли їх кілька, і ШІ може підготувати наступні на основі вже написаного.",
+    "nudge.content.thin_course_d5.cta": "Додати уроки",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "У {org_name} поки немає жодної роботи",
+    "nudge.content.assignment_no_submissions_d5.heading": "Ніхто нічого не здав",
+    "nudge.content.assignment_no_submissions_d5.body": "Ви створили завдання в {org_name}, але робіт поки немає. Варто перевірити, чи воно опубліковане та чи мають учасники доступ до відповідного курсу.",
+    "nudge.content.assignment_no_submissions_d5.cta": "Перевірити завдання",
+
+    "nudge.audience.published_no_members_d1.subject": "«{course_name}» опубліковано, але там нікого немає",
+    "nudge.audience.published_no_members_d1.heading": "Час когось запросити",
+    "nudge.audience.published_no_members_d1.body": "«{course_name}» опубліковано й готово до читання. У {org_name} поки немає учасників, тож наступний крок — запросити тих, для кого ви його писали.",
+    "nudge.audience.published_no_members_d1.cta": "Запросити учасників",
+
+    "nudge.audience.published_no_members_d7.subject": "У «{course_name}» досі немає учасників",
+    "nudge.audience.published_no_members_d7.heading": "Тиждень онлайн, ніхто не читає",
+    "nudge.audience.published_no_members_d7.body": "«{course_name}» опубліковано тиждень тому, а в {org_name} досі немає учасників. Можна запрошувати по одному, вставити список або просто поділитися посиланням.",
+    "nudge.audience.published_no_members_d7.cta": "Запросити людей",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "Ваші учасники ще не почали",
+    "nudge.audience.members_no_enrollment_d3.heading": "Приєдналися, але нічого не відкрили",
+    "nudge.audience.members_no_enrollment_d3.body": "Люди приєдналися до {org_name}, але ніхто не почав курс. Зазвичай достатньо короткого повідомлення з прямим посиланням — більшість просто не знайшли вхід.",
+    "nudge.audience.members_no_enrollment_d3.cta": "Переглянути учасників",
+
+    "nudge.audience.share_public_page_d14.subject": "Сторінка курсу публічна — ось посилання",
+    "nudge.audience.share_public_page_d14.heading": "Прочитати може будь-хто за посиланням",
+    "nudge.audience.share_public_page_d14.body": "«{course_name}» відкрито публічно, тож ділитися ним можна будь-де й без запрошень. Посилання нижче — саме те, яке варто надсилати.",
+    "nudge.audience.share_public_page_d14.cta": "Відкрити публічну сторінку",
+
+    "nudge.audience.stalled_learners_d14.subject": "Дехто з учасників спинився на середині",
+    "nudge.audience.stalled_learners_d14.heading": "Кілька людей застрягли",
+    "nudge.audience.stalled_learners_d14.body": "Дехто з учасників {org_name} почав курс і не повертався вже два тижні. Часто допомагає повідомлення від вас — або погляд на те, де саме вони спинилися.",
+    "nudge.audience.stalled_learners_d14.cta": "Переглянути учасників",
+
+    "nudge.monetization.course_limit_d1.subject": "Ви використали всі курси тарифу {plan_name}",
+    "nudge.monetization.course_limit_d1.heading": "Досягнуто ліміт курсів",
+    "nudge.monetization.course_limit_d1.body": "{org_name} на тарифі {plan_name} і використала всі включені курси. Перехід на {next_plan} знімає це обмеження, якщо хочете продовжувати.",
+    "nudge.monetization.course_limit_d1.cta": "Переглянути тарифи",
+
+    "nudge.monetization.member_limit_near.subject": "Ви близько до ліміту учасників на тарифі {plan_name}",
+    "nudge.monetization.member_limit_near.heading": "Майже досягнуто ліміт учасників",
+    "nudge.monetization.member_limit_near.body": "{org_name} наближається до кількості учасників, яку дозволяє тариф {plan_name}. Перехід на {next_plan} піднімає її, щоб ніхто не спинився на пів дорозі до реєстрації.",
+    "nudge.monetization.member_limit_near.cta": "Переглянути тарифи",
+
+    "nudge.monetization.ai_credits_low.subject": "Кредити ШІ майже вичерпано",
+    "nudge.monetization.ai_credits_low.heading": "Кредитів ШІ лишилося мало",
+    "nudge.monetization.ai_credits_low.body": "{org_name} витратила більшу частину кредитів ШІ, включених у тариф {plan_name}. На тарифі {next_plan} їх більше — якщо ШІ став частиною того, як ви готуєте курси.",
+    "nudge.monetization.ai_credits_low.cta": "Переглянути тарифи",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "Що {next_plan} дасть {org_name}",
+    "nudge.monetization.upgrade_recap_d21.heading": "Ви побудували щось справжнє",
+    "nudge.monetization.upgrade_recap_d21.body": "У {org_name} є опубліковані курси й люди, які їх читають. Тариф {next_plan} дає запас для зростання та кілька речей, яких немає в тарифі {plan_name}, — варто глянути, якщо плануєте розширюватися.",
+    "nudge.monetization.upgrade_recap_d21.cta": "Порівняти тарифи",
+
+    "nudge.dormancy.no_login_14d.subject": "У {org_name} було тихо",
+    "nudge.dormancy.no_login_14d.heading": "Минуло два тижні",
+    "nudge.dormancy.no_login_14d.body": "Від вашого останнього візиту в {org_name} нічого не змінилося. Якщо ви були в процесі, усе лежить саме там, де ви залишили.",
+    "nudge.dormancy.no_login_14d.cta": "Відкрити панель",
+
+    "nudge.dormancy.no_login_30d.subject": "Ваші курси в {org_name} нікуди не поділися",
+    "nudge.dormancy.no_login_30d.heading": "Минуло кілька тижнів",
+    "nudge.dormancy.no_login_30d.body": "Поки вас не було, нічого не змінилося — {org_name} і все в ній саме там, де ви залишили. Повернутися — це один клік.",
+    "nudge.dormancy.no_login_30d.cta": "Відкрити панель",
+
+    "nudge.dormancy.no_login_60d.subject": "Останнє повідомлення про {org_name}",
+    "nudge.dormancy.no_login_60d.heading": "Більше не турбуємо",
+    "nudge.dormancy.no_login_60d.body": "{org_name} мовчить уже пару місяців, тож це останній такий лист. Усе, що ви побудували, лишається як є — на випадок, коли знадобиться.",
+    "nudge.dormancy.no_login_60d.cta": "Відкрити панель",
+
+    "nudge.dormancy.winback_q.subject": "Що нового від вашого останнього візиту в {org_name}",
+    "nudge.dormancy.winback_q.heading": "Дещо змінилося",
+    "nudge.dormancy.winback_q.body": "Ви давно не заходили в {org_name}. Продукт відтоді помітно просунувся, а все, що ви побудували, досі на місці.",
+    "nudge.dormancy.winback_q.cta": "Подивитися",
+
+    "nudge.milestone.first_course_published.subject": "«{course_name}» опубліковано",
+    "nudge.milestone.first_course_published.heading": "Ви опублікували перший курс",
+    "nudge.milestone.first_course_published.body": "«{course_name}» опубліковано, і його можна читати. Далі головне — щоб хтось його прочитав, нехай навіть одна-дві людини для початку.",
+    "nudge.milestone.first_course_published.cta": "Запросити перших учасників",
+
+    "nudge.milestone.first_learner_enrolled.subject": "Хтось почав «{course_name}»",
+    "nudge.milestone.first_learner_enrolled.heading": "У вас перший учасник",
+    "nudge.milestone.first_learner_enrolled.body": "Уперше хтось почав курс у {org_name}. Стежити за прогресом можна в панелі.",
+    "nudge.milestone.first_learner_enrolled.cta": "Переглянути прогрес",
+
+    "nudge.milestone.first_completion.subject": "Хтось пройшов курс у {org_name}",
+    "nudge.milestone.first_completion.heading": "Перше завершення",
+    "nudge.milestone.first_completion.body": "Учасник пройшов курс у {org_name} від початку до кінця. Щоб відзначити це як належить, можна додати сертифікат — або почати готувати наступний курс.",
+    "nudge.milestone.first_completion.cta": "Відкрити панель",
+}

--- a/apps/api/src/services/email/nudge_translations/vi.py
+++ b/apps/api/src/services/email/nudge_translations/vi.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "Hủy đăng ký nhận những email này",
     "nudge.common.footer": "Bạn nhận được email này vì bạn là quản trị viên của {org_name}.",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "Khóa học",
+    "nudge.stat.chapters": "Chương",
+    "nudge.stat.lessons": "Bài học",
+    "nudge.stat.members": "Thành viên",
+    "nudge.stat.learners": "Người học",
+    "nudge.stat.completed": "Hoàn thành",
+
     "nudge.activation.first_course_d1.subject": "Khóa học đầu tiên của bạn trên {org_name}",
     "nudge.activation.first_course_d1.heading": "Khi nào bạn sẵn sàng",
     "nudge.activation.first_course_d1.body": "{org_name} đã sẵn sàng và đang chờ khóa học đầu tiên. Phần lớn mọi người bắt đầu từ nhỏ: một chủ đề, vài bài học. Bạn luôn có thể bổ sung sau.",
@@ -152,4 +161,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "Lần hoàn thành đầu tiên",
     "nudge.milestone.first_completion.body": "Một người học đã hoàn thành khóa học trong {org_name} từ đầu đến cuối. Nếu muốn ghi nhận đàng hoàng, bạn có thể thêm chứng chỉ — hoặc bắt tay vào khóa tiếp theo.",
     "nudge.milestone.first_completion.cta": "Mở bảng điều khiển",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "Học viện của bạn trên {org_name} vẫn còn đây",
+    "nudge.reactivation.opener.heading": "Vẫn ở đây, đúng như bạn để lại",
+    "nudge.reactivation.opener.body": "Không ai động vào {org_name} kể từ lần cuối bạn ghé — mọi khóa học, chương và bài học đều ở nguyên chỗ. Quay lại chỉ mất một cú nhấp.",
+    "nudge.reactivation.opener.cta": "Mở bảng điều khiển",
+    "nudge.reactivation.whats_changed.subject": "Có vài thay đổi trên LearnHouse",
+    "nudge.reactivation.whats_changed.heading": "Kể từ lần cuối bạn ghé",
+    "nudge.reactivation.whats_changed.body": "Sản phẩm đã tiến khá xa trong lúc {org_name} im ắng: trình soạn thảo, công cụ khóa học và lộ trình của người học đều đã được làm lại đáng kể. Mọi thứ bạn dựng vẫn chạy như cũ.",
+    "nudge.reactivation.whats_changed.cta": "Xem điều gì mới",
+    "nudge.reactivation.need_a_hand.subject": "Cần hỗ trợ để quay lại {org_name} không?",
+    "nudge.reactivation.need_a_hand.heading": "Có gì cản trở không?",
+    "nudge.reactivation.need_a_hand.body": "Nếu có lý do khiến {org_name} dừng lại — điều gì đó khó hiểu, thiếu sót, hay đơn giản là không có thời gian — chúng tôi thật sự muốn nghe. Trả lời email này, nó đến thẳng chỗ chúng tôi.",
+    "nudge.reactivation.closing.subject": "Lời nhắn cuối về {org_name}",
+    "nudge.reactivation.closing.heading": "Chúng tôi dừng ở đây",
+    "nudge.reactivation.closing.body": "Đây là email cuối thuộc loại này. {org_name} vẫn giữ nguyên và không có gì hết hạn — nếu có ngày bạn muốn quay lại, mọi thứ vẫn đang chờ.",
+    "nudge.reactivation.closing.cta": "Mở bảng điều khiển",
 }

--- a/apps/api/src/services/email/nudge_translations/vi.py
+++ b/apps/api/src/services/email/nudge_translations/vi.py
@@ -1,0 +1,155 @@
+"""Vietnamese nudge copy."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "Hủy đăng ký nhận những email này",
+    "nudge.common.footer": "Bạn nhận được email này vì bạn là quản trị viên của {org_name}.",
+
+    "nudge.activation.first_course_d1.subject": "Khóa học đầu tiên của bạn trên {org_name}",
+    "nudge.activation.first_course_d1.heading": "Khi nào bạn sẵn sàng",
+    "nudge.activation.first_course_d1.body": "{org_name} đã sẵn sàng và đang chờ khóa học đầu tiên. Phần lớn mọi người bắt đầu từ nhỏ: một chủ đề, vài bài học. Bạn luôn có thể bổ sung sau.",
+    "nudge.activation.first_course_d1.cta": "Tạo khóa học đầu tiên",
+
+    "nudge.activation.come_back_d2.subject": "Tiếp tục từ chỗ bạn dừng lại",
+    "nudge.activation.come_back_d2.heading": "Phần thiết lập vẫn đang chờ bạn",
+    "nudge.activation.come_back_d2.body": "Bạn đã tạo {org_name} và chưa quay lại từ đó. Mọi thứ vẫn còn nguyên, và đưa khóa học đầu tiên lên chỉ mất khoảng mười phút.",
+    "nudge.activation.come_back_d2.cta": "Vào bảng điều khiển",
+
+    "nudge.activation.ai_course_help_d4.subject": "Trang trắng mới là phần khó",
+    "nudge.activation.ai_course_help_d4.heading": "Để AI viết dàn ý",
+    "nudge.activation.ai_course_help_d4.body": "Nếu {org_name} vẫn trống vì bạn chưa biết bắt đầu từ đâu, hãy mô tả chủ đề và AI sẽ phác thảo các chương và bài học. Phần chỉnh sửa là của bạn.",
+    "nudge.activation.ai_course_help_d4.cta": "Tạo khóa học bằng AI",
+
+    "nudge.activation.import_existing_d5.subject": "Mang theo những gì bạn đã có",
+    "nudge.activation.import_existing_d5.heading": "Không cần bắt đầu từ con số không",
+    "nudge.activation.import_existing_d5.body": "Nếu tài liệu của bạn đã tồn tại dưới dạng văn bản, slide hay bản xuất từ nền tảng khác, bạn có thể đưa vào {org_name} thay vì gõ lại.",
+    "nudge.activation.import_existing_d5.cta": "Nhập tài liệu của bạn",
+
+    "nudge.activation.setup_checklist_d7.subject": "Mười lăm phút để có một học viện chạy được",
+    "nudge.activation.setup_checklist_d7.heading": "Một danh sách ngắn",
+    "nudge.activation.setup_checklist_d7.body": "{org_name} vẫn đang chờ khóa học đầu tiên. Danh sách thiết lập sẽ dẫn bạn qua vài bước ngắn — phần lớn mọi người xong trong khoảng mười lăm phút.",
+    "nudge.activation.setup_checklist_d7.cta": "Mở danh sách",
+
+    "nudge.activation.whats_blocking_d14.subject": "Điều gì đã cản trở?",
+    "nudge.activation.whats_blocking_d14.heading": "Chúng tôi hỏi được không, điều gì khiến bạn dừng lại?",
+    "nudge.activation.whats_blocking_d14.body": "Bạn tạo {org_name} cách đây hai tuần và vẫn chưa thêm khóa học nào. Nếu có gì khó hiểu hoặc còn thiếu, chúng tôi rất muốn biết — chỉ cần trả lời email này, nó đến thẳng chỗ chúng tôi.",
+
+    "nudge.activation.last_call_d30.subject": "Email cuối về {org_name}",
+    "nudge.activation.last_call_d30.heading": "Đây là email cuối",
+    "nudge.activation.last_call_d30.body": "{org_name} đã im ắng một tháng, nên chúng tôi sẽ dừng gửi những email này. Tài khoản và mọi thứ trong đó vẫn còn nguyên — nếu bạn quay lại, mọi thứ vẫn ở chỗ cũ.",
+    "nudge.activation.last_call_d30.cta": "Mở bảng điều khiển",
+
+    "nudge.content.course_no_chapter_d1.subject": "«{course_name}» cần chương đầu tiên",
+    "nudge.content.course_no_chapter_d1.heading": "Còn thiếu một chương",
+    "nudge.content.course_no_chapter_d1.body": "«{course_name}» đã có nhưng chưa có chương nào, nên chưa có gì để mở. Chương chỉ là các phần — mỗi chủ đề một chương là hợp lý.",
+    "nudge.content.course_no_chapter_d1.cta": "Thêm một chương",
+
+    "nudge.content.chapter_no_activity_d1.subject": "Thêm bài học đầu tiên vào «{course_name}»",
+    "nudge.content.chapter_no_activity_d1.heading": "Các chương đã sẵn sàng",
+    "nudge.content.chapter_no_activity_d1.body": "«{course_name}» có chương nhưng bên trong vẫn trống. Một bài học có thể là trang văn bản, video hay bài trắc nghiệm — tùy chủ đề.",
+    "nudge.content.chapter_no_activity_d1.cta": "Thêm bài học",
+
+    "nudge.content.activity_unpublished_d2.subject": "Các bài học trong «{course_name}» vẫn chưa hiển thị",
+    "nudge.content.activity_unpublished_d2.heading": "Bài học vẫn đang ẩn",
+    "nudge.content.activity_unpublished_d2.body": "Bạn đã viết bài học trong «{course_name}», nhưng chưa bài nào được xuất bản nên người học chỉ thấy một khóa trống. Xuất bản không khóa gì cả — bạn vẫn chỉnh sửa được sau đó.",
+    "nudge.content.activity_unpublished_d2.cta": "Xuất bản bài học",
+
+    "nudge.content.course_draft_d3.subject": "«{course_name}» vẫn là bản nháp",
+    "nudge.content.course_draft_d3.heading": "«{course_name}» sắp xong rồi",
+    "nudge.content.course_draft_d3.body": "Bạn đã thêm bài học vào «{course_name}», nhưng khóa chưa được xuất bản nên không ai mở được. Không cần phải hoàn chỉnh — xuất bản chỉ làm nó hiển thị, và bạn vẫn chỉnh sửa tiếp được.",
+    "nudge.content.course_draft_d3.cta": "Xuất bản",
+
+    "nudge.content.course_draft_d10.subject": "«{course_name}» đã ở dạng nháp khá lâu",
+    "nudge.content.course_draft_d10.heading": "Chắc là đã đủ rồi",
+    "nudge.content.course_draft_d10.body": "«{course_name}» chưa xuất bản đã hơn một tuần. Khóa học hiếm khi có cảm giác hoàn chỉnh — xuất bản làm nó hiển thị, và bạn vẫn cải thiện được khi đã có người đọc.",
+    "nudge.content.course_draft_d10.cta": "Xuất bản",
+
+    "nudge.content.thin_course_d5.subject": "«{course_name}» có thể thêm chút nữa",
+    "nudge.content.thin_course_d5.heading": "Mới có một hai bài",
+    "nudge.content.thin_course_d5.body": "«{course_name}» hiện có một hai bài học. Khóa học thường thuyết phục hơn khi có thêm vài bài, và AI có thể phác thảo các bài tiếp theo từ nội dung sẵn có.",
+    "nudge.content.thin_course_d5.cta": "Thêm bài học",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "Chưa có bài nộp nào trong {org_name}",
+    "nudge.content.assignment_no_submissions_d5.heading": "Chưa ai nộp bài",
+    "nudge.content.assignment_no_submissions_d5.body": "Bạn đã tạo bài tập trong {org_name} nhưng chưa có ai nộp. Nên kiểm tra xem nó đã được xuất bản chưa và người học có vào được khóa liên quan không.",
+    "nudge.content.assignment_no_submissions_d5.cta": "Kiểm tra bài tập",
+
+    "nudge.audience.published_no_members_d1.subject": "«{course_name}» đã lên nhưng chưa có ai",
+    "nudge.audience.published_no_members_d1.heading": "Đã đến lúc mời ai đó",
+    "nudge.audience.published_no_members_d1.body": "«{course_name}» đã xuất bản và sẵn sàng để đọc. {org_name} chưa có người học nào, nên bước tiếp theo là mời những người mà bạn viết cho họ.",
+    "nudge.audience.published_no_members_d1.cta": "Mời người học",
+
+    "nudge.audience.published_no_members_d7.subject": "«{course_name}» vẫn chưa có người học",
+    "nudge.audience.published_no_members_d7.heading": "Một tuần đã lên, chưa ai đọc",
+    "nudge.audience.published_no_members_d7.body": "«{course_name}» đã xuất bản được một tuần và {org_name} vẫn chưa có người học. Bạn có thể mời từng người, dán một danh sách, hoặc chỉ cần chia sẻ liên kết tham gia.",
+    "nudge.audience.published_no_members_d7.cta": "Mời mọi người",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "Người học của bạn vẫn chưa bắt đầu",
+    "nudge.audience.members_no_enrollment_d3.heading": "Đã tham gia nhưng chưa mở gì",
+    "nudge.audience.members_no_enrollment_d3.body": "Có người đã tham gia {org_name} nhưng chưa ai bắt đầu khóa học. Một tin nhắn ngắn kèm liên kết trực tiếp thường là đủ — phần lớn chỉ là chưa tìm ra lối vào.",
+    "nudge.audience.members_no_enrollment_d3.cta": "Xem thành viên",
+
+    "nudge.audience.share_public_page_d14.subject": "Trang khóa học của bạn là công khai — liên kết đây",
+    "nudge.audience.share_public_page_d14.heading": "Ai có liên kết đều đọc được",
+    "nudge.audience.share_public_page_d14.body": "«{course_name}» ở chế độ công khai, nên bạn có thể chia sẻ ở bất cứ đâu mà không ai cần lời mời. Liên kết bên dưới là cái để gửi đi.",
+    "nudge.audience.share_public_page_d14.cta": "Xem trang công khai",
+
+    "nudge.audience.stalled_learners_d14.subject": "Một số người học dừng giữa chừng",
+    "nudge.audience.stalled_learners_d14.heading": "Vài người đang mắc lại",
+    "nudge.audience.stalled_learners_d14.body": "Một số người học trong {org_name} đã bắt đầu khóa học và hai tuần nay chưa quay lại. Một tin nhắn từ bạn thường có tác dụng, hoặc xem họ dừng ở đâu.",
+    "nudge.audience.stalled_learners_d14.cta": "Kiểm tra người học",
+
+    "nudge.monetization.course_limit_d1.subject": "Bạn đã dùng hết số khóa học của gói {plan_name}",
+    "nudge.monetization.course_limit_d1.heading": "Bạn đã chạm giới hạn khóa học",
+    "nudge.monetization.course_limit_d1.body": "{org_name} đang dùng gói {plan_name} và đã dùng hết số khóa học đi kèm. Chuyển lên {next_plan} sẽ bỏ giới hạn đó nếu bạn muốn tiếp tục.",
+    "nudge.monetization.course_limit_d1.cta": "Xem các gói",
+
+    "nudge.monetization.member_limit_near.subject": "Bạn sắp chạm giới hạn thành viên của gói {plan_name}",
+    "nudge.monetization.member_limit_near.heading": "Gần chạm giới hạn thành viên",
+    "nudge.monetization.member_limit_near.body": "{org_name} đang tiến gần số thành viên mà gói {plan_name} cho phép. Chuyển lên {next_plan} sẽ nâng con số đó, để không ai bị chặn giữa chừng khi đăng ký.",
+    "nudge.monetization.member_limit_near.cta": "Xem các gói",
+
+    "nudge.monetization.ai_credits_low.subject": "Tín dụng AI của bạn sắp hết",
+    "nudge.monetization.ai_credits_low.heading": "Còn ít tín dụng AI",
+    "nudge.monetization.ai_credits_low.body": "{org_name} đã dùng gần hết tín dụng AI đi kèm gói {plan_name}. Gói {next_plan} có nhiều hơn, nếu AI đã thành một phần trong cách bạn xây khóa học.",
+    "nudge.monetization.ai_credits_low.cta": "Xem các gói",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "{next_plan} sẽ mang lại gì cho {org_name}",
+    "nudge.monetization.upgrade_recap_d21.heading": "Bạn đã dựng được điều gì đó thật sự",
+    "nudge.monetization.upgrade_recap_d21.body": "{org_name} có khóa học đã xuất bản và người đọc chúng. Gói {next_plan} cho thêm chỗ để lớn lên và vài thứ mà gói {plan_name} không có — đáng xem nếu bạn định mở rộng.",
+    "nudge.monetization.upgrade_recap_d21.cta": "So sánh các gói",
+
+    "nudge.dormancy.no_login_14d.subject": "{org_name} đã im ắng",
+    "nudge.dormancy.no_login_14d.heading": "Đã hai tuần trôi qua",
+    "nudge.dormancy.no_login_14d.body": "Không có gì thay đổi trong {org_name} kể từ lần cuối bạn ghé. Nếu bạn đang làm dở việc gì, nó vẫn nằm đúng chỗ bạn để lại.",
+    "nudge.dormancy.no_login_14d.cta": "Mở bảng điều khiển",
+
+    "nudge.dormancy.no_login_30d.subject": "Các khóa học của bạn trên {org_name} vẫn còn đây",
+    "nudge.dormancy.no_login_30d.heading": "Đã vài tuần trôi qua",
+    "nudge.dormancy.no_login_30d.body": "Không có gì thay đổi khi bạn vắng mặt — {org_name} và mọi thứ trong đó vẫn đúng chỗ bạn để lại. Quay lại chỉ mất một cú nhấp.",
+    "nudge.dormancy.no_login_30d.cta": "Mở bảng điều khiển",
+
+    "nudge.dormancy.no_login_60d.subject": "Lời nhắn cuối về {org_name}",
+    "nudge.dormancy.no_login_60d.heading": "Chúng tôi sẽ không làm phiền nữa",
+    "nudge.dormancy.no_login_60d.body": "{org_name} đã im ắng khoảng hai tháng, nên đây là email cuối thuộc loại này. Mọi thứ bạn đã dựng vẫn giữ nguyên, chờ khi nào bạn cần.",
+    "nudge.dormancy.no_login_60d.cta": "Mở bảng điều khiển",
+
+    "nudge.dormancy.winback_q.subject": "Có gì mới kể từ lần cuối bạn vào {org_name}",
+    "nudge.dormancy.winback_q.heading": "Một vài thứ đã thay đổi",
+    "nudge.dormancy.winback_q.body": "Đã lâu rồi bạn chưa ghé {org_name}. Sản phẩm đã tiến khá xa kể từ đó, và mọi thứ bạn dựng vẫn còn nguyên.",
+    "nudge.dormancy.winback_q.cta": "Ghé xem",
+
+    "nudge.milestone.first_course_published.subject": "«{course_name}» đã lên",
+    "nudge.milestone.first_course_published.heading": "Bạn đã xuất bản khóa học đầu tiên",
+    "nudge.milestone.first_course_published.body": "«{course_name}» đã lên và đọc được. Điều tạo khác biệt lúc này là có người đọc nó — dù ban đầu chỉ một hai người.",
+    "nudge.milestone.first_course_published.cta": "Mời những người học đầu tiên",
+
+    "nudge.milestone.first_learner_enrolled.subject": "Có người đã bắt đầu «{course_name}»",
+    "nudge.milestone.first_learner_enrolled.heading": "Người học đầu tiên đã vào",
+    "nudge.milestone.first_learner_enrolled.body": "Lần đầu tiên có người bắt đầu một khóa học trong {org_name}. Bạn có thể theo dõi tiến độ từ bảng điều khiển.",
+    "nudge.milestone.first_learner_enrolled.cta": "Xem tiến độ",
+
+    "nudge.milestone.first_completion.subject": "Có người hoàn thành một khóa học trong {org_name}",
+    "nudge.milestone.first_completion.heading": "Lần hoàn thành đầu tiên",
+    "nudge.milestone.first_completion.body": "Một người học đã hoàn thành khóa học trong {org_name} từ đầu đến cuối. Nếu muốn ghi nhận đàng hoàng, bạn có thể thêm chứng chỉ — hoặc bắt tay vào khóa tiếp theo.",
+    "nudge.milestone.first_completion.cta": "Mở bảng điều khiển",
+}

--- a/apps/api/src/services/email/nudge_translations/zh.py
+++ b/apps/api/src/services/email/nudge_translations/zh.py
@@ -1,0 +1,155 @@
+"""Simplified Chinese nudge copy."""
+
+STRINGS: dict[str, str] = {
+    "nudge.common.unsubscribe": "退订这些邮件",
+    "nudge.common.footer": "您收到此邮件是因为您是 {org_name} 的管理员。",
+
+    "nudge.activation.first_course_d1.subject": "您在 {org_name} 的第一门课程",
+    "nudge.activation.first_course_d1.heading": "随时都可以开始",
+    "nudge.activation.first_course_d1.body": "{org_name} 已经就绪，正等着第一门课程。多数人从小处入手：一个主题，几节课。之后随时可以补充。",
+    "nudge.activation.first_course_d1.cta": "创建第一门课程",
+
+    "nudge.activation.come_back_d2.subject": "接着上次继续",
+    "nudge.activation.come_back_d2.heading": "您的设置还在等着",
+    "nudge.activation.come_back_d2.body": "您创建了 {org_name}，之后就没再回来。一切都还在，把第一门课程发布出去大约需要十分钟。",
+    "nudge.activation.come_back_d2.cta": "前往控制台",
+
+    "nudge.activation.ai_course_help_d4.subject": "最难的是空白页",
+    "nudge.activation.ai_course_help_d4.heading": "让 AI 写大纲",
+    "nudge.activation.ai_course_help_d4.body": "如果 {org_name} 还空着，只是因为不知从何下手，那就描述一下主题，AI 会拟出章节和课时。之后由您来修改。",
+    "nudge.activation.ai_course_help_d4.cta": "用 AI 起草课程",
+
+    "nudge.activation.import_existing_d5.subject": "把现有的内容带过来",
+    "nudge.activation.import_existing_d5.heading": "不必从零开始",
+    "nudge.activation.import_existing_d5.body": "如果您的材料已经是文档、幻灯片，或从其他平台导出的文件，可以直接导入 {org_name}，不用重新录入。",
+    "nudge.activation.import_existing_d5.cta": "导入您的材料",
+
+    "nudge.activation.setup_checklist_d7.subject": "十五分钟搭起一个可用的学院",
+    "nudge.activation.setup_checklist_d7.heading": "一份简短的清单",
+    "nudge.activation.setup_checklist_d7.body": "{org_name} 仍在等待第一门课程。设置清单会用几个简短的步骤带您走完，多数人一刻钟左右就能完成。",
+    "nudge.activation.setup_checklist_d7.cta": "打开清单",
+
+    "nudge.activation.whats_blocking_d14.subject": "是什么挡住了？",
+    "nudge.activation.whats_blocking_d14.heading": "能问问是什么让您停下的吗？",
+    "nudge.activation.whats_blocking_d14.body": "您两周前创建了 {org_name}，到现在还没添加课程。如果有让人困惑或缺失的地方，我们很想知道——直接回复这封邮件就好，会直接到我们手上。",
+
+    "nudge.activation.last_call_d30.subject": "关于 {org_name} 的最后一封邮件",
+    "nudge.activation.last_call_d30.heading": "这是最后一封",
+    "nudge.activation.last_call_d30.body": "{org_name} 已经安静了一个月，所以我们不再发这类邮件了。账户和里面的一切都会保留——您回来时，都还在原处。",
+    "nudge.activation.last_call_d30.cta": "打开控制台",
+
+    "nudge.content.course_no_chapter_d1.subject": "《{course_name}》还缺第一个章节",
+    "nudge.content.course_no_chapter_d1.heading": "还差一个章节",
+    "nudge.content.course_no_chapter_d1.body": "《{course_name}》已经建好，但还没有章节，所以没有内容可打开。章节就是分段，一个主题一个章节效果不错。",
+    "nudge.content.course_no_chapter_d1.cta": "添加章节",
+
+    "nudge.content.chapter_no_activity_d1.subject": "为《{course_name}》添加第一节课",
+    "nudge.content.chapter_no_activity_d1.heading": "章节已经就位",
+    "nudge.content.chapter_no_activity_d1.body": "《{course_name}》有章节，但里面还是空的。一节课可以是一页文字、一段视频、一份测验——只要贴合主题就行。",
+    "nudge.content.chapter_no_activity_d1.cta": "添加课时",
+
+    "nudge.content.activity_unpublished_d2.subject": "《{course_name}》中的课时还看不到",
+    "nudge.content.activity_unpublished_d2.heading": "课时仍处于隐藏状态",
+    "nudge.content.activity_unpublished_d2.body": "您在《{course_name}》里写了课时，但都没有发布，所以学员看到的是一门空课。发布不会锁定任何内容，之后仍可继续编辑。",
+    "nudge.content.activity_unpublished_d2.cta": "发布课时",
+
+    "nudge.content.course_draft_d3.subject": "《{course_name}》仍是草稿",
+    "nudge.content.course_draft_d3.heading": "《{course_name}》就快好了",
+    "nudge.content.course_draft_d3.body": "您已经为《{course_name}》添加了课时，但课程尚未发布，所以没人能打开。它不需要完全做完——发布只是让它可见，之后还能继续编辑。",
+    "nudge.content.course_draft_d3.cta": "发布",
+
+    "nudge.content.course_draft_d10.subject": "《{course_name}》做草稿有一阵子了",
+    "nudge.content.course_draft_d10.heading": "多半已经可以了",
+    "nudge.content.course_draft_d10.body": "《{course_name}》未发布已超过一周。课程很少会让人觉得真的做完了——发布让它可见，您可以在有人阅读的同时继续打磨。",
+    "nudge.content.course_draft_d10.cta": "发布",
+
+    "nudge.content.thin_course_d5.subject": "《{course_name}》可以再充实一点",
+    "nudge.content.thin_course_d5.heading": "目前只有一两节课",
+    "nudge.content.thin_course_d5.body": "《{course_name}》目前只有一两节课。课程通常内容多几节效果更好，AI 可以根据已有内容起草接下来的几节。",
+    "nudge.content.thin_course_d5.cta": "添加更多课时",
+
+    "nudge.content.assignment_no_submissions_d5.subject": "{org_name} 还没有任何提交",
+    "nudge.content.assignment_no_submissions_d5.heading": "还没有人交作业",
+    "nudge.content.assignment_no_submissions_d5.body": "您在 {org_name} 里创建了作业，但还没有人提交。可以检查一下它是否已发布，以及学员能否进入所属的课程。",
+    "nudge.content.assignment_no_submissions_d5.cta": "检查作业",
+
+    "nudge.audience.published_no_members_d1.subject": "《{course_name}》已上线，但还没有人",
+    "nudge.audience.published_no_members_d1.heading": "该邀请人了",
+    "nudge.audience.published_no_members_d1.body": "《{course_name}》已发布，随时可以阅读。{org_name} 还没有学员，所以下一步是邀请您为之而写的那些人。",
+    "nudge.audience.published_no_members_d1.cta": "邀请学员",
+
+    "nudge.audience.published_no_members_d7.subject": "《{course_name}》仍然没有学员",
+    "nudge.audience.published_no_members_d7.heading": "上线一周，无人阅读",
+    "nudge.audience.published_no_members_d7.body": "《{course_name}》已发布一周，{org_name} 依然没有学员。您可以逐个邀请、粘贴一份名单，或者直接分享加入链接。",
+    "nudge.audience.published_no_members_d7.cta": "邀请他人",
+
+    "nudge.audience.members_no_enrollment_d3.subject": "您的学员还没开始",
+    "nudge.audience.members_no_enrollment_d3.heading": "加入了，但什么都没打开",
+    "nudge.audience.members_no_enrollment_d3.body": "有人加入了 {org_name}，但还没有人开始学习课程。通常一条带直达链接的简短消息就够了——多数人只是没找到入口。",
+    "nudge.audience.members_no_enrollment_d3.cta": "查看成员",
+
+    "nudge.audience.share_public_page_d14.subject": "您的课程页面是公开的——链接在这里",
+    "nudge.audience.share_public_page_d14.heading": "任何拿到链接的人都能阅读",
+    "nudge.audience.share_public_page_d14.body": "《{course_name}》是公开的，因此可以随处分享，别人不需要邀请。下面这个链接就是可以发出去的那个。",
+    "nudge.audience.share_public_page_d14.cta": "查看公开页面",
+
+    "nudge.audience.stalled_learners_d14.subject": "有学员学到一半停下了",
+    "nudge.audience.stalled_learners_d14.heading": "有几个人卡住了",
+    "nudge.audience.stalled_learners_d14.body": "{org_name} 中有些学员开始了课程，但两周没再回来。您发一条消息往往管用，看看他们停在哪里也有帮助。",
+    "nudge.audience.stalled_learners_d14.cta": "查看学员情况",
+
+    "nudge.monetization.course_limit_d1.subject": "{plan_name} 方案的课程名额已用完",
+    "nudge.monetization.course_limit_d1.heading": "已达到课程上限",
+    "nudge.monetization.course_limit_d1.body": "{org_name} 使用的是 {plan_name} 方案，其中包含的课程名额已全部用完。如果想继续创建，升级到 {next_plan} 可以取消这个限制。",
+    "nudge.monetization.course_limit_d1.cta": "查看方案",
+
+    "nudge.monetization.member_limit_near.subject": "{plan_name} 方案的成员上限快到了",
+    "nudge.monetization.member_limit_near.heading": "接近成员上限",
+    "nudge.monetization.member_limit_near.body": "{org_name} 快要达到 {plan_name} 方案允许的成员数量。升级到 {next_plan} 会提高上限，避免有人在注册途中被挡下。",
+    "nudge.monetization.member_limit_near.cta": "查看方案",
+
+    "nudge.monetization.ai_credits_low.subject": "AI 额度快用完了",
+    "nudge.monetization.ai_credits_low.heading": "AI 额度所剩不多",
+    "nudge.monetization.ai_credits_low.body": "{org_name} 已用掉 {plan_name} 方案所含 AI 额度的大部分。如果 AI 已成为您做课程的一部分，{next_plan} 方案包含更多额度。",
+    "nudge.monetization.ai_credits_low.cta": "查看方案",
+
+    "nudge.monetization.upgrade_recap_d21.subject": "{next_plan} 能为 {org_name} 带来什么",
+    "nudge.monetization.upgrade_recap_d21.heading": "您已经做出了实在的东西",
+    "nudge.monetization.upgrade_recap_d21.body": "{org_name} 有已发布的课程，也有在读的人。{next_plan} 方案提供了成长空间，还包含一些 {plan_name} 方案没有的功能——如果打算扩展，值得看看。",
+    "nudge.monetization.upgrade_recap_d21.cta": "对比方案",
+
+    "nudge.dormancy.no_login_14d.subject": "{org_name} 最近很安静",
+    "nudge.dormancy.no_login_14d.heading": "已经两周了",
+    "nudge.dormancy.no_login_14d.body": "自您上次来过之后，{org_name} 没有任何变化。如果当时正做到一半，东西还在原来的地方。",
+    "nudge.dormancy.no_login_14d.cta": "打开控制台",
+
+    "nudge.dormancy.no_login_30d.subject": "{org_name} 上的课程都还在",
+    "nudge.dormancy.no_login_30d.heading": "已经过去几周了",
+    "nudge.dormancy.no_login_30d.body": "您不在的这段时间没有任何变化——{org_name} 和里面的一切都在原处。重新开始只需一次点击。",
+    "nudge.dormancy.no_login_30d.cta": "打开控制台",
+
+    "nudge.dormancy.no_login_60d.subject": "关于 {org_name} 的最后一次问候",
+    "nudge.dormancy.no_login_60d.heading": "我们就不打扰了",
+    "nudge.dormancy.no_login_60d.body": "{org_name} 已经安静了两个月，所以这暂时是最后一封这类邮件。您做的一切都会原样保留，等您需要时再用。",
+    "nudge.dormancy.no_login_60d.cta": "打开控制台",
+
+    "nudge.dormancy.winback_q.subject": "自您上次来 {org_name} 之后的新变化",
+    "nudge.dormancy.winback_q.heading": "有一些变化",
+    "nudge.dormancy.winback_q.body": "距离您上次来 {org_name} 已经有一段时间了。产品在这期间有不少推进，而您做过的一切都还在。",
+    "nudge.dormancy.winback_q.cta": "去看看",
+
+    "nudge.milestone.first_course_published.subject": "《{course_name}》已上线",
+    "nudge.milestone.first_course_published.heading": "您发布了第一门课程",
+    "nudge.milestone.first_course_published.body": "《{course_name}》已经上线，可以阅读了。接下来真正起作用的，是有人来读——哪怕先只有一两个人。",
+    "nudge.milestone.first_course_published.cta": "邀请第一批学员",
+
+    "nudge.milestone.first_learner_enrolled.subject": "有人开始学《{course_name}》了",
+    "nudge.milestone.first_learner_enrolled.heading": "第一位学员来了",
+    "nudge.milestone.first_learner_enrolled.body": "{org_name} 里第一次有人开始学习课程。您可以在控制台里跟进他的进度。",
+    "nudge.milestone.first_learner_enrolled.cta": "查看进度",
+
+    "nudge.milestone.first_completion.subject": "有人学完了 {org_name} 的一门课程",
+    "nudge.milestone.first_completion.heading": "第一次结课",
+    "nudge.milestone.first_completion.body": "有学员把 {org_name} 的一门课程从头学到尾。想正式记录一下，可以添加证书——或者开始筹备下一门。",
+    "nudge.milestone.first_completion.cta": "打开控制台",
+}

--- a/apps/api/src/services/email/nudge_translations/zh.py
+++ b/apps/api/src/services/email/nudge_translations/zh.py
@@ -4,6 +4,15 @@ STRINGS: dict[str, str] = {
     "nudge.common.unsubscribe": "退订这些邮件",
     "nudge.common.footer": "您收到此邮件是因为您是 {org_name} 的管理员。",
 
+    # Stat-strip labels. A label beside a bare number needs no plural
+    # agreement, which is why the figures are not written into prose.
+    "nudge.stat.courses": "课程",
+    "nudge.stat.chapters": "章节",
+    "nudge.stat.lessons": "课时",
+    "nudge.stat.members": "成员",
+    "nudge.stat.learners": "学员",
+    "nudge.stat.completed": "已完成",
+
     "nudge.activation.first_course_d1.subject": "您在 {org_name} 的第一门课程",
     "nudge.activation.first_course_d1.heading": "随时都可以开始",
     "nudge.activation.first_course_d1.body": "{org_name} 已经就绪，正等着第一门课程。多数人从小处入手：一个主题，几节课。之后随时可以补充。",
@@ -152,4 +161,21 @@ STRINGS: dict[str, str] = {
     "nudge.milestone.first_completion.heading": "第一次结课",
     "nudge.milestone.first_completion.body": "有学员把 {org_name} 的一门课程从头学到尾。想正式记录一下，可以添加证书——或者开始筹备下一门。",
     "nudge.milestone.first_completion.cta": "打开控制台",
+
+    # -- reactivation ------------------------------------------------------
+    "nudge.reactivation.opener.subject": "您在 {org_name} 的学院还在",
+    "nudge.reactivation.opener.heading": "一切照旧，和您离开时一样",
+    "nudge.reactivation.opener.body": "自您上次来过之后，没人动过 {org_name}——每一门课程、章节和课时都在原处。想接着做，只需一次点击。",
+    "nudge.reactivation.opener.cta": "打开控制台",
+    "nudge.reactivation.whats_changed.subject": "LearnHouse 有了一些变化",
+    "nudge.reactivation.whats_changed.heading": "自您上次来过之后",
+    "nudge.reactivation.whats_changed.body": "在 {org_name} 安静的这段时间，产品推进了不少：编辑器、课程工具和学员的学习路径都做了实在的改动。您做过的一切仍照常运行。",
+    "nudge.reactivation.whats_changed.cta": "看看有什么新变化",
+    "nudge.reactivation.need_a_hand.subject": "需要帮您重新上手 {org_name} 吗？",
+    "nudge.reactivation.need_a_hand.heading": "是有什么挡住了吗？",
+    "nudge.reactivation.need_a_hand.body": "如果 {org_name} 停下来是有原因的——某处让人困惑、缺了什么，或者只是没时间——我们很想知道。直接回复这封邮件就好，会直接到我们手上。",
+    "nudge.reactivation.closing.subject": "关于 {org_name} 的最后一封",
+    "nudge.reactivation.closing.heading": "我们就说到这里",
+    "nudge.reactivation.closing.body": "这是这类邮件的最后一封。{org_name} 会原样保留，也不会过期——哪天想回来，一切都还在。",
+    "nudge.reactivation.closing.cta": "打开控制台",
 }

--- a/apps/api/src/services/email/translations.py
+++ b/apps/api/src/services/email/translations.py
@@ -964,6 +964,14 @@ EMAIL_TRANSLATIONS: dict[str, dict[str, str]] = {
 }
 
 
+# Lifecycle nudge copy lives in its own module to keep this bundle readable,
+# but shares the same namespace and the same `t()` lookup.
+from src.services.email.nudge_translations import NUDGE_TRANSLATIONS  # noqa: E402
+
+for _nudge_lang, _nudge_keys in NUDGE_TRANSLATIONS.items():
+    EMAIL_TRANSLATIONS.setdefault(_nudge_lang, {}).update(_nudge_keys)
+
+
 def normalize_language(lang: str | None) -> str:
     """Return a supported locale code, falling back to English."""
     if not lang:

--- a/apps/api/src/services/email/utils.py
+++ b/apps/api/src/services/email/utils.py
@@ -91,9 +91,34 @@ def _is_allowed_base_url(url: str) -> bool:
     return False
 
 
+def _configured_frontend_base_url() -> Optional[str]:
+    """Request-free frontend base URL, for callers with no HTTP request.
+
+    Background jobs (cron-invoked lifecycle mail) build links outside any
+    request, so the request-derived fallbacks below are unavailable to them.
+    Resolve from explicit config instead; returns None when nothing usable is
+    configured, so callers can decide whether that is fatal.
+    """
+    platform_url = os.environ.get("LEARNHOUSE_PLATFORM_URL")
+    if platform_url:
+        return platform_url.rstrip("/")
+
+    config = get_learnhouse_config()
+    scheme = "https" if config.hosting_config.ssl else "http"
+    frontend_domain = (config.hosting_config.frontend_domain or "").strip().rstrip("/")
+    if frontend_domain and "localhost" not in frontend_domain:
+        return f"{scheme}://{frontend_domain}"
+
+    base_domain = (config.hosting_config.domain or "").strip().rstrip("/")
+    if base_domain and "localhost" not in base_domain:
+        return f"{scheme}://{base_domain}"
+
+    return None
+
+
 async def get_org_signup_base_url(
     org_slug: str,
-    request: Request,
+    request: Optional[Request] = None,
     db_session=None,
     org_id: Optional[int] = None,
 ) -> str:
@@ -112,11 +137,16 @@ async def get_org_signup_base_url(
            to the user's existing session on the custom domain.
         2. Else fall back to ``{slug}.{hosting_config.domain}``.
         3. Misconfigured (no domain or localhost) → request-derived URL.
+
+    ``request`` is optional so background jobs can build links too; without
+    one, the request-derived fallbacks resolve from config instead.
     """
     config = get_learnhouse_config()
 
     if config.hosting_config.tenancy == "single":
-        return get_base_url_from_request(request)
+        if request is not None:
+            return get_base_url_from_request(request)
+        return _configured_frontend_base_url() or ""
 
     scheme = "https" if config.hosting_config.ssl else "http"
 
@@ -127,12 +157,14 @@ async def get_org_signup_base_url(
 
     base_domain = (config.hosting_config.domain or "").strip().rstrip("/")
     if not base_domain or "localhost" in base_domain:
-        return get_base_url_from_request(request)
+        if request is not None:
+            return get_base_url_from_request(request)
+        return _configured_frontend_base_url() or ""
 
     return f"{scheme}://{org_slug}.{base_domain}"
 
 
-def get_media_base_url(request: Request) -> str:
+def get_media_base_url(request: Optional[Request] = None) -> str:
     """Public base URL that serves ``/content/...`` files (org logos, etc.).
 
     Email HTML can't reference local assets, so an embedded org logo needs an
@@ -147,6 +179,9 @@ def get_media_base_url(request: Request) -> str:
        when a real domain is configured.
     3. The request's own host as a last resort (correct for single-tenant /
        self-hosted where API and content share the request origin).
+
+    ``request`` is optional so background jobs can resolve a logo URL; without
+    one, step 3 is unavailable and this returns "" rather than guessing.
     """
     override = os.environ.get("LEARNHOUSE_MEDIA_URL") or os.environ.get(
         "LEARNHOUSE_BACKEND_URL"
@@ -161,10 +196,12 @@ def get_media_base_url(request: Request) -> str:
         return f"{scheme}://api.{base_domain}"
 
     # Single-tenant / dev: the API answering this request also serves /content.
+    if request is None:
+        return ""
     return str(request.base_url).rstrip("/")
 
 
-def get_org_logo_url(org, request: Request) -> Optional[str]:
+def get_org_logo_url(org, request: Optional[Request] = None) -> Optional[str]:
     """Absolute URL of an org's uploaded logo, or None when it has none.
 
     Mirrors the frontend's ``getOrgLogoMediaDirectory`` path shape
@@ -176,6 +213,11 @@ def get_org_logo_url(org, request: Request) -> Optional[str]:
     if not org or not logo_image or not org_uuid:
         return None
     base = get_media_base_url(request)
+    if not base:
+        # No absolute media host resolvable (no request, nothing configured).
+        # A relative src would render broken in every mail client, so fall
+        # back to the default LearnHouse mark instead.
+        return None
     return f"{base}/content/orgs/{org_uuid}/logos/{logo_image}"
 
 
@@ -266,7 +308,19 @@ def get_base_url_from_request(request: Request) -> str:
     return f"{request.url.scheme}://{request.url.netloc}"
 
 
-def send_email(to: EmailStr, subject: str, body: str):
+def send_email(
+    to: EmailStr,
+    subject: str,
+    body: str,
+    headers: Optional[dict[str, str]] = None,
+):
+    """Send one HTML email.
+
+    ``headers`` carries extra SMTP headers through to the provider. Bulk
+    lifecycle mail needs ``List-Unsubscribe`` / ``List-Unsubscribe-Post``;
+    Gmail and Outlook penalise bulk senders that omit them. Transactional
+    callers pass nothing and are unaffected.
+    """
     from fastapi import HTTPException
 
     lh_config = get_learnhouse_config()
@@ -284,9 +338,9 @@ def send_email(to: EmailStr, subject: str, body: str):
         raise HTTPException(status_code=400, detail="Invalid recipient email address")
 
     if mailing.email_provider == "smtp":
-        return _send_email_smtp(sender, to_addr, subject, body, mailing)
+        return _send_email_smtp(sender, to_addr, subject, body, mailing, headers)
     else:
-        return _send_email_resend(sender, to_addr, subject, body, mailing)
+        return _send_email_resend(sender, to_addr, subject, body, mailing, headers)
 
 
 # Transient provider hiccups (read timeouts, connection resets, 5xx) usually
@@ -306,7 +360,14 @@ def _is_transient_email_error(exc: BaseException) -> bool:
     )
 
 
-def _send_email_resend(sender: str, to: str, subject: str, body: str, mailing):
+def _send_email_resend(
+    sender: str,
+    to: str,
+    subject: str,
+    body: str,
+    mailing,
+    headers: Optional[dict[str, str]] = None,
+):
     from fastapi import HTTPException
     resend.api_key = mailing.resend_api_key
     payload = {
@@ -315,6 +376,8 @@ def _send_email_resend(sender: str, to: str, subject: str, body: str, mailing):
         "subject": subject,
         "html": body,
     }
+    if headers:
+        payload["headers"] = dict(headers)
     for attempt in range(_RESEND_RETRIES + 1):
         try:
             return resend.Emails.send(payload)
@@ -330,12 +393,21 @@ def _send_email_resend(sender: str, to: str, subject: str, body: str, mailing):
 _SMTP_TIMEOUT = 15
 
 
-def _send_email_smtp(sender: str, to: str, subject: str, body: str, mailing):
+def _send_email_smtp(
+    sender: str,
+    to: str,
+    subject: str,
+    body: str,
+    mailing,
+    headers: Optional[dict[str, str]] = None,
+):
     from fastapi import HTTPException
     msg = MIMEMultipart("alternative")
     msg["From"] = sender
     msg["To"] = to
     msg["Subject"] = subject
+    for header_name, header_value in (headers or {}).items():
+        msg[header_name] = header_value
     msg.attach(MIMEText(body, "html"))
 
     server = None

--- a/apps/api/src/services/nudges/catalog.py
+++ b/apps/api/src/services/nudges/catalog.py
@@ -1,0 +1,606 @@
+"""
+The nudge catalog: which email fires, for whom, and when.
+
+Each entry is a pure declaration. The runner is generic over them, so adding a
+nudge means adding a ``NudgeSpec`` and its copy — never touching the send loop.
+
+Two properties are load-bearing:
+
+``day_max`` — every window has an upper bound. This is what makes a backfill
+over years of existing organizations safe: an org created 400 days ago cannot
+match a "day 1" activation nudge, so switching the system on does not blast the
+entire history with the whole catalog. Only the dormancy track deliberately has
+no upper bound on org age, and it is the sparsest track by design.
+
+Windows are at least two days wide. Most of the timestamps behind them are
+naive strings written by whichever pod handled the request, so they are
+accurate to about a day; a one-day window would flip on clock skew alone.
+
+One interaction worth knowing: a spec with ``suppress_if_active`` cannot fire
+inside ``ACTIVE_WINDOW_DAYS`` of the org's last engagement. Where the anchor is
+*itself* an engagement signal (a course was created, a lesson was written), the
+earliest the nudge can actually send is that window — so those specs declare a
+``day_min`` of at least ``ACTIVE_WINDOW_DAYS`` rather than a smaller number
+that would never be reached. Activation and dormancy are unaffected: they
+anchor on org creation and on inactivity respectively, neither of which is
+engagement.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from src.security.features_utils.plans import (
+    AI_CREDIT_LIMITS,
+    PLAN_HIERARCHY,
+    PLAN_LIMITS,
+)
+from src.services.nudges import links
+from src.services.nudges.snapshot import OrgSnapshot
+
+# Tracks, in the order they claim an admin's daily slot when several fire at
+# once. Earlier means more urgent.
+TRACK_ACTIVATION = "activation"
+TRACK_CONTENT = "content"
+TRACK_AUDIENCE = "audience"
+TRACK_MONETIZATION = "monetization"
+TRACK_DORMANCY = "dormancy"
+TRACK_MILESTONE = "milestone"
+
+
+@dataclass(frozen=True)
+class NudgeSpec:
+    """One nudge: when it fires, what it links to, how often it may repeat."""
+
+    id: str
+    track: str
+    day_min: int
+    day_max: int
+    # Which snapshot timestamp the window is measured from. ``None`` means the
+    # predicate does its own timing (dormancy measures from last_touch).
+    anchor: Callable[[OrgSnapshot], Optional[float]]
+    predicate: Callable[[OrgSnapshot], bool]
+    cta: Callable[[OrgSnapshot, str], str]
+    # None = once per org, ever. "quarterly" = at most once per calendar
+    # quarter, so a long-dormant org hears from us four times a year at most.
+    repeat: Optional[str] = None
+    suppress_if_active: bool = True
+    priority: int = 50
+    # Some nudges are a genuine question rather than a call to action; those
+    # render without a button so a reply is the obvious response.
+    has_cta: bool = True
+
+    def window_matches(self, snapshot: OrgSnapshot) -> bool:
+        age = self.anchor(snapshot)
+        if age is None:
+            return False
+        return self.day_min <= age <= self.day_max
+
+    def matches(self, snapshot: OrgSnapshot) -> bool:
+        if self.suppress_if_active and snapshot.org_active:
+            return False
+        if not self.window_matches(snapshot):
+            return False
+        return self.predicate(snapshot)
+
+
+# --------------------------------------------------------------------------
+# Plan helpers — read at match time, never hardcoded into copy.
+#
+# The limits are not monotonic across tiers (free allows 10 members, personal
+# allows 1), so any threshold typed as a literal would be wrong for most plans
+# and silently wrong for the rest as soon as the config changes.
+# --------------------------------------------------------------------------
+
+
+def plan_limit(plan: str, resource: str) -> int:
+    """Limit for a resource on a plan. ``0`` means unlimited."""
+    return PLAN_LIMITS.get(plan, PLAN_LIMITS["free"]).get(resource, 0)
+
+
+def next_plan(plan: str) -> Optional[str]:
+    """The tier above this one, or None at the top of the hierarchy."""
+    try:
+        index = PLAN_HIERARCHY.index(plan)
+    except ValueError:
+        return PLAN_HIERARCHY[1] if len(PLAN_HIERARCHY) > 1 else None
+    if index + 1 >= len(PLAN_HIERARCHY):
+        return None
+    return PLAN_HIERARCHY[index + 1]
+
+
+def at_resource_limit(snapshot: OrgSnapshot, resource: str, count: int) -> bool:
+    """True when the org has hit a real (non-unlimited) cap on this resource."""
+    limit = plan_limit(snapshot.plan, resource)
+    if limit <= 0:  # 0 == unlimited; never nudge about a cap that doesn't exist
+        return False
+    return count >= limit
+
+
+def near_resource_limit(
+    snapshot: OrgSnapshot, resource: str, count: int, ratio: float = 0.8
+) -> bool:
+    limit = plan_limit(snapshot.plan, resource)
+    if limit <= 0:
+        return False
+    return count >= limit * ratio and count < limit
+
+
+def ai_credit_limit(plan: str) -> int:
+    """Credit allowance for a plan. ``-1`` means unlimited, ``0`` no access."""
+    return AI_CREDIT_LIMITS.get(plan, 0)
+
+
+def ai_credits_nearly_spent(snapshot: OrgSnapshot, ratio: float = 0.8) -> bool:
+    """True when the org has burned most of a finite AI allowance.
+
+    Usage comes from Redis and reads as zero when that is unavailable, so this
+    fails closed: no cache, no nudge.
+    """
+    limit = ai_credit_limit(snapshot.plan)
+    if limit <= 0:  # -1 unlimited, 0 no access — neither is a warning worth sending
+        return False
+    return snapshot.ai_credits_used >= limit * ratio
+
+
+# --------------------------------------------------------------------------
+# Anchors
+# --------------------------------------------------------------------------
+
+
+def _anchor_org(s: OrgSnapshot):
+    return s.org_age_days
+
+
+def _anchor_last_course_updated(s: OrgSnapshot):
+    return s.age_days(s.last_course_updated_at)
+
+
+def _anchor_first_published(s: OrgSnapshot):
+    return s.age_days(s.first_published_at)
+
+
+def _anchor_last_course_created(s: OrgSnapshot):
+    return s.age_days(s.last_course_created_at)
+
+
+def _anchor_touch(s: OrgSnapshot):
+    return s.days_since_touch
+
+
+def _anchor_last_chapter_created(s: OrgSnapshot):
+    return s.age_days(s.last_chapter_created_at)
+
+
+def _anchor_last_activity_created(s: OrgSnapshot):
+    return s.age_days(s.last_activity_created_at)
+
+
+def _anchor_last_assignment_created(s: OrgSnapshot):
+    return s.age_days(s.last_assignment_created_at)
+
+
+def _anchor_first_member(s: OrgSnapshot):
+    return s.age_days(s.first_member_joined_at)
+
+
+def _anchor_last_member(s: OrgSnapshot):
+    return s.age_days(s.last_member_joined_at)
+
+
+def _anchor_last_trailrun_updated(s: OrgSnapshot):
+    return s.age_days(s.last_trailrun_updated_at)
+
+
+def _anchor_first_trailrun(s: OrgSnapshot):
+    return s.age_days(s.first_trailrun_at)
+
+
+def _anchor_first_completion(s: OrgSnapshot):
+    return s.age_days(s.first_completed_trailrun_at)
+
+
+def _no_second_visit(s: OrgSnapshot) -> bool:
+    """True when nobody appears to have come back after signing up.
+
+    ``last_engagement`` already excludes the org's own creation and covers a
+    later admin login, so its absence is the whole signal — an explicit
+    "logged in within a day of signing up" comparison would be unreachable.
+
+    ``last_login_at`` is null for the large majority of admins, so a missing
+    value reads as "no evidence of a return" rather than proof of one. That is
+    the honest reading, and the conservative one here: the worst case is
+    sending a come-back email to someone who did quietly come back.
+    """
+    return s.last_engagement is None
+
+
+def _draft_link(s: OrgSnapshot, base: str) -> str:
+    return links.course_editor_url(
+        base, s.oldest_draft_course_uuid or s.newest_course_uuid or "", "general"
+    )
+
+
+def _content_link(s: OrgSnapshot, base: str) -> str:
+    return links.course_editor_url(
+        base, s.newest_course_uuid or s.oldest_draft_course_uuid or "", "content"
+    )
+
+
+# --------------------------------------------------------------------------
+# The catalog — thirty nudges across six tracks.
+#
+# Priorities encode what is worth an admin's single daily slot. Milestones
+# outrank everything (they are congratulations, and stale congratulations are
+# worthless), then activation, then the audience gap, then content, then
+# monetization, and dormancy last.
+# --------------------------------------------------------------------------
+
+NUDGE_CATALOG: tuple[NudgeSpec, ...] = (
+    # ---------------------------------------------------------------- track 1
+    # Most new orgs never create a single course. The first and largest cliff.
+    NudgeSpec(
+        id="activation.first_course_d1",
+        track=TRACK_ACTIVATION,
+        day_min=1,
+        day_max=2,
+        anchor=_anchor_org,
+        predicate=lambda s: s.course_count == 0,
+        cta=lambda s, base: links.courses_url(base),
+        priority=10,
+    ),
+    # Signed up, looked around once, never came back.
+    NudgeSpec(
+        id="activation.come_back_d2",
+        track=TRACK_ACTIVATION,
+        day_min=2,
+        day_max=4,
+        anchor=_anchor_org,
+        predicate=lambda s: s.course_count == 0 and _no_second_visit(s),
+        cta=lambda s, base: links.dashboard_url(base),
+        priority=11,
+    ),
+    # The blank page is the obstacle; offer to fill it.
+    NudgeSpec(
+        id="activation.ai_course_help_d4",
+        track=TRACK_ACTIVATION,
+        day_min=5,
+        day_max=7,
+        anchor=_anchor_org,
+        predicate=lambda s: s.course_count == 0,
+        cta=lambda s, base: links.courses_url(base),
+        priority=12,
+    ),
+    # For people who already have material and don't want to retype it.
+    NudgeSpec(
+        id="activation.import_existing_d5",
+        track=TRACK_ACTIVATION,
+        day_min=8,
+        day_max=10,
+        anchor=_anchor_org,
+        predicate=lambda s: s.course_count == 0,
+        cta=lambda s, base: links.course_migrate_url(base),
+        priority=13,
+    ),
+    NudgeSpec(
+        id="activation.setup_checklist_d7",
+        track=TRACK_ACTIVATION,
+        day_min=11,
+        day_max=13,
+        anchor=_anchor_org,
+        predicate=lambda s: s.course_count == 0,
+        cta=lambda s, base: links.onboarding_url(base),
+        priority=14,
+    ),
+    # A real question with no button. A reply reaches a person.
+    NudgeSpec(
+        id="activation.whats_blocking_d14",
+        track=TRACK_ACTIVATION,
+        day_min=14,
+        day_max=17,
+        anchor=_anchor_org,
+        predicate=lambda s: s.course_count == 0,
+        cta=lambda s, base: links.dashboard_url(base),
+        has_cta=False,
+        priority=15,
+    ),
+    # Says plainly that it is the last one. That earns more goodwill than any
+    # subject-line trick, and it ends the track.
+    NudgeSpec(
+        id="activation.last_call_d30",
+        track=TRACK_ACTIVATION,
+        day_min=30,
+        day_max=35,
+        anchor=_anchor_org,
+        predicate=lambda s: s.course_count == 0,
+        cta=lambda s, base: links.dashboard_url(base),
+        priority=16,
+    ),
+    # ---------------------------------------------------------------- track 2
+    NudgeSpec(
+        id="content.course_no_chapter_d1",
+        track=TRACK_CONTENT,
+        day_min=3,
+        day_max=6,
+        anchor=_anchor_last_course_created,
+        predicate=lambda s: s.course_count > 0 and s.chapter_count == 0,
+        cta=_content_link,
+        priority=30,
+    ),
+    NudgeSpec(
+        id="content.chapter_no_activity_d1",
+        track=TRACK_CONTENT,
+        day_min=3,
+        day_max=6,
+        anchor=_anchor_last_chapter_created,
+        predicate=lambda s: s.chapter_count > 0 and s.activity_count == 0,
+        cta=_content_link,
+        priority=31,
+    ),
+    NudgeSpec(
+        id="content.activity_unpublished_d2",
+        track=TRACK_CONTENT,
+        day_min=3,
+        day_max=6,
+        anchor=_anchor_last_activity_created,
+        predicate=lambda s: s.activity_count > 0 and s.published_activity_count == 0,
+        cta=_content_link,
+        priority=32,
+    ),
+    # Courses get built and then sit in draft indefinitely — the most common
+    # state for an org that has done real work.
+    NudgeSpec(
+        id="content.course_draft_d3",
+        track=TRACK_CONTENT,
+        day_min=3,
+        day_max=5,
+        anchor=_anchor_last_course_updated,
+        predicate=lambda s: s.course_count > 0
+        and s.published_course_count == 0
+        and s.activity_count > 0,
+        cta=_draft_link,
+        priority=20,
+    ),
+    # Same case, a week later, answering the "it isn't ready" objection.
+    NudgeSpec(
+        id="content.course_draft_d10",
+        track=TRACK_CONTENT,
+        day_min=10,
+        day_max=14,
+        anchor=_anchor_last_course_updated,
+        predicate=lambda s: s.course_count > 0
+        and s.published_course_count == 0
+        and s.activity_count > 0,
+        cta=_draft_link,
+        priority=21,
+    ),
+    NudgeSpec(
+        id="content.thin_course_d5",
+        track=TRACK_CONTENT,
+        day_min=5,
+        day_max=8,
+        anchor=_anchor_last_course_created,
+        predicate=lambda s: s.course_count > 0 and 0 < s.activity_count < 3,
+        cta=_content_link,
+        priority=33,
+    ),
+    NudgeSpec(
+        id="content.assignment_no_submissions_d5",
+        track=TRACK_CONTENT,
+        day_min=5,
+        day_max=9,
+        anchor=_anchor_last_assignment_created,
+        predicate=lambda s: s.assignment_count > 0
+        and s.assignment_submission_count == 0
+        and s.member_count > 0,
+        cta=lambda s, base: links.dashboard_url(base),
+        priority=34,
+    ),
+    # ---------------------------------------------------------------- track 3
+    # A published course with nobody to read it — the widest gap in the
+    # product. Almost no org ever adds a second person.
+    NudgeSpec(
+        id="audience.published_no_members_d1",
+        track=TRACK_AUDIENCE,
+        day_min=3,
+        day_max=6,
+        anchor=_anchor_first_published,
+        predicate=lambda s: s.published_course_count > 0 and s.member_count == 0,
+        cta=lambda s, base: links.members_url(base),
+        priority=17,
+    ),
+    NudgeSpec(
+        id="audience.published_no_members_d7",
+        track=TRACK_AUDIENCE,
+        day_min=7,
+        day_max=10,
+        anchor=_anchor_first_published,
+        predicate=lambda s: s.published_course_count > 0 and s.member_count == 0,
+        cta=lambda s, base: links.members_url(base),
+        priority=18,
+    ),
+    # People were invited and never opened anything.
+    NudgeSpec(
+        id="audience.members_no_enrollment_d3",
+        track=TRACK_AUDIENCE,
+        day_min=3,
+        day_max=6,
+        anchor=_anchor_first_member,
+        predicate=lambda s: s.member_count > 0 and s.trailrun_count == 0,
+        cta=lambda s, base: links.members_url(base),
+        priority=19,
+    ),
+    # Public and published, so the link is the whole answer.
+    NudgeSpec(
+        id="audience.share_public_page_d14",
+        track=TRACK_AUDIENCE,
+        day_min=14,
+        day_max=18,
+        anchor=_anchor_first_published,
+        predicate=lambda s: s.published_course_count > 0
+        and s.public_course_count > 0
+        and s.member_count == 0,
+        cta=lambda s, base: links.public_course_url(base, s.newest_course_uuid or ""),
+        priority=22,
+    ),
+    # Learners started and stopped. Worth knowing about before writing more.
+    NudgeSpec(
+        id="audience.stalled_learners_d14",
+        track=TRACK_AUDIENCE,
+        day_min=14,
+        day_max=21,
+        anchor=_anchor_last_trailrun_updated,
+        predicate=lambda s: s.in_progress_trailrun_count > 0,
+        cta=lambda s, base: links.dashboard_url(base),
+        priority=23,
+    ),
+    # ---------------------------------------------------------------- track 4
+    # They hit a real ceiling and stopped. Only fires where the cap is finite.
+    NudgeSpec(
+        id="monetization.course_limit_d1",
+        track=TRACK_MONETIZATION,
+        day_min=1,
+        day_max=3,
+        anchor=_anchor_last_course_created,
+        predicate=lambda s: at_resource_limit(s, "courses", s.course_count)
+        and next_plan(s.plan) is not None,
+        cta=lambda s, base: links.org_settings_url(base, "general"),
+        suppress_if_active=False,
+        priority=40,
+    ),
+    # Warn before the wall, not after it blocks the work.
+    NudgeSpec(
+        id="monetization.member_limit_near",
+        track=TRACK_MONETIZATION,
+        day_min=0,
+        day_max=7,
+        anchor=_anchor_last_member,
+        predicate=lambda s: near_resource_limit(s, "members", s.member_count)
+        and next_plan(s.plan) is not None,
+        cta=lambda s, base: links.org_settings_url(base, "general"),
+        suppress_if_active=False,
+        priority=41,
+    ),
+    NudgeSpec(
+        id="monetization.ai_credits_low",
+        track=TRACK_MONETIZATION,
+        day_min=0,
+        day_max=7,
+        anchor=_anchor_last_activity_created,
+        predicate=lambda s: ai_credits_nearly_spent(s) and next_plan(s.plan) is not None,
+        cta=lambda s, base: links.org_settings_url(base, "general"),
+        suppress_if_active=False,
+        priority=42,
+    ),
+    # A recap for an org that is actually using the product.
+    NudgeSpec(
+        id="monetization.upgrade_recap_d21",
+        track=TRACK_MONETIZATION,
+        day_min=21,
+        day_max=25,
+        anchor=_anchor_org,
+        predicate=lambda s: s.published_course_count > 0
+        and next_plan(s.plan) is not None,
+        cta=lambda s, base: links.org_settings_url(base, "general"),
+        priority=43,
+    ),
+    # ---------------------------------------------------------------- track 5
+    NudgeSpec(
+        id="dormancy.no_login_14d",
+        track=TRACK_DORMANCY,
+        day_min=14,
+        day_max=17,
+        anchor=_anchor_touch,
+        predicate=lambda s: s.content_exists,
+        cta=lambda s, base: links.dashboard_url(base),
+        priority=60,
+    ),
+    # The only track that reaches organizations created long before this
+    # system existed.
+    NudgeSpec(
+        id="dormancy.no_login_30d",
+        track=TRACK_DORMANCY,
+        day_min=30,
+        day_max=35,
+        anchor=_anchor_touch,
+        predicate=lambda s: s.content_exists,
+        cta=lambda s, base: links.dashboard_url(base),
+        priority=61,
+    ),
+    # Says it is the last check-in, and means it.
+    NudgeSpec(
+        id="dormancy.no_login_60d",
+        track=TRACK_DORMANCY,
+        day_min=60,
+        day_max=70,
+        anchor=_anchor_touch,
+        predicate=lambda s: s.content_exists,
+        cta=lambda s, base: links.dashboard_url(base),
+        priority=62,
+    ),
+    # After the sequence ends, at most four times a year, forever.
+    NudgeSpec(
+        id="dormancy.winback_q",
+        track=TRACK_DORMANCY,
+        day_min=120,
+        day_max=3650,
+        anchor=_anchor_touch,
+        predicate=lambda s: s.content_exists,
+        cta=lambda s, base: links.dashboard_url(base),
+        repeat="quarterly",
+        priority=63,
+    ),
+    # ---------------------------------------------------------------- track 6
+    # Congratulations go out immediately or not at all, so these never
+    # suppress on activity — the whole point is that something just happened.
+    NudgeSpec(
+        id="milestone.first_course_published",
+        track=TRACK_MILESTONE,
+        day_min=0,
+        day_max=2,
+        anchor=_anchor_first_published,
+        predicate=lambda s: s.published_course_count > 0,
+        cta=lambda s, base: links.members_url(base),
+        suppress_if_active=False,
+        priority=5,
+    ),
+    NudgeSpec(
+        id="milestone.first_learner_enrolled",
+        track=TRACK_MILESTONE,
+        day_min=0,
+        day_max=2,
+        anchor=_anchor_first_trailrun,
+        predicate=lambda s: s.trailrun_count > 0,
+        cta=lambda s, base: links.dashboard_url(base),
+        suppress_if_active=False,
+        priority=6,
+    ),
+    NudgeSpec(
+        id="milestone.first_completion",
+        track=TRACK_MILESTONE,
+        day_min=0,
+        day_max=2,
+        anchor=_anchor_first_completion,
+        predicate=lambda s: s.completed_trailrun_count > 0,
+        cta=lambda s, base: links.dashboard_url(base),
+        suppress_if_active=False,
+        priority=7,
+    ),
+)
+
+
+CATALOG_BY_ID: dict[str, NudgeSpec] = {spec.id: spec for spec in NUDGE_CATALOG}
+
+
+def get_spec(nudge_id: str) -> Optional[NudgeSpec]:
+    return CATALOG_BY_ID.get(nudge_id)
+
+
+def matching_specs(snapshot: OrgSnapshot) -> list[NudgeSpec]:
+    """Specs that fire for this org, most urgent first.
+
+    Ordering matters because an admin receives at most one nudge per day: the
+    highest-value message must claim the slot rather than whichever spec
+    happens to be declared first.
+    """
+    matched = [spec for spec in NUDGE_CATALOG if spec.matches(snapshot)]
+    return sorted(matched, key=lambda s: (s.priority, s.id))

--- a/apps/api/src/services/nudges/catalog.py
+++ b/apps/api/src/services/nudges/catalog.py
@@ -45,6 +45,7 @@ TRACK_AUDIENCE = "audience"
 TRACK_MONETIZATION = "monetization"
 TRACK_DORMANCY = "dormancy"
 TRACK_MILESTONE = "milestone"
+TRACK_REACTIVATION = "reactivation"
 
 
 @dataclass(frozen=True)
@@ -199,6 +200,16 @@ def _anchor_first_completion(s: OrgSnapshot):
     return s.age_days(s.first_completed_trailrun_at)
 
 
+def _anchor_first_nudge(s: OrgSnapshot):
+    """Days since this org first heard from us.
+
+    The reactivation ladder runs on this clock. An org quiet for two years has
+    a last-touch figure that never advances, so a sequence anchored on activity
+    would fire its first step forever and its second step never.
+    """
+    return s.days_since_first_nudge
+
+
 def _no_second_visit(s: OrgSnapshot) -> bool:
     """True when nobody appears to have come back after signing up.
 
@@ -303,8 +314,10 @@ NUDGE_CATALOG: tuple[NudgeSpec, ...] = (
         has_cta=False,
         priority=15,
     ),
-    # Says plainly that it is the last one. That earns more goodwill than any
-    # subject-line trick, and it ends the track.
+    # Says plainly that it is the last one, and it is: every activation nudge
+    # is once-per-org-forever, and this is the last window in the track, so
+    # once it has fired the ledger keeps the whole track closed. That promise
+    # is kept by the dedupe key, not by a separate terminal marker.
     NudgeSpec(
         id="activation.last_call_d30",
         track=TRACK_ACTIVATION,
@@ -548,6 +561,58 @@ NUDGE_CATALOG: tuple[NudgeSpec, ...] = (
         cta=lambda s, base: links.dashboard_url(base),
         repeat="quarterly",
         priority=63,
+    ),
+    # ---------------------------------------------------------------- track 7
+    # Reactivation: a real sequence for organizations that went cold long ago.
+    #
+    # These exist because every other track is bounded by `day_max`, so an org
+    # quiet for a year qualifies for essentially nothing — the frequency cap was
+    # never what limited them, the absence of anything to send was. The ladder
+    # is anchored on first contact so it can actually advance, and it opens the
+    # door once: after the last step, `dormancy.winback_q` takes over at its
+    # quarterly cadence.
+    NudgeSpec(
+        id="reactivation.opener",
+        track=TRACK_REACTIVATION,
+        day_min=90,
+        day_max=3650,
+        anchor=_anchor_touch,
+        # No prior contact — this is the step that starts the sequence and
+        # stamps the clock the rest of it measures from.
+        predicate=lambda s: s.content_exists and s.first_nudged_at is None,
+        cta=lambda s, base: links.dashboard_url(base),
+        priority=64,
+    ),
+    NudgeSpec(
+        id="reactivation.whats_changed",
+        track=TRACK_REACTIVATION,
+        day_min=3,
+        day_max=6,
+        anchor=_anchor_first_nudge,
+        predicate=lambda s: s.is_cold and s.content_exists,
+        cta=lambda s, base: links.dashboard_url(base),
+        priority=65,
+    ),
+    NudgeSpec(
+        id="reactivation.need_a_hand",
+        track=TRACK_REACTIVATION,
+        day_min=8,
+        day_max=12,
+        anchor=_anchor_first_nudge,
+        predicate=lambda s: s.is_cold and s.content_exists,
+        cta=lambda s, base: links.dashboard_url(base),
+        has_cta=False,
+        priority=66,
+    ),
+    NudgeSpec(
+        id="reactivation.closing",
+        track=TRACK_REACTIVATION,
+        day_min=16,
+        day_max=21,
+        anchor=_anchor_first_nudge,
+        predicate=lambda s: s.is_cold and s.content_exists,
+        cta=lambda s, base: links.dashboard_url(base),
+        priority=67,
     ),
     # ---------------------------------------------------------------- track 6
     # Congratulations go out immediately or not at all, so these never

--- a/apps/api/src/services/nudges/delivery.py
+++ b/apps/api/src/services/nudges/delivery.py
@@ -1,0 +1,111 @@
+"""
+Read delivery outcomes back from the provider, so bounces and complaints are
+noticed without anyone configuring a webhook.
+
+Resend records the state of each message and exposes it as ``last_event`` on
+the email object, so the ledger can simply ask. That costs one API call per
+message sent, once, a day or two later — trivial at any volume this job
+produces, and it means the feature protects the sending domain from a deploy
+alone rather than a deploy plus a dashboard step somebody has to remember.
+
+The webhook endpoint still exists and still works. Where it is configured it is
+strictly better: it carries the bounce sub-type, so a permanent failure can be
+told from a temporary one, and it arrives in seconds rather than a day. This is
+the floor, not the ceiling.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from src.db.nudges import NudgeSend, NudgeSendStatus
+from src.services.nudges.preferences import suppress_address
+
+logger = logging.getLogger(__name__)
+
+# `last_event` values meaning the address should not be mailed again.
+TERMINAL_EVENTS = {
+    "bounced": "bounce",
+    "complained": "complaint",
+}
+
+# Wait before judging a message. A receiving server retries a transient failure
+# for a while, and a message read too early can look bounced when it is only
+# delayed — which would throw away a good address.
+MIN_AGE_HOURS = 36
+
+# Past this there is nothing useful left to learn.
+MAX_AGE_DAYS = 7
+
+# Bounded so one run cannot spend minutes talking to the provider.
+MAX_PER_RUN = 500
+
+
+async def _last_event(provider_id: str) -> Optional[str]:
+    """Ask the provider what became of one message."""
+    import resend
+
+    email = await asyncio.to_thread(resend.Emails.get, provider_id)
+    if isinstance(email, dict):
+        return email.get("last_event")
+    return getattr(email, "last_event", None)
+
+
+async def reconcile_delivery(
+    db_session: AsyncSession,
+    now: Optional[datetime] = None,
+    limit: int = MAX_PER_RUN,
+) -> dict:
+    """Poll recent sends and suppress the addresses that failed.
+
+    Each message is checked at most once: the flag is set whatever the outcome,
+    so a delivered message is never asked about again. A lookup that errors
+    leaves the flag unset, so a provider outage delays the check rather than
+    skipping it.
+    """
+    now = now or datetime.now(timezone.utc)
+
+    rows = (
+        await db_session.execute(
+            select(NudgeSend)
+            .where(
+                NudgeSend.status == NudgeSendStatus.SENT,
+                NudgeSend.delivery_checked.is_(False),
+                NudgeSend.provider_id.is_not(None),
+                NudgeSend.sent_at <= now - timedelta(hours=MIN_AGE_HOURS),
+                NudgeSend.sent_at >= now - timedelta(days=MAX_AGE_DAYS),
+            )
+            .order_by(NudgeSend.sent_at)
+            .limit(limit)
+        )
+    ).scalars().all()
+
+    checked = 0
+    suppressed = 0
+
+    for row in rows:
+        try:
+            event = await _last_event(row.provider_id)
+        except Exception as exc:
+            logger.warning("Delivery lookup failed for %s: %s", row.provider_id, exc)
+            continue
+
+        reason = TERMINAL_EVENTS.get(str(event or "").lower())
+        if reason:
+            address = (row.meta or {}).get("email")
+            if address and await suppress_address(db_session, address, reason):
+                suppressed += 1
+
+        row.delivery_checked = True
+        db_session.add(row)
+        checked += 1
+
+    if checked:
+        await db_session.commit()
+        logger.info("Delivery reconcile: checked=%s suppressed=%s", checked, suppressed)
+
+    return {"checked": checked, "suppressed": suppressed}

--- a/apps/api/src/services/nudges/eligibility.py
+++ b/apps/api/src/services/nudges/eligibility.py
@@ -1,0 +1,477 @@
+"""
+Build one :class:`OrgSnapshot` per organization, cheaply.
+
+The shape that matters here is "a fixed number of grouped queries per batch of
+orgs", not "a few queries per org". The existing cross-org billing sweep calls
+a per-org summary in a loop, which is fine at its call frequency and would not
+be fine here: this runs against every organization, every day.
+
+Orgs are walked by keyset pagination so memory stays flat no matter how many
+there are.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import AsyncIterator, Optional, Sequence
+
+from sqlalchemy import case, func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from src.db.courses.activities import Activity
+from src.db.courses.assignments import (
+    Assignment,
+    AssignmentTask,
+    AssignmentTaskSubmission,
+)
+from src.db.courses.chapters import Chapter
+from src.db.courses.courses import Course
+from src.db.organization_config import OrganizationConfig
+from src.db.organizations import Organization
+from src.db.trail_runs import StatusEnum, TrailRun
+from src.db.user_activity import UserActivityDay
+from src.db.user_organizations import UserOrganization
+from src.db.users import User
+from src.security.features_utils.usage import _plan_from_config_dict
+from src.security.rbac.constants import ADMIN_ROLE_ID
+from src.services.nudges.snapshot import AdminRow, OrgSnapshot, parse_ts
+from src.services.orgs.orgs import get_org_default_language
+
+logger = logging.getLogger(__name__)
+
+ORG_CHUNK_SIZE = 500
+
+
+def _rows_by_org(rows) -> dict:
+    return {row[0]: row for row in rows}
+
+
+async def _course_facts(db_session: AsyncSession, org_ids: Sequence[int]) -> dict:
+    """Counts and timestamps per org, plus the courses worth deep-linking to."""
+    rows = (
+        await db_session.execute(
+            select(
+                Course.org_id,
+                func.count().label("course_count"),
+                func.sum(case((Course.published.is_(True), 1), else_=0)).label("published"),
+                func.sum(case((Course.public.is_(True), 1), else_=0)).label("public"),
+                func.max(Course.creation_date).label("last_created"),
+                func.max(Course.update_date).label("last_updated"),
+                func.min(
+                    case((Course.published.is_(True), Course.update_date), else_=None)
+                ).label("first_published"),
+            )
+            .where(Course.org_id.in_(org_ids))
+            .group_by(Course.org_id)
+        )
+    ).all()
+    facts = _rows_by_org(rows)
+
+    # The newest course, and the oldest still-unpublished one — nudges link to
+    # a specific course by name, never to a generic list.
+    newest: dict[int, tuple[str, str]] = {}
+    drafts: dict[int, tuple[str, str]] = {}
+    detail_rows = (
+        await db_session.execute(
+            select(
+                Course.org_id,
+                Course.course_uuid,
+                Course.name,
+                Course.published,
+                Course.creation_date,
+            )
+            .where(Course.org_id.in_(org_ids))
+            .order_by(Course.org_id, Course.creation_date)
+        )
+    ).all()
+    for org_id, uuid, name, published, _created in detail_rows:
+        newest[org_id] = (uuid, name)  # ordered ascending, so the last wins
+        if not published and org_id not in drafts:
+            drafts[org_id] = (uuid, name)
+
+    return {"agg": facts, "newest": newest, "drafts": drafts}
+
+
+async def _membership_facts(db_session: AsyncSession, org_ids: Sequence[int]) -> dict:
+    """Admin and member counts in a single pass, split by role."""
+    non_admin = UserOrganization.role_id != ADMIN_ROLE_ID
+    rows = (
+        await db_session.execute(
+            select(
+                UserOrganization.org_id,
+                func.sum(
+                    case((UserOrganization.role_id == ADMIN_ROLE_ID, 1), else_=0)
+                ).label("admin_count"),
+                func.sum(case((non_admin, 1), else_=0)).label("member_count"),
+                func.min(
+                    case((non_admin, UserOrganization.creation_date), else_=None)
+                ).label("first_member"),
+                func.max(
+                    case((non_admin, UserOrganization.creation_date), else_=None)
+                ).label("last_member"),
+            )
+            .where(UserOrganization.org_id.in_(org_ids))
+            .group_by(UserOrganization.org_id)
+        )
+    ).all()
+    return _rows_by_org(rows)
+
+
+async def _admin_rows(db_session: AsyncSession, org_ids: Sequence[int]) -> dict:
+    """Every org admin, with the fields needed to address and gate an email."""
+    rows = (
+        await db_session.execute(
+            select(
+                UserOrganization.org_id,
+                User.id,
+                User.user_uuid,
+                User.email,
+                User.first_name,
+                User.username,
+                User.email_verified,
+                User.last_login_at,
+            )
+            .join(User, User.id == UserOrganization.user_id)
+            .where(
+                UserOrganization.org_id.in_(org_ids),
+                UserOrganization.role_id == ADMIN_ROLE_ID,
+            )
+        )
+    ).all()
+
+    by_org: dict[int, list[AdminRow]] = {}
+    for org_id, uid, uuid, email, first, username, verified, last_login in rows:
+        by_org.setdefault(org_id, []).append(
+            AdminRow(
+                user_id=uid,
+                user_uuid=uuid or "",
+                email=str(email or ""),
+                first_name=first,
+                username=username,
+                email_verified=bool(verified),
+                last_login_at=parse_ts(last_login),
+            )
+        )
+    return by_org
+
+
+async def _simple_count_facts(db_session: AsyncSession, org_ids: Sequence[int]) -> dict:
+    """Chapters, activities and trail runs — three small grouped queries."""
+    chapters = _rows_by_org(
+        (
+            await db_session.execute(
+                select(
+                    Chapter.org_id,
+                    func.count().label("n"),
+                    func.max(Chapter.creation_date).label("last_created"),
+                )
+                .where(Chapter.org_id.in_(org_ids))
+                .group_by(Chapter.org_id)
+            )
+        ).all()
+    )
+
+    activities = _rows_by_org(
+        (
+            await db_session.execute(
+                select(
+                    Activity.org_id,
+                    func.count().label("n"),
+                    func.sum(case((Activity.published.is_(True), 1), else_=0)).label("published"),
+                    func.max(Activity.creation_date).label("last_created"),
+                )
+                .where(Activity.org_id.in_(org_ids))
+                .group_by(Activity.org_id)
+            )
+        ).all()
+    )
+
+    trailruns = _rows_by_org(
+        (
+            await db_session.execute(
+                select(
+                    TrailRun.org_id,
+                    func.count().label("n"),
+                    func.count(func.distinct(TrailRun.user_id)).label("learners"),
+                    func.sum(
+                        case((TrailRun.status == StatusEnum.STATUS_IN_PROGRESS, 1), else_=0)
+                    ).label("in_progress"),
+                    func.sum(
+                        case((TrailRun.status == StatusEnum.STATUS_COMPLETED, 1), else_=0)
+                    ).label("completed"),
+                    func.min(TrailRun.creation_date).label("first"),
+                    func.max(TrailRun.update_date).label("last_updated"),
+                    func.min(
+                        case(
+                            (
+                                TrailRun.status == StatusEnum.STATUS_COMPLETED,
+                                TrailRun.update_date,
+                            ),
+                            else_=None,
+                        )
+                    ).label("first_completed"),
+                )
+                .where(TrailRun.org_id.in_(org_ids))
+                .group_by(TrailRun.org_id)
+            )
+        ).all()
+    )
+
+    return {"chapters": chapters, "activities": activities, "trailruns": trailruns}
+
+
+async def _assignment_facts(db_session: AsyncSession, org_ids: Sequence[int]) -> dict:
+    """Assignments per org, and how many submissions they have attracted.
+
+    Submissions carry no ``org_id`` of their own, so they are counted through
+    ``AssignmentTask``, which does.
+    """
+    assignments = _rows_by_org(
+        (
+            await db_session.execute(
+                select(
+                    Assignment.org_id,
+                    func.count().label("n"),
+                    func.max(Assignment.creation_date).label("last_created"),
+                )
+                .where(Assignment.org_id.in_(org_ids))
+                .group_by(Assignment.org_id)
+            )
+        ).all()
+    )
+
+    submissions = _rows_by_org(
+        (
+            await db_session.execute(
+                select(AssignmentTask.org_id, func.count().label("n"))
+                .join(
+                    AssignmentTaskSubmission,
+                    AssignmentTaskSubmission.assignment_task_id == AssignmentTask.id,
+                )
+                .where(AssignmentTask.org_id.in_(org_ids))
+                .group_by(AssignmentTask.org_id)
+            )
+        ).all()
+    )
+
+    return {"assignments": assignments, "submissions": submissions}
+
+
+async def _ai_credit_usage(org_ids: Sequence[int]) -> dict[int, int]:
+    """Credits consumed per org, read from Redis in one round trip.
+
+    Deliberately degrades to "no usage recorded" when Redis is unavailable:
+    the credit nudge then simply never fires, which is the right failure for a
+    background job that must not depend on a cache being up.
+    """
+    try:
+        from src.core.redis import get_redis_client
+
+        client = get_redis_client()
+        if client is None:
+            return {}
+
+        keys = [f"ai_credits_used:{org_id}" for org_id in org_ids]
+        values = await asyncio.to_thread(client.mget, keys)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("AI credit usage unavailable for this nudge run: %s", exc)
+        return {}
+
+    usage: dict[int, int] = {}
+    for org_id, raw in zip(org_ids, values or []):
+        try:
+            usage[org_id] = int(raw) if raw else 0
+        except (TypeError, ValueError):
+            usage[org_id] = 0
+    return usage
+
+
+async def _activity_day_facts(db_session: AsyncSession, org_ids: Sequence[int]) -> dict:
+    """Newest recorded activity day per org.
+
+    The best freshness signal we have, and absent for most orgs — the table is
+    SaaS-gated and only recently populated, so it refines ``last_touch`` rather
+    than defining it.
+    """
+    rows = (
+        await db_session.execute(
+            select(
+                UserActivityDay.org_id,
+                func.max(UserActivityDay.activity_date).label("last_day"),
+            )
+            .where(UserActivityDay.org_id.in_(org_ids))
+            .group_by(UserActivityDay.org_id)
+        )
+    ).all()
+    return _rows_by_org(rows)
+
+
+async def _config_facts(db_session: AsyncSession, org_ids: Sequence[int]) -> dict:
+    rows = (
+        await db_session.execute(
+            select(OrganizationConfig).where(OrganizationConfig.org_id.in_(org_ids))
+        )
+    ).scalars().all()
+    return {c.org_id: c for c in rows}
+
+
+async def _admin_login_facts(db_session: AsyncSession, org_ids: Sequence[int]) -> dict:
+    rows = (
+        await db_session.execute(
+            select(
+                UserOrganization.org_id,
+                func.max(User.last_login_at).label("last_login"),
+            )
+            .join(User, User.id == UserOrganization.user_id)
+            .where(
+                UserOrganization.org_id.in_(org_ids),
+                UserOrganization.role_id == ADMIN_ROLE_ID,
+            )
+            .group_by(UserOrganization.org_id)
+        )
+    ).all()
+    return _rows_by_org(rows)
+
+
+def _org_is_active(config: Optional[OrganizationConfig]) -> bool:
+    """v2 configs can mark an org inactive; absent means active."""
+    if config is None or not config.config:
+        return True
+    value = config.config.get("active")
+    return True if value is None else bool(value)
+
+
+async def build_snapshots(
+    db_session: AsyncSession,
+    orgs: Sequence[Organization],
+    now: Optional[datetime] = None,
+) -> list[OrgSnapshot]:
+    """Assemble snapshots for one batch of orgs using grouped queries only."""
+    if not orgs:
+        return []
+
+    now = now or datetime.now(timezone.utc)
+    org_ids = [o.id for o in orgs if o.id is not None]
+    if not org_ids:
+        return []
+
+    courses = await _course_facts(db_session, org_ids)
+    memberships = await _membership_facts(db_session, org_ids)
+    admins = await _admin_rows(db_session, org_ids)
+    counts = await _simple_count_facts(db_session, org_ids)
+    assignments = await _assignment_facts(db_session, org_ids)
+    activity_days = await _activity_day_facts(db_session, org_ids)
+    configs = await _config_facts(db_session, org_ids)
+    admin_logins = await _admin_login_facts(db_session, org_ids)
+    ai_usage = await _ai_credit_usage(org_ids)
+
+    snapshots: list[OrgSnapshot] = []
+    for org in orgs:
+        oid = org.id
+        course_agg = courses["agg"].get(oid)
+        member_agg = memberships.get(oid)
+        chapter_agg = counts["chapters"].get(oid)
+        activity_agg = counts["activities"].get(oid)
+        trail_agg = counts["trailruns"].get(oid)
+        config = configs.get(oid)
+        newest = courses["newest"].get(oid)
+        draft = courses["drafts"].get(oid)
+        login_agg = admin_logins.get(oid)
+        day_agg = activity_days.get(oid)
+        assignment_agg = assignments["assignments"].get(oid)
+        submission_agg = assignments["submissions"].get(oid)
+
+        snapshots.append(
+            OrgSnapshot(
+                org_id=oid,
+                org_slug=org.slug,
+                org_name=org.name,
+                org_uuid=org.org_uuid,
+                logo_image=getattr(org, "logo_image", None),
+                plan=_plan_from_config_dict(config.config if config else {}),
+                lang=get_org_default_language(config),
+                org_active_flag=_org_is_active(config),
+                created_at=parse_ts(org.creation_date),
+                org_updated_at=parse_ts(org.update_date),
+                member_count=int(member_agg[2] or 0) if member_agg else 0,
+                admin_count=int(member_agg[1] or 0) if member_agg else 0,
+                first_member_joined_at=parse_ts(member_agg[3]) if member_agg else None,
+                last_member_joined_at=parse_ts(member_agg[4]) if member_agg else None,
+                course_count=int(course_agg[1] or 0) if course_agg else 0,
+                published_course_count=int(course_agg[2] or 0) if course_agg else 0,
+                public_course_count=int(course_agg[3] or 0) if course_agg else 0,
+                last_course_created_at=parse_ts(course_agg[4]) if course_agg else None,
+                last_course_updated_at=parse_ts(course_agg[5]) if course_agg else None,
+                first_published_at=parse_ts(course_agg[6]) if course_agg else None,
+                newest_course_uuid=newest[0] if newest else None,
+                newest_course_name=newest[1] if newest else None,
+                oldest_draft_course_uuid=draft[0] if draft else None,
+                oldest_draft_course_name=draft[1] if draft else None,
+                chapter_count=int(chapter_agg[1] or 0) if chapter_agg else 0,
+                last_chapter_created_at=parse_ts(chapter_agg[2]) if chapter_agg else None,
+                activity_count=int(activity_agg[1] or 0) if activity_agg else 0,
+                published_activity_count=int(activity_agg[2] or 0) if activity_agg else 0,
+                last_activity_created_at=parse_ts(activity_agg[3]) if activity_agg else None,
+                trailrun_count=int(trail_agg[1] or 0) if trail_agg else 0,
+                learner_count=int(trail_agg[2] or 0) if trail_agg else 0,
+                in_progress_trailrun_count=int(trail_agg[3] or 0) if trail_agg else 0,
+                completed_trailrun_count=int(trail_agg[4] or 0) if trail_agg else 0,
+                first_trailrun_at=parse_ts(trail_agg[5]) if trail_agg else None,
+                last_trailrun_updated_at=parse_ts(trail_agg[6]) if trail_agg else None,
+                first_completed_trailrun_at=(
+                    parse_ts(trail_agg[7]) if trail_agg else None
+                ),
+                assignment_count=int(assignment_agg[1] or 0) if assignment_agg else 0,
+                last_assignment_created_at=(
+                    parse_ts(assignment_agg[2]) if assignment_agg else None
+                ),
+                assignment_submission_count=(
+                    int(submission_agg[1] or 0) if submission_agg else 0
+                ),
+                ai_credits_used=ai_usage.get(oid, 0),
+                last_admin_login_at=parse_ts(login_agg[1]) if login_agg else None,
+                last_activity_day=parse_ts(day_agg[1]) if day_agg else None,
+                admins=tuple(admins.get(oid, ())),
+                now=now,
+            )
+        )
+    return snapshots
+
+
+async def iter_snapshots(
+    db_session: AsyncSession,
+    now: Optional[datetime] = None,
+    org_id: Optional[int] = None,
+    chunk_size: int = ORG_CHUNK_SIZE,
+) -> AsyncIterator[OrgSnapshot]:
+    """Yield a snapshot for every org, a batch at a time.
+
+    Keyset pagination on the primary key rather than OFFSET: the scan holds one
+    chunk in memory regardless of how many organizations exist.
+    """
+    cursor = 0
+    while True:
+        query = select(Organization).order_by(Organization.id).limit(chunk_size)
+        if org_id is not None:
+            query = query.where(Organization.id == org_id)
+        else:
+            query = query.where(Organization.id > cursor)
+
+        orgs = (await db_session.execute(query)).scalars().all()
+        if not orgs:
+            return
+
+        # Read the cursor before yielding. The consumer commits between
+        # snapshots, which expires these instances; touching one afterwards
+        # triggers a lazy refresh from inside the generator and blows up in
+        # async context.
+        next_cursor = orgs[-1].id
+        snapshots = await build_snapshots(db_session, orgs, now=now)
+
+        for snapshot in snapshots:
+            yield snapshot
+
+        if org_id is not None:
+            return
+        cursor = next_cursor

--- a/apps/api/src/services/nudges/eligibility.py
+++ b/apps/api/src/services/nudges/eligibility.py
@@ -307,6 +307,29 @@ async def _activity_day_facts(db_session: AsyncSession, org_ids: Sequence[int]) 
     return _rows_by_org(rows)
 
 
+async def _first_nudge_facts(db_session: AsyncSession, org_ids: Sequence[int]) -> dict:
+    """When each org first received a nudge.
+
+    The reactivation ladder measures from this instead of from last activity —
+    a long-dormant org's last-touch figure never moves, so nothing anchored on
+    it can advance through a sequence.
+    """
+    from src.db.nudges import NudgeSend, NudgeSendStatus
+
+    rows = (
+        await db_session.execute(
+            select(NudgeSend.org_id, func.min(NudgeSend.sent_at).label("first_sent"))
+            .where(
+                NudgeSend.org_id.in_(org_ids),
+                NudgeSend.status == NudgeSendStatus.SENT,
+                NudgeSend.sent_at.is_not(None),
+            )
+            .group_by(NudgeSend.org_id)
+        )
+    ).all()
+    return _rows_by_org(rows)
+
+
 async def _config_facts(db_session: AsyncSession, org_ids: Sequence[int]) -> dict:
     rows = (
         await db_session.execute(
@@ -364,6 +387,7 @@ async def build_snapshots(
     activity_days = await _activity_day_facts(db_session, org_ids)
     configs = await _config_facts(db_session, org_ids)
     admin_logins = await _admin_login_facts(db_session, org_ids)
+    first_nudges = await _first_nudge_facts(db_session, org_ids)
     ai_usage = await _ai_credit_usage(org_ids)
 
     snapshots: list[OrgSnapshot] = []
@@ -379,6 +403,7 @@ async def build_snapshots(
         draft = courses["drafts"].get(oid)
         login_agg = admin_logins.get(oid)
         day_agg = activity_days.get(oid)
+        first_nudge_agg = first_nudges.get(oid)
         assignment_agg = assignments["assignments"].get(oid)
         submission_agg = assignments["submissions"].get(oid)
 
@@ -432,6 +457,9 @@ async def build_snapshots(
                 ai_credits_used=ai_usage.get(oid, 0),
                 last_admin_login_at=parse_ts(login_agg[1]) if login_agg else None,
                 last_activity_day=parse_ts(day_agg[1]) if day_agg else None,
+                first_nudged_at=(
+                    parse_ts(first_nudge_agg[1]) if first_nudge_agg else None
+                ),
                 admins=tuple(admins.get(oid, ())),
                 now=now,
             )

--- a/apps/api/src/services/nudges/illustrations.py
+++ b/apps/api/src/services/nudges/illustrations.py
@@ -1,0 +1,165 @@
+"""
+Per-track illustrations for nudge emails, drawn as table cells.
+
+Every obvious way to put a picture in an email fails somewhere that matters:
+Gmail strips inline ``<svg>`` entirely, and both Gmail and Outlook refuse
+``data:`` URIs — so a base64 image renders as a blank gap. A remote ``<img>``
+works, but images are blocked by default until the reader clicks "display
+images", which is precisely the moment we are trying to earn.
+
+A grid of background-coloured table cells has none of those problems. It is
+the oldest trick in HTML email and still the only one that renders identically
+in Outlook 2016, Gmail, Apple Mail and every webmail client, with no hosting,
+no asset pipeline and nothing to block.
+
+Each motif is an 8x8 bitmap: ``1`` is the track colour, ``2`` a light tint of
+it, ``0`` transparent. Shape carries the meaning, so the illustration still
+reads if a client drops the colours.
+"""
+
+from typing import Final
+
+# Muted enough to sit beside the monochrome layout without fighting the black
+# CTA button, distinct enough that six tracks read apart at a glance.
+TRACK_COLORS: Final[dict[str, str]] = {
+    "activation": "#b45309",
+    "content": "#0f766e",
+    "audience": "#4338ca",
+    "monetization": "#a16207",
+    "dormancy": "#57534e",
+    "milestone": "#15803d",
+    "reactivation": "#be123c",
+}
+
+DEFAULT_COLOR = "#3f3f46"
+
+# 8x8, one per track. Read them as pixel art — the shape is the message.
+MOTIFS: Final[dict[str, tuple[str, ...]]] = {
+    # A plus: make something that isn't there yet.
+    "activation": (
+        "00022000",
+        "00022000",
+        "00011000",
+        "22111122",
+        "22111122",
+        "00011000",
+        "00022000",
+        "00022000",
+    ),
+    # Stacked bands: chapters and lessons piling up, the last one still faint.
+    "content": (
+        "00000000",
+        "11111111",
+        "11111111",
+        "00000000",
+        "11111111",
+        "11111111",
+        "00000000",
+        "22222222",
+    ),
+    # A small crowd — three, then two.
+    "audience": (
+        "00000000",
+        "11011011",
+        "11011011",
+        "00000000",
+        "00110110",
+        "00110110",
+        "00000000",
+        "22222222",
+    ),
+    # A staircase: the tier you are on, and the one above it.
+    "monetization": (
+        "00000000",
+        "00000011",
+        "00000011",
+        "00002211",
+        "00002211",
+        "00222211",
+        "00222211",
+        "22222211",
+    ),
+    # Two dimmed bars, fading out.
+    "dormancy": (
+        "00000000",
+        "01100110",
+        "01100110",
+        "01100110",
+        "02200220",
+        "02200220",
+        "00000000",
+        "00000000",
+    ),
+    # A ring: come back around. Left open at top and bottom so it reads as a
+    # return rather than a full stop.
+    "reactivation": (
+        "00022000",
+        "02111120",
+        "21100112",
+        "21000012",
+        "21000012",
+        "21100112",
+        "02111120",
+        "00022000",
+    ),
+    # A filled diamond: something actually happened.
+    "milestone": (
+        "00011000",
+        "00111100",
+        "01111110",
+        "11111111",
+        "11111111",
+        "01111110",
+        "00111100",
+        "00011000",
+    ),
+}
+
+CELL_PX = 5
+
+
+def _tint(hex_color: str, amount: float = 0.78) -> str:
+    """Mix a colour toward white. Used for the motif's secondary tone."""
+    hex_color = hex_color.lstrip("#")
+    r, g, b = (int(hex_color[i : i + 2], 16) for i in (0, 2, 4))
+    mix = lambda c: round(c + (255 - c) * amount)  # noqa: E731
+    return f"#{mix(r):02x}{mix(g):02x}{mix(b):02x}"
+
+
+def render_illustration(track: str) -> str:
+    """An 8x8 mosaic for a track, as a nested table.
+
+    Returns "" for an unknown track so a new track ships without an
+    illustration rather than without an email.
+    """
+    motif = MOTIFS.get(track)
+    if not motif:
+        return ""
+
+    solid = TRACK_COLORS.get(track, DEFAULT_COLOR)
+    soft = _tint(solid)
+    tone = {"1": solid, "2": soft}
+
+    rows = []
+    for line in motif:
+        cells = []
+        for char in line:
+            color = tone.get(char)
+            # bgcolor as well as the style: Outlook ignores background-color on
+            # a td often enough that the attribute is the one doing the work.
+            bg = f' bgcolor="{color}"' if color else ""
+            style = f"background-color:{color};" if color else ""
+            cells.append(
+                f'<td width="{CELL_PX}" height="{CELL_PX}"{bg} '
+                f'style="width:{CELL_PX}px;height:{CELL_PX}px;{style}'
+                'font-size:0;line-height:0;">&nbsp;</td>'
+            )
+        rows.append(f"<tr>{''.join(cells)}</tr>")
+
+    return (
+        '<table role="presentation" aria-hidden="true" cellpadding="0" '
+        'cellspacing="0" border="0" align="center" '
+        'style="border-collapse:collapse;margin:0 auto 24px auto;">'
+        f"{''.join(rows)}"
+        "</table>"
+    )

--- a/apps/api/src/services/nudges/links.py
+++ b/apps/api/src/services/nudges/links.py
@@ -1,0 +1,93 @@
+"""
+CTA and unsubscribe URLs for lifecycle email.
+
+Every link a nudge can contain is built here, for one reason: a warm email that
+lands on a 404 is worse than no email at all, and the failure is invisible from
+the sending side. Centralising the construction means the route shapes are
+asserted in one test file rather than scattered across thirty templates.
+
+The trap worth knowing about: the frontend addresses a course by its *bare*
+uuid, while the database column stores it with a ``course_`` prefix
+(``removeCoursePrefix`` in ``apps/web/components/Objects/Thumbnails/
+CourseThumbnail.tsx``). Passing the stored value straight into a URL yields a
+dead link.
+"""
+
+from typing import Optional
+from urllib.parse import quote
+
+from src.services.email.utils import get_org_signup_base_url
+from src.services.nudges.tokens import make_unsubscribe_token
+
+# The `[subpage]` segment of the course editor route is a closed set; anything
+# else renders a broken tab rather than 404ing, which is harder to notice.
+COURSE_SUBPAGES = frozenset(
+    {"general", "content", "access", "contributors", "seo", "certification", "analytics"}
+)
+
+
+def strip_course_prefix(course_uuid: str) -> str:
+    """``course_abc123`` -> ``abc123``, matching the frontend's URL shape."""
+    return (course_uuid or "").replace("course_", "", 1)
+
+
+async def org_base_url(org_slug: str, db_session=None, org_id: Optional[int] = None) -> str:
+    """Frontend base URL for an org, honouring its verified custom domain.
+
+    Preferring the custom domain is not cosmetic: an org that has one keeps its
+    session there, so a link to the generic ``{slug}.{domain}`` subdomain would
+    land the reader cross-origin and bounce them to a login screen.
+    """
+    return (await get_org_signup_base_url(org_slug, None, db_session, org_id)).rstrip("/")
+
+
+def dashboard_url(base: str) -> str:
+    return f"{base}/dash"
+
+
+def courses_url(base: str) -> str:
+    return f"{base}/dash/courses"
+
+
+def course_migrate_url(base: str) -> str:
+    return f"{base}/dash/courses/migrate"
+
+
+def onboarding_url(base: str) -> str:
+    return f"{base}/dash/onboarding"
+
+
+def members_url(base: str) -> str:
+    return f"{base}/dash/users"
+
+
+def org_settings_url(base: str, subpage: str = "general") -> str:
+    return f"{base}/dash/org/settings/{quote(subpage, safe='')}"
+
+
+def course_editor_url(base: str, course_uuid: str, subpage: str = "content") -> str:
+    """Deep link into one course's editor.
+
+    Falls back to ``content`` on an unknown subpage rather than emitting a URL
+    that renders an empty tab.
+    """
+    if subpage not in COURSE_SUBPAGES:
+        subpage = "content"
+    bare = quote(strip_course_prefix(course_uuid), safe="")
+    return f"{base}/dash/courses/course/{bare}/{subpage}"
+
+
+def public_course_url(base: str, course_uuid: str) -> str:
+    """The shareable, learner-facing course page."""
+    bare = quote(strip_course_prefix(course_uuid), safe="")
+    return f"{base}/course/{bare}"
+
+
+def unsubscribe_url(api_base_url: str, user_uuid: str) -> str:
+    """One-click unsubscribe link, also used for the List-Unsubscribe header.
+
+    Points at the API rather than the frontend: the endpoint is the action
+    target for RFC 8058 one-click, which posts directly without loading a page.
+    """
+    token = make_unsubscribe_token(user_uuid)
+    return f"{api_base_url.rstrip('/')}/api/v1/emails/unsubscribe?token={quote(token, safe='')}"

--- a/apps/api/src/services/nudges/preferences.py
+++ b/apps/api/src/services/nudges/preferences.py
@@ -10,6 +10,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Iterable, Optional, Set
 
+from sqlalchemy import or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -28,7 +29,13 @@ async def get_user_by_uuid(db_session: AsyncSession, user_uuid: str) -> Optional
 async def get_opted_out_user_ids(
     db_session: AsyncSession, user_ids: Iterable[int]
 ) -> Set[int]:
-    """User ids from the given set that have opted out of lifecycle email."""
+    """Ids from the given set that must not be mailed.
+
+    Covers two different things deliberately: someone who asked to stop, and
+    an address a provider told us is undeliverable or whose owner reported us
+    as spam. The first is a preference; the second is a fact, and mailing
+    through it is what actually burns a sending domain.
+    """
     ids = list(user_ids)
     if not ids:
         return set()
@@ -37,11 +44,63 @@ async def get_opted_out_user_ids(
         await db_session.execute(
             select(EmailPreference.user_id).where(
                 EmailPreference.user_id.in_(ids),
-                EmailPreference.lifecycle_opt_out.is_(True),
+                or_(
+                    EmailPreference.lifecycle_opt_out.is_(True),
+                    EmailPreference.suppressed.is_(True),
+                ),
             )
         )
     ).scalars().all()
     return set(rows)
+
+
+async def suppress_address(
+    db_session: AsyncSession, email: str, reason: str
+) -> Optional[EmailPreference]:
+    """Stop mailing an address after a hard bounce or a spam complaint.
+
+    Keyed on the address rather than a user id because that is all a provider
+    webhook gives us. Returns None when the address matches no account, which
+    is normal — the bounce may be for a user since deleted.
+
+    This is set independently of ``lifecycle_opt_out`` so that a later
+    re-subscribe cannot silently undo it.
+    """
+    user = (
+        await db_session.execute(select(User).where(User.email == email))
+    ).scalars().first()
+    if user is None or user.id is None:
+        logger.info("Suppression for unknown address ignored (%s)", reason)
+        return None
+
+    pref = (
+        await db_session.execute(
+            select(EmailPreference).where(EmailPreference.user_id == user.id)
+        )
+    ).scalars().first()
+
+    if pref is None:
+        pref = EmailPreference(user_id=user.id, source=reason)
+        db_session.add(pref)
+
+    pref.suppressed = True
+    pref.suppressed_reason = reason
+    if pref.unsubscribed_at is None:
+        pref.unsubscribed_at = datetime.now(timezone.utc)
+    db_session.add(pref)
+    await db_session.commit()
+    await db_session.refresh(pref)
+    logger.info("Suppressed address for user %s (%s)", user.id, reason)
+    return pref
+
+
+async def is_suppressed(db_session: AsyncSession, user_id: int) -> bool:
+    pref = (
+        await db_session.execute(
+            select(EmailPreference).where(EmailPreference.user_id == user_id)
+        )
+    ).scalars().first()
+    return bool(pref and pref.suppressed)
 
 
 async def is_opted_out(db_session: AsyncSession, user_id: int) -> bool:
@@ -87,6 +146,9 @@ async def set_lifecycle_opt_out(
             pref.unsubscribed_at = now
         if not opted_out:
             pref.unsubscribed_at = None
+        # `suppressed` is untouched on purpose: a hard bounce or spam complaint
+        # is a delivery fact, and re-subscribing cannot make a dead address
+        # deliverable again.
         pref.source = source
         db_session.add(pref)
 

--- a/apps/api/src/services/nudges/preferences.py
+++ b/apps/api/src/services/nudges/preferences.py
@@ -1,0 +1,95 @@
+"""
+Read and write per-user email preferences.
+
+The absence of a row means "opted in, never asked", so reads coalesce to False
+and writes upsert. Callers on the send path use :func:`get_opted_out_user_ids`
+to fetch the whole opt-out set in one query rather than probing per user.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Iterable, Optional, Set
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from src.db.nudges import EmailPreference
+from src.db.users import User
+
+logger = logging.getLogger(__name__)
+
+
+async def get_user_by_uuid(db_session: AsyncSession, user_uuid: str) -> Optional[User]:
+    return (
+        await db_session.execute(select(User).where(User.user_uuid == user_uuid))
+    ).scalars().first()
+
+
+async def get_opted_out_user_ids(
+    db_session: AsyncSession, user_ids: Iterable[int]
+) -> Set[int]:
+    """User ids from the given set that have opted out of lifecycle email."""
+    ids = list(user_ids)
+    if not ids:
+        return set()
+
+    rows = (
+        await db_session.execute(
+            select(EmailPreference.user_id).where(
+                EmailPreference.user_id.in_(ids),
+                EmailPreference.lifecycle_opt_out.is_(True),
+            )
+        )
+    ).scalars().all()
+    return set(rows)
+
+
+async def is_opted_out(db_session: AsyncSession, user_id: int) -> bool:
+    pref = (
+        await db_session.execute(
+            select(EmailPreference).where(EmailPreference.user_id == user_id)
+        )
+    ).scalars().first()
+    return bool(pref and pref.lifecycle_opt_out)
+
+
+async def set_lifecycle_opt_out(
+    db_session: AsyncSession,
+    user_id: int,
+    opted_out: bool = True,
+    source: str = "email_link",
+) -> EmailPreference:
+    """Upsert the user's lifecycle preference. Idempotent.
+
+    One-click unsubscribe is retried by some mail providers, and people click
+    the link twice — repeating the call must not error or change the outcome.
+    """
+    pref = (
+        await db_session.execute(
+            select(EmailPreference).where(EmailPreference.user_id == user_id)
+        )
+    ).scalars().first()
+
+    now = datetime.now(timezone.utc)
+    if pref is None:
+        pref = EmailPreference(
+            user_id=user_id,
+            lifecycle_opt_out=opted_out,
+            unsubscribed_at=now if opted_out else None,
+            source=source,
+        )
+        db_session.add(pref)
+    else:
+        pref.lifecycle_opt_out = opted_out
+        # Keep the original opt-out timestamp on a repeat click; only stamp it
+        # on the transition into the opted-out state.
+        if opted_out and pref.unsubscribed_at is None:
+            pref.unsubscribed_at = now
+        if not opted_out:
+            pref.unsubscribed_at = None
+        pref.source = source
+        db_session.add(pref)
+
+    await db_session.commit()
+    await db_session.refresh(pref)
+    return pref

--- a/apps/api/src/services/nudges/runner.py
+++ b/apps/api/src/services/nudges/runner.py
@@ -35,15 +35,25 @@ logger = logging.getLogger(__name__)
 # An admin hears from us at most this often, across every org they administer.
 # Someone who runs three organizations should not receive triple the mail.
 DEFAULT_WEEKLY_CAP = 2
-DEFAULT_DAILY_CAP = 1
+# The gap is the binding constraint, not a separate daily cap: two days between
+# sends already implies at most one a day, so a daily cap would be dead weight.
 MIN_GAP_HOURS = 48
 
 # Blast radius fuse. Reached, the run stops and logs what it deferred; nothing
 # was claimed, so those candidates are simply reconsidered tomorrow.
 DEFAULT_MAX_SENDS = 500
 
-# Only the dormancy track may reach organizations that predate this system.
-BACKFILL_TRACKS = frozenset({"dormancy"})
+# The only tracks allowed to reach organizations that predate this system.
+# Both exist for exactly that audience; everything else is bounded by day_max
+# and could not reach them anyway.
+BACKFILL_TRACKS = frozenset({"dormancy", "reactivation"})
+
+# Long-dormant organizations are a different audience from someone who signed
+# up on Tuesday: there is no ongoing relationship to pace, and the sequence
+# only works if its steps land close enough together to read as a sequence.
+# These override the ordinary caps for orgs that predate the start date.
+DEFAULT_LEGACY_WEEKLY_CAP = 7
+DEFAULT_LEGACY_MIN_GAP_HOURS = 20
 
 
 def _flag(name: str, default: bool = False) -> bool:
@@ -62,6 +72,25 @@ def _int_env(name: str, default: int) -> int:
 
 def nudges_enabled() -> bool:
     return _flag("LEARNHOUSE_NUDGES_ENABLED", False)
+
+
+def send_slots() -> int:
+    """How many slots the day's sending is spread across.
+
+    ``1`` (the default) keeps the original behaviour: one daily run, everything
+    at once. Set it higher and run the job hourly — each org is pinned to a
+    slot by its id, so the day's mail trickles out instead of arriving as one
+    burst. A burst looks like a blast to spam filters and like a robot to
+    readers, and it also means a bad send hits everyone before anyone notices.
+    """
+    return max(1, _int_env("LEARNHOUSE_NUDGES_SLOTS", 1))
+
+
+def _slot_matches(org_id: int, now: datetime, slots: int) -> bool:
+    """Whether this org's slot is the one currently open."""
+    if slots <= 1:
+        return True
+    return org_id % slots == now.hour % slots
 
 
 def backfill_mode() -> str:
@@ -96,6 +125,7 @@ class RunStats:
     skipped_optout: int = 0
     skipped_backfill: int = 0
     skipped_inactive_org: int = 0
+    skipped_slot: int = 0
     failed: int = 0
     budget_exhausted: bool = False
     by_nudge: dict = field(default_factory=dict)
@@ -113,6 +143,7 @@ class RunStats:
             "skipped_optout": self.skipped_optout,
             "skipped_backfill": self.skipped_backfill,
             "skipped_inactive_org": self.skipped_inactive_org,
+            "skipped_slot": self.skipped_slot,
             "budget_exhausted": self.budget_exhausted,
             "by_nudge": dict(sorted(self.by_nudge.items())),
         }
@@ -182,18 +213,60 @@ async def _recent_send_counts(
     return counts
 
 
+def legacy_caps() -> tuple[int, int]:
+    """Weekly cap and minimum gap for organizations older than the start date."""
+    return (
+        _int_env("LEARNHOUSE_NUDGES_LEGACY_WEEKLY_CAP", DEFAULT_LEGACY_WEEKLY_CAP),
+        _int_env("LEARNHOUSE_NUDGES_LEGACY_MIN_GAP_HOURS", DEFAULT_LEGACY_MIN_GAP_HOURS),
+    )
+
+
 def _cap_blocks(
     counts: dict[int, tuple[int, Optional[datetime]]],
     user_id: int,
     now: datetime,
     weekly_cap: int,
+    min_gap_hours: int = MIN_GAP_HOURS,
 ) -> bool:
     count, latest = counts.get(user_id, (0, None))
     if count >= weekly_cap:
         return True
-    if latest is not None and (now - latest) < timedelta(hours=MIN_GAP_HOURS):
+    if latest is not None and (now - latest) < timedelta(hours=min_gap_hours):
         return True
     return False
+
+
+# Which figures are worth showing per track. Keys resolve to `nudge.stat.<key>`
+# labels; the value beside them is a bare number, so no locale has to solve
+# plural agreement.
+TRACK_STATS: dict[str, tuple[str, ...]] = {
+    "content": ("chapters", "lessons"),
+    "audience": ("members", "learners"),
+    "dormancy": ("courses", "lessons"),
+    "milestone": ("learners", "completed"),
+    # The whole message is "your work is still here" — the figures say it
+    # faster than the sentence does.
+    "reactivation": ("courses", "lessons"),
+    # activation: an empty org has nothing but zeros, and a row of them reads
+    # as an accusation rather than a prompt.
+    # monetization: the plan and its ceiling are already the subject of the copy.
+}
+
+
+def _stats_for(spec: NudgeSpec, snapshot: OrgSnapshot) -> list[tuple[str, int]]:
+    """Figures to show beneath the copy, or [] when none would help."""
+    available = {
+        "courses": snapshot.course_count,
+        "chapters": snapshot.chapter_count,
+        "lessons": snapshot.activity_count,
+        "members": snapshot.member_count,
+        "learners": snapshot.learner_count,
+        "completed": snapshot.completed_trailrun_count,
+    }
+    keys = TRACK_STATS.get(spec.track, ())
+    stats = [(key, available[key]) for key in keys]
+    # All-zero tells the reader nothing they did not already know.
+    return stats if any(value for _key, value in stats) else []
 
 
 def _copy_vars(snapshot: OrgSnapshot, spec: NudgeSpec) -> dict:
@@ -257,6 +330,32 @@ async def _claim(
     return row
 
 
+async def _record_sent(spec: NudgeSpec, snapshot: OrgSnapshot, admin: AdminRow) -> None:
+    """Emit an analytics event for one delivered nudge.
+
+    Without this there is no way to tell which of the catalog earns its place —
+    the ledger records that mail went out, not whether it brought anyone back.
+    Failures are swallowed: analytics must never be the reason a send loop dies.
+    """
+    try:
+        from src.services.analytics.analytics import track
+        from src.services.analytics.events import NUDGE_SENT
+
+        await track(
+            event_name=NUDGE_SENT,
+            org_id=snapshot.org_id,
+            user_id=admin.user_id,
+            properties={
+                "nudge_id": spec.id,
+                "track": spec.track,
+                "plan": snapshot.plan,
+                "lang": snapshot.lang,
+            },
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Nudge analytics event not recorded: %s", exc)
+
+
 async def run_nudges(
     db_session: AsyncSession,
     *,
@@ -282,6 +381,8 @@ async def run_nudges(
     )
     weekly_cap = _int_env("LEARNHOUSE_NUDGES_WEEKLY_CAP", DEFAULT_WEEKLY_CAP)
     cutoff = start_date()
+    slots = send_slots()
+    legacy_weekly_cap, legacy_gap = legacy_caps()
 
     if not force and get_deployment_mode() != "saas":
         logger.info("Nudges skipped: deployment mode is not saas")
@@ -298,6 +399,10 @@ async def run_nudges(
             stats.budget_exhausted = True
             logger.info("Nudge budget of %s reached; deferring the rest", max_sends)
             break
+
+        if not _slot_matches(snapshot.org_id, now, slots):
+            stats.skipped_slot += 1
+            continue
 
         if not snapshot.org_active_flag:
             stats.skipped_inactive_org += 1
@@ -331,7 +436,15 @@ async def run_nudges(
                 stats.skipped_optout += 1
                 continue
 
-            if not seed and _cap_blocks(counts, admin.user_id, now, weekly_cap):
+            # An org that predates the system gets the looser pacing: there is
+            # no ongoing relationship to protect, and the reactivation ladder
+            # only reads as a sequence if its steps arrive close together.
+            cap, gap = (
+                (legacy_weekly_cap, legacy_gap)
+                if _is_preexisting(snapshot, cutoff)
+                else (weekly_cap, MIN_GAP_HOURS)
+            )
+            if not seed and _cap_blocks(counts, admin.user_id, now, cap, gap):
                 stats.skipped_cap += 1
                 continue
 
@@ -381,6 +494,8 @@ async def run_nudges(
                     lang=snapshot.lang,
                     logo_url=logo_url,
                     has_cta=spec.has_cta,
+                    track=spec.track,
+                    stats=_stats_for(spec, snapshot),
                     **_copy_vars(snapshot, spec),
                 )
 
@@ -397,6 +512,7 @@ async def run_nudges(
                         counts.get(admin.user_id, (0, None))[0] + 1,
                         now,
                     )
+                    await _record_sent(spec, snapshot, admin)
 
                 db_session.add(row)
                 await db_session.commit()

--- a/apps/api/src/services/nudges/runner.py
+++ b/apps/api/src/services/nudges/runner.py
@@ -77,6 +77,12 @@ def backfill_mode() -> str:
     return (os.environ.get("LEARNHOUSE_NUDGES_BACKFILL_MODE") or "off").strip().lower()
 
 
+async def _ledger_has_rows(db_session: AsyncSession) -> bool:
+    return (
+        await db_session.execute(select(func.count()).select_from(NudgeSend))
+    ).scalar_one() > 0
+
+
 async def activation_date(db_session: AsyncSession) -> datetime:
     """When this system started running here.
 
@@ -109,6 +115,9 @@ class RunStats:
     skipped_inactive_org: int = 0
     failed: int = 0
     budget_exhausted: bool = False
+    # True when this run seeded the backlog rather than sending, which happens
+    # once, automatically, the first time the job runs anywhere.
+    auto_seeded: bool = False
     by_nudge: dict = field(default_factory=dict)
 
     def record(self, nudge_id: str) -> None:
@@ -125,6 +134,7 @@ class RunStats:
             "skipped_backfill": self.skipped_backfill,
             "skipped_inactive_org": self.skipped_inactive_org,
             "budget_exhausted": self.budget_exhausted,
+            "auto_seeded": self.auto_seeded,
             "by_nudge": dict(sorted(self.by_nudge.items())),
         }
 
@@ -359,6 +369,18 @@ async def run_nudges(
     if not force and not dry_run and not seed and not nudges_enabled():
         logger.info("Nudges skipped: LEARNHOUSE_NUDGES_ENABLED is not set")
         return stats
+
+    # First run here: seed instead of sending. Seeding consumes the dedupe
+    # keys for everything that happens to be true today, so switching the
+    # system on cannot fire a backlog accumulated over the org's whole life.
+    # Doing it automatically means there is no prerequisite step to forget.
+    if not seed and not dry_run and not await _ledger_has_rows(db_session):
+        logger.info("First nudge run here — seeding the backlog instead of sending")
+        seeded = await run_nudges(
+            db_session, seed=True, now=now, org_id=org_id, force=True
+        )
+        seeded.auto_seeded = True
+        return seeded
 
     media_base = get_media_base_url(None)
 

--- a/apps/api/src/services/nudges/runner.py
+++ b/apps/api/src/services/nudges/runner.py
@@ -297,6 +297,9 @@ async def _claim(
         lang=snapshot.lang,
         claimed_at=now,
         meta={
+            # The recipient, so a delivery check days later knows which
+            # address to suppress without re-deriving it.
+            "email": admin.email,
             "track": spec.track,
             "plan": snapshot.plan,
             "course_count": snapshot.course_count,
@@ -381,6 +384,15 @@ async def run_nudges(
         )
         seeded.auto_seeded = True
         return seeded
+
+    # Ask the provider what became of recent messages before sending more.
+    # This is what lets bounces and complaints be noticed without a webhook.
+    try:
+        from src.services.nudges.delivery import reconcile_delivery
+
+        await reconcile_delivery(db_session, now=now)
+    except Exception as exc:
+        logger.warning("Delivery reconcile skipped: %s", exc)
 
     media_base = get_media_base_url(None)
 
@@ -495,6 +507,8 @@ async def run_nudges(
                 else:
                     row.status = NudgeSendStatus.SENT
                     row.sent_at = now
+                    if isinstance(result, dict) and result.get("id"):
+                        row.provider_id = str(result["id"])
                     stats.sent += 1
                     stats.record(spec.id)
                     counts[admin.user_id] = (

--- a/apps/api/src/services/nudges/runner.py
+++ b/apps/api/src/services/nudges/runner.py
@@ -1,0 +1,405 @@
+"""
+The nudge send loop and its guardrails.
+
+Ordering here is deliberate. The ledger row is written *before* the provider is
+called, so a process that dies mid-send loses one email rather than sending it
+twice on the next run. Every other guard is a cheap check in front of that.
+
+Defaults are conservative on purpose: the kill switch is off, the deployment
+gate is SaaS-only, and the per-run budget is finite. Merging this code sends
+nothing until somebody deliberately turns it on.
+"""
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from src.core.deployment_mode import get_deployment_mode
+from src.db.nudges import NudgeSend, NudgeSendStatus
+from src.services.email.utils import get_media_base_url
+from src.services.nudges import links
+from src.services.nudges.catalog import NudgeSpec, matching_specs, next_plan
+from src.services.nudges.eligibility import iter_snapshots
+from src.services.nudges.preferences import get_opted_out_user_ids
+from src.services.nudges.snapshot import AdminRow, OrgSnapshot
+from src.services.users.emails import send_nudge_email
+
+logger = logging.getLogger(__name__)
+
+# An admin hears from us at most this often, across every org they administer.
+# Someone who runs three organizations should not receive triple the mail.
+DEFAULT_WEEKLY_CAP = 2
+DEFAULT_DAILY_CAP = 1
+MIN_GAP_HOURS = 48
+
+# Blast radius fuse. Reached, the run stops and logs what it deferred; nothing
+# was claimed, so those candidates are simply reconsidered tomorrow.
+DEFAULT_MAX_SENDS = 500
+
+# Only the dormancy track may reach organizations that predate this system.
+BACKFILL_TRACKS = frozenset({"dormancy"})
+
+
+def _flag(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, "") or default)
+    except ValueError:
+        return default
+
+
+def nudges_enabled() -> bool:
+    return _flag("LEARNHOUSE_NUDGES_ENABLED", False)
+
+
+def backfill_mode() -> str:
+    """``off`` | ``winback`` | ``full``.
+
+    ``full`` exists only as an escape hatch and is not a supported setting —
+    it would evaluate the entire catalog against years of history.
+    """
+    return (os.environ.get("LEARNHOUSE_NUDGES_BACKFILL_MODE") or "off").strip().lower()
+
+
+def start_date() -> Optional[datetime]:
+    """Orgs created before this are "pre-existing" and only the dormancy track
+    may reach them. Unset means every org counts as new."""
+    raw = os.environ.get("LEARNHOUSE_NUDGES_START_DATE")
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.strip())
+    except ValueError:
+        logger.warning("Ignoring unparseable LEARNHOUSE_NUDGES_START_DATE: %r", raw)
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+@dataclass
+class RunStats:
+    considered: int = 0
+    sent: int = 0
+    skipped_dedupe: int = 0
+    skipped_cap: int = 0
+    skipped_optout: int = 0
+    skipped_backfill: int = 0
+    skipped_inactive_org: int = 0
+    failed: int = 0
+    budget_exhausted: bool = False
+    by_nudge: dict = field(default_factory=dict)
+
+    def record(self, nudge_id: str) -> None:
+        self.by_nudge[nudge_id] = self.by_nudge.get(nudge_id, 0) + 1
+
+    def as_dict(self) -> dict:
+        return {
+            "considered": self.considered,
+            "sent": self.sent,
+            "failed": self.failed,
+            "skipped_dedupe": self.skipped_dedupe,
+            "skipped_cap": self.skipped_cap,
+            "skipped_optout": self.skipped_optout,
+            "skipped_backfill": self.skipped_backfill,
+            "skipped_inactive_org": self.skipped_inactive_org,
+            "budget_exhausted": self.budget_exhausted,
+            "by_nudge": dict(sorted(self.by_nudge.items())),
+        }
+
+
+def dedupe_key(spec: NudgeSpec, org_id: int, user_id: int, now: datetime, dry_run: bool) -> str:
+    """The idempotency boundary.
+
+    A dry run uses a separate namespace so a rehearsal never consumes the key
+    that the real send will need.
+    """
+    key = f"{spec.id}:{org_id}:{user_id}"
+    if spec.repeat == "quarterly":
+        key = f"{key}:{now.year}-Q{(now.month - 1) // 3 + 1}"
+    elif spec.repeat == "monthly":
+        key = f"{key}:{now.year}-{now.month:02d}"
+    return f"dryrun:{key}" if dry_run else key
+
+
+def _is_preexisting(snapshot: OrgSnapshot, cutoff: Optional[datetime]) -> bool:
+    if cutoff is None or snapshot.created_at is None:
+        return False
+    return snapshot.created_at < cutoff
+
+
+def _backfill_allows(spec: NudgeSpec, snapshot: OrgSnapshot, cutoff: Optional[datetime]) -> bool:
+    """Whether a spec may reach an organization older than this system.
+
+    This is the structural half of the backfill guard — the other half is
+    ``day_max`` on every spec, which already excludes old orgs from the
+    recency-anchored tracks. Together they mean the worst case for a long
+    dormant org on day one is one email, not the whole catalog.
+    """
+    if not _is_preexisting(snapshot, cutoff):
+        return True
+    mode = backfill_mode()
+    if mode == "full":
+        return True
+    if mode == "winback":
+        return spec.track in BACKFILL_TRACKS
+    return False
+
+
+async def _recent_send_counts(
+    db_session: AsyncSession, user_ids: list[int], now: datetime
+) -> dict[int, tuple[int, Optional[datetime]]]:
+    """Sends per user in the trailing week, in one query for the whole batch."""
+    if not user_ids:
+        return {}
+
+    rows = (
+        await db_session.execute(
+            select(NudgeSend.user_id, NudgeSend.sent_at).where(
+                NudgeSend.user_id.in_(user_ids),
+                NudgeSend.status == NudgeSendStatus.SENT,
+                NudgeSend.sent_at.is_not(None),
+                NudgeSend.sent_at >= now - timedelta(days=7),
+            )
+        )
+    ).all()
+
+    counts: dict[int, tuple[int, Optional[datetime]]] = {}
+    for user_id, sent_at in rows:
+        count, latest = counts.get(user_id, (0, None))
+        stamp = sent_at if sent_at.tzinfo else sent_at.replace(tzinfo=timezone.utc)
+        counts[user_id] = (count + 1, max(latest, stamp) if latest else stamp)
+    return counts
+
+
+def _cap_blocks(
+    counts: dict[int, tuple[int, Optional[datetime]]],
+    user_id: int,
+    now: datetime,
+    weekly_cap: int,
+) -> bool:
+    count, latest = counts.get(user_id, (0, None))
+    if count >= weekly_cap:
+        return True
+    if latest is not None and (now - latest) < timedelta(hours=MIN_GAP_HOURS):
+        return True
+    return False
+
+
+def _copy_vars(snapshot: OrgSnapshot, spec: NudgeSpec) -> dict:
+    """Placeholder values for a nudge's copy.
+
+    Plan names and tiers are resolved here rather than written into the
+    translation strings, because the limits and hierarchy live in one place and
+    change without anyone remembering the emails.
+    """
+    course_name = (
+        snapshot.oldest_draft_course_name
+        or snapshot.newest_course_name
+        or snapshot.org_name
+    )
+    # org_name is deliberately absent: send_nudge_email takes it as a named
+    # argument, and repeating it here collides with that parameter.
+    return {
+        "course_name": course_name,
+        "plan_name": snapshot.plan,
+        "next_plan": next_plan(snapshot.plan) or "",
+    }
+
+
+async def _claim(
+    db_session: AsyncSession,
+    spec: NudgeSpec,
+    snapshot: OrgSnapshot,
+    admin: AdminRow,
+    key: str,
+    now: datetime,
+    dry_run: bool,
+) -> Optional[NudgeSend]:
+    """Insert the ledger row. Returns None when someone already holds the key.
+
+    The unique constraint, not the preceding read, is what makes this safe:
+    two runs racing the same tick collide in the database rather than in
+    someone's inbox.
+    """
+    row = NudgeSend(
+        nudge_id=spec.id,
+        dedupe_key=key,
+        org_id=snapshot.org_id,
+        user_id=admin.user_id,
+        status=NudgeSendStatus.DRY_RUN if dry_run else NudgeSendStatus.CLAIMED,
+        lang=snapshot.lang,
+        claimed_at=now,
+        meta={
+            "track": spec.track,
+            "plan": snapshot.plan,
+            "course_count": snapshot.course_count,
+            "published_course_count": snapshot.published_course_count,
+            "member_count": snapshot.member_count,
+        },
+    )
+    db_session.add(row)
+    try:
+        await db_session.commit()
+    except IntegrityError:
+        await db_session.rollback()
+        return None
+    return row
+
+
+async def run_nudges(
+    db_session: AsyncSession,
+    *,
+    dry_run: bool = False,
+    max_sends: Optional[int] = None,
+    only: Optional[str] = None,
+    org_id: Optional[int] = None,
+    now: Optional[datetime] = None,
+    force: bool = False,
+    seed: bool = False,
+) -> RunStats:
+    """Evaluate every organization and send what is due.
+
+    ``seed`` writes suppressed ledger rows instead of sending, permanently
+    consuming those dedupe keys. Run once before switching the system on, so
+    the first live run does not fire a backlog of everything that happens to be
+    true today.
+    """
+    stats = RunStats()
+    now = now or datetime.now(timezone.utc)
+    max_sends = max_sends if max_sends is not None else _int_env(
+        "LEARNHOUSE_NUDGES_MAX_SENDS", DEFAULT_MAX_SENDS
+    )
+    weekly_cap = _int_env("LEARNHOUSE_NUDGES_WEEKLY_CAP", DEFAULT_WEEKLY_CAP)
+    cutoff = start_date()
+
+    if not force and get_deployment_mode() != "saas":
+        logger.info("Nudges skipped: deployment mode is not saas")
+        return stats
+
+    if not force and not dry_run and not seed and not nudges_enabled():
+        logger.info("Nudges skipped: LEARNHOUSE_NUDGES_ENABLED is not set")
+        return stats
+
+    media_base = get_media_base_url(None)
+
+    async for snapshot in iter_snapshots(db_session, now=now, org_id=org_id):
+        if stats.sent >= max_sends:
+            stats.budget_exhausted = True
+            logger.info("Nudge budget of %s reached; deferring the rest", max_sends)
+            break
+
+        if not snapshot.org_active_flag:
+            stats.skipped_inactive_org += 1
+            continue
+
+        admins = snapshot.mailable_admins
+        if not admins:
+            continue
+
+        specs = matching_specs(snapshot)
+        if only:
+            specs = [s for s in specs if s.id == only]
+        if not specs:
+            continue
+
+        opted_out = await get_opted_out_user_ids(db_session, [a.user_id for a in admins])
+        counts = await _recent_send_counts(
+            db_session, [a.user_id for a in admins], now
+        )
+
+        base_url = await links.org_base_url(
+            snapshot.org_slug, db_session, snapshot.org_id
+        )
+
+        for admin in admins:
+            if stats.sent >= max_sends:
+                stats.budget_exhausted = True
+                break
+
+            if admin.user_id in opted_out:
+                stats.skipped_optout += 1
+                continue
+
+            if not seed and _cap_blocks(counts, admin.user_id, now, weekly_cap):
+                stats.skipped_cap += 1
+                continue
+
+            # At most one nudge per admin per run: the highest-priority spec
+            # takes the slot and the rest wait for another day.
+            for spec in specs:
+                stats.considered += 1
+
+                if not _backfill_allows(spec, snapshot, cutoff):
+                    stats.skipped_backfill += 1
+                    continue
+
+                key = dedupe_key(spec, snapshot.org_id, admin.user_id, now, dry_run)
+                row = await _claim(
+                    db_session, spec, snapshot, admin, key, now, dry_run or seed
+                )
+                if row is None:
+                    stats.skipped_dedupe += 1
+                    continue
+
+                if seed:
+                    row.status = NudgeSendStatus.SUPPRESSED
+                    db_session.add(row)
+                    await db_session.commit()
+                    break
+
+                if dry_run:
+                    stats.record(spec.id)
+                    logger.info(
+                        "[dry-run] %s -> %s (org %s)", spec.id, admin.email, snapshot.org_slug
+                    )
+                    break
+
+                logo_url = None
+                if snapshot.logo_image and snapshot.org_uuid and media_base:
+                    logo_url = (
+                        f"{media_base}/content/orgs/{snapshot.org_uuid}"
+                        f"/logos/{snapshot.logo_image}"
+                    )
+
+                result = send_nudge_email(
+                    nudge_id=spec.id,
+                    email=admin.email,
+                    org_name=snapshot.org_name,
+                    cta_url=spec.cta(snapshot, base_url),
+                    unsubscribe_url=links.unsubscribe_url(media_base, admin.user_uuid),
+                    lang=snapshot.lang,
+                    logo_url=logo_url,
+                    has_cta=spec.has_cta,
+                    **_copy_vars(snapshot, spec),
+                )
+
+                if result is False:
+                    row.status = NudgeSendStatus.FAILED
+                    row.error = "provider rejected or unavailable"
+                    stats.failed += 1
+                else:
+                    row.status = NudgeSendStatus.SENT
+                    row.sent_at = now
+                    stats.sent += 1
+                    stats.record(spec.id)
+                    counts[admin.user_id] = (
+                        counts.get(admin.user_id, (0, None))[0] + 1,
+                        now,
+                    )
+
+                db_session.add(row)
+                await db_session.commit()
+                break
+
+    return stats

--- a/apps/api/src/services/nudges/runner.py
+++ b/apps/api/src/services/nudges/runner.py
@@ -18,6 +18,7 @@ from typing import Optional
 
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import func
 from sqlmodel import select
 
 from src.core.deployment_mode import get_deployment_mode
@@ -34,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 # An admin hears from us at most this often, across every org they administer.
 # Someone who runs three organizations should not receive triple the mail.
-DEFAULT_WEEKLY_CAP = 2
+WEEKLY_CAP = 2
 # The gap is the binding constraint, not a separate daily cap: two days between
 # sends already implies at most one a day, so a daily cap would be dead weight.
 MIN_GAP_HOURS = 48
@@ -52,8 +53,8 @@ BACKFILL_TRACKS = frozenset({"dormancy", "reactivation"})
 # up on Tuesday: there is no ongoing relationship to pace, and the sequence
 # only works if its steps land close enough together to read as a sequence.
 # These override the ordinary caps for orgs that predate the start date.
-DEFAULT_LEGACY_WEEKLY_CAP = 7
-DEFAULT_LEGACY_MIN_GAP_HOURS = 20
+LEGACY_WEEKLY_CAP = 7
+LEGACY_MIN_GAP_HOURS = 20
 
 
 def _flag(name: str, default: bool = False) -> bool:
@@ -63,34 +64,8 @@ def _flag(name: str, default: bool = False) -> bool:
     return raw.strip().lower() in ("1", "true", "yes", "on")
 
 
-def _int_env(name: str, default: int) -> int:
-    try:
-        return int(os.environ.get(name, "") or default)
-    except ValueError:
-        return default
-
-
 def nudges_enabled() -> bool:
     return _flag("LEARNHOUSE_NUDGES_ENABLED", False)
-
-
-def send_slots() -> int:
-    """How many slots the day's sending is spread across.
-
-    ``1`` (the default) keeps the original behaviour: one daily run, everything
-    at once. Set it higher and run the job hourly — each org is pinned to a
-    slot by its id, so the day's mail trickles out instead of arriving as one
-    burst. A burst looks like a blast to spam filters and like a robot to
-    readers, and it also means a bad send hits everyone before anyone notices.
-    """
-    return max(1, _int_env("LEARNHOUSE_NUDGES_SLOTS", 1))
-
-
-def _slot_matches(org_id: int, now: datetime, slots: int) -> bool:
-    """Whether this org's slot is the one currently open."""
-    if slots <= 1:
-        return True
-    return org_id % slots == now.hour % slots
 
 
 def backfill_mode() -> str:
@@ -102,18 +77,25 @@ def backfill_mode() -> str:
     return (os.environ.get("LEARNHOUSE_NUDGES_BACKFILL_MODE") or "off").strip().lower()
 
 
-def start_date() -> Optional[datetime]:
-    """Orgs created before this are "pre-existing" and only the dormancy track
-    may reach them. Unset means every org counts as new."""
-    raw = os.environ.get("LEARNHOUSE_NUDGES_START_DATE")
-    if not raw:
-        return None
-    try:
-        parsed = datetime.fromisoformat(raw.strip())
-    except ValueError:
-        logger.warning("Ignoring unparseable LEARNHOUSE_NUDGES_START_DATE: %r", raw)
-        return None
-    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+async def activation_date(db_session: AsyncSession) -> datetime:
+    """When this system started running here.
+
+    Orgs created before it are "pre-existing" and only the winback tracks may
+    reach them. Derived from the ledger rather than configured: the first row —
+    written by `nudges-seed`, or by the first live send — *is* the boundary,
+    so there is no date to remember to set and no way to set it wrongly.
+
+    An empty ledger means nothing has run here yet, so every existing org
+    predates the system and only the winback tracks may reach it. Running
+    `nudges-seed` is what pins the boundary and lets ordinary tracks start
+    applying to organizations created from then on.
+    """
+    earliest = (
+        await db_session.execute(select(func.min(NudgeSend.claimed_at)))
+    ).scalar_one_or_none()
+    if earliest is None:
+        return datetime.now(timezone.utc)
+    return earliest if earliest.tzinfo else earliest.replace(tzinfo=timezone.utc)
 
 
 @dataclass
@@ -125,7 +107,6 @@ class RunStats:
     skipped_optout: int = 0
     skipped_backfill: int = 0
     skipped_inactive_org: int = 0
-    skipped_slot: int = 0
     failed: int = 0
     budget_exhausted: bool = False
     by_nudge: dict = field(default_factory=dict)
@@ -143,7 +124,6 @@ class RunStats:
             "skipped_optout": self.skipped_optout,
             "skipped_backfill": self.skipped_backfill,
             "skipped_inactive_org": self.skipped_inactive_org,
-            "skipped_slot": self.skipped_slot,
             "budget_exhausted": self.budget_exhausted,
             "by_nudge": dict(sorted(self.by_nudge.items())),
         }
@@ -163,13 +143,14 @@ def dedupe_key(spec: NudgeSpec, org_id: int, user_id: int, now: datetime, dry_ru
     return f"dryrun:{key}" if dry_run else key
 
 
-def _is_preexisting(snapshot: OrgSnapshot, cutoff: Optional[datetime]) -> bool:
-    if cutoff is None or snapshot.created_at is None:
+def _is_preexisting(snapshot: OrgSnapshot, cutoff: datetime) -> bool:
+    """Whether this org predates the system running here."""
+    if snapshot.created_at is None:
         return False
     return snapshot.created_at < cutoff
 
 
-def _backfill_allows(spec: NudgeSpec, snapshot: OrgSnapshot, cutoff: Optional[datetime]) -> bool:
+def _backfill_allows(spec: NudgeSpec, snapshot: OrgSnapshot, cutoff: datetime) -> bool:
     """Whether a spec may reach an organization older than this system.
 
     This is the structural half of the backfill guard — the other half is
@@ -211,14 +192,6 @@ async def _recent_send_counts(
         stamp = sent_at if sent_at.tzinfo else sent_at.replace(tzinfo=timezone.utc)
         counts[user_id] = (count + 1, max(latest, stamp) if latest else stamp)
     return counts
-
-
-def legacy_caps() -> tuple[int, int]:
-    """Weekly cap and minimum gap for organizations older than the start date."""
-    return (
-        _int_env("LEARNHOUSE_NUDGES_LEGACY_WEEKLY_CAP", DEFAULT_LEGACY_WEEKLY_CAP),
-        _int_env("LEARNHOUSE_NUDGES_LEGACY_MIN_GAP_HOURS", DEFAULT_LEGACY_MIN_GAP_HOURS),
-    )
 
 
 def _cap_blocks(
@@ -376,13 +349,8 @@ async def run_nudges(
     """
     stats = RunStats()
     now = now or datetime.now(timezone.utc)
-    max_sends = max_sends if max_sends is not None else _int_env(
-        "LEARNHOUSE_NUDGES_MAX_SENDS", DEFAULT_MAX_SENDS
-    )
-    weekly_cap = _int_env("LEARNHOUSE_NUDGES_WEEKLY_CAP", DEFAULT_WEEKLY_CAP)
-    cutoff = start_date()
-    slots = send_slots()
-    legacy_weekly_cap, legacy_gap = legacy_caps()
+    max_sends = max_sends if max_sends is not None else DEFAULT_MAX_SENDS
+    cutoff = await activation_date(db_session)
 
     if not force and get_deployment_mode() != "saas":
         logger.info("Nudges skipped: deployment mode is not saas")
@@ -399,10 +367,6 @@ async def run_nudges(
             stats.budget_exhausted = True
             logger.info("Nudge budget of %s reached; deferring the rest", max_sends)
             break
-
-        if not _slot_matches(snapshot.org_id, now, slots):
-            stats.skipped_slot += 1
-            continue
 
         if not snapshot.org_active_flag:
             stats.skipped_inactive_org += 1
@@ -440,9 +404,9 @@ async def run_nudges(
             # no ongoing relationship to protect, and the reactivation ladder
             # only reads as a sequence if its steps arrive close together.
             cap, gap = (
-                (legacy_weekly_cap, legacy_gap)
+                (LEGACY_WEEKLY_CAP, LEGACY_MIN_GAP_HOURS)
                 if _is_preexisting(snapshot, cutoff)
-                else (weekly_cap, MIN_GAP_HOURS)
+                else (WEEKLY_CAP, MIN_GAP_HOURS)
             )
             if not seed and _cap_blocks(counts, admin.user_id, now, cap, gap):
                 stats.skipped_cap += 1
@@ -453,7 +417,10 @@ async def run_nudges(
             for spec in specs:
                 stats.considered += 1
 
-                if not _backfill_allows(spec, snapshot, cutoff):
+                # Seeding deliberately ignores the backfill gate: its whole
+                # job is to consume the keys for everything true today, and a
+                # key left unconsumed is one that fires on the first live run.
+                if not seed and not _backfill_allows(spec, snapshot, cutoff):
                     stats.skipped_backfill += 1
                     continue
 

--- a/apps/api/src/services/nudges/scheduler.py
+++ b/apps/api/src/services/nudges/scheduler.py
@@ -1,0 +1,131 @@
+"""
+Runs the nudge job on a daily tick from inside the API, so no external cron is
+required for the feature to work.
+
+Correctness does not depend on only one replica running this. The ledger's
+unique dedupe key is written before the provider is called, so if several pods
+wake at the same moment they collide in the database rather than in someone's
+inbox — the loser of the race simply skips. The Redis day-lock below is an
+optimisation that stops N pods each doing the same full scan; when Redis is
+absent the job still runs correctly, just more than once.
+
+The CLI commands remain the operator's interface for dry runs, stats and
+one-off invocations. This only removes the need to schedule anything.
+"""
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# One tick a day. Late morning UTC lands in working hours across Europe and the
+# Americas, which is when an email about your own academy is worth reading.
+RUN_AT_HOUR_UTC = 9
+
+# Held for well under a day so a pod that dies mid-run does not block tomorrow.
+_LOCK_TTL_SECONDS = 6 * 60 * 60
+
+_task: Optional[asyncio.Task] = None
+
+
+def _lock_key(day: datetime) -> str:
+    return f"learnhouse:nudges:daily:{day.date().isoformat()}"
+
+
+async def _claim_day(now: datetime) -> bool:
+    """Try to become the pod that runs today's job.
+
+    Returns True when Redis is unavailable: the ledger already guarantees a
+    nudge is sent once, so running without the lock is wasteful rather than
+    wrong, and silently doing nothing would be worse.
+    """
+    try:
+        from src.core.redis import get_redis_client
+
+        client = get_redis_client()
+        if client is None:
+            return True
+        acquired = await asyncio.to_thread(
+            client.set, _lock_key(now), "1", nx=True, ex=_LOCK_TTL_SECONDS
+        )
+        return bool(acquired)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Nudge day-lock unavailable, running anyway: %s", exc)
+        return True
+
+
+def _seconds_until_next_run(now: datetime) -> float:
+    target = now.replace(hour=RUN_AT_HOUR_UTC, minute=0, second=0, microsecond=0)
+    if target <= now:
+        target += timedelta(days=1)
+    return (target - now).total_seconds()
+
+
+async def _run_once() -> None:
+    from src.core.events.database import _async_session_factory
+    from src.services.nudges.runner import run_nudges
+
+    async with _async_session_factory() as db_session:
+        stats = await run_nudges(db_session)
+    result = stats.as_dict()
+    if result["auto_seeded"]:
+        logger.info("Nudge backlog seeded; sending begins on the next run")
+    else:
+        logger.info(
+            "Nudge run complete: sent=%s failed=%s", result["sent"], result["failed"]
+        )
+
+
+async def _loop() -> None:
+    while True:
+        now = datetime.now(timezone.utc)
+        await asyncio.sleep(_seconds_until_next_run(now))
+        try:
+            today = datetime.now(timezone.utc)
+            if await _claim_day(today):
+                await _run_once()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            # A failed run must not kill the loop, or the feature silently
+            # stops until the next deploy.
+            logger.exception("Nudge run failed, will retry tomorrow: %s", exc)
+
+
+def start_scheduler() -> None:
+    """Start the daily tick, unless the feature is switched off.
+
+    Deliberately checks the kill switch here as well as inside the job: an
+    instance with nudges disabled should not carry a background task at all.
+    """
+    global _task
+
+    from src.core.deployment_mode import get_deployment_mode
+    from src.services.nudges.runner import nudges_enabled
+
+    if not nudges_enabled():
+        return
+    if get_deployment_mode() != "saas":
+        return
+    if os.environ.get("LEARNHOUSE_NUDGES_NO_SCHEDULER"):
+        # For deployments that would rather drive the CLI from their own cron.
+        logger.info("Nudge scheduler disabled; drive `nudges-run` yourself")
+        return
+
+    _task = asyncio.create_task(_loop())
+    logger.info("Nudge scheduler started (daily at %02d:00 UTC)", RUN_AT_HOUR_UTC)
+
+
+async def stop_scheduler() -> None:
+    global _task
+    if _task is None:
+        return
+    _task.cancel()
+    try:
+        await _task
+    except (asyncio.CancelledError, Exception):
+        pass
+    _task = None

--- a/apps/api/src/services/nudges/scheduler.py
+++ b/apps/api/src/services/nudges/scheduler.py
@@ -98,28 +98,35 @@ async def _loop() -> None:
 def start_scheduler() -> None:
     """Start the daily tick, unless the feature is switched off.
 
-    Deliberately checks the kill switch here as well as inside the job: an
+    Never raises: this runs during application startup, and a background email
+    job must not be able to stop the API from booting.
+
+    Deliberately checks the kill switch here as well as inside the job — an
     instance with nudges disabled should not carry a background task at all.
     """
     global _task
 
-    from src.core.deployment_mode import get_deployment_mode
-    from src.services.nudges.runner import nudges_enabled
+    try:
+        from src.core.deployment_mode import get_deployment_mode
+        from src.services.nudges.runner import nudges_enabled
 
-    if not nudges_enabled():
-        return
-    if get_deployment_mode() != "saas":
-        return
-    if os.environ.get("LEARNHOUSE_NUDGES_NO_SCHEDULER"):
-        # For deployments that would rather drive the CLI from their own cron.
-        logger.info("Nudge scheduler disabled; drive `nudges-run` yourself")
-        return
+        if not nudges_enabled():
+            return
+        if get_deployment_mode() != "saas":
+            return
+        if os.environ.get("LEARNHOUSE_NUDGES_NO_SCHEDULER"):
+            # For deployments that would rather drive the CLI from their own cron.
+            logger.info("Nudge scheduler disabled; drive `nudges-run` yourself")
+            return
 
-    _task = asyncio.create_task(_loop())
-    logger.info("Nudge scheduler started (daily at %02d:00 UTC)", RUN_AT_HOUR_UTC)
+        _task = asyncio.create_task(_loop())
+        logger.info("Nudge scheduler started (daily at %02d:00 UTC)", RUN_AT_HOUR_UTC)
+    except Exception as exc:
+        logger.warning("Nudge scheduler not started: %s", exc)
 
 
 async def stop_scheduler() -> None:
+    """Stop the tick. Never raises, for the same reason as `start_scheduler`."""
     global _task
     if _task is None:
         return
@@ -128,4 +135,5 @@ async def stop_scheduler() -> None:
         await _task
     except (asyncio.CancelledError, Exception):
         pass
-    _task = None
+    finally:
+        _task = None

--- a/apps/api/src/services/nudges/snapshot.py
+++ b/apps/api/src/services/nudges/snapshot.py
@@ -15,6 +15,10 @@ from src.services.security.account_age import parse_creation_date
 # calendar says about its anchors — chasing it would be noise.
 ACTIVE_WINDOW_DAYS = 3
 
+# Past this, every ordinary track's `day_max` has long since excluded the org.
+# These are the ones a reactivation sequence exists for.
+COLD_AFTER_DAYS = 90
+
 
 @dataclass(frozen=True)
 class AdminRow:
@@ -96,6 +100,12 @@ class OrgSnapshot:
     last_admin_login_at: Optional[datetime] = None
     last_activity_day: Optional[datetime] = None
 
+    # When this org first received any nudge. The reactivation ladder measures
+    # from here rather than from last activity: an org quiet for two years has
+    # a last-touch number that never moves, so nothing anchored on it can form
+    # a sequence.
+    first_nudged_at: Optional[datetime] = None
+
     admins: tuple[AdminRow, ...] = field(default_factory=tuple)
 
     # Injected so a run can be replayed "as of" a past date, and so tests are
@@ -160,6 +170,16 @@ class OrgSnapshot:
     @property
     def days_since_touch(self) -> Optional[float]:
         return self.age_days(self.last_touch)
+
+    @property
+    def days_since_first_nudge(self) -> Optional[float]:
+        return self.age_days(self.first_nudged_at)
+
+    @property
+    def is_cold(self) -> bool:
+        """Quiet long enough that no ordinary track can reach them."""
+        days = self.days_since_touch
+        return days is not None and days >= COLD_AFTER_DAYS
 
     @property
     def org_active(self) -> bool:

--- a/apps/api/src/services/nudges/snapshot.py
+++ b/apps/api/src/services/nudges/snapshot.py
@@ -1,0 +1,197 @@
+"""
+The per-org fact row that nudge predicates run against.
+
+Kept separate from the queries that build it so the whole catalog can be
+unit-tested by constructing snapshots by hand, with no database at all.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+from src.services.security.account_age import parse_creation_date
+
+# An org that has done something very recently is not dormant, whatever the
+# calendar says about its anchors — chasing it would be noise.
+ACTIVE_WINDOW_DAYS = 3
+
+
+@dataclass(frozen=True)
+class AdminRow:
+    """One org admin eligible to receive mail."""
+
+    user_id: int
+    user_uuid: str
+    email: str
+    first_name: Optional[str]
+    username: Optional[str]
+    email_verified: bool
+    last_login_at: Optional[datetime]
+
+    @property
+    def display_name(self) -> str:
+        """What to greet them by, preferring the most human option available."""
+        return (self.first_name or "").strip() or (self.username or "").strip() or "there"
+
+
+@dataclass(frozen=True)
+class OrgSnapshot:
+    """Everything a nudge predicate is allowed to look at, for one org.
+
+    Timestamps are tz-aware UTC. The ones sourced from naive string columns
+    (course/activity/org dates) are parsed through ``parse_creation_date`` and
+    are accurate to roughly a day — every catalog window is at least two days
+    wide so that fuzziness can never flip eligibility.
+    """
+
+    org_id: int
+    org_slug: str
+    org_name: str
+    plan: str
+    lang: str
+    org_active_flag: bool = True
+    logo_image: Optional[str] = None
+    org_uuid: Optional[str] = None
+
+    created_at: Optional[datetime] = None
+    org_updated_at: Optional[datetime] = None
+
+    member_count: int = 0            # non-admin members
+    admin_count: int = 0
+    first_member_joined_at: Optional[datetime] = None
+    last_member_joined_at: Optional[datetime] = None
+
+    course_count: int = 0
+    published_course_count: int = 0
+    public_course_count: int = 0
+    last_course_created_at: Optional[datetime] = None
+    last_course_updated_at: Optional[datetime] = None
+    first_published_at: Optional[datetime] = None
+    newest_course_uuid: Optional[str] = None
+    newest_course_name: Optional[str] = None
+    oldest_draft_course_uuid: Optional[str] = None
+    oldest_draft_course_name: Optional[str] = None
+
+    chapter_count: int = 0
+    last_chapter_created_at: Optional[datetime] = None
+
+    activity_count: int = 0
+    published_activity_count: int = 0
+    last_activity_created_at: Optional[datetime] = None
+
+    assignment_count: int = 0
+    assignment_submission_count: int = 0
+    last_assignment_created_at: Optional[datetime] = None
+
+    trailrun_count: int = 0
+    learner_count: int = 0
+    in_progress_trailrun_count: int = 0
+    completed_trailrun_count: int = 0
+    first_trailrun_at: Optional[datetime] = None
+    last_trailrun_updated_at: Optional[datetime] = None
+    first_completed_trailrun_at: Optional[datetime] = None
+
+    ai_credits_used: int = 0
+
+    last_admin_login_at: Optional[datetime] = None
+    last_activity_day: Optional[datetime] = None
+
+    admins: tuple[AdminRow, ...] = field(default_factory=tuple)
+
+    # Injected so a run can be replayed "as of" a past date, and so tests are
+    # not at the mercy of the wall clock.
+    now: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    # -- derived ----------------------------------------------------------
+
+    def age_days(self, moment: Optional[datetime]) -> Optional[float]:
+        """Days between ``moment`` and this snapshot's clock, or None."""
+        if moment is None:
+            return None
+        return (self.now - moment).total_seconds() / 86400.0
+
+    @property
+    def org_age_days(self) -> Optional[float]:
+        return self.age_days(self.created_at)
+
+    @property
+    def content_exists(self) -> bool:
+        return self.course_count > 0 or self.activity_count > 0
+
+    @property
+    def last_engagement(self) -> Optional[datetime]:
+        """When someone last *did* something here, or None if nobody ever has.
+
+        Deliberately excludes the org's own creation and update timestamps.
+        Creating an account is not engagement: counting it would mark every
+        brand-new org as active for its first few days, which is exactly the
+        window the activation emails exist to cover — they would never fire.
+
+        ``user_activity_day`` would be the ideal signal, but it is SaaS-gated
+        and only recently populated, and ``user.last_login_at`` is null for the
+        large majority of admins. So this is the newest of everything else we
+        hold, and it is legitimately None for an org where nothing happened.
+        """
+        candidates = [
+            self.last_activity_day,
+            self.last_admin_login_at,
+            self.last_course_updated_at,
+            self.last_course_created_at,
+            self.last_activity_created_at,
+            self.last_chapter_created_at,
+            self.last_trailrun_updated_at,
+            self.last_member_joined_at,
+        ]
+        known = [c for c in candidates if c is not None]
+        return max(known) if known else None
+
+    @property
+    def last_touch(self) -> Optional[datetime]:
+        """Newest signal of any kind, falling back to the org's own dates.
+
+        Always defined for a real org, which is what the dormancy track needs
+        to anchor against — including for organizations that predate any of
+        this instrumentation.
+        """
+        fallbacks = [t for t in (self.org_updated_at, self.created_at) if t is not None]
+        candidates = [t for t in (self.last_engagement, *fallbacks) if t is not None]
+        return max(candidates) if candidates else None
+
+    @property
+    def days_since_touch(self) -> Optional[float]:
+        return self.age_days(self.last_touch)
+
+    @property
+    def org_active(self) -> bool:
+        """True when someone has engaged with the org inside the active window.
+
+        An org that came back on its own does not get chased.
+        """
+        days = self.age_days(self.last_engagement)
+        return days is not None and days < ACTIVE_WINDOW_DAYS
+
+    @property
+    def mailable_admins(self) -> tuple[AdminRow, ...]:
+        """Admins we are permitted to email at all.
+
+        Unverified addresses are excluded everywhere: sending to unconfirmed
+        recipients is the fastest way to lose a sending domain's reputation,
+        and it takes the transactional mail down with it.
+        """
+        return tuple(
+            a for a in self.admins if a.email_verified and a.email and "@" in a.email
+        )
+
+
+def parse_ts(raw) -> Optional[datetime]:
+    """Coerce any stored timestamp shape into tz-aware UTC, or None.
+
+    The schema mixes real ``DateTime(timezone=True)`` columns with naive
+    ``str(datetime.now())`` strings, and aggregates over the latter come back
+    as strings. Both land here.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, datetime):
+        return raw if raw.tzinfo else raw.replace(tzinfo=timezone.utc)
+    return parse_creation_date(str(raw))

--- a/apps/api/src/services/nudges/tokens.py
+++ b/apps/api/src/services/nudges/tokens.py
@@ -1,0 +1,90 @@
+"""
+Stateless unsubscribe tokens for lifecycle email.
+
+A token carries the user's UUID and an HMAC over it, so rendering an
+unsubscribe link needs nothing but the user row already loaded — no token
+table, no extra query, no expiry to sweep.
+
+Trade-off, deliberate: the key is derived from the application's JWT secret, so
+rotating that secret invalidates every unsubscribe link already sitting in
+people's inboxes. The endpoint therefore treats an unverifiable token as
+"expired" and points the reader at their dashboard, rather than returning a
+bare 403 to someone who is legitimately trying to opt out.
+"""
+
+import base64
+import binascii
+import functools
+import hashlib
+import hmac
+from typing import Optional
+
+from config.config import get_learnhouse_config
+
+# Bumped if the token format ever changes, so old tokens fail closed rather
+# than being reinterpreted under new rules.
+_TOKEN_VERSION = "v1"
+
+# Categories are namespaced into the signature so a token minted for lifecycle
+# mail can never be replayed to opt someone out of a different category (or
+# vice versa) once more categories exist.
+CATEGORY_LIFECYCLE = "lifecycle"
+
+_SIGNATURE_LENGTH = 32
+
+
+@functools.lru_cache(maxsize=1)
+def _unsub_secret() -> bytes:
+    """Derive the unsubscribe signing key from the application's JWT secret.
+
+    Domain-separated from every other JWT-secret-derived credential (e.g. the
+    webhook Fernet key) so a token from one subsystem is meaningless in another.
+    """
+    secret = get_learnhouse_config().security_config.auth_jwt_secret_key
+    return hashlib.sha256(f"learnhouse.unsubscribe.{_TOKEN_VERSION}|".encode() + secret.encode()).digest()
+
+
+def _sign(user_uuid: str, category: str) -> str:
+    return hmac.new(
+        _unsub_secret(),
+        f"{category}:{user_uuid}".encode(),
+        hashlib.sha256,
+    ).hexdigest()[:_SIGNATURE_LENGTH]
+
+
+def make_unsubscribe_token(user_uuid: str, category: str = CATEGORY_LIFECYCLE) -> str:
+    """Mint an unsubscribe token for a user. Safe to embed in a URL."""
+    payload = base64.urlsafe_b64encode(user_uuid.encode()).decode().rstrip("=")
+    return f"{payload}.{_sign(user_uuid, category)}"
+
+
+def verify_unsubscribe_token(
+    token: str, category: str = CATEGORY_LIFECYCLE
+) -> Optional[str]:
+    """Return the user UUID a token attests to, or None if it doesn't verify.
+
+    Returns None rather than raising: every failure mode here (tampering, a
+    rotated secret, a mail client mangling the URL) lands on the same
+    user-facing outcome.
+    """
+    if not token or "." not in token:
+        return None
+
+    payload, _, signature = token.rpartition(".")
+    if not payload or not signature:
+        return None
+
+    # Restore the padding stripped at mint time.
+    padded = payload + "=" * (-len(payload) % 4)
+    try:
+        user_uuid = base64.urlsafe_b64decode(padded.encode()).decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError, ValueError):
+        return None
+
+    if not user_uuid:
+        return None
+
+    if not hmac.compare_digest(signature, _sign(user_uuid, category)):
+        return None
+
+    return user_uuid

--- a/apps/api/src/services/users/emails.py
+++ b/apps/api/src/services/users/emails.py
@@ -79,18 +79,39 @@ def _email_layout(
     body_content: str,
     footer_note: str = "",
     logo_html: str = LOGO_SVG,
+    unsubscribe_url: str = "",
+    unsubscribe_label: str = "Unsubscribe from these emails",
 ) -> str:
     """Wrap content in the standard email layout.
 
     ``logo_html`` defaults to the LearnHouse mark; white-labeled emails pass the
     org's logo <img> instead.
+
+    ``unsubscribe_url`` is set only by bulk lifecycle mail. Transactional email
+    (password reset, invitation, verification) leaves it empty and renders
+    byte-identically to before — you cannot unsubscribe from a password reset.
+    The link is deliberately legible rather than hidden: someone who wants out
+    and can't find the exit reports spam instead, which costs the sending domain
+    far more than the opt-out does.
     """
-    footer_html = ""
+    note_html = ""
     if footer_note:
+        note_html = f'\n            <p style="{STYLES["footer_text"]}">{footer_note}</p>'
+
+    unsub_html = ""
+    if unsubscribe_url:
+        unsub_html = (
+            f'\n            <p style="{STYLES["footer_text"]} margin-top: 12px;">'
+            f'<a href="{html.escape(unsubscribe_url)}" '
+            'style="color: rgba(0,0,0,0.35); text-decoration: underline;">'
+            f'{html.escape(unsubscribe_label)}</a></p>'
+        )
+
+    footer_html = ""
+    if note_html or unsub_html:
         footer_html = f"""
         <div style="{STYLES['footer']}">
-            <hr style="{STYLES['divider']}" />
-            <p style="{STYLES['footer_text']}">{footer_note}</p>
+            <hr style="{STYLES['divider']}" />{note_html}{unsub_html}
         </div>"""
 
     return f"""<!DOCTYPE html>
@@ -549,4 +570,78 @@ def send_email_verification_email(
             body_content=body_content,
             footer_note=t(lang, "email_verification.footer"),
         ),
+    )
+
+
+def send_nudge_email(
+    nudge_id: str,
+    email: EmailStr,
+    org_name: str,
+    cta_url: str,
+    unsubscribe_url: str,
+    lang: str = "en",
+    logo_url: str | None = None,
+    has_cta: bool = True,
+    **copy_vars,
+):
+    """Send one lifecycle nudge.
+
+    Generic over the catalog: the nudge id selects its copy from the
+    ``nudge.<id>.*`` namespace, so adding a nudge never means adding a function
+    here. ``copy_vars`` fills the placeholders that nudge's strings declare
+    (course name, plan name, and so on) — every value is escaped before it
+    reaches the template.
+
+    Unlike transactional mail this always carries an unsubscribe link and the
+    matching ``List-Unsubscribe`` headers. Gmail and Outlook expect them on
+    bulk mail, and without them a run at any real volume puts the sending
+    domain at risk.
+
+    Failures are swallowed via ``_send_notification_email``: a nudge nobody
+    asked for must never be the reason a batch job dies.
+    """
+    safe_org_name = html.escape(org_name)
+    raw_vars = {key: str(value) for key, value in copy_vars.items() if value is not None}
+    raw_vars.setdefault("org_name", org_name)
+    safe_vars = {key: html.escape(value) for key, value in raw_vars.items()}
+
+    heading = t(lang, f"nudge.{nudge_id}.heading", **safe_vars)
+    body_text = t(lang, f"nudge.{nudge_id}.body", **safe_vars)
+    # The subject is plain text, not HTML: escaping it would deliver
+    # "Maths &amp; Physics" to the inbox, and ampersands in course names are
+    # common enough that this is not an edge case.
+    subject = t(lang, f"nudge.{nudge_id}.subject", **raw_vars)
+
+    body_content = f"""
+        <h1 style="{STYLES['h1']}">{heading}</h1>
+        <p style="{STYLES['p']}">
+            {body_text}
+        </p>
+    """
+    if has_cta and cta_url:
+        cta = t(lang, f"nudge.{nudge_id}.cta", **safe_vars)
+        body_content += f"""
+        <a href="{html.escape(cta_url)}" style="{STYLES['button']}">
+            {cta}
+        </a>
+        <p style="{STYLES['link_text']}">{html.escape(cta_url)}</p>
+    """
+
+    return _send_notification_email(
+        to=email,
+        subject=subject,
+        body=_email_layout(
+            title=heading,
+            body_content=body_content,
+            footer_note=t(lang, "nudge.common.footer", org_name=safe_org_name),
+            logo_html=_org_logo_img(logo_url, org_name) if logo_url else LOGO_SVG,
+            unsubscribe_url=unsubscribe_url,
+            unsubscribe_label=t(lang, "nudge.common.unsubscribe"),
+        ),
+        headers={
+            "List-Unsubscribe": f"<{unsubscribe_url}>",
+            "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+        }
+        if unsubscribe_url
+        else None,
     )

--- a/apps/api/src/services/users/emails.py
+++ b/apps/api/src/services/users/emails.py
@@ -74,6 +74,92 @@ def _org_logo_img(logo_url: str, alt: str) -> str:
     )
 
 
+def _first_sentence(text: str, limit: int = 110) -> str:
+    """Opening sentence of a body string, for use as preheader text.
+
+    Handles the full stops of every locale we ship — the CJK ideographic
+    period, the Arabic and Devanagari terminators — then falls back to a word
+    boundary. Inbox previews are cut around 100 characters anyway.
+    """
+    if not text:
+        return ""
+
+    for terminator in ("。", "۔", "।", ". ", "! ", "? ", "؟ "):
+        head, sep, _tail = text.partition(terminator)
+        if sep and len(head) <= limit:
+            return (head + sep).strip()
+
+    if len(text) <= limit:
+        return text.strip()
+    return text[:limit].rsplit(" ", 1)[0].strip() + "…"
+
+
+def _reply_to_address() -> str:
+    """Where a reply to a lifecycle email should land, or "" if unconfigured."""
+    try:
+        from config.config import get_learnhouse_config
+
+        return (get_learnhouse_config().contact_email or "").strip()
+    except Exception:  # pragma: no cover - config is always present in practice
+        return ""
+
+
+def _stat_strip(stats: list[tuple[str, int]]) -> str:
+    """A row of label/value pairs, e.g. "LESSONS 8   LEARNERS 0".
+
+    Deliberately not prose. Writing "8 lessons" into copy means solving plural
+    agreement in twenty languages — Russian has three forms, Arabic six — and
+    without an ICU library the result is "1 lessons" in production. A label
+    beside a bare figure needs no agreement in any of them, and it reads faster
+    than a sentence anyway.
+    """
+    if not stats:
+        return ""
+
+    cells = []
+    for label, value in stats:
+        cells.append(
+            '<td style="padding: 0 14px; text-align: center;">'
+            '<div style="font-size: 22px; font-weight: 900; color: #000000; '
+            f'line-height: 1.2;">{value}</div>'
+            '<div style="font-size: 10px; font-weight: 700; letter-spacing: 0.08em; '
+            'text-transform: uppercase; color: rgba(0,0,0,0.35); margin-top: 2px;">'
+            f"{html.escape(label)}</div>"
+            "</td>"
+        )
+
+    return (
+        '<table role="presentation" cellpadding="0" cellspacing="0" border="0" '
+        'align="center" style="margin: 0 auto 24px auto; border-collapse: collapse;">'
+        f"<tr>{''.join(cells)}</tr>"
+        "</table>"
+    )
+
+
+def _preheader_block(text: str) -> str:
+    """The grey line an inbox list shows after the subject.
+
+    Without one, clients scrape the first visible text — which here is the
+    heading, so the list entry reads as the subject said twice. Setting it
+    explicitly buys a second line of information in the only place a reader
+    looks before deciding to open.
+
+    The zero-width padding after the text stops the client continuing into the
+    body copy once the preheader runs out.
+    """
+    if not text:
+        return ""
+    padding = "&#847;&zwnj;&nbsp;" * 60
+    hide = (
+        "display:none;max-height:0;overflow:hidden;mso-hide:all;"
+        "font-size:1px;line-height:1px;color:#ffffff;opacity:0;"
+    )
+    return (
+        f'<div style="{hide}">{html.escape(text)}</div>'
+        f'<div style="{hide}">{padding}</div>'
+    )
+
+
 def _email_layout(
     title: str,
     body_content: str,
@@ -81,6 +167,7 @@ def _email_layout(
     logo_html: str = LOGO_SVG,
     unsubscribe_url: str = "",
     unsubscribe_label: str = "Unsubscribe from these emails",
+    preheader: str = "",
 ) -> str:
     """Wrap content in the standard email layout.
 
@@ -114,10 +201,16 @@ def _email_layout(
             <hr style="{STYLES['divider']}" />{note_html}{unsub_html}
         </div>"""
 
+    # Prefixed with its own newline so that an absent preheader leaves the
+    # document byte-identical to before — the twelve transactional emails
+    # share this layout and none of their output may shift.
+    block = _preheader_block(preheader)
+    preheader_html = f"\n    {block}" if block else ""
+
     return f"""<!DOCTYPE html>
 <html>
 <head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
-<body style="{STYLES['body']}">
+<body style="{STYLES['body']}">{preheader_html}
     <div style="{STYLES['wrapper']}">
         <div style="{STYLES['container']}">
             <div style="{STYLES['header']}">
@@ -582,6 +675,8 @@ def send_nudge_email(
     lang: str = "en",
     logo_url: str | None = None,
     has_cta: bool = True,
+    track: str = "",
+    stats: list[tuple[str, int]] | None = None,
     **copy_vars,
 ):
     """Send one lifecycle nudge.
@@ -591,6 +686,11 @@ def send_nudge_email(
     here. ``copy_vars`` fills the placeholders that nudge's strings declare
     (course name, plan name, and so on) — every value is escaped before it
     reaches the template.
+
+    ``track`` selects the illustration. It is drawn as a table mosaic rather
+    than an image because Gmail strips inline SVG and both Gmail and Outlook
+    block ``data:`` URIs, so an embedded picture would render as a blank gap
+    for a large share of readers.
 
     Unlike transactional mail this always carries an unsubscribe link and the
     matching ``List-Unsubscribe`` headers. Gmail and Outlook expect them on
@@ -612,12 +712,19 @@ def send_nudge_email(
     # common enough that this is not an edge case.
     subject = t(lang, f"nudge.{nudge_id}.subject", **raw_vars)
 
+    from src.services.nudges.illustrations import render_illustration
+
+    stat_html = _stat_strip(
+        [(t(lang, f"nudge.stat.{key}"), value) for key, value in (stats or [])]
+    )
+
     body_content = f"""
+        {render_illustration(track)}
         <h1 style="{STYLES['h1']}">{heading}</h1>
         <p style="{STYLES['p']}">
             {body_text}
         </p>
-    """
+        {stat_html}"""
     if has_cta and cta_url:
         cta = t(lang, f"nudge.{nudge_id}.cta", **safe_vars)
         body_content += f"""
@@ -626,6 +733,22 @@ def send_nudge_email(
         </a>
         <p style="{STYLES['link_text']}">{html.escape(cta_url)}</p>
     """
+
+    # The preheader is the body's opening sentence rather than a thirty-first
+    # set of translated strings. It is already localised, and it gives the
+    # inbox list a second line of information instead of echoing the subject.
+    preheader = _first_sentence(t(lang, f"nudge.{nudge_id}.body", **raw_vars))
+
+    headers: dict[str, str] = {}
+    if unsubscribe_url:
+        headers["List-Unsubscribe"] = f"<{unsubscribe_url}>"
+        headers["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
+
+    # Several nudges invite a reply. Without this they would arrive from the
+    # no-reply sender and the invitation would be a lie.
+    reply_to = _reply_to_address()
+    if reply_to:
+        headers["Reply-To"] = reply_to
 
     return _send_notification_email(
         to=email,
@@ -637,11 +760,7 @@ def send_nudge_email(
             logo_html=_org_logo_img(logo_url, org_name) if logo_url else LOGO_SVG,
             unsubscribe_url=unsubscribe_url,
             unsubscribe_label=t(lang, "nudge.common.unsubscribe"),
+            preheader=preheader,
         ),
-        headers={
-            "List-Unsubscribe": f"<{unsubscribe_url}>",
-            "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
-        }
-        if unsubscribe_url
-        else None,
+        headers=headers or None,
     )

--- a/apps/api/src/tests/routers/test_nudges_router.py
+++ b/apps/api/src/tests/routers/test_nudges_router.py
@@ -166,6 +166,32 @@ class TestDeletedUser:
         assert "expired" in response.text.lower()
 
 
+def _svix_sign(payload: str, secret: str, msg_id: str = "msg_1", ts: int | None = None):
+    """Produce the headers Resend would send.
+
+    Mirrors the scheme `resend.Webhooks.verify` checks: HMAC-SHA256 over
+    "{id}.{timestamp}.{payload}" keyed by the base64-decoded signing secret.
+    """
+    import base64
+    import hashlib
+    import hmac
+    import time
+
+    ts = ts if ts is not None else int(time.time())
+    key = base64.b64decode(secret.removeprefix("whsec_"))
+    signed = f"{msg_id}.{ts}.{payload}".encode()
+    sig = base64.b64encode(hmac.new(key, signed, hashlib.sha256).digest()).decode()
+    return {
+        "svix-id": msg_id,
+        "svix-timestamp": str(ts),
+        "svix-signature": f"v1,{sig}",
+        "content-type": "application/json",
+    }
+
+
+SIGNING_SECRET = "whsec_" + __import__("base64").b64encode(b"test-signing-key").decode()
+
+
 class TestDeliveryEvents:
     """The provider callback that stops us mailing dead or hostile addresses."""
 
@@ -175,7 +201,7 @@ class TestDeliveryEvents:
 
         from src.routers.nudges import internal_router
 
-        monkeypatch.setenv("LEARNHOUSE_EMAIL_WEBHOOK_SECRET", "s3cret")
+        monkeypatch.setenv("LEARNHOUSE_RESEND_WEBHOOK_SECRET", SIGNING_SECRET)
         app = FastAPI()
         app.include_router(internal_router, prefix="/api/v1/internal/emails")
         app.dependency_overrides[get_db_session] = lambda: db
@@ -198,61 +224,114 @@ class TestDeliveryEvents:
             )
         ).scalars().first()
 
-    async def test_hard_bounce_suppresses(self, wclient, db, admin_user):
-        r = await wclient.post(
+    async def _post(self, wclient, body: dict, **sign_kwargs):
+        import json as _json
+
+        payload = _json.dumps(body)
+        return await wclient.post(
             "/api/v1/internal/emails/delivery-events",
-            headers={"x-webhook-secret": "s3cret"},
-            json={
+            headers=_svix_sign(payload, SIGNING_SECRET, **sign_kwargs),
+            content=payload,
+        )
+
+    async def test_permanent_bounce_suppresses(self, wclient, db, admin_user):
+        """Resend says "Permanent", not "hard" — getting this wrong means the
+        endpoint silently discards every real bounce."""
+        r = await self._post(
+            wclient,
+            {
                 "type": "email.bounced",
-                "data": {"to": [admin_user.email], "bounce": {"type": "hard"}},
+                "data": {
+                    "to": [admin_user.email],
+                    "bounce": {"type": "Permanent", "subType": "General", "message": "no such user"},
+                },
             },
         )
-        assert r.status_code == 200
+        assert r.status_code == 200, r.text
         assert r.json()["suppressed"] == 1
         assert (await self._prefs(db, admin_user.id)).suppressed is True
 
-    async def test_soft_bounce_does_not_suppress(self, wclient, db, admin_user):
-        """A full mailbox is temporary; the address is still good."""
-        r = await wclient.post(
-            "/api/v1/internal/emails/delivery-events",
-            headers={"x-webhook-secret": "s3cret"},
-            json={
+    async def test_temporary_bounce_does_not_suppress(self, wclient, db, admin_user):
+        """A full mailbox is not a dead address."""
+        r = await self._post(
+            wclient,
+            {
                 "type": "email.bounced",
-                "data": {"to": [admin_user.email], "bounce": {"type": "soft"}},
+                "data": {"to": [admin_user.email], "bounce": {"type": "Temporary"}},
             },
         )
-        assert r.json()["reason"] == "soft bounce"
+        assert r.status_code == 200
+        assert "non-permanent" in r.json()["reason"]
+        assert await self._prefs(db, admin_user.id) is None
+
+    async def test_bounce_without_a_type_is_not_suppressed(self, wclient, db, admin_user):
+        """Unknown shape: leave the address alone rather than guess."""
+        await self._post(
+            wclient, {"type": "email.bounced", "data": {"to": [admin_user.email]}}
+        )
         assert await self._prefs(db, admin_user.id) is None
 
     async def test_complaint_suppresses(self, wclient, db, admin_user):
-        r = await wclient.post(
-            "/api/v1/internal/emails/delivery-events",
-            headers={"x-webhook-secret": "s3cret"},
-            json={"type": "email.complained", "data": {"to": admin_user.email}},
+        r = await self._post(
+            wclient, {"type": "email.complained", "data": {"to": admin_user.email}}
         )
         assert r.json()["reason"] == "complaint"
         pref = await self._prefs(db, admin_user.id)
         assert pref.suppressed is True and pref.suppressed_reason == "complaint"
 
+    async def test_provider_suppression_is_mirrored(self, wclient, db, admin_user):
+        r = await self._post(
+            wclient, {"type": "email.suppressed", "data": {"to": [admin_user.email]}}
+        )
+        assert r.json()["suppressed"] == 1
+
     async def test_unhandled_event_is_ignored(self, wclient, db, admin_user):
-        r = await wclient.post(
-            "/api/v1/internal/emails/delivery-events",
-            headers={"x-webhook-secret": "s3cret"},
-            json={"type": "email.delivered", "data": {"to": admin_user.email}},
+        r = await self._post(
+            wclient, {"type": "email.delivered", "data": {"to": admin_user.email}}
         )
         assert r.json()["reason"] == "unhandled event"
         assert await self._prefs(db, admin_user.id) is None
 
-    async def test_wrong_secret_is_rejected(self, wclient, db, admin_user):
+    async def test_a_forged_signature_is_rejected(self, wclient, db, admin_user):
+        import json as _json
+
+        payload = _json.dumps(
+            {"type": "email.complained", "data": {"to": admin_user.email}}
+        )
+        headers = _svix_sign(payload, SIGNING_SECRET)
+        headers["svix-signature"] = "v1,Zm9yZ2Vk"
         r = await wclient.post(
-            "/api/v1/internal/emails/delivery-events",
-            headers={"x-webhook-secret": "wrong"},
-            json={"type": "email.complained", "data": {"to": admin_user.email}},
+            "/api/v1/internal/emails/delivery-events", headers=headers, content=payload
         )
         assert r.status_code == 403
         assert await self._prefs(db, admin_user.id) is None
 
-    async def test_missing_secret_is_rejected(self, wclient, db, admin_user):
+    async def test_a_tampered_body_is_rejected(self, wclient, db, admin_user):
+        """The signature covers the body, so editing it after signing fails."""
+        import json as _json
+
+        signed = _json.dumps({"type": "email.delivered", "data": {"to": "x@y.z"}})
+        headers = _svix_sign(signed, SIGNING_SECRET)
+        tampered = _json.dumps(
+            {"type": "email.complained", "data": {"to": admin_user.email}}
+        )
+        r = await wclient.post(
+            "/api/v1/internal/emails/delivery-events", headers=headers, content=tampered
+        )
+        assert r.status_code == 403
+
+    async def test_a_stale_timestamp_is_rejected(self, wclient, db, admin_user):
+        """Replay protection: an old capture cannot be resent."""
+        import time
+
+        r = await self._post(
+            wclient,
+            {"type": "email.complained", "data": {"to": admin_user.email}},
+            ts=int(time.time()) - 60 * 60 * 24,
+        )
+        assert r.status_code == 403
+
+    async def test_missing_svix_headers_are_rejected(self, wclient, admin_user):
         r = await wclient.post(
             "/api/v1/internal/emails/delivery-events",
             json={"type": "email.complained", "data": {"to": admin_user.email}},
@@ -262,36 +341,15 @@ class TestDeliveryEvents:
     async def test_unset_secret_fails_closed(self, wclient, db, admin_user, monkeypatch):
         """An unauthenticated endpoint that suppresses addresses would be a
         denial of service on your own mail."""
-        monkeypatch.delenv("LEARNHOUSE_EMAIL_WEBHOOK_SECRET", raising=False)
-        r = await wclient.post(
-            "/api/v1/internal/emails/delivery-events",
-            headers={"x-webhook-secret": ""},
-            json={"type": "email.complained", "data": {"to": admin_user.email}},
+        monkeypatch.delenv("LEARNHOUSE_RESEND_WEBHOOK_SECRET", raising=False)
+        r = await self._post(
+            wclient, {"type": "email.complained", "data": {"to": admin_user.email}}
         )
         assert r.status_code == 403
 
-    async def test_unparseable_payload_is_ignored(self, wclient):
-        r = await wclient.post(
-            "/api/v1/internal/emails/delivery-events",
-            headers={"x-webhook-secret": "s3cret", "content-type": "application/json"},
-            content=b"not json",
-        )
-        assert r.status_code == 200
-        assert r.json()["status"] == "ignored"
-
     async def test_unknown_address_is_handled(self, wclient):
-        r = await wclient.post(
-            "/api/v1/internal/emails/delivery-events",
-            headers={"x-webhook-secret": "s3cret"},
-            json={"type": "email.complained", "data": {"to": "ghost@nowhere.test"}},
+        r = await self._post(
+            wclient, {"type": "email.complained", "data": {"to": "ghost@nowhere.test"}}
         )
         assert r.status_code == 200
         assert r.json()["suppressed"] == 0
-
-    async def test_bounce_without_a_type_is_treated_as_hard(self, wclient, db, admin_user):
-        r = await wclient.post(
-            "/api/v1/internal/emails/delivery-events",
-            headers={"x-webhook-secret": "s3cret"},
-            json={"type": "email.bounced", "data": {"to": [admin_user.email]}},
-        )
-        assert r.json()["suppressed"] == 1

--- a/apps/api/src/tests/routers/test_nudges_router.py
+++ b/apps/api/src/tests/routers/test_nudges_router.py
@@ -140,3 +140,27 @@ class TestRouterMounting:
         token is the only authorisation these routes get."""
         for route in public_router.routes:
             assert route.dependencies == [], route.path
+
+
+class TestDeletedUser:
+    async def test_token_for_a_deleted_user_shows_the_expired_page(
+        self, client, db, admin_user
+    ):
+        """The token stays valid forever by design, so it outlives the account
+        it names. That must not 500."""
+        from sqlmodel import delete
+
+        from src.db.nudges import EmailPreference
+        from src.db.users import User
+
+        token = make_unsubscribe_token(admin_user.user_uuid)
+        await db.execute(delete(EmailPreference).where(EmailPreference.user_id == admin_user.id))
+        await db.execute(delete(User).where(User.id == admin_user.id))
+        await db.commit()
+
+        response = await client.post(
+            "/api/v1/emails/unsubscribe", data={"token": token}
+        )
+
+        assert response.status_code == 200
+        assert "expired" in response.text.lower()

--- a/apps/api/src/tests/routers/test_nudges_router.py
+++ b/apps/api/src/tests/routers/test_nudges_router.py
@@ -164,3 +164,134 @@ class TestDeletedUser:
 
         assert response.status_code == 200
         assert "expired" in response.text.lower()
+
+
+class TestDeliveryEvents:
+    """The provider callback that stops us mailing dead or hostile addresses."""
+
+    @pytest.fixture
+    def app_with_internal(self, db, monkeypatch):
+        from fastapi import FastAPI
+
+        from src.routers.nudges import internal_router
+
+        monkeypatch.setenv("LEARNHOUSE_EMAIL_WEBHOOK_SECRET", "s3cret")
+        app = FastAPI()
+        app.include_router(internal_router, prefix="/api/v1/internal/emails")
+        app.dependency_overrides[get_db_session] = lambda: db
+        yield app
+        app.dependency_overrides.clear()
+
+    @pytest.fixture
+    async def wclient(self, app_with_internal):
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_internal), base_url="http://test"
+        ) as c:
+            yield c
+
+    async def _prefs(self, db, user_id):
+        from src.db.nudges import EmailPreference
+
+        return (
+            await db.execute(
+                select(EmailPreference).where(EmailPreference.user_id == user_id)
+            )
+        ).scalars().first()
+
+    async def test_hard_bounce_suppresses(self, wclient, db, admin_user):
+        r = await wclient.post(
+            "/api/v1/internal/emails/delivery-events",
+            headers={"x-webhook-secret": "s3cret"},
+            json={
+                "type": "email.bounced",
+                "data": {"to": [admin_user.email], "bounce": {"type": "hard"}},
+            },
+        )
+        assert r.status_code == 200
+        assert r.json()["suppressed"] == 1
+        assert (await self._prefs(db, admin_user.id)).suppressed is True
+
+    async def test_soft_bounce_does_not_suppress(self, wclient, db, admin_user):
+        """A full mailbox is temporary; the address is still good."""
+        r = await wclient.post(
+            "/api/v1/internal/emails/delivery-events",
+            headers={"x-webhook-secret": "s3cret"},
+            json={
+                "type": "email.bounced",
+                "data": {"to": [admin_user.email], "bounce": {"type": "soft"}},
+            },
+        )
+        assert r.json()["reason"] == "soft bounce"
+        assert await self._prefs(db, admin_user.id) is None
+
+    async def test_complaint_suppresses(self, wclient, db, admin_user):
+        r = await wclient.post(
+            "/api/v1/internal/emails/delivery-events",
+            headers={"x-webhook-secret": "s3cret"},
+            json={"type": "email.complained", "data": {"to": admin_user.email}},
+        )
+        assert r.json()["reason"] == "complaint"
+        pref = await self._prefs(db, admin_user.id)
+        assert pref.suppressed is True and pref.suppressed_reason == "complaint"
+
+    async def test_unhandled_event_is_ignored(self, wclient, db, admin_user):
+        r = await wclient.post(
+            "/api/v1/internal/emails/delivery-events",
+            headers={"x-webhook-secret": "s3cret"},
+            json={"type": "email.delivered", "data": {"to": admin_user.email}},
+        )
+        assert r.json()["reason"] == "unhandled event"
+        assert await self._prefs(db, admin_user.id) is None
+
+    async def test_wrong_secret_is_rejected(self, wclient, db, admin_user):
+        r = await wclient.post(
+            "/api/v1/internal/emails/delivery-events",
+            headers={"x-webhook-secret": "wrong"},
+            json={"type": "email.complained", "data": {"to": admin_user.email}},
+        )
+        assert r.status_code == 403
+        assert await self._prefs(db, admin_user.id) is None
+
+    async def test_missing_secret_is_rejected(self, wclient, db, admin_user):
+        r = await wclient.post(
+            "/api/v1/internal/emails/delivery-events",
+            json={"type": "email.complained", "data": {"to": admin_user.email}},
+        )
+        assert r.status_code == 403
+
+    async def test_unset_secret_fails_closed(self, wclient, db, admin_user, monkeypatch):
+        """An unauthenticated endpoint that suppresses addresses would be a
+        denial of service on your own mail."""
+        monkeypatch.delenv("LEARNHOUSE_EMAIL_WEBHOOK_SECRET", raising=False)
+        r = await wclient.post(
+            "/api/v1/internal/emails/delivery-events",
+            headers={"x-webhook-secret": ""},
+            json={"type": "email.complained", "data": {"to": admin_user.email}},
+        )
+        assert r.status_code == 403
+
+    async def test_unparseable_payload_is_ignored(self, wclient):
+        r = await wclient.post(
+            "/api/v1/internal/emails/delivery-events",
+            headers={"x-webhook-secret": "s3cret", "content-type": "application/json"},
+            content=b"not json",
+        )
+        assert r.status_code == 200
+        assert r.json()["status"] == "ignored"
+
+    async def test_unknown_address_is_handled(self, wclient):
+        r = await wclient.post(
+            "/api/v1/internal/emails/delivery-events",
+            headers={"x-webhook-secret": "s3cret"},
+            json={"type": "email.complained", "data": {"to": "ghost@nowhere.test"}},
+        )
+        assert r.status_code == 200
+        assert r.json()["suppressed"] == 0
+
+    async def test_bounce_without_a_type_is_treated_as_hard(self, wclient, db, admin_user):
+        r = await wclient.post(
+            "/api/v1/internal/emails/delivery-events",
+            headers={"x-webhook-secret": "s3cret"},
+            json={"type": "email.bounced", "data": {"to": [admin_user.email]}},
+        )
+        assert r.json()["suppressed"] == 1

--- a/apps/api/src/tests/routers/test_nudges_router.py
+++ b/apps/api/src/tests/routers/test_nudges_router.py
@@ -1,0 +1,142 @@
+"""Router tests for src/routers/nudges.py (public unsubscribe)."""
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlmodel import select
+
+from src.core.events.database import get_db_session
+from src.db.nudges import EmailPreference
+from src.routers.nudges import public_router
+from src.services.nudges.tokens import make_unsubscribe_token
+
+
+@pytest.fixture
+def app(db):
+    app = FastAPI()
+    app.include_router(public_router, prefix="/api/v1/emails")
+    app.dependency_overrides[get_db_session] = lambda: db
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def client(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+async def _prefs(db, user_id: int):
+    return (
+        await db.execute(
+            select(EmailPreference).where(EmailPreference.user_id == user_id)
+        )
+    ).scalars().first()
+
+
+class TestUnsubscribeGet:
+    async def test_get_renders_a_confirmation_page(self, client, db, admin_user):
+        token = make_unsubscribe_token(admin_user.user_uuid)
+        response = await client.get(f"/api/v1/emails/unsubscribe?token={token}")
+
+        assert response.status_code == 200
+        assert "Confirm unsubscribe" in response.text
+        assert admin_user.email in response.text
+
+    async def test_get_has_no_side_effect(self, client, db, admin_user):
+        """Link scanners prefetch every href; a mutating GET would opt people
+        out who never clicked anything."""
+        token = make_unsubscribe_token(admin_user.user_uuid)
+        await client.get(f"/api/v1/emails/unsubscribe?token={token}")
+
+        assert await _prefs(db, admin_user.id) is None
+
+    async def test_get_with_bad_token_shows_the_expired_page(self, client, db):
+        response = await client.get("/api/v1/emails/unsubscribe?token=garbage.abc")
+
+        assert response.status_code == 200
+        assert "expired" in response.text.lower()
+
+    async def test_get_for_unknown_user_shows_the_expired_page(self, client, db):
+        # Signature verifies, but no such user — must not 500.
+        token = make_unsubscribe_token("user_does_not_exist")
+        response = await client.get(f"/api/v1/emails/unsubscribe?token={token}")
+
+        assert response.status_code == 200
+        assert "expired" in response.text.lower()
+
+    async def test_get_without_a_token_is_a_validation_error(self, client):
+        response = await client.get("/api/v1/emails/unsubscribe")
+        assert response.status_code == 422
+
+
+class TestUnsubscribePost:
+    async def test_post_records_the_opt_out(self, client, db, admin_user):
+        token = make_unsubscribe_token(admin_user.user_uuid)
+        response = await client.post(
+            "/api/v1/emails/unsubscribe", data={"token": token}
+        )
+
+        assert response.status_code == 200
+        assert "unsubscribed" in response.text.lower()
+
+        pref = await _prefs(db, admin_user.id)
+        assert pref is not None
+        assert pref.lifecycle_opt_out is True
+        assert pref.unsubscribed_at is not None
+        assert pref.source == "email_link"
+
+    async def test_post_is_idempotent(self, client, db, admin_user):
+        """One-click unsubscribe gets retried by providers, and people
+        double-click. The second call must not error or move the timestamp."""
+        token = make_unsubscribe_token(admin_user.user_uuid)
+        await client.post("/api/v1/emails/unsubscribe", data={"token": token})
+        first = await _prefs(db, admin_user.id)
+        first_stamp = first.unsubscribed_at
+
+        response = await client.post(
+            "/api/v1/emails/unsubscribe", data={"token": token}
+        )
+        assert response.status_code == 200
+
+        await db.refresh(first)
+        assert first.lifecycle_opt_out is True
+        assert first.unsubscribed_at == first_stamp
+
+    async def test_post_accepts_the_token_in_the_query_string(self, client, db, admin_user):
+        """RFC 8058 one-click posts without a form body."""
+        token = make_unsubscribe_token(admin_user.user_uuid)
+        response = await client.post(f"/api/v1/emails/unsubscribe?token={token}")
+
+        assert response.status_code == 200
+        pref = await _prefs(db, admin_user.id)
+        assert pref is not None and pref.lifecycle_opt_out is True
+
+    async def test_post_with_a_tampered_token_changes_nothing(self, client, db, admin_user):
+        token = make_unsubscribe_token(admin_user.user_uuid)
+        payload, _, signature = token.rpartition(".")
+        forged = f"{payload}.{'0' * len(signature)}"
+
+        response = await client.post(
+            "/api/v1/emails/unsubscribe", data={"token": forged}
+        )
+
+        assert response.status_code == 200
+        assert "expired" in response.text.lower()
+        assert await _prefs(db, admin_user.id) is None
+
+    async def test_post_without_a_token_shows_the_expired_page(self, client, db):
+        response = await client.post("/api/v1/emails/unsubscribe")
+
+        assert response.status_code == 200
+        assert "expired" in response.text.lower()
+
+
+class TestRouterMounting:
+    def test_unsubscribe_routes_carry_no_auth_dependency(self):
+        """The recipient of a nudge may have no session at all — the HMAC
+        token is the only authorisation these routes get."""
+        for route in public_router.routes:
+            assert route.dependencies == [], route.path

--- a/apps/api/src/tests/services/test_email_unsubscribe_support.py
+++ b/apps/api/src/tests/services/test_email_unsubscribe_support.py
@@ -1,0 +1,273 @@
+"""Tests for the bulk-email support added to the shared email plumbing.
+
+Covers `_email_layout(unsubscribe_url=...)` and `send_email(headers=...)`.
+The regression guard matters most: twelve transactional emails share this
+layout, and none of their output may shift.
+"""
+
+from src.services.users.emails import _email_layout
+
+
+class TestLayoutRegression:
+    def test_no_unsubscribe_url_renders_identically_to_before(self):
+        """The pre-existing footer HTML, byte for byte.
+
+        Pinned as a literal rather than compared against another call of the
+        same function, so a refactor that changes both paths at once still
+        fails here.
+        """
+        html = _email_layout("Title", "<p>body</p>", footer_note="A note")
+        assert (
+            '<hr style="margin: 28px 0; border: none; border-top: 1px solid #f0f0f0;" />\n'
+            '            <p style="margin: 0; font-size: 12px; color: rgba(0,0,0,0.2); '
+            'font-weight: 500; line-height: 1.6;">A note</p>'
+        ) in html
+        assert "unsubscribe" not in html.lower()
+
+    def test_no_footer_note_and_no_unsubscribe_renders_no_footer_block(self):
+        html = _email_layout("Title", "<p>body</p>")
+        assert "<hr" not in html
+        assert "unsubscribe" not in html.lower()
+
+
+class TestUnsubscribeFooter:
+    def test_unsubscribe_url_renders_a_link(self):
+        html = _email_layout(
+            "Title",
+            "<p>body</p>",
+            unsubscribe_url="https://app.test/api/v1/emails/unsubscribe?token=abc.def",
+        )
+        assert 'href="https://app.test/api/v1/emails/unsubscribe?token=abc.def"' in html
+        assert "Unsubscribe from these emails" in html
+
+    def test_unsubscribe_renders_without_a_footer_note(self):
+        # The footer <div> is gated on either piece being present; an
+        # unsubscribe-only footer must still produce the divider.
+        html = _email_layout(
+            "Title", "<p>body</p>", unsubscribe_url="https://app.test/u?token=x"
+        )
+        assert "<hr" in html
+
+    def test_note_and_unsubscribe_both_render(self):
+        html = _email_layout(
+            "Title",
+            "<p>body</p>",
+            footer_note="Because you're an admin.",
+            unsubscribe_url="https://app.test/u?token=x",
+        )
+        assert "Because you&#x27;re an admin." in html or "Because you're an admin." in html
+        assert "https://app.test/u?token=x" in html
+
+    def test_url_and_label_are_escaped(self):
+        html = _email_layout(
+            "Title",
+            "<p>body</p>",
+            unsubscribe_url='https://app.test/u?t=x"><script>alert(1)</script>',
+            unsubscribe_label="<b>Stop</b>",
+        )
+        assert "<script>" not in html
+        assert "<b>Stop</b>" not in html
+        assert "&lt;b&gt;Stop&lt;/b&gt;" in html
+
+    def test_label_is_translatable(self):
+        html = _email_layout(
+            "Title",
+            "<p>body</p>",
+            unsubscribe_url="https://app.test/u?token=x",
+            unsubscribe_label="Se désabonner de ces e-mails",
+        )
+        assert "Se désabonner de ces e-mails" in html
+
+
+class TestSendEmailHeaders:
+    def test_headers_reach_the_resend_payload(self, monkeypatch):
+        from src.services.email import utils as email_utils
+
+        captured = {}
+
+        def fake_send(payload):
+            captured.update(payload)
+            return {"id": "sent"}
+
+        monkeypatch.setattr(email_utils.resend.Emails, "send", staticmethod(fake_send))
+        email_utils._send_email_resend(
+            "LearnHouse <no-reply@test>",
+            "user@test.com",
+            "hi",
+            "<p>hi</p>",
+            _mailing(),
+            {"List-Unsubscribe": "<https://app.test/u>"},
+        )
+        assert captured["headers"] == {"List-Unsubscribe": "<https://app.test/u>"}
+
+    def test_no_headers_leaves_the_payload_unchanged(self, monkeypatch):
+        from src.services.email import utils as email_utils
+
+        captured = {}
+
+        def fake_send(payload):
+            captured.update(payload)
+            return {"id": "sent"}
+
+        monkeypatch.setattr(email_utils.resend.Emails, "send", staticmethod(fake_send))
+        email_utils._send_email_resend(
+            "LearnHouse <no-reply@test>", "user@test.com", "hi", "<p>hi</p>", _mailing()
+        )
+        assert "headers" not in captured
+
+    def test_headers_reach_the_smtp_message(self, monkeypatch):
+        from src.services.email import utils as email_utils
+
+        sent = {}
+
+        class FakeSMTP:
+            def __init__(self, *a, **kw):
+                pass
+
+            def starttls(self):
+                pass
+
+            def login(self, *a):
+                pass
+
+            def sendmail(self, _from, _to, message):
+                sent["message"] = message
+
+            def quit(self):
+                pass
+
+        monkeypatch.setattr(email_utils.smtplib, "SMTP", FakeSMTP)
+        email_utils._send_email_smtp(
+            "LearnHouse <no-reply@test>",
+            "user@test.com",
+            "hi",
+            "<p>hi</p>",
+            _mailing(provider="smtp"),
+            {
+                "List-Unsubscribe": "<https://app.test/u>",
+                "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+            },
+        )
+        assert "List-Unsubscribe: <https://app.test/u>" in sent["message"]
+        assert "List-Unsubscribe-Post: List-Unsubscribe=One-Click" in sent["message"]
+
+    def test_send_email_forwards_headers_to_the_provider(self, monkeypatch):
+        from src.services.email import utils as email_utils
+
+        captured = {}
+
+        def fake_resend(sender, to, subject, body, mailing, headers=None):
+            captured["headers"] = headers
+            return {"id": "sent"}
+
+        monkeypatch.setattr(email_utils, "_send_email_resend", fake_resend)
+        email_utils.send_email(
+            "user@test.com", "hi", "<p>hi</p>", headers={"List-Unsubscribe": "<x>"}
+        )
+        assert captured["headers"] == {"List-Unsubscribe": "<x>"}
+
+
+def _mailing(provider: str = "resend"):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        email_provider=provider,
+        system_email_address="no-reply@test",
+        resend_api_key="test-key",
+        smtp_host="localhost",
+        smtp_port=25,
+        smtp_username="",
+        smtp_password="",
+        smtp_use_tls=False,
+    )
+
+
+class TestNudgeRendering:
+    """`send_nudge_email` is the generic renderer for the whole catalog."""
+
+    def _send(self, **overrides):
+        from unittest.mock import patch
+
+        from src.services.users.emails import send_nudge_email
+
+        kwargs = dict(
+            nudge_id="content.course_draft_d3",
+            email="admin@test.com",
+            org_name="Maths & Physics",
+            cta_url="https://acme.test/dash/courses/course/abc/general",
+            unsubscribe_url="https://api.test/api/v1/emails/unsubscribe?token=t.s",
+            lang="en",
+            course_name="Intro & Basics",
+            plan_name="free",
+            next_plan="personal",
+        )
+        kwargs.update(overrides)
+
+        captured = {}
+        with patch(
+            "src.services.users.emails.send_email",
+            side_effect=lambda **k: captured.update(k) or {"id": "sent"},
+        ):
+            send_nudge_email(**kwargs)
+        return captured
+
+    def test_subject_is_plain_text_not_html(self):
+        """Subjects are not rendered as HTML, so escaping them delivers
+        "Maths &amp; Physics" to the inbox."""
+        captured = self._send()
+        assert "&amp;" not in captured["subject"]
+        assert "Intro & Basics" in captured["subject"]
+
+    def test_body_escapes_interpolated_values(self):
+        captured = self._send(course_name="<script>alert(1)</script>")
+        assert "<script>" not in captured["body"]
+        assert "&lt;script&gt;" in captured["body"]
+
+    def test_body_escapes_the_org_name(self):
+        captured = self._send()
+        assert "Maths &amp; Physics" in captured["body"]
+
+    def test_list_unsubscribe_headers_are_set(self):
+        captured = self._send()
+        assert captured["headers"]["List-Unsubscribe"] == (
+            "<https://api.test/api/v1/emails/unsubscribe?token=t.s>"
+        )
+        assert captured["headers"]["List-Unsubscribe-Post"] == (
+            "List-Unsubscribe=One-Click"
+        )
+
+    def test_no_unsubscribe_url_means_no_headers(self):
+        captured = self._send(unsubscribe_url="")
+        assert captured["headers"] is None
+
+    def test_cta_button_is_rendered(self):
+        captured = self._send()
+        assert "https://acme.test/dash/courses/course/abc/general" in captured["body"]
+
+    def test_no_cta_renders_a_button_free_email(self):
+        """The "what stopped you?" nudge is a genuine question — a button
+        would undercut the ask to just reply.
+
+        The unsubscribe link is still an anchor, so this checks for the button
+        specifically rather than for anchors in general.
+        """
+        from src.services.users.emails import STYLES
+
+        captured = self._send(
+            nudge_id="activation.whats_blocking_d14", has_cta=False
+        )
+        assert STYLES["button"] not in captured["body"]
+        assert "https://acme.test/dash" not in captured["body"]
+        # ...but the reader can still opt out.
+        assert "unsubscribe" in captured["body"].lower()
+
+    def test_translated_copy_is_used(self):
+        captured = self._send(lang="fr")
+        assert "brouillon" in captured["subject"]
+        assert "Se désabonner" in captured["body"]
+
+    def test_no_unrendered_placeholders(self):
+        for lang in ("en", "fr", "ja", "ar"):
+            captured = self._send(lang=lang)
+            assert "{" not in captured["body"], lang
+            assert "{" not in captured["subject"], lang

--- a/apps/api/src/tests/services/test_email_unsubscribe_support.py
+++ b/apps/api/src/tests/services/test_email_unsubscribe_support.py
@@ -236,9 +236,19 @@ class TestNudgeRendering:
             "List-Unsubscribe=One-Click"
         )
 
-    def test_no_unsubscribe_url_means_no_headers(self):
+    def test_no_unsubscribe_url_means_no_unsubscribe_headers(self):
+        """Reply-To survives — a reader should be able to answer a lifecycle
+        email whether or not it carried an opt-out link."""
         captured = self._send(unsubscribe_url="")
-        assert captured["headers"] is None
+        headers = captured["headers"] or {}
+        assert "List-Unsubscribe" not in headers
+        assert "List-Unsubscribe-Post" not in headers
+
+    def test_reply_to_is_set(self):
+        """Several nudges invite a reply; from a no-reply sender that would be
+        a lie."""
+        captured = self._send()
+        assert "@" in captured["headers"]["Reply-To"]
 
     def test_cta_button_is_rendered(self):
         captured = self._send()

--- a/apps/api/src/tests/services/test_email_urls_without_request.py
+++ b/apps/api/src/tests/services/test_email_urls_without_request.py
@@ -1,0 +1,216 @@
+"""Tests for building email URLs with no HTTP request.
+
+A cron job has no `Request`, so every fallback these builders take when
+`request is None` is on the lifecycle-email hot path. Untested, a wrong branch
+here produces a link that 404s or points at the wrong tenant — invisible from
+the sending side.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.services.email import utils as email_utils
+
+
+def _config(
+    tenancy="multi", domain="learnhouse.io", frontend_domain="", ssl=True
+):
+    return SimpleNamespace(
+        hosting_config=SimpleNamespace(
+            tenancy=tenancy,
+            domain=domain,
+            frontend_domain=frontend_domain,
+            ssl=ssl,
+        ),
+        general_config=SimpleNamespace(development_mode=False),
+    )
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    for var in (
+        "LEARNHOUSE_PLATFORM_URL",
+        "LEARNHOUSE_MEDIA_URL",
+        "LEARNHOUSE_BACKEND_URL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestConfiguredFrontendBaseUrl:
+    def test_platform_url_wins(self, monkeypatch, clean_env):
+        monkeypatch.setenv("LEARNHOUSE_PLATFORM_URL", "https://app.example.com/")
+        monkeypatch.setattr(email_utils, "get_learnhouse_config", _config)
+
+        assert email_utils._configured_frontend_base_url() == "https://app.example.com"
+
+    def test_falls_back_to_frontend_domain(self, monkeypatch, clean_env):
+        monkeypatch.setattr(
+            email_utils,
+            "get_learnhouse_config",
+            lambda: _config(frontend_domain="app.example.com"),
+        )
+
+        assert email_utils._configured_frontend_base_url() == "https://app.example.com"
+
+    def test_falls_back_to_base_domain(self, monkeypatch, clean_env):
+        monkeypatch.setattr(
+            email_utils, "get_learnhouse_config", lambda: _config(domain="example.com")
+        )
+
+        assert email_utils._configured_frontend_base_url() == "https://example.com"
+
+    def test_respects_the_ssl_setting(self, monkeypatch, clean_env):
+        monkeypatch.setattr(
+            email_utils,
+            "get_learnhouse_config",
+            lambda: _config(domain="example.com", ssl=False),
+        )
+
+        assert email_utils._configured_frontend_base_url() == "http://example.com"
+
+    @pytest.mark.parametrize("value", ["", "localhost:3000"])
+    def test_localhost_and_empty_are_not_usable(self, monkeypatch, clean_env, value):
+        """A localhost link in an email is dead on arrival for the recipient."""
+        monkeypatch.setattr(
+            email_utils,
+            "get_learnhouse_config",
+            lambda: _config(domain=value, frontend_domain=value),
+        )
+
+        assert email_utils._configured_frontend_base_url() is None
+
+
+class TestOrgSignupBaseUrlWithoutRequest:
+    async def test_multi_tenant_builds_the_org_subdomain(self, monkeypatch, clean_env):
+        monkeypatch.setattr(email_utils, "get_learnhouse_config", _config)
+
+        url = await email_utils.get_org_signup_base_url("acme")
+        assert url == "https://acme.learnhouse.io"
+
+    async def test_single_tenant_uses_configured_url(self, monkeypatch, clean_env):
+        monkeypatch.setenv("LEARNHOUSE_PLATFORM_URL", "https://school.example.com")
+        monkeypatch.setattr(
+            email_utils, "get_learnhouse_config", lambda: _config(tenancy="single")
+        )
+
+        assert await email_utils.get_org_signup_base_url("acme") == (
+            "https://school.example.com"
+        )
+
+    async def test_single_tenant_with_nothing_configured_returns_empty(
+        self, monkeypatch, clean_env
+    ):
+        """Better an obviously-empty base than a link to the wrong host."""
+        monkeypatch.setattr(
+            email_utils,
+            "get_learnhouse_config",
+            lambda: _config(tenancy="single", domain="", frontend_domain=""),
+        )
+
+        assert await email_utils.get_org_signup_base_url("acme") == ""
+
+    async def test_multi_tenant_with_localhost_domain_falls_back(
+        self, monkeypatch, clean_env
+    ):
+        monkeypatch.setenv("LEARNHOUSE_PLATFORM_URL", "https://app.example.com")
+        monkeypatch.setattr(
+            email_utils,
+            "get_learnhouse_config",
+            lambda: _config(domain="localhost:3000"),
+        )
+
+        assert await email_utils.get_org_signup_base_url("acme") == (
+            "https://app.example.com"
+        )
+
+    async def test_multi_tenant_with_nothing_configured_returns_empty(
+        self, monkeypatch, clean_env
+    ):
+        monkeypatch.setattr(
+            email_utils,
+            "get_learnhouse_config",
+            lambda: _config(domain="", frontend_domain=""),
+        )
+
+        assert await email_utils.get_org_signup_base_url("acme") == ""
+
+    async def test_a_verified_custom_domain_still_wins(self, monkeypatch, clean_env):
+        """An org on a custom domain keeps its session there — linking to the
+        generic subdomain would land the reader cross-origin."""
+        monkeypatch.setattr(email_utils, "get_learnhouse_config", _config)
+
+        async def fake_custom_domain(_db, _org_id):
+            return "learn.acme.com"
+
+        monkeypatch.setattr(
+            email_utils, "_get_primary_verified_custom_domain", fake_custom_domain
+        )
+
+        url = await email_utils.get_org_signup_base_url(
+            "acme", None, db_session=object(), org_id=1
+        )
+        assert url == "https://learn.acme.com"
+
+
+class TestMediaBaseUrlWithoutRequest:
+    def test_explicit_override_wins(self, monkeypatch, clean_env):
+        monkeypatch.setenv("LEARNHOUSE_MEDIA_URL", "https://media.example.com/")
+        assert email_utils.get_media_base_url(None) == "https://media.example.com"
+
+    def test_backend_url_is_also_honoured(self, monkeypatch, clean_env):
+        monkeypatch.setenv("LEARNHOUSE_BACKEND_URL", "https://api.example.com")
+        assert email_utils.get_media_base_url(None) == "https://api.example.com"
+
+    def test_saas_convention_is_derived_from_the_domain(self, monkeypatch, clean_env):
+        monkeypatch.setattr(email_utils, "get_learnhouse_config", _config)
+        assert email_utils.get_media_base_url(None) == "https://api.learnhouse.io"
+
+    def test_no_request_and_nothing_configured_returns_empty(
+        self, monkeypatch, clean_env
+    ):
+        monkeypatch.setattr(
+            email_utils, "get_learnhouse_config", lambda: _config(domain="localhost")
+        )
+        assert email_utils.get_media_base_url(None) == ""
+
+
+class TestOrgLogoUrlWithoutRequest:
+    ORG = SimpleNamespace(logo_image="logo.png", org_uuid="org_abc")
+
+    def test_builds_an_absolute_url(self, monkeypatch, clean_env):
+        monkeypatch.setattr(email_utils, "get_learnhouse_config", _config)
+
+        assert email_utils.get_org_logo_url(self.ORG, None) == (
+            "https://api.learnhouse.io/content/orgs/org_abc/logos/logo.png"
+        )
+
+    def test_unresolvable_media_host_falls_back_to_the_default_mark(
+        self, monkeypatch, clean_env
+    ):
+        """A relative src renders broken in every mail client, so returning
+        None (and letting the caller use the LearnHouse wordmark) is the only
+        acceptable outcome."""
+        monkeypatch.setattr(
+            email_utils, "get_learnhouse_config", lambda: _config(domain="localhost")
+        )
+
+        assert email_utils.get_org_logo_url(self.ORG, None) is None
+
+    def test_org_without_a_logo_returns_none(self, monkeypatch, clean_env):
+        monkeypatch.setattr(email_utils, "get_learnhouse_config", _config)
+        bare = SimpleNamespace(logo_image="", org_uuid="org_abc")
+
+        assert email_utils.get_org_logo_url(bare, None) is None
+
+
+class TestRecipientValidation:
+    @pytest.mark.parametrize("bad", ["", "   ", "not-an-email"])
+    def test_malformed_recipients_are_refused(self, bad):
+        """Surfaces here rather than as an opaque provider 4xx."""
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as excinfo:
+            email_utils.send_email(bad, "hi", "<p>hi</p>")
+
+        assert excinfo.value.status_code == 400

--- a/apps/api/src/tests/services/test_nudges_audience_and_reputation.py
+++ b/apps/api/src/tests/services/test_nudges_audience_and_reputation.py
@@ -1,0 +1,217 @@
+"""Who is allowed to receive a nudge, and what stops us mailing them.
+
+Two invariants worth a dedicated file:
+
+* only organization admins are ever mailed — never members, never learners;
+* an address a provider has told us is bad is never mailed again.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from sqlmodel import select
+
+from src.db.nudges import EmailPreference
+from src.db.user_organizations import UserOrganization
+from src.db.users import User
+from src.security.rbac.constants import ADMIN_ROLE_ID
+from src.services.nudges import runner as runner_module
+from src.services.nudges.eligibility import build_snapshots
+from src.services.nudges.preferences import (
+    get_opted_out_user_ids,
+    is_suppressed,
+    set_lifecycle_opt_out,
+    suppress_address,
+)
+from src.services.nudges.runner import run_nudges
+
+NOW = datetime(2026, 7, 28, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _stored(days_ago: float) -> str:
+    return str((NOW - timedelta(days=days_ago)).replace(tzinfo=None))
+
+
+async def _fake_base_url(org_slug, db_session=None, org_id=None):
+    return f"https://{org_slug}.test"
+
+
+@pytest.fixture(autouse=True)
+def _gates(monkeypatch):
+    monkeypatch.setenv("LEARNHOUSE_NUDGES_ENABLED", "true")
+    monkeypatch.setattr(runner_module, "get_deployment_mode", lambda: "saas")
+    monkeypatch.setattr(runner_module.links, "org_base_url", _fake_base_url)
+    monkeypatch.setattr(
+        runner_module, "get_media_base_url", lambda _r=None: "https://api.test"
+    )
+
+
+@pytest.fixture
+def sender():
+    with patch("src.services.nudges.runner.send_nudge_email") as mock:
+        mock.return_value = {"id": "sent"}
+        yield mock
+
+
+@pytest.fixture
+async def populated_org(db, org, admin_role, user_role, admin_user, regular_user):
+    """One admin, several non-admin members, all verified and mailable.
+
+    Aged past the activity window on purpose: members who joined yesterday
+    make the org active, and an active org is deliberately left alone.
+    """
+    org.creation_date = _stored(32)
+    org.update_date = _stored(32)
+    db.add(org)
+
+    for index in range(3):
+        uid = 40 + index
+        db.add(
+            User(
+                id=uid,
+                username=f"learner{index}",
+                first_name="Learner",
+                last_name=str(index),
+                email=f"learner{index}@test.com",
+                password="x",
+                user_uuid=f"user_learner{index}",
+                email_verified=True,
+                creation_date=_stored(31),
+                update_date=_stored(31),
+            )
+        )
+        db.add(
+            UserOrganization(
+                user_id=uid,
+                org_id=org.id,
+                role_id=user_role.id,
+                creation_date=_stored(31),
+                update_date=_stored(31),
+            )
+        )
+
+    row = (await db.execute(select(User).where(User.id == admin_user.id))).scalars().first()
+    row.email_verified = True
+    db.add(row)
+    await db.commit()
+
+    # The shared `regular_user` fixture joins with today's date, which would
+    # make the org read as active and silence every track. Age every
+    # membership so the org is genuinely quiet.
+    links = (
+        await db.execute(
+            select(UserOrganization).where(UserOrganization.org_id == org.id)
+        )
+    ).scalars().all()
+    for link in links:
+        link.creation_date = _stored(31)
+        link.update_date = _stored(31)
+        db.add(link)
+    await db.commit()
+    return org
+
+
+class TestOnlyAdminsAreMailed:
+    async def test_snapshot_collects_admins_only(self, db, populated_org, admin_user):
+        snap = (await build_snapshots(db, [populated_org]))[0]
+
+        assert snap.member_count == 4  # regular_user + three learners
+        assert [a.user_id for a in snap.admins] == [admin_user.id]
+
+    async def test_a_run_mails_only_the_admin(self, db, populated_org, admin_user, sender):
+        stats = await run_nudges(db, now=NOW)
+
+        assert stats.sent == 1
+        recipients = {call.kwargs["email"] for call in sender.call_args_list}
+        assert recipients == {admin_user.email}
+
+    async def test_no_member_address_is_ever_a_recipient(
+        self, db, populated_org, sender
+    ):
+        await run_nudges(db, now=NOW)
+
+        recipients = {call.kwargs["email"] for call in sender.call_args_list}
+        for address in recipients:
+            assert "learner" not in address
+            assert "user@test.com" not in address
+
+    async def test_promoting_a_member_brings_them_in(
+        self, db, populated_org, admin_role, sender
+    ):
+        """The gate is the role, not a static list — a promotion takes effect."""
+        link = (
+            await db.execute(
+                select(UserOrganization).where(UserOrganization.user_id == 40)
+            )
+        ).scalars().first()
+        link.role_id = admin_role.id
+        db.add(link)
+        await db.commit()
+
+        snap = (await build_snapshots(db, [populated_org]))[0]
+        assert {a.user_id for a in snap.admins} == {1, 40}
+
+    async def test_the_admin_query_filters_on_the_admin_role_id(self, db, populated_org):
+        """Guards the constant itself: if ADMIN_ROLE_ID ever changed without
+        the query changing, this is what would catch it."""
+        rows = (
+            await db.execute(
+                select(UserOrganization.user_id).where(
+                    UserOrganization.org_id == populated_org.id,
+                    UserOrganization.role_id == ADMIN_ROLE_ID,
+                )
+            )
+        ).scalars().all()
+        snap = (await build_snapshots(db, [populated_org]))[0]
+        assert {a.user_id for a in snap.admins} == set(rows)
+
+
+class TestDeliverySuppression:
+    async def test_a_hard_bounce_stops_future_mail(self, db, populated_org, admin_user, sender):
+        await suppress_address(db, admin_user.email, "bounce")
+
+        stats = await run_nudges(db, now=NOW)
+
+        assert stats.sent == 0
+        assert stats.skipped_optout == 1
+        sender.assert_not_called()
+
+    async def test_a_complaint_stops_future_mail(self, db, populated_org, admin_user, sender):
+        await suppress_address(db, admin_user.email, "complaint")
+        assert await is_suppressed(db, admin_user.id) is True
+
+        stats = await run_nudges(db, now=NOW)
+        assert stats.sent == 0
+
+    async def test_suppression_survives_a_resubscribe(self, db, admin_user):
+        """Re-subscribing is a preference; a dead address is a fact. Consent
+        cannot make mail deliverable again."""
+        await suppress_address(db, admin_user.email, "bounce")
+        await set_lifecycle_opt_out(db, admin_user.id, opted_out=False)
+
+        assert await is_suppressed(db, admin_user.id) is True
+        assert await get_opted_out_user_ids(db, [admin_user.id]) == {admin_user.id}
+
+    async def test_suppression_records_its_reason(self, db, admin_user):
+        await suppress_address(db, admin_user.email, "complaint")
+
+        pref = (
+            await db.execute(
+                select(EmailPreference).where(EmailPreference.user_id == admin_user.id)
+            )
+        ).scalars().first()
+        assert pref.suppressed is True
+        assert pref.suppressed_reason == "complaint"
+
+    async def test_an_unknown_address_is_ignored(self, db):
+        """Bounces arrive for users since deleted; that must not raise."""
+        assert await suppress_address(db, "nobody@nowhere.test", "bounce") is None
+
+    async def test_suppression_is_idempotent(self, db, admin_user):
+        first = await suppress_address(db, admin_user.email, "bounce")
+        stamp = first.unsubscribed_at
+        second = await suppress_address(db, admin_user.email, "bounce")
+
+        assert second.suppressed is True
+        assert second.unsubscribed_at == stamp

--- a/apps/api/src/tests/services/test_nudges_audience_and_reputation.py
+++ b/apps/api/src/tests/services/test_nudges_audience_and_reputation.py
@@ -47,6 +47,28 @@ def _gates(monkeypatch):
     )
 
 
+@pytest.fixture(autouse=True)
+async def _seeded_ledger(db, org):
+    """Pin the activation boundary in the past.
+
+    An empty ledger means every org predates the system; production pins the
+    boundary with `nudges-seed`, and the tests pin it here.
+    """
+    from src.db.nudges import NudgeSend, NudgeSendStatus
+
+    db.add(
+        NudgeSend(
+            nudge_id="bootstrap",
+            dedupe_key="bootstrap:0:0",
+            org_id=org.id,
+            user_id=1,
+            status=NudgeSendStatus.SUPPRESSED,
+            claimed_at=NOW - timedelta(days=400),
+        )
+    )
+    await db.commit()
+
+
 @pytest.fixture
 def sender():
     with patch("src.services.nudges.runner.send_nudge_email") as mock:

--- a/apps/api/src/tests/services/test_nudges_catalog.py
+++ b/apps/api/src/tests/services/test_nudges_catalog.py
@@ -1,0 +1,587 @@
+"""Tests for src/services/nudges/catalog.py.
+
+Predicates are pure functions of one snapshot, so the whole catalog is testable
+without touching a database.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.security.features_utils.plans import PLAN_HIERARCHY, PLAN_LIMITS
+from src.services.nudges.catalog import (
+    CATALOG_BY_ID,
+    NUDGE_CATALOG,
+    ai_credit_limit,
+    ai_credits_nearly_spent,
+    at_resource_limit,
+    get_spec,
+    matching_specs,
+    near_resource_limit,
+    next_plan,
+    plan_limit,
+)
+from src.services.nudges.snapshot import OrgSnapshot
+
+NOW = datetime(2026, 7, 28, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def snap(**kwargs) -> OrgSnapshot:
+    """A snapshot with sane defaults; override only what a test cares about."""
+    base = dict(
+        org_id=1,
+        org_slug="acme",
+        org_name="Acme",
+        plan="free",
+        lang="en",
+        now=NOW,
+        # Far enough back that nothing counts as "recently active" unless the
+        # test says so.
+        created_at=NOW - timedelta(days=400),
+        org_updated_at=NOW - timedelta(days=400),
+    )
+    base.update(kwargs)
+    return OrgSnapshot(**base)
+
+
+def ago(days: float) -> datetime:
+    return NOW - timedelta(days=days)
+
+
+class TestCatalogIntegrity:
+    def test_ids_are_unique(self):
+        ids = [s.id for s in NUDGE_CATALOG]
+        assert len(ids) == len(set(ids))
+
+    def test_lookup_matches_the_tuple(self):
+        assert len(CATALOG_BY_ID) == len(NUDGE_CATALOG)
+        for spec in NUDGE_CATALOG:
+            assert get_spec(spec.id) is spec
+
+    def test_unknown_id_returns_none(self):
+        assert get_spec("nope.does_not_exist") is None
+
+    def test_every_window_is_ordered(self):
+        for spec in NUDGE_CATALOG:
+            assert spec.day_min <= spec.day_max, spec.id
+
+    def test_every_window_is_at_least_two_days_wide(self):
+        """Most anchors come from naive strings written by whichever pod
+        handled the request, so they are accurate to roughly a day. A
+        single-day window would flip on clock skew alone."""
+        for spec in NUDGE_CATALOG:
+            assert spec.day_max - spec.day_min >= 1, spec.id
+
+    def test_id_prefix_matches_track(self):
+        for spec in NUDGE_CATALOG:
+            assert spec.id.startswith(f"{spec.track}."), spec.id
+
+    def test_every_spec_has_english_copy(self):
+        from src.services.email.translations import EMAIL_TRANSLATIONS
+
+        english = EMAIL_TRANSLATIONS["en"]
+        for spec in NUDGE_CATALOG:
+            for part in ("subject", "heading", "body"):
+                key = f"nudge.{spec.id}.{part}"
+                assert key in english, f"missing copy: {key}"
+                assert english[key] != key
+
+    def test_cta_specs_have_a_button_label(self):
+        from src.services.email.translations import EMAIL_TRANSLATIONS
+
+        english = EMAIL_TRANSLATIONS["en"]
+        for spec in NUDGE_CATALOG:
+            if spec.has_cta:
+                assert f"nudge.{spec.id}.cta" in english, spec.id
+
+
+class TestPlanHelpers:
+    def test_limits_are_read_from_the_plan_config(self):
+        for plan in PLAN_HIERARCHY:
+            assert plan_limit(plan, "courses") == PLAN_LIMITS[plan]["courses"]
+            assert plan_limit(plan, "members") == PLAN_LIMITS[plan]["members"]
+
+    def test_member_limits_are_not_monotonic(self):
+        """The reason no threshold may be hardcoded: the free tier allows more
+        members than the first paid tier."""
+        assert plan_limit("free", "members") > plan_limit("personal", "members")
+
+    def test_unknown_plan_falls_back_to_free(self):
+        assert plan_limit("nonsense", "courses") == PLAN_LIMITS["free"]["courses"]
+
+    def test_next_plan_walks_the_hierarchy(self):
+        assert next_plan("free") == "personal"
+        assert next_plan(PLAN_HIERARCHY[-2]) == PLAN_HIERARCHY[-1]
+
+    def test_next_plan_at_the_top_is_none(self):
+        assert next_plan(PLAN_HIERARCHY[-1]) is None
+
+    def test_next_plan_for_an_unknown_plan_does_not_raise(self):
+        assert next_plan("nonsense") == PLAN_HIERARCHY[1]
+
+    def test_zero_limit_means_unlimited_and_never_fires(self):
+        """0 encodes "unlimited". Treating it as a cap would nudge every paid
+        org that it had run out of an allowance it does not have."""
+        s = snap(plan="pro")
+        assert plan_limit("pro", "courses") == 0
+        assert at_resource_limit(s, "courses", 9999) is False
+        assert near_resource_limit(s, "courses", 9999) is False
+
+    def test_at_limit_fires_on_a_real_cap(self):
+        s = snap(plan="free")
+        assert at_resource_limit(s, "courses", plan_limit("free", "courses")) is True
+        assert at_resource_limit(s, "courses", 0) is False
+
+    def test_near_limit_fires_only_in_the_approach(self):
+        s = snap(plan="free")
+        limit = plan_limit("free", "members")  # 10
+        assert near_resource_limit(s, "members", int(limit * 0.8)) is True
+        assert near_resource_limit(s, "members", 1) is False
+        # At the cap it is no longer "near" — the at-limit nudge owns that.
+        assert near_resource_limit(s, "members", limit) is False
+
+
+class TestActivationFirstCourse:
+    SPEC = "activation.first_course_d1"
+
+    def test_fires_for_a_new_org_with_no_course(self):
+        s = snap(created_at=ago(1.5), org_updated_at=ago(1.5))
+        assert get_spec(self.SPEC).matches(s) is True
+
+    def test_does_not_fire_once_a_course_exists(self):
+        s = snap(created_at=ago(1.5), org_updated_at=ago(1.5), course_count=1)
+        assert get_spec(self.SPEC).matches(s) is False
+
+    @pytest.mark.parametrize("age", [0.5, 3.0])
+    def test_does_not_fire_outside_the_window(self, age):
+        s = snap(created_at=ago(age), org_updated_at=ago(age))
+        assert get_spec(self.SPEC).matches(s) is False
+
+    def test_does_not_fire_for_a_long_dormant_org(self):
+        """The backfill guarantee: switching this on must not mail years of
+        history a day-one activation email."""
+        s = snap(created_at=ago(400), org_updated_at=ago(400))
+        assert get_spec(self.SPEC).matches(s) is False
+
+    def test_unparseable_creation_date_never_fires(self):
+        s = snap(created_at=None, org_updated_at=None)
+        assert get_spec(self.SPEC).matches(s) is False
+
+
+class TestContentCourseDraft:
+    SPEC = "content.course_draft_d3"
+
+    def test_fires_for_a_draft_with_content(self):
+        s = snap(
+            course_count=1,
+            activity_count=2,
+            published_course_count=0,
+            last_course_updated_at=ago(4),
+        )
+        assert get_spec(self.SPEC).matches(s) is True
+
+    def test_does_not_fire_once_published(self):
+        s = snap(
+            course_count=1,
+            activity_count=2,
+            published_course_count=1,
+            last_course_updated_at=ago(4),
+        )
+        assert get_spec(self.SPEC).matches(s) is False
+
+    def test_does_not_fire_for_an_empty_course(self):
+        """Nothing to publish yet — that is the content track's job, not this."""
+        s = snap(course_count=1, activity_count=0, last_course_updated_at=ago(4))
+        assert get_spec(self.SPEC).matches(s) is False
+
+    def test_links_to_the_draft_course(self):
+        s = snap(
+            course_count=1,
+            activity_count=1,
+            last_course_updated_at=ago(4),
+            oldest_draft_course_uuid="course_abc",
+        )
+        url = get_spec(self.SPEC).cta(s, "https://acme.test")
+        assert url == "https://acme.test/dash/courses/course/abc/general"
+
+
+class TestAudiencePublishedNoMembers:
+    SPEC = "audience.published_no_members_d1"
+
+    def test_fires_when_published_with_nobody_to_read_it(self):
+        s = snap(published_course_count=1, member_count=0, first_published_at=ago(4))
+        assert get_spec(self.SPEC).matches(s) is True
+
+    def test_does_not_fire_immediately_after_publishing(self):
+        """The milestone email already congratulates them on publishing and
+        points at inviting. This is the follow-up, not a duplicate."""
+        s = snap(
+            published_course_count=1,
+            member_count=0,
+            first_published_at=ago(1),
+            last_course_updated_at=ago(1),
+        )
+        assert get_spec(self.SPEC).matches(s) is False
+
+    def test_does_not_fire_once_someone_has_joined(self):
+        s = snap(published_course_count=1, member_count=1, first_published_at=ago(4))
+        assert get_spec(self.SPEC).matches(s) is False
+
+    def test_does_not_fire_before_anything_is_published(self):
+        s = snap(published_course_count=0, member_count=0, first_published_at=None)
+        assert get_spec(self.SPEC).matches(s) is False
+
+
+class TestMonetizationCourseLimit:
+    SPEC = "monetization.course_limit_d1"
+
+    def test_fires_at_the_free_course_cap(self):
+        s = snap(
+            plan="free",
+            course_count=plan_limit("free", "courses"),
+            last_course_created_at=ago(2),
+        )
+        assert get_spec(self.SPEC).matches(s) is True
+
+    def test_does_not_fire_on_a_plan_with_unlimited_courses(self):
+        s = snap(plan="pro", course_count=500, last_course_created_at=ago(2))
+        assert get_spec(self.SPEC).matches(s) is False
+
+    def test_does_not_fire_at_the_top_of_the_hierarchy(self):
+        s = snap(
+            plan=PLAN_HIERARCHY[-1], course_count=9999, last_course_created_at=ago(2)
+        )
+        assert get_spec(self.SPEC).matches(s) is False
+
+    def test_is_not_suppressed_by_recent_activity(self):
+        """They hit the wall *while* working — suppressing on activity would
+        mean this never fires at all."""
+        s = snap(
+            plan="free",
+            course_count=plan_limit("free", "courses"),
+            last_course_created_at=ago(2),
+            last_activity_created_at=ago(0.1),
+        )
+        assert s.org_active is True
+        assert get_spec(self.SPEC).matches(s) is True
+
+
+class TestDormancy:
+    SPEC = "dormancy.no_login_30d"
+
+    def test_fires_for_a_dormant_org_with_content(self):
+        s = snap(course_count=1, created_at=ago(200), org_updated_at=ago(32))
+        assert get_spec(self.SPEC).matches(s) is True
+
+    def test_does_not_fire_for_an_empty_org(self):
+        """Nothing to come back to — activation owns that case."""
+        s = snap(course_count=0, activity_count=0, org_updated_at=ago(32))
+        assert get_spec(self.SPEC).matches(s) is False
+
+    def test_does_not_fire_outside_the_window(self):
+        s = snap(course_count=1, created_at=ago(400), org_updated_at=ago(90))
+        assert get_spec(self.SPEC).matches(s) is False
+
+    def test_reaches_organizations_older_than_the_system(self):
+        """The dormancy track is deliberately the only route to legacy orgs."""
+        s = snap(course_count=1, created_at=ago(900), org_updated_at=ago(31))
+        assert get_spec(self.SPEC).matches(s) is True
+
+
+class TestEngagementVsCreation:
+    def test_a_brand_new_org_is_not_active(self):
+        """Creating an account is not engagement.
+
+        Counting it would mark every new org active for its first days — the
+        exact window the activation emails exist to cover — so they would never
+        fire at all.
+        """
+        s = snap(created_at=ago(1.5), org_updated_at=ago(1.5))
+        assert s.last_engagement is None
+        assert s.org_active is False
+
+    def test_real_work_makes_an_org_active(self):
+        s = snap(created_at=ago(1.5), last_course_created_at=ago(0.1))
+        assert s.org_active is True
+
+    def test_last_touch_falls_back_to_org_dates(self):
+        """Legacy orgs predate every engagement signal, but dormancy still
+        needs something to anchor against."""
+        s = snap(created_at=ago(400), org_updated_at=ago(400))
+        assert s.last_engagement is None
+        assert s.days_since_touch == pytest.approx(400, abs=0.1)
+
+
+class TestCatalogComposition:
+    def test_all_thirty_nudges_ship(self):
+        assert len(NUDGE_CATALOG) == 30
+
+    def test_track_sizes(self):
+        from collections import Counter
+
+        counts = Counter(spec.track for spec in NUDGE_CATALOG)
+        assert counts == {
+            "activation": 7,
+            "content": 7,
+            "audience": 5,
+            "monetization": 4,
+            "dormancy": 4,
+            "milestone": 3,
+        }
+
+    def test_priorities_are_unique_so_ordering_is_deterministic(self):
+        priorities = [spec.priority for spec in NUDGE_CATALOG]
+        assert len(priorities) == len(set(priorities))
+
+    def test_milestones_outrank_everything(self):
+        """Congratulations that arrive late are worthless, so they claim the
+        admin's single daily slot ahead of any prompt."""
+        milestones = [s.priority for s in NUDGE_CATALOG if s.track == "milestone"]
+        others = [s.priority for s in NUDGE_CATALOG if s.track != "milestone"]
+        assert max(milestones) < min(others)
+
+    def test_only_dormancy_reaches_arbitrarily_old_orgs(self):
+        """The structural half of the backfill guard: every other track is
+        anchored to a recent event with a bounded window."""
+        for spec in NUDGE_CATALOG:
+            if spec.track != "dormancy":
+                assert spec.day_max <= 90, spec.id
+
+    def test_only_dormancy_repeats(self):
+        for spec in NUDGE_CATALOG:
+            if spec.repeat is not None:
+                assert spec.track == "dormancy", spec.id
+
+
+class TestSecondVisitDetection:
+    ID = "activation.come_back_d2"
+
+    def test_fires_when_nothing_has_happened_since_signup(self):
+        s = snap(created_at=ago(3))
+        assert get_spec(self.ID).matches(s) is True
+
+    def test_does_not_fire_once_there_is_real_engagement(self):
+        s = snap(created_at=ago(3), last_course_created_at=ago(2.5))
+        assert get_spec(self.ID).matches(s) is False
+
+    def test_a_login_a_week_later_counts_as_coming_back(self):
+        s = snap(created_at=ago(3), last_admin_login_at=ago(0.5))
+        # last_admin_login_at is an engagement signal, so this org is active.
+        assert get_spec(self.ID).matches(s) is False
+
+    def test_any_engagement_signal_counts_as_coming_back(self):
+        """Including an admin login, which is itself an engagement signal —
+        the reason no separate login-timing comparison is needed."""
+        from src.services.nudges.catalog import _no_second_visit
+
+        assert _no_second_visit(snap(created_at=ago(3))) is True
+        assert _no_second_visit(snap(created_at=ago(3), last_admin_login_at=ago(1))) is False
+        assert _no_second_visit(snap(created_at=ago(3), last_member_joined_at=ago(1))) is False
+
+
+class TestAiCredits:
+    from src.services.nudges.catalog import ai_credit_limit as _limit
+
+    def test_fires_when_most_of_a_finite_allowance_is_spent(self):
+        limit = ai_credit_limit("free")
+        s = snap(plan="free", ai_credits_used=limit, last_activity_created_at=ago(2))
+        assert get_spec("monetization.ai_credits_low").matches(s) is True
+
+    def test_does_not_fire_early_in_the_allowance(self):
+        s = snap(plan="free", ai_credits_used=1, last_activity_created_at=ago(2))
+        assert get_spec("monetization.ai_credits_low").matches(s) is False
+
+    def test_unlimited_allowance_never_warns(self):
+        """enterprise is -1 (unlimited); a "running low" email would be a lie."""
+        assert ai_credit_limit("enterprise") == -1
+        s = snap(
+            plan="enterprise", ai_credits_used=999999, last_activity_created_at=ago(2)
+        )
+        assert ai_credits_nearly_spent(s) is False
+
+    def test_unknown_plan_has_no_allowance_and_never_warns(self):
+        s = snap(plan="nonsense", ai_credits_used=999, last_activity_created_at=ago(2))
+        assert ai_credits_nearly_spent(s) is False
+
+    def test_missing_redis_reads_as_zero_and_stays_silent(self):
+        """Usage comes from a cache that may be down. Fail closed."""
+        s = snap(plan="free", ai_credits_used=0, last_activity_created_at=ago(2))
+        assert ai_credits_nearly_spent(s) is False
+
+
+class TestNewContentAndAudienceNudges:
+    def test_course_without_chapters(self):
+        s = snap(course_count=1, chapter_count=0, last_course_created_at=ago(4))
+        assert get_spec("content.course_no_chapter_d1").matches(s) is True
+
+    def test_course_without_chapters_waits_out_the_active_window(self):
+        """Nagging someone who created the course yesterday, while they are
+        still working on it, is exactly the wrong moment."""
+        s = snap(course_count=1, chapter_count=0, last_course_created_at=ago(1))
+        assert s.org_active is True
+        assert get_spec("content.course_no_chapter_d1").matches(s) is False
+
+    def test_chapters_without_lessons(self):
+        s = snap(
+            course_count=1,
+            chapter_count=2,
+            activity_count=0,
+            last_chapter_created_at=ago(4),
+        )
+        assert get_spec("content.chapter_no_activity_d1").matches(s) is True
+
+    def test_lessons_all_unpublished(self):
+        s = snap(
+            activity_count=3,
+            published_activity_count=0,
+            last_activity_created_at=ago(4),
+        )
+        assert get_spec("content.activity_unpublished_d2").matches(s) is True
+
+    def test_thin_course_needs_at_least_one_lesson(self):
+        """An empty course belongs to course_no_chapter, not here."""
+        empty = snap(course_count=1, activity_count=0, last_course_created_at=ago(6))
+        thin = snap(course_count=1, activity_count=2, last_course_created_at=ago(6))
+        assert get_spec("content.thin_course_d5").matches(empty) is False
+        assert get_spec("content.thin_course_d5").matches(thin) is True
+
+    def test_assignment_without_submissions_needs_an_audience(self):
+        """With no members there is nobody to submit — the audience track owns
+        that case, and this email would just be confusing."""
+        no_members = snap(
+            assignment_count=1,
+            assignment_submission_count=0,
+            member_count=0,
+            last_assignment_created_at=ago(6),
+        )
+        with_members = snap(
+            assignment_count=1,
+            assignment_submission_count=0,
+            member_count=5,
+            last_assignment_created_at=ago(6),
+        )
+        spec = get_spec("content.assignment_no_submissions_d5")
+        assert spec.matches(no_members) is False
+        assert spec.matches(with_members) is True
+
+    def test_members_who_never_enrolled(self):
+        s = snap(member_count=4, trailrun_count=0, first_member_joined_at=ago(4))
+        assert get_spec("audience.members_no_enrollment_d3").matches(s) is True
+
+    def test_public_share_needs_both_published_and_public(self):
+        spec = get_spec("audience.share_public_page_d14")
+        private = snap(
+            published_course_count=1,
+            public_course_count=0,
+            member_count=0,
+            first_published_at=ago(15),
+        )
+        public = snap(
+            published_course_count=1,
+            public_course_count=1,
+            member_count=0,
+            first_published_at=ago(15),
+        )
+        assert spec.matches(private) is False
+        assert spec.matches(public) is True
+
+    def test_share_link_points_at_the_public_course_page(self):
+        s = snap(
+            published_course_count=1,
+            public_course_count=1,
+            member_count=0,
+            first_published_at=ago(15),
+            newest_course_uuid="course_xyz",
+        )
+        url = get_spec("audience.share_public_page_d14").cta(s, "https://acme.test")
+        assert url == "https://acme.test/course/xyz"
+
+    def test_stalled_learners(self):
+        s = snap(in_progress_trailrun_count=3, last_trailrun_updated_at=ago(16))
+        assert get_spec("audience.stalled_learners_d14").matches(s) is True
+
+
+class TestMilestones:
+    def test_first_publish_fires_immediately(self):
+        s = snap(published_course_count=1, first_published_at=ago(0.5))
+        assert get_spec("milestone.first_course_published").matches(s) is True
+
+    def test_milestones_are_not_suppressed_by_activity(self):
+        """The org is active by definition — something just happened."""
+        s = snap(
+            published_course_count=1,
+            first_published_at=ago(0.5),
+            last_course_updated_at=ago(0.1),
+        )
+        assert s.org_active is True
+        assert get_spec("milestone.first_course_published").matches(s) is True
+
+    def test_first_learner(self):
+        s = snap(trailrun_count=1, first_trailrun_at=ago(1))
+        assert get_spec("milestone.first_learner_enrolled").matches(s) is True
+
+    def test_first_completion(self):
+        s = snap(
+            completed_trailrun_count=1, first_completed_trailrun_at=ago(1)
+        )
+        assert get_spec("milestone.first_completion").matches(s) is True
+
+    def test_milestones_go_stale(self):
+        """Congratulating someone a week late is worse than silence."""
+        s = snap(published_course_count=1, first_published_at=ago(6))
+        assert get_spec("milestone.first_course_published").matches(s) is False
+
+
+class TestDormancySequence:
+    def test_windows_do_not_overlap(self):
+        dormancy = sorted(
+            (s for s in NUDGE_CATALOG if s.track == "dormancy"),
+            key=lambda s: s.day_min,
+        )
+        for earlier, later in zip(dormancy, dormancy[1:]):
+            assert earlier.day_max < later.day_min
+
+    @pytest.mark.parametrize(
+        "days,expected",
+        [
+            (15, "dormancy.no_login_14d"),
+            (32, "dormancy.no_login_30d"),
+            (65, "dormancy.no_login_60d"),
+            (200, "dormancy.winback_q"),
+        ],
+    )
+    def test_each_stage_fires_in_its_own_window(self, days, expected):
+        s = snap(course_count=1, created_at=ago(400), org_updated_at=ago(days))
+        matched = [x.id for x in matching_specs(s) if x.track == "dormancy"]
+        assert matched == [expected]
+
+
+class TestMatching:
+    def test_active_orgs_are_left_alone(self):
+        s = snap(created_at=ago(1.5), last_course_created_at=ago(0.1))
+        assert s.org_active is True
+        assert [x.id for x in matching_specs(s)] == []
+
+    def test_results_are_ordered_by_priority(self):
+        s = snap(
+            created_at=ago(1.5),
+            org_updated_at=ago(1.5),
+            published_course_count=1,
+            first_published_at=ago(2),
+            member_count=0,
+        )
+        matched = matching_specs(s)
+        priorities = [spec.priority for spec in matched]
+        assert priorities == sorted(priorities)
+
+    def test_no_match_for_a_quiet_well_run_org(self):
+        s = snap(
+            course_count=3,
+            published_course_count=3,
+            activity_count=10,
+            member_count=25,
+            trailrun_count=40,
+            created_at=ago(200),
+            org_updated_at=ago(10),
+        )
+        assert matching_specs(s) == []

--- a/apps/api/src/tests/services/test_nudges_catalog.py
+++ b/apps/api/src/tests/services/test_nudges_catalog.py
@@ -313,8 +313,8 @@ class TestEngagementVsCreation:
 
 
 class TestCatalogComposition:
-    def test_all_thirty_nudges_ship(self):
-        assert len(NUDGE_CATALOG) == 30
+    def test_the_whole_catalog_ships(self):
+        assert len(NUDGE_CATALOG) == 34
 
     def test_track_sizes(self):
         from collections import Counter
@@ -327,6 +327,7 @@ class TestCatalogComposition:
             "monetization": 4,
             "dormancy": 4,
             "milestone": 3,
+            "reactivation": 4,
         }
 
     def test_priorities_are_unique_so_ordering_is_deterministic(self):
@@ -340,11 +341,12 @@ class TestCatalogComposition:
         others = [s.priority for s in NUDGE_CATALOG if s.track != "milestone"]
         assert max(milestones) < min(others)
 
-    def test_only_dormancy_reaches_arbitrarily_old_orgs(self):
+    def test_only_winback_tracks_reach_arbitrarily_old_orgs(self):
         """The structural half of the backfill guard: every other track is
-        anchored to a recent event with a bounded window."""
+        anchored to a recent event with a bounded window, so switching the
+        system on cannot reach years of history."""
         for spec in NUDGE_CATALOG:
-            if spec.track != "dormancy":
+            if spec.track not in ("dormancy", "reactivation"):
                 assert spec.day_max <= 90, spec.id
 
     def test_only_dormancy_repeats(self):

--- a/apps/api/src/tests/services/test_nudges_delivery.py
+++ b/apps/api/src/tests/services/test_nudges_delivery.py
@@ -1,0 +1,280 @@
+"""Tests for reading delivery outcomes back from the provider.
+
+This is what protects the sending domain when no webhook is configured, so the
+cases that matter are: a bad address gets suppressed, a good one does not, and
+a provider outage delays the check rather than losing it.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlmodel import select
+
+from src.db.nudges import EmailPreference, NudgeSend, NudgeSendStatus
+
+# Imported for its side effect: the in-memory schema is built from whatever
+# models have been imported, and a full run touches every table the snapshot
+# scan reads.
+from src.services.nudges import eligibility as _eligibility  # noqa: F401
+from src.services.nudges.delivery import (
+    MAX_AGE_DAYS,
+    MIN_AGE_HOURS,
+    reconcile_delivery,
+)
+
+NOW = datetime(2026, 7, 28, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+async def sent_row(db, org, admin_user):
+    def _make(hours_ago=48, provider_id="re_1", email=None, checked=False):
+        row = NudgeSend(
+            nudge_id="content.course_draft_d3",
+            dedupe_key=f"k:{provider_id}",
+            org_id=org.id,
+            user_id=admin_user.id,
+            status=NudgeSendStatus.SENT,
+            claimed_at=NOW - timedelta(hours=hours_ago),
+            sent_at=NOW - timedelta(hours=hours_ago),
+            provider_id=provider_id,
+            delivery_checked=checked,
+            meta={"email": email or admin_user.email},
+        )
+        db.add(row)
+        return row
+
+    return _make
+
+
+async def _pref(db, user_id):
+    return (
+        await db.execute(
+            select(EmailPreference).where(EmailPreference.user_id == user_id)
+        )
+    ).scalars().first()
+
+
+class TestOutcomes:
+    @pytest.mark.parametrize(
+        "event,reason", [("bounced", "bounce"), ("complained", "complaint")]
+    )
+    async def test_a_failed_message_suppresses_the_address(
+        self, db, sent_row, admin_user, event, reason
+    ):
+        sent_row()
+        await db.commit()
+
+        with patch(
+            "src.services.nudges.delivery._last_event", AsyncMock(return_value=event)
+        ):
+            result = await reconcile_delivery(db, now=NOW)
+
+        assert result == {"checked": 1, "suppressed": 1}
+        pref = await _pref(db, admin_user.id)
+        assert pref.suppressed is True and pref.suppressed_reason == reason
+
+    @pytest.mark.parametrize("event", ["delivered", "sent", "opened", "delivery_delayed"])
+    async def test_a_healthy_message_suppresses_nothing(
+        self, db, sent_row, admin_user, event
+    ):
+        sent_row()
+        await db.commit()
+
+        with patch(
+            "src.services.nudges.delivery._last_event", AsyncMock(return_value=event)
+        ):
+            result = await reconcile_delivery(db, now=NOW)
+
+        assert result == {"checked": 1, "suppressed": 0}
+        assert await _pref(db, admin_user.id) is None
+
+    async def test_an_unknown_event_is_treated_as_healthy(self, db, sent_row, admin_user):
+        """A new event name the provider adds must not start suppressing."""
+        sent_row()
+        await db.commit()
+
+        with patch(
+            "src.services.nudges.delivery._last_event",
+            AsyncMock(return_value="some_future_event"),
+        ):
+            assert (await reconcile_delivery(db, now=NOW))["suppressed"] == 0
+
+    async def test_a_missing_event_is_treated_as_healthy(self, db, sent_row, admin_user):
+        sent_row()
+        await db.commit()
+
+        with patch(
+            "src.services.nudges.delivery._last_event", AsyncMock(return_value=None)
+        ):
+            assert (await reconcile_delivery(db, now=NOW))["suppressed"] == 0
+
+
+class TestWhatGetsPolled:
+    async def test_each_message_is_asked_about_once(self, db, sent_row):
+        sent_row()
+        await db.commit()
+
+        lookup = AsyncMock(return_value="delivered")
+        with patch("src.services.nudges.delivery._last_event", lookup):
+            await reconcile_delivery(db, now=NOW)
+            await reconcile_delivery(db, now=NOW)
+
+        assert lookup.await_count == 1
+
+    async def test_recent_messages_are_left_to_settle(self, db, sent_row):
+        """Read too early, a delayed message looks bounced — and suppressing on
+        that would throw away a perfectly good address."""
+        sent_row(hours_ago=MIN_AGE_HOURS - 1)
+        await db.commit()
+
+        lookup = AsyncMock(return_value="bounced")
+        with patch("src.services.nudges.delivery._last_event", lookup):
+            result = await reconcile_delivery(db, now=NOW)
+
+        assert result["checked"] == 0
+        lookup.assert_not_awaited()
+
+    async def test_ancient_messages_are_not_polled(self, db, sent_row):
+        sent_row(hours_ago=(MAX_AGE_DAYS + 2) * 24)
+        await db.commit()
+
+        with patch("src.services.nudges.delivery._last_event", AsyncMock()) as lookup:
+            assert (await reconcile_delivery(db, now=NOW))["checked"] == 0
+        lookup.assert_not_awaited()
+
+    async def test_rows_without_a_provider_id_are_skipped(self, db, sent_row):
+        """Dry runs and seeded rows never reached the provider."""
+        sent_row(provider_id=None)
+        await db.commit()
+
+        with patch("src.services.nudges.delivery._last_event", AsyncMock()) as lookup:
+            assert (await reconcile_delivery(db, now=NOW))["checked"] == 0
+        lookup.assert_not_awaited()
+
+    async def test_the_batch_is_bounded(self, db, sent_row):
+        for index in range(5):
+            sent_row(provider_id=f"re_{index}")
+        await db.commit()
+
+        with patch(
+            "src.services.nudges.delivery._last_event", AsyncMock(return_value="delivered")
+        ):
+            result = await reconcile_delivery(db, now=NOW, limit=2)
+
+        assert result["checked"] == 2
+
+
+class TestFailureHandling:
+    async def test_a_provider_outage_defers_rather_than_loses_the_check(
+        self, db, sent_row
+    ):
+        """The flag stays unset, so the message is asked about again next run."""
+        sent_row()
+        await db.commit()
+
+        with patch(
+            "src.services.nudges.delivery._last_event",
+            AsyncMock(side_effect=RuntimeError("resend down")),
+        ):
+            result = await reconcile_delivery(db, now=NOW)
+
+        assert result == {"checked": 0, "suppressed": 0}
+
+        with patch(
+            "src.services.nudges.delivery._last_event", AsyncMock(return_value="bounced")
+        ):
+            retried = await reconcile_delivery(db, now=NOW)
+        assert retried["suppressed"] == 1
+
+    async def test_a_row_without_a_recorded_address_is_marked_checked(self, db, sent_row):
+        """Nothing to suppress, but re-asking forever would be pointless."""
+        row = sent_row()
+        row.meta = {}
+        await db.commit()
+
+        with patch(
+            "src.services.nudges.delivery._last_event", AsyncMock(return_value="bounced")
+        ):
+            result = await reconcile_delivery(db, now=NOW)
+
+        assert result == {"checked": 1, "suppressed": 0}
+
+    async def test_nothing_to_do_is_cheap(self, db):
+        with patch("src.services.nudges.delivery._last_event", AsyncMock()) as lookup:
+            assert await reconcile_delivery(db, now=NOW) == {
+                "checked": 0,
+                "suppressed": 0,
+            }
+        lookup.assert_not_awaited()
+
+
+class TestLastEventShapes:
+    async def test_reads_a_dict_response(self):
+        from src.services.nudges.delivery import _last_event
+
+        with patch("resend.Emails.get", return_value={"last_event": "bounced"}):
+            assert await _last_event("re_1") == "bounced"
+
+    async def test_reads_an_object_response(self):
+        from src.services.nudges.delivery import _last_event
+
+        class Email:
+            last_event = "delivered"
+
+        with patch("resend.Emails.get", return_value=Email()):
+            assert await _last_event("re_1") == "delivered"
+
+
+class TestReconcileInsideARun:
+    async def test_a_run_reconciles_before_it_sends(self, db, org, monkeypatch):
+        """The check happens first, so an address that just bounced is already
+        suppressed by the time this run decides who to mail."""
+        from src.services.nudges import runner as runner_module
+
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_ENABLED", "true")
+        monkeypatch.setattr(runner_module, "get_deployment_mode", lambda: "saas")
+
+        called = AsyncMock(return_value={"checked": 0, "suppressed": 0})
+        monkeypatch.setattr(
+            "src.services.nudges.delivery.reconcile_delivery", called
+        )
+        db.add(
+            NudgeSend(
+                nudge_id="bootstrap",
+                dedupe_key="bootstrap:0:0",
+                org_id=org.id,
+                user_id=1,
+                status=NudgeSendStatus.SUPPRESSED,
+                claimed_at=NOW - timedelta(days=400),
+            )
+        )
+        await db.commit()
+
+        await runner_module.run_nudges(db, now=NOW)
+        called.assert_awaited_once()
+
+    async def test_a_broken_reconcile_never_stops_the_send(self, db, org, monkeypatch):
+        """Losing the delivery check is bad; losing the whole run is worse."""
+        from src.services.nudges import runner as runner_module
+
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_ENABLED", "true")
+        monkeypatch.setattr(runner_module, "get_deployment_mode", lambda: "saas")
+        monkeypatch.setattr(
+            "src.services.nudges.delivery.reconcile_delivery",
+            AsyncMock(side_effect=RuntimeError("provider down")),
+        )
+        db.add(
+            NudgeSend(
+                nudge_id="bootstrap",
+                dedupe_key="bootstrap:0:0",
+                org_id=org.id,
+                user_id=1,
+                status=NudgeSendStatus.SUPPRESSED,
+                claimed_at=NOW - timedelta(days=400),
+            )
+        )
+        await db.commit()
+
+        stats = await runner_module.run_nudges(db, now=NOW)
+        assert stats.failed == 0

--- a/apps/api/src/tests/services/test_nudges_eligibility.py
+++ b/apps/api/src/tests/services/test_nudges_eligibility.py
@@ -1,0 +1,483 @@
+"""Tests for src/services/nudges/eligibility.py."""
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import event
+
+from src.db.courses.courses import Course
+from src.db.organization_config import OrganizationConfig
+from src.services.nudges.eligibility import build_snapshots, iter_snapshots
+
+
+def _ts(days_ago: float = 0) -> str:
+    """A stored timestamp in the naive format the schema actually uses."""
+    return str(datetime.now() - timedelta(days=days_ago))
+
+
+async def _snapshot(db, org, **kwargs):
+    snapshots = await build_snapshots(db, [org], **kwargs)
+    return snapshots[0]
+
+
+async def _db_user(db, user_id: int):
+    """The persisted User row.
+
+    The ``admin_user`` fixture hands back a ``PublicUser`` projection, which
+    has no ``email_verified``; anything mutating mail eligibility needs the
+    real row.
+    """
+    from sqlmodel import select
+
+    from src.db.users import User
+
+    return (await db.execute(select(User).where(User.id == user_id))).scalars().first()
+
+
+class TestSnapshotShape:
+    async def test_bare_org_yields_zeroed_counts(self, db, org):
+        snap = await _snapshot(db, org)
+
+        assert snap.org_id == org.id
+        assert snap.org_slug == org.slug
+        assert snap.course_count == 0
+        assert snap.member_count == 0
+        assert snap.admins == ()
+        assert snap.plan == "free"
+        assert snap.lang == "en"
+
+    async def test_course_counts_and_flags(self, db, org, course):
+        snap = await _snapshot(db, org)
+
+        assert snap.course_count == 1
+        assert snap.published_course_count == 1
+        assert snap.public_course_count == 1
+        assert snap.newest_course_uuid == "course_test"
+        assert snap.newest_course_name == "Test Course"
+        # Published, so there is no draft to link to.
+        assert snap.oldest_draft_course_uuid is None
+
+    async def test_draft_course_is_identified_for_deep_linking(self, db, org):
+        db.add(
+            Course(
+                id=7,
+                name="Draft Course",
+                description="",
+                public=False,
+                published=False,
+                open_to_contributors=False,
+                org_id=org.id,
+                course_uuid="course_draft",
+                creation_date=_ts(4),
+                update_date=_ts(4),
+            )
+        )
+        await db.commit()
+
+        snap = await _snapshot(db, org)
+        assert snap.published_course_count == 0
+        assert snap.oldest_draft_course_uuid == "course_draft"
+        assert snap.oldest_draft_course_name == "Draft Course"
+
+    async def test_content_counts(self, db, org, course, chapter, activity):
+        snap = await _snapshot(db, org)
+
+        assert snap.chapter_count == 1
+        assert snap.activity_count == 1
+        assert snap.published_activity_count == 1
+        assert snap.content_exists is True
+
+    async def test_admins_are_collected(self, db, org, admin_user):
+        snap = await _snapshot(db, org)
+
+        assert len(snap.admins) == 1
+        assert snap.admins[0].user_id == admin_user.id
+        assert snap.admins[0].email == admin_user.email
+
+    async def test_members_and_admins_are_counted_separately(
+        self, db, org, admin_user, regular_user
+    ):
+        snap = await _snapshot(db, org)
+
+        assert snap.admin_count == 1
+        assert snap.member_count == 1
+
+
+class TestMailableAdmins:
+    async def test_unverified_admins_are_excluded(self, db, org, admin_user):
+        """Mailing unconfirmed addresses is the fastest way to lose a sending
+        domain — and it takes the transactional mail down with it."""
+        row = await _db_user(db, admin_user.id)
+        row.email_verified = False
+        db.add(row)
+        await db.commit()
+
+        snap = await _snapshot(db, org)
+        assert len(snap.admins) == 1
+        assert snap.mailable_admins == ()
+
+    async def test_verified_admins_are_mailable(self, db, org, admin_user):
+        row = await _db_user(db, admin_user.id)
+        row.email_verified = True
+        db.add(row)
+        await db.commit()
+
+        snap = await _snapshot(db, org)
+        assert len(snap.mailable_admins) == 1
+
+    async def test_admin_without_a_usable_email_is_excluded(self, db, org, admin_user):
+        row = await _db_user(db, admin_user.id)
+        row.email_verified = True
+        row.email = "not-an-email"
+        db.add(row)
+        await db.commit()
+
+        snap = await _snapshot(db, org)
+        assert snap.mailable_admins == ()
+
+    async def test_display_name_falls_back_through_to_a_greeting(self, db, org, admin_user):
+        row = await _db_user(db, admin_user.id)
+        row.email_verified = True
+        row.first_name = ""
+        db.add(row)
+        await db.commit()
+
+        snap = await _snapshot(db, org)
+        assert snap.admins[0].display_name == "admin"
+
+        row.username = ""
+        db.add(row)
+        await db.commit()
+        snap = await _snapshot(db, org)
+        assert snap.admins[0].display_name == "there"
+
+
+class TestTimestampHandling:
+    async def test_naive_string_dates_parse_to_utc(self, db, org):
+        snap = await _snapshot(db, org)
+
+        assert snap.created_at is not None
+        assert snap.created_at.tzinfo is not None
+        assert snap.org_age_days is not None and snap.org_age_days < 1
+
+    @pytest.mark.parametrize("bad", ["", "not-a-date", "2026-13-45"])
+    async def test_unparseable_dates_degrade_to_none(self, db, org, bad):
+        """A malformed timestamp must skip the org, never crash the run."""
+        org.creation_date = bad
+        db.add(org)
+        await db.commit()
+
+        snap = await _snapshot(db, org)
+        assert snap.created_at is None
+        assert snap.org_age_days is None
+
+    async def test_iso_z_dates_parse(self, db, org):
+        org.creation_date = "2026-07-01T10:00:00Z"
+        db.add(org)
+        await db.commit()
+
+        snap = await _snapshot(db, org)
+        assert snap.created_at is not None
+        assert snap.created_at.tzinfo is not None
+
+    async def test_last_touch_prefers_the_newest_signal(self, db, org, course):
+        course.update_date = _ts(0)
+        org.creation_date = _ts(100)
+        db.add_all([course, org])
+        await db.commit()
+
+        snap = await _snapshot(db, org)
+        assert snap.days_since_touch is not None
+        assert snap.days_since_touch < 1
+
+    async def test_org_active_reflects_recent_activity(self, db, org, course):
+        snap = await _snapshot(db, org)
+        assert snap.org_active is True
+
+    async def test_org_with_only_old_signals_is_not_active(self, db, org):
+        org.creation_date = _ts(90)
+        org.update_date = _ts(90)
+        db.add(org)
+        await db.commit()
+
+        snap = await _snapshot(db, org)
+        assert snap.org_active is False
+        assert snap.days_since_touch > 80
+
+
+class TestPlanAndConfig:
+    async def test_v1_config_plan_is_read(self, db, org):
+        db.add(
+            OrganizationConfig(
+                org_id=org.id,
+                config={"config_version": "1.4", "cloud": {"plan": "pro"}},
+                creation_date=_ts(),
+                update_date=_ts(),
+            )
+        )
+        await db.commit()
+
+        snap = await _snapshot(db, org)
+        assert snap.plan == "pro"
+
+    async def test_v2_config_plan_and_active_flag_are_read(self, db, org):
+        db.add(
+            OrganizationConfig(
+                org_id=org.id,
+                config={"config_version": "2.0", "plan": "standard", "active": False},
+                creation_date=_ts(),
+                update_date=_ts(),
+            )
+        )
+        await db.commit()
+
+        snap = await _snapshot(db, org)
+        assert snap.plan == "standard"
+        assert snap.org_active_flag is False
+
+    async def test_missing_config_defaults_to_free_and_active(self, db, org):
+        snap = await _snapshot(db, org)
+        assert snap.plan == "free"
+        assert snap.org_active_flag is True
+
+
+class TestTrailRunFacts:
+    async def test_statuses_are_split(self, db, org, course, admin_user):
+        from src.db.trail_runs import StatusEnum, TrailRun
+        from src.db.trails import Trail
+
+        db.add(
+            Trail(
+                id=1,
+                org_id=org.id,
+                user_id=admin_user.id,
+                trail_uuid="trail_1",
+                creation_date=_ts(5),
+                update_date=_ts(5),
+            )
+        )
+        # A run is unique per (trail, course, user), so the two statuses need
+        # two courses.
+        db.add(
+            Course(
+                id=2,
+                name="Second Course",
+                description="",
+                public=True,
+                published=True,
+                open_to_contributors=False,
+                org_id=org.id,
+                course_uuid="course_second",
+                creation_date=_ts(5),
+                update_date=_ts(5),
+            )
+        )
+        await db.commit()
+
+        for index, (course_id, status) in enumerate(
+            (
+                (course.id, StatusEnum.STATUS_IN_PROGRESS),
+                (2, StatusEnum.STATUS_COMPLETED),
+            ),
+            start=1,
+        ):
+            db.add(
+                TrailRun(
+                    id=index,
+                    trail_id=1,
+                    course_id=course_id,
+                    org_id=org.id,
+                    user_id=admin_user.id,
+                    status=status,
+                    data={},
+                    creation_date=_ts(5),
+                    update_date=_ts(2),
+                )
+            )
+        await db.commit()
+
+        snap = await _snapshot(db, org)
+        assert snap.trailrun_count == 2
+        assert snap.in_progress_trailrun_count == 1
+        assert snap.completed_trailrun_count == 1
+        assert snap.first_completed_trailrun_at is not None
+
+
+class TestAssignmentFacts:
+    async def test_assignments_and_submissions_are_counted(
+        self, db, org, course, chapter, activity, admin_user
+    ):
+        """Submissions carry no org_id of their own — they are counted through
+        AssignmentTask, which does."""
+        from src.db.courses.assignments import (
+            Assignment,
+            AssignmentTask,
+            AssignmentTaskSubmission,
+            GradingTypeEnum,
+        )
+
+        db.add(
+            Assignment(
+                id=1,
+                title="Essay",
+                description="",
+                assignment_uuid="assignment_1",
+                org_id=org.id,
+                course_id=course.id,
+                chapter_id=chapter.id,
+                activity_id=activity.id,
+                published=True,
+                due_date=_ts(-7),
+                grading_type=GradingTypeEnum.ALPHABET,
+                creation_date=_ts(6),
+                update_date=_ts(6),
+            )
+        )
+        await db.commit()
+
+        snap = await _snapshot(db, org)
+        assert snap.assignment_count == 1
+        assert snap.assignment_submission_count == 0
+        assert snap.last_assignment_created_at is not None
+
+        db.add(
+            AssignmentTask(
+                id=1,
+                title="Task",
+                description="",
+                hint="",
+                reference_file="",
+                assignment_task_uuid="assignmenttask_1",
+                assignment_id=1,
+                org_id=org.id,
+                course_id=course.id,
+                chapter_id=chapter.id,
+                activity_id=activity.id,
+                assignment_type="FILE_SUBMISSION",
+                contents={},
+                max_grade_value=100,
+                creation_date=_ts(6),
+                update_date=_ts(6),
+            )
+        )
+        await db.commit()
+        db.add(
+            AssignmentTaskSubmission(
+                id=1,
+                assignment_task_submission_uuid="submission_1",
+                task_submission={},
+                assignment_type="FILE_SUBMISSION",
+                grade=0,
+                task_submission_grade_feedback="",
+                user_id=admin_user.id,
+                assignment_task_id=1,
+                course_id=course.id,
+                activity_id=activity.id,
+                creation_date=_ts(1),
+                update_date=_ts(1),
+            )
+        )
+        await db.commit()
+
+        snap = await _snapshot(db, org)
+        assert snap.assignment_submission_count == 1
+
+
+class TestAiCreditUsage:
+    async def test_absent_redis_reads_as_no_usage(self, db, org, monkeypatch):
+        """A background job must not depend on a cache being up — the credit
+        nudge simply never fires instead."""
+        from src.services.nudges import eligibility
+
+        monkeypatch.setattr(
+            "src.core.redis.get_redis_client", lambda: None, raising=False
+        )
+        assert await eligibility._ai_credit_usage([org.id]) == {}
+
+        snap = await _snapshot(db, org)
+        assert snap.ai_credits_used == 0
+
+    async def test_usage_is_read_in_one_round_trip(self, monkeypatch):
+        from src.services.nudges import eligibility
+
+        calls = []
+
+        class FakeRedis:
+            def mget(self, keys):
+                calls.append(keys)
+                return ["7", None, "not-a-number"]
+
+        monkeypatch.setattr(
+            "src.core.redis.get_redis_client", lambda: FakeRedis(), raising=False
+        )
+
+        usage = await eligibility._ai_credit_usage([1, 2, 3])
+        assert usage == {1: 7, 2: 0, 3: 0}
+        assert len(calls) == 1
+        assert calls[0] == [
+            "ai_credits_used:1",
+            "ai_credits_used:2",
+            "ai_credits_used:3",
+        ]
+
+    async def test_redis_failure_is_swallowed(self, monkeypatch):
+        from src.services.nudges import eligibility
+
+        class Exploding:
+            def mget(self, keys):
+                raise RuntimeError("redis is down")
+
+        monkeypatch.setattr(
+            "src.core.redis.get_redis_client", lambda: Exploding(), raising=False
+        )
+        assert await eligibility._ai_credit_usage([1]) == {}
+
+
+class TestIteration:
+    async def test_iter_yields_every_org(self, db, org, other_org):
+        seen = [s.org_id async for s in iter_snapshots(db)]
+        assert set(seen) == {org.id, other_org.id}
+
+    async def test_iter_can_target_a_single_org(self, db, org, other_org):
+        seen = [s.org_id async for s in iter_snapshots(db, org_id=other_org.id)]
+        assert seen == [other_org.id]
+
+    async def test_small_chunks_still_cover_everything(self, db, org, other_org):
+        seen = [s.org_id async for s in iter_snapshots(db, chunk_size=1)]
+        assert set(seen) == {org.id, other_org.id}
+
+    async def test_empty_batch_returns_no_snapshots(self, db):
+        assert await build_snapshots(db, []) == []
+
+
+class TestQueryCount:
+    async def test_query_count_does_not_grow_with_org_count(
+        self, db, engine, org, other_org
+    ):
+        """The anti-N+1 guarantee.
+
+        This job runs against every organization daily. If the query count
+        tracks the org count, it stops being viable well before the org count
+        becomes interesting.
+        """
+
+        counter = {"n": 0}
+
+        @event.listens_for(engine.sync_engine, "before_cursor_execute")
+        def _count(conn, cursor, statement, params, context, executemany):
+            counter["n"] += 1
+
+        try:
+            counter["n"] = 0
+            await build_snapshots(db, [org])
+            one_org = counter["n"]
+
+            counter["n"] = 0
+            await build_snapshots(db, [org, other_org])
+            two_orgs = counter["n"]
+        finally:
+            event.remove(engine.sync_engine, "before_cursor_execute", _count)
+
+        assert one_org == two_orgs, (
+            f"{one_org} queries for 1 org vs {two_orgs} for 2 — the scan is per-org"
+        )

--- a/apps/api/src/tests/services/test_nudges_engagement.py
+++ b/apps/api/src/tests/services/test_nudges_engagement.py
@@ -1,0 +1,217 @@
+"""Tests for the engagement additions: preheader, stat strip, slots, tracking.
+
+Each of these changes what lands in an inbox, so the tests are about the
+rendered output rather than the internals.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from src.services.email.nudge_translations import NUDGE_TRANSLATIONS
+from src.services.nudges import runner as runner_module
+from src.services.nudges.catalog import get_spec
+from src.services.nudges.runner import TRACK_STATS, _slot_matches, _stats_for
+from src.services.nudges.snapshot import OrgSnapshot
+from src.services.users.emails import _email_layout, _first_sentence, _stat_strip
+
+NOW = datetime(2026, 7, 28, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def snap(**kw):
+    base = dict(org_id=1, org_slug="acme", org_name="Acme", plan="free", lang="en", now=NOW)
+    base.update(kw)
+    return OrgSnapshot(**base)
+
+
+class TestFirstSentence:
+    def test_takes_the_opening_sentence(self):
+        assert _first_sentence("One thing. Then another.") == "One thing."
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("これは一つ。次は二つ。", "これは一つ。"),
+            ("पहला वाक्य। दूसरा।", "पहला वाक्य।"),
+            ("Really? Yes.", "Really?"),
+            ("Stop! Go.", "Stop!"),
+        ],
+    )
+    def test_handles_other_scripts_terminators(self, text, expected):
+        assert _first_sentence(text) == expected
+
+    def test_short_text_without_punctuation_passes_through(self):
+        assert _first_sentence("No terminator here") == "No terminator here"
+
+    def test_long_text_is_truncated_on_a_word_boundary(self):
+        out = _first_sentence("word " * 60)
+        assert len(out) <= 111
+        assert out.endswith("…")
+
+    def test_empty_is_empty(self):
+        assert _first_sentence("") == ""
+
+    def test_a_late_full_stop_does_not_produce_a_giant_preheader(self):
+        """Inbox previews cut around 100 characters; a 300-character first
+        sentence would just be truncated by the client anyway."""
+        out = _first_sentence("x" * 300 + ". Short one.")
+        assert len(out) <= 111
+
+
+class TestPreheader:
+    def test_absent_preheader_leaves_the_document_unchanged(self):
+        """The twelve transactional emails share this layout."""
+        before = _email_layout("T", "<p>b</p>", footer_note="note")
+        assert "<body style=" in before
+        assert "mso-hide" not in before
+        assert '<body style="margin: 0; padding: 0; background-color: #f5f5f5;' in before
+
+    def test_preheader_is_hidden_from_the_rendered_body(self):
+        html = _email_layout("T", "<p>b</p>", preheader="Second line of info")
+        assert "Second line of info" in html
+        assert "display:none" in html
+        assert "mso-hide:all" in html
+
+    def test_preheader_is_padded(self):
+        """Without padding the client keeps reading into the body copy."""
+        html = _email_layout("T", "<p>b</p>", preheader="Hi")
+        assert html.count("&#847;") > 20
+
+    def test_preheader_is_escaped(self):
+        html = _email_layout("T", "<p>b</p>", preheader='<script>alert(1)</script>')
+        assert "<script>" not in html
+
+    def test_preheader_appears_before_the_content(self):
+        html = _email_layout("T", "<p>body-marker</p>", preheader="pre-marker")
+        assert html.index("pre-marker") < html.index("body-marker")
+
+
+class TestStatStrip:
+    def test_no_stats_renders_nothing(self):
+        assert _stat_strip([]) == ""
+
+    def test_renders_label_and_value(self):
+        html = _stat_strip([("Lessons", 8), ("Learners", 0)])
+        assert ">8<" in html and ">0<" in html
+        assert "Lessons" in html and "Learners" in html
+
+    def test_uses_no_prose_so_no_plural_agreement_is_needed(self):
+        """Writing "8 lessons" into copy means solving plural rules in twenty
+        languages; Russian has three forms and Arabic six."""
+        html = _stat_strip([("Lessons", 1)])
+        assert "1 Lessons" not in html
+        assert "1 lesson" not in html
+
+    def test_labels_are_escaped(self):
+        html = _stat_strip([("<b>x</b>", 1)])
+        assert "<b>x</b>" not in html
+
+    def test_is_a_table_so_outlook_lays_it_out(self):
+        html = _stat_strip([("Lessons", 3)])
+        assert "<table" in html and 'role="presentation"' in html
+
+
+class TestStatsSelection:
+    def test_content_track_shows_structure(self):
+        s = snap(chapter_count=3, activity_count=9)
+        assert _stats_for(get_spec("content.course_draft_d3"), s) == [
+            ("chapters", 3),
+            ("lessons", 9),
+        ]
+
+    def test_audience_track_shows_people(self):
+        s = snap(member_count=12, learner_count=4)
+        assert _stats_for(get_spec("audience.published_no_members_d7"), s) == [
+            ("members", 12),
+            ("learners", 4),
+        ]
+
+    def test_all_zero_stats_are_suppressed(self):
+        """A row of noughts reads as an accusation, not a prompt."""
+        s = snap(chapter_count=0, activity_count=0)
+        assert _stats_for(get_spec("content.course_draft_d3"), s) == []
+
+    def test_activation_never_shows_stats(self):
+        """An org with nothing in it has nothing worth counting."""
+        assert "activation" not in TRACK_STATS
+        s = snap(course_count=0)
+        assert _stats_for(get_spec("activation.first_course_d1"), s) == []
+
+    def test_monetization_never_shows_stats(self):
+        assert "monetization" not in TRACK_STATS
+
+    def test_every_stat_key_has_a_label_in_every_locale(self):
+        keys = {key for keys in TRACK_STATS.values() for key in keys}
+        for locale, strings in NUDGE_TRANSLATIONS.items():
+            for key in keys:
+                assert f"nudge.stat.{key}" in strings, f"{locale}:{key}"
+
+
+class TestSendSlots:
+    def test_one_slot_admits_everything(self):
+        assert all(_slot_matches(i, NOW, 1) for i in range(50))
+
+    def test_slots_partition_orgs_across_the_day(self):
+        """Every org lands in exactly one of the day's slots."""
+        for org_id in range(60):
+            matches = [
+                hour
+                for hour in range(24)
+                if _slot_matches(org_id, NOW.replace(hour=hour), 6)
+            ]
+            assert len(matches) == 4  # 24 hours / 6 slots
+
+    def test_a_given_hour_admits_only_its_share(self):
+        admitted = [i for i in range(60) if _slot_matches(i, NOW.replace(hour=0), 6)]
+        assert len(admitted) == 10
+        assert all(i % 6 == 0 for i in admitted)
+
+    def test_slot_count_is_read_from_the_environment(self, monkeypatch):
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_SLOTS", "4")
+        assert runner_module.send_slots() == 4
+
+    def test_default_is_a_single_slot(self, monkeypatch):
+        monkeypatch.delenv("LEARNHOUSE_NUDGES_SLOTS", raising=False)
+        assert runner_module.send_slots() == 1
+
+    @pytest.mark.parametrize("value", ["0", "-3", "nonsense"])
+    def test_nonsense_slot_counts_fall_back_to_one(self, monkeypatch, value):
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_SLOTS", value)
+        assert runner_module.send_slots() == 1
+
+
+class TestAnalyticsEvent:
+    async def test_a_delivered_nudge_is_recorded(self):
+        from src.services.nudges.runner import _record_sent
+        from src.services.nudges.snapshot import AdminRow
+
+        admin = AdminRow(
+            user_id=7,
+            user_uuid="user_x",
+            email="a@b.com",
+            first_name="A",
+            username="a",
+            email_verified=True,
+            last_login_at=None,
+        )
+        with patch("src.services.analytics.analytics.track") as tracked:
+            await _record_sent(get_spec("content.course_draft_d3"), snap(), admin)
+
+        kwargs = tracked.call_args.kwargs
+        assert kwargs["event_name"] == "nudge_sent"
+        assert kwargs["org_id"] == 1
+        assert kwargs["user_id"] == 7
+        assert kwargs["properties"]["nudge_id"] == "content.course_draft_d3"
+        assert kwargs["properties"]["track"] == "content"
+
+    async def test_analytics_failure_never_breaks_the_send_loop(self):
+        from src.services.nudges.runner import _record_sent
+        from src.services.nudges.snapshot import AdminRow
+
+        admin = AdminRow(7, "user_x", "a@b.com", "A", "a", True, None)
+        with patch(
+            "src.services.analytics.analytics.track",
+            side_effect=RuntimeError("tinybird down"),
+        ):
+            await _record_sent(get_spec("content.course_draft_d3"), snap(), admin)

--- a/apps/api/src/tests/services/test_nudges_engagement.py
+++ b/apps/api/src/tests/services/test_nudges_engagement.py
@@ -10,9 +10,8 @@ from unittest.mock import patch
 import pytest
 
 from src.services.email.nudge_translations import NUDGE_TRANSLATIONS
-from src.services.nudges import runner as runner_module
 from src.services.nudges.catalog import get_spec
-from src.services.nudges.runner import TRACK_STATS, _slot_matches, _stats_for
+from src.services.nudges.runner import TRACK_STATS, _stats_for
 from src.services.nudges.snapshot import OrgSnapshot
 from src.services.users.emails import _email_layout, _first_sentence, _stat_strip
 
@@ -146,39 +145,6 @@ class TestStatsSelection:
         for locale, strings in NUDGE_TRANSLATIONS.items():
             for key in keys:
                 assert f"nudge.stat.{key}" in strings, f"{locale}:{key}"
-
-
-class TestSendSlots:
-    def test_one_slot_admits_everything(self):
-        assert all(_slot_matches(i, NOW, 1) for i in range(50))
-
-    def test_slots_partition_orgs_across_the_day(self):
-        """Every org lands in exactly one of the day's slots."""
-        for org_id in range(60):
-            matches = [
-                hour
-                for hour in range(24)
-                if _slot_matches(org_id, NOW.replace(hour=hour), 6)
-            ]
-            assert len(matches) == 4  # 24 hours / 6 slots
-
-    def test_a_given_hour_admits_only_its_share(self):
-        admitted = [i for i in range(60) if _slot_matches(i, NOW.replace(hour=0), 6)]
-        assert len(admitted) == 10
-        assert all(i % 6 == 0 for i in admitted)
-
-    def test_slot_count_is_read_from_the_environment(self, monkeypatch):
-        monkeypatch.setenv("LEARNHOUSE_NUDGES_SLOTS", "4")
-        assert runner_module.send_slots() == 4
-
-    def test_default_is_a_single_slot(self, monkeypatch):
-        monkeypatch.delenv("LEARNHOUSE_NUDGES_SLOTS", raising=False)
-        assert runner_module.send_slots() == 1
-
-    @pytest.mark.parametrize("value", ["0", "-3", "nonsense"])
-    def test_nonsense_slot_counts_fall_back_to_one(self, monkeypatch, value):
-        monkeypatch.setenv("LEARNHOUSE_NUDGES_SLOTS", value)
-        assert runner_module.send_slots() == 1
 
 
 class TestAnalyticsEvent:

--- a/apps/api/src/tests/services/test_nudges_illustrations.py
+++ b/apps/api/src/tests/services/test_nudges_illustrations.py
@@ -1,0 +1,161 @@
+"""Tests for src/services/nudges/illustrations.py.
+
+The whole point of drawing these as table cells is that they survive clients
+which strip or block real images, so the tests guard the properties that keep
+that true.
+"""
+
+import re
+
+import pytest
+
+from src.services.nudges.catalog import NUDGE_CATALOG
+from src.services.nudges.illustrations import (
+    CELL_PX,
+    MOTIFS,
+    TRACK_COLORS,
+    _tint,
+    render_illustration,
+)
+
+
+class TestMotifs:
+    def test_every_track_in_the_catalog_has_one(self):
+        for spec in NUDGE_CATALOG:
+            assert spec.track in MOTIFS, spec.track
+
+    @pytest.mark.parametrize("track", sorted(MOTIFS))
+    def test_motifs_are_eight_by_eight(self, track):
+        motif = MOTIFS[track]
+        assert len(motif) == 8, track
+        for row in motif:
+            assert len(row) == 8, track
+
+    @pytest.mark.parametrize("track", sorted(MOTIFS))
+    def test_motifs_use_only_known_tones(self, track):
+        for row in MOTIFS[track]:
+            assert set(row) <= {"0", "1", "2"}, track
+
+    @pytest.mark.parametrize("track", sorted(MOTIFS))
+    def test_motifs_are_not_blank(self, track):
+        assert any("1" in row for row in MOTIFS[track]), track
+
+    def test_every_track_has_a_colour(self):
+        assert set(TRACK_COLORS) == set(MOTIFS)
+
+    def test_tracks_are_visually_distinct(self):
+        """Six motifs that render the same defeat the purpose."""
+        rendered = {track: MOTIFS[track] for track in MOTIFS}
+        assert len(set(map(tuple, rendered.values()))) == len(rendered)
+
+    def test_colours_are_distinct(self):
+        assert len(set(TRACK_COLORS.values())) == len(TRACK_COLORS)
+
+
+class TestTint:
+    def test_tint_moves_toward_white(self):
+        assert _tint("#000000", 0.5) == "#808080"
+        assert _tint("#000000", 1.0) == "#ffffff"
+
+    def test_tint_of_white_stays_white(self):
+        assert _tint("#ffffff") == "#ffffff"
+
+    def test_tint_accepts_a_bare_hex(self):
+        assert _tint("b45309") == _tint("#b45309")
+
+
+class TestRendering:
+    @pytest.mark.parametrize("track", sorted(MOTIFS))
+    def test_renders_a_full_grid(self, track):
+        html = render_illustration(track)
+        assert html.count("<tr>") == 8
+        assert html.count("<td") == 64
+
+    def test_unknown_track_renders_nothing(self):
+        """A new track should ship without an illustration, not without an
+        email."""
+        assert render_illustration("does_not_exist") == ""
+        assert render_illustration("") == ""
+
+    @pytest.mark.parametrize("track", sorted(MOTIFS))
+    def test_uses_no_images_at_all(self, track):
+        """Gmail strips inline SVG; Gmail and Outlook block data: URIs. Any of
+        those would render as a blank gap for a large share of readers."""
+        html = render_illustration(track)
+        assert "<img" not in html
+        assert "<svg" not in html
+        assert "data:" not in html
+        assert "background-image" not in html
+
+    @pytest.mark.parametrize("track", sorted(MOTIFS))
+    def test_carries_the_bgcolor_attribute_not_just_css(self, track):
+        """Outlook ignores background-color on a td often enough that the
+        attribute is the one actually doing the work."""
+        html = render_illustration(track)
+        assert 'bgcolor="' in html
+        for match in re.findall(r'bgcolor="([^"]+)"', html):
+            assert re.fullmatch(r"#[0-9a-f]{6}", match), match
+
+    @pytest.mark.parametrize("track", sorted(MOTIFS))
+    def test_is_hidden_from_screen_readers(self, track):
+        """Decorative: the copy already says everything it says."""
+        html = render_illustration(track)
+        assert 'role="presentation"' in html
+        assert 'aria-hidden="true"' in html
+
+    @pytest.mark.parametrize("track", sorted(MOTIFS))
+    def test_cells_are_sized_in_both_attribute_and_style(self, track):
+        html = render_illustration(track)
+        assert f'width="{CELL_PX}"' in html
+        assert f"width:{CELL_PX}px" in html
+        # Zeroed font metrics stop clients adding phantom line-height between
+        # rows, which is what turns a mosaic into a striped mess.
+        assert "font-size:0" in html
+        assert "line-height:0" in html
+
+    def test_empty_cells_carry_no_colour(self):
+        html = render_illustration("activation")
+        assert "&nbsp;" in html
+        # The corner of the activation plus is transparent.
+        assert html.count("<td") > html.count("bgcolor=")
+
+
+class TestInEmail:
+    def _render(self, track):
+        from unittest.mock import patch
+
+        from src.services.users.emails import send_nudge_email
+
+        captured = {}
+        with patch(
+            "src.services.users.emails.send_email",
+            side_effect=lambda **k: captured.update(k),
+        ):
+            send_nudge_email(
+                nudge_id="content.course_draft_d3",
+                email="a@b.com",
+                org_name="Acme",
+                cta_url="https://acme.test/dash",
+                unsubscribe_url="https://api.test/u?token=t.s",
+                track=track,
+                course_name="Course",
+                plan_name="free",
+                next_plan="personal",
+            )
+        return captured["body"]
+
+    def test_illustration_reaches_the_email(self):
+        body = self._render("content")
+        assert TRACK_COLORS["content"] in body
+        assert 'role="presentation"' in body
+
+    def test_illustration_sits_above_the_heading(self):
+        body = self._render("content")
+        assert body.index('role="presentation"') < body.index("<h1")
+
+    def test_no_track_still_produces_a_valid_email(self):
+        """Illustrations are decoration — their absence must not break the
+        message."""
+        body = self._render("")
+        assert "<h1" in body
+        assert 'role="presentation"' not in body

--- a/apps/api/src/tests/services/test_nudges_links.py
+++ b/apps/api/src/tests/services/test_nudges_links.py
@@ -1,0 +1,108 @@
+"""Tests for src/services/nudges/links.py.
+
+The point of this file is that every CTA in a nudge resolves. A broken link in
+a lifecycle email fails silently — the recipient just leaves.
+"""
+
+import pytest
+
+from src.services.nudges.links import (
+    COURSE_SUBPAGES,
+    course_editor_url,
+    course_migrate_url,
+    courses_url,
+    dashboard_url,
+    members_url,
+    onboarding_url,
+    org_settings_url,
+    public_course_url,
+    strip_course_prefix,
+    unsubscribe_url,
+)
+from src.services.nudges.tokens import verify_unsubscribe_token
+
+BASE = "https://acme.learnhouse.io"
+
+
+def _all_urls():
+    return [
+        dashboard_url(BASE),
+        courses_url(BASE),
+        course_migrate_url(BASE),
+        onboarding_url(BASE),
+        members_url(BASE),
+        org_settings_url(BASE),
+        course_editor_url(BASE, "course_abc123", "content"),
+        course_editor_url(BASE, "course_abc123", "general"),
+        public_course_url(BASE, "course_abc123"),
+    ]
+
+
+class TestCoursePrefixTrap:
+    def test_prefix_is_stripped(self):
+        assert strip_course_prefix("course_abc123") == "abc123"
+
+    def test_only_the_leading_prefix_is_stripped(self):
+        # A uuid that happens to contain the substring later must keep it.
+        assert strip_course_prefix("course_abccourse_123") == "abccourse_123"
+
+    def test_bare_uuid_passes_through(self):
+        assert strip_course_prefix("abc123") == "abc123"
+
+    def test_empty_uuid_does_not_raise(self):
+        assert strip_course_prefix("") == ""
+
+    def test_no_built_url_leaks_the_stored_prefix(self):
+        """The regression this module exists to prevent."""
+        for url in _all_urls():
+            assert "/course_" not in url, url
+
+    def test_course_urls_use_the_bare_uuid(self):
+        assert course_editor_url(BASE, "course_abc123") == (
+            f"{BASE}/dash/courses/course/abc123/content"
+        )
+        assert public_course_url(BASE, "course_abc123") == f"{BASE}/course/abc123"
+
+
+class TestRouteShapes:
+    def test_every_url_is_absolute(self):
+        for url in _all_urls():
+            assert url.startswith("https://"), url
+
+    def test_no_url_has_a_double_slash_in_its_path(self):
+        for url in _all_urls():
+            assert "//" not in url[len("https://") :], url
+
+    @pytest.mark.parametrize("subpage", sorted(COURSE_SUBPAGES))
+    def test_every_valid_subpage_builds(self, subpage):
+        url = course_editor_url(BASE, "course_abc123", subpage)
+        assert url.endswith(f"/{subpage}")
+
+    def test_unknown_subpage_falls_back_to_content(self):
+        """An unknown segment renders an empty tab rather than 404ing, which is
+        harder to spot than a dead link — so refuse to emit one."""
+        url = course_editor_url(BASE, "course_abc123", "does-not-exist")
+        assert url.endswith("/content")
+
+    def test_uuid_is_url_quoted(self):
+        url = course_editor_url(BASE, "course_a b/c")
+        assert " " not in url
+        assert url.endswith("/a%20b%2Fc/content")
+
+    def test_settings_subpage_is_quoted(self):
+        assert org_settings_url(BASE, "general").endswith("/dash/org/settings/general")
+
+
+class TestUnsubscribeUrl:
+    def test_token_round_trips_from_the_built_url(self):
+        url = unsubscribe_url("https://api.learnhouse.io", "user_abc")
+        token = url.split("token=", 1)[1]
+        assert verify_unsubscribe_token(token) == "user_abc"
+
+    def test_points_at_the_api_endpoint(self):
+        url = unsubscribe_url("https://api.learnhouse.io", "user_abc")
+        assert url.startswith("https://api.learnhouse.io/api/v1/emails/unsubscribe?token=")
+
+    def test_trailing_slash_on_the_base_is_tolerated(self):
+        url = unsubscribe_url("https://api.learnhouse.io/", "user_abc")
+        assert "//api/v1" not in url

--- a/apps/api/src/tests/services/test_nudges_preferences.py
+++ b/apps/api/src/tests/services/test_nudges_preferences.py
@@ -62,3 +62,79 @@ class TestBulkOptOutSet:
         await set_lifecycle_opt_out(db, admin_user.id, opted_out=False)
 
         assert await get_opted_out_user_ids(db, [admin_user.id, regular_user.id]) == set()
+
+
+class TestEdgeCases:
+    async def test_naive_datetimes_are_stamped_utc(self):
+        """Aggregates over the naive string columns come back without a zone;
+        comparing one to an aware `now` would raise."""
+        from datetime import datetime
+
+        from src.services.nudges.snapshot import parse_ts
+
+        parsed = parse_ts(datetime(2026, 7, 28, 12, 0, 0))
+        assert parsed is not None and parsed.tzinfo is not None
+
+    async def test_aware_datetimes_pass_through(self):
+        from datetime import datetime, timezone
+
+        from src.services.nudges.snapshot import parse_ts
+
+        stamp = datetime(2026, 7, 28, tzinfo=timezone.utc)
+        assert parse_ts(stamp) is stamp
+
+    async def test_orgs_without_ids_yield_no_snapshots(self, db):
+        """Defensive: an unflushed Organization has no primary key yet."""
+        from src.db.organizations import Organization
+        from src.services.nudges.eligibility import build_snapshots
+
+        assert await build_snapshots(db, [Organization(name="x", slug="x")]) == []
+
+    async def test_org_base_url_strips_a_trailing_slash(self, monkeypatch):
+        """Every CTA concatenates a path onto this, so a trailing slash would
+        produce a double slash in the link."""
+        from src.services.nudges import links
+
+        async def fake(org_slug, request=None, db_session=None, org_id=None):
+            return "https://acme.test/"
+
+        monkeypatch.setattr(links, "get_org_signup_base_url", fake)
+        assert await links.org_base_url("acme") == "https://acme.test"
+
+
+class TestResubscribeThenOptOutAgain:
+    async def test_second_opt_out_after_resubscribing_stamps_a_fresh_time(
+        self, db, admin_user
+    ):
+        """The row already exists and its timestamp was cleared on resubscribe,
+        so the next opt-out has to stamp it again rather than leave it null."""
+        await set_lifecycle_opt_out(db, admin_user.id, opted_out=True)
+        await set_lifecycle_opt_out(db, admin_user.id, opted_out=False)
+
+        pref = await set_lifecycle_opt_out(db, admin_user.id, opted_out=True)
+
+        assert pref.lifecycle_opt_out is True
+        assert pref.unsubscribed_at is not None
+
+
+class TestEmptyBatches:
+    async def test_recent_send_counts_short_circuits_on_no_users(self, db):
+        from datetime import datetime, timezone
+
+        from src.services.nudges.runner import _recent_send_counts
+
+        assert await _recent_send_counts(db, [], datetime.now(timezone.utc)) == {}
+
+    def test_content_cta_prefers_the_newest_course(self):
+        from src.services.nudges.catalog import _content_link
+        from src.services.nudges.snapshot import OrgSnapshot
+
+        base = dict(org_id=1, org_slug="acme", org_name="Acme", plan="free", lang="en")
+        newest = OrgSnapshot(**base, newest_course_uuid="course_new")
+        assert _content_link(newest, "https://acme.test") == (
+            "https://acme.test/dash/courses/course/new/content"
+        )
+
+        # Falls back to the draft when there is no newest course recorded.
+        draft_only = OrgSnapshot(**base, oldest_draft_course_uuid="course_draft")
+        assert _content_link(draft_only, "https://acme.test").endswith("/draft/content")

--- a/apps/api/src/tests/services/test_nudges_preferences.py
+++ b/apps/api/src/tests/services/test_nudges_preferences.py
@@ -1,0 +1,64 @@
+"""Tests for src/services/nudges/preferences.py."""
+
+from src.services.nudges.preferences import (
+    get_opted_out_user_ids,
+    get_user_by_uuid,
+    is_opted_out,
+    set_lifecycle_opt_out,
+)
+
+
+class TestLookup:
+    async def test_get_user_by_uuid(self, db, admin_user):
+        found = await get_user_by_uuid(db, admin_user.user_uuid)
+        assert found is not None and found.id == admin_user.id
+
+    async def test_get_user_by_uuid_returns_none_when_absent(self, db):
+        assert await get_user_by_uuid(db, "user_nope") is None
+
+
+class TestOptOutState:
+    async def test_absence_of_a_row_means_opted_in(self, db, admin_user):
+        """No row is the "never asked" state — everyone starts subscribed."""
+        assert await is_opted_out(db, admin_user.id) is False
+
+    async def test_set_then_read(self, db, admin_user):
+        await set_lifecycle_opt_out(db, admin_user.id)
+        assert await is_opted_out(db, admin_user.id) is True
+
+    async def test_resubscribe_clears_the_timestamp(self, db, admin_user):
+        await set_lifecycle_opt_out(db, admin_user.id, opted_out=True)
+        pref = await set_lifecycle_opt_out(
+            db, admin_user.id, opted_out=False, source="dashboard"
+        )
+
+        assert pref.lifecycle_opt_out is False
+        assert pref.unsubscribed_at is None
+        assert pref.source == "dashboard"
+        assert await is_opted_out(db, admin_user.id) is False
+
+    async def test_repeat_opt_out_keeps_the_original_timestamp(self, db, admin_user):
+        first = await set_lifecycle_opt_out(db, admin_user.id)
+        original = first.unsubscribed_at
+
+        second = await set_lifecycle_opt_out(db, admin_user.id)
+        assert second.unsubscribed_at == original
+
+
+class TestBulkOptOutSet:
+    async def test_empty_input_avoids_a_query(self, db):
+        assert await get_opted_out_user_ids(db, []) == set()
+
+    async def test_returns_only_opted_out_ids(self, db, admin_user, regular_user):
+        await set_lifecycle_opt_out(db, admin_user.id)
+
+        result = await get_opted_out_user_ids(db, [admin_user.id, regular_user.id])
+        assert result == {admin_user.id}
+
+    async def test_resubscribed_users_drop_out_of_the_set(
+        self, db, admin_user, regular_user
+    ):
+        await set_lifecycle_opt_out(db, admin_user.id)
+        await set_lifecycle_opt_out(db, admin_user.id, opted_out=False)
+
+        assert await get_opted_out_user_ids(db, [admin_user.id, regular_user.id]) == set()

--- a/apps/api/src/tests/services/test_nudges_runner.py
+++ b/apps/api/src/tests/services/test_nudges_runner.py
@@ -620,3 +620,85 @@ class TestBudgetMidOrganization:
 
         assert stats.sent == 2
         assert stats.budget_exhausted is True
+
+
+class TestSlotsInTheRun:
+    async def test_an_org_outside_the_current_slot_is_deferred(
+        self, db, activation_org, sender, monkeypatch
+    ):
+        """Spreading the day's mail across slots keeps a single burst from
+        looking like a blast to spam filters — and means a bad send reaches a
+        fraction of the list before anyone notices."""
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_SLOTS", "6")
+        # org id 1 belongs to slot 1; run during slot 0.
+        stats = await run_nudges(db, now=NOW.replace(hour=0))
+
+        assert stats.sent == 0
+        assert stats.skipped_slot == 1
+        sender.assert_not_called()
+
+    async def test_the_org_sends_when_its_slot_comes_round(
+        self, db, activation_org, sender, monkeypatch
+    ):
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_SLOTS", "6")
+        stats = await run_nudges(db, now=NOW.replace(hour=1))
+
+        assert stats.sent == 1
+        assert stats.skipped_slot == 0
+
+    async def test_stats_expose_the_deferred_count(self, db, activation_org, sender, monkeypatch):
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_SLOTS", "6")
+        stats = await run_nudges(db, now=NOW.replace(hour=0))
+        assert stats.as_dict()["skipped_slot"] == 1
+
+
+class TestStatStripReachesTheEmail:
+    async def test_content_nudge_carries_its_figures(self, db, org, verified_admin, sender):
+        from src.db.courses.courses import Course
+
+        org.creation_date = _stored(40)
+        org.update_date = _stored(40)
+        db.add(org)
+        db.add(
+            Course(
+                id=60,
+                name="Draft",
+                description="",
+                public=False,
+                published=False,
+                open_to_contributors=False,
+                org_id=org.id,
+                course_uuid="course_d",
+                creation_date=_stored(30),
+                update_date=_stored(4),
+            )
+        )
+        await db.commit()
+
+        from src.db.courses.activities import (
+            Activity,
+            ActivitySubTypeEnum,
+            ActivityTypeEnum,
+        )
+
+        for index in (1, 2):
+            db.add(
+                Activity(
+                    id=index,
+                    name=f"Lesson {index}",
+                    activity_type=ActivityTypeEnum.TYPE_DYNAMIC,
+                    activity_sub_type=ActivitySubTypeEnum.SUBTYPE_DYNAMIC_PAGE,
+                    content={},
+                    published=False,
+                    org_id=org.id,
+                    course_id=60,
+                    activity_uuid=f"activity_{index}",
+                    creation_date=_stored(30),
+                    update_date=_stored(30),
+                )
+            )
+        await db.commit()
+
+        await run_nudges(db, now=NOW, only="content.course_draft_d3")
+
+        assert sender.call_args.kwargs["stats"] == [("chapters", 0), ("lessons", 2)]

--- a/apps/api/src/tests/services/test_nudges_runner.py
+++ b/apps/api/src/tests/services/test_nudges_runner.py
@@ -1,0 +1,532 @@
+"""Tests for src/services/nudges/runner.py.
+
+The guardrails are the product here. A nudge system that double-sends, ignores
+an opt-out, or mails an unverified address costs more than it earns.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from sqlmodel import select
+
+from src.db.courses.courses import Course
+from src.db.nudges import NudgeSend, NudgeSendStatus
+from src.services.nudges import runner as runner_module
+from src.services.nudges.preferences import set_lifecycle_opt_out
+from src.services.nudges.runner import RunStats, dedupe_key, run_nudges
+from src.services.nudges.catalog import get_spec
+
+NOW = datetime(2026, 7, 28, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _stored(days_ago: float) -> str:
+    """A timestamp in the naive string format the schema uses."""
+    return str((NOW - timedelta(days=days_ago)).replace(tzinfo=None))
+
+
+@pytest.fixture(autouse=True)
+def _saas_and_enabled(monkeypatch):
+    """Both gates open by default; individual tests close one to assert it."""
+    monkeypatch.setenv("LEARNHOUSE_NUDGES_ENABLED", "true")
+    monkeypatch.setattr(runner_module, "get_deployment_mode", lambda: "saas")
+    monkeypatch.setattr(
+        runner_module.links, "org_base_url", _fake_base_url
+    )
+    monkeypatch.setattr(runner_module, "get_media_base_url", lambda _r=None: "https://api.test")
+
+
+async def _fake_base_url(org_slug, db_session=None, org_id=None):
+    return f"https://{org_slug}.test"
+
+
+@pytest.fixture
+def sender():
+    """Patch the provider call and record what would go out."""
+    with patch("src.services.nudges.runner.send_nudge_email") as mock:
+        mock.return_value = {"id": "sent"}
+        yield mock
+
+
+@pytest.fixture
+async def verified_admin(db, admin_user):
+    from src.db.users import User
+
+    row = (
+        await db.execute(select(User).where(User.id == admin_user.id))
+    ).scalars().first()
+    row.email_verified = True
+    db.add(row)
+    await db.commit()
+    return row
+
+
+@pytest.fixture
+async def activation_org(db, org, verified_admin):
+    """An org one and a half days old with no course — the day-1 case."""
+    org.creation_date = _stored(1.5)
+    org.update_date = _stored(1.5)
+    db.add(org)
+    await db.commit()
+    return org
+
+
+async def _ledger(db):
+    return (await db.execute(select(NudgeSend))).scalars().all()
+
+
+class TestGates:
+    async def test_non_saas_deployments_send_nothing(
+        self, db, activation_org, sender, monkeypatch
+    ):
+        """Self-hosted instances must not mail their own admins on our behalf."""
+        monkeypatch.setattr(runner_module, "get_deployment_mode", lambda: "oss")
+
+        stats = await run_nudges(db, now=NOW)
+
+        assert stats.sent == 0
+        sender.assert_not_called()
+        assert await _ledger(db) == []
+
+    async def test_kill_switch_off_sends_nothing(
+        self, db, activation_org, sender, monkeypatch
+    ):
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_ENABLED", "false")
+
+        stats = await run_nudges(db, now=NOW)
+
+        assert stats.sent == 0
+        sender.assert_not_called()
+
+    async def test_force_overrides_the_gates(
+        self, db, activation_org, sender, monkeypatch
+    ):
+        monkeypatch.setattr(runner_module, "get_deployment_mode", lambda: "oss")
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_ENABLED", "false")
+
+        stats = await run_nudges(db, now=NOW, force=True)
+
+        assert stats.sent == 1
+
+
+class TestSending:
+    async def test_sends_the_activation_nudge(self, db, activation_org, sender):
+        stats = await run_nudges(db, now=NOW)
+
+        assert stats.sent == 1
+        assert stats.by_nudge == {"activation.first_course_d1": 1}
+        sender.assert_called_once()
+
+        kwargs = sender.call_args.kwargs
+        assert kwargs["nudge_id"] == "activation.first_course_d1"
+        assert kwargs["cta_url"] == "https://test-org.test/dash/courses"
+        assert kwargs["unsubscribe_url"].startswith(
+            "https://api.test/api/v1/emails/unsubscribe?token="
+        )
+
+    async def test_ledger_row_records_the_send(self, db, activation_org, sender):
+        await run_nudges(db, now=NOW)
+
+        rows = await _ledger(db)
+        assert len(rows) == 1
+        assert rows[0].status == NudgeSendStatus.SENT
+        assert rows[0].sent_at is not None
+        assert rows[0].nudge_id == "activation.first_course_d1"
+        assert rows[0].meta["track"] == "activation"
+
+    async def test_only_filters_to_one_nudge(self, db, activation_org, sender):
+        stats = await run_nudges(db, now=NOW, only="dormancy.no_login_30d")
+
+        assert stats.sent == 0
+        sender.assert_not_called()
+
+    async def test_org_id_targets_a_single_org(
+        self, db, activation_org, other_org, sender
+    ):
+        stats = await run_nudges(db, now=NOW, org_id=other_org.id)
+
+        assert stats.sent == 0
+
+
+class TestDedupe:
+    async def test_running_twice_sends_once(self, db, activation_org, sender):
+        first = await run_nudges(db, now=NOW)
+        second = await run_nudges(db, now=NOW + timedelta(days=1))
+
+        assert first.sent == 1
+        assert second.sent == 0
+        assert sender.call_count == 1
+        assert len(await _ledger(db)) == 1
+
+    async def test_dedupe_holds_even_once_the_cap_has_cleared(
+        self, db, activation_org, verified_admin, sender
+    ):
+        """The frequency cap masks a re-send for a couple of days. Past that,
+        the dedupe key is the only thing standing between an admin and a
+        second copy of the same email."""
+        await run_nudges(db, now=NOW)
+
+        # Clear the trailing-week cap so only dedupe can block the second run,
+        # while keeping the org inside the activation window.
+        rows = await _ledger(db)
+        rows[0].sent_at = NOW - timedelta(days=30)
+        db.add(rows[0])
+        await db.commit()
+
+        stats = await run_nudges(db, now=NOW)
+
+        assert stats.sent == 0
+        assert stats.skipped_dedupe >= 1
+        assert sender.call_count == 1
+
+    async def test_dry_run_does_not_consume_the_real_key(
+        self, db, activation_org, sender
+    ):
+        """A rehearsal must not silently disqualify the live send."""
+        await run_nudges(db, now=NOW, dry_run=True)
+        stats = await run_nudges(db, now=NOW)
+
+        assert stats.sent == 1
+
+    def test_repeatable_nudges_key_by_period(self):
+        spec = get_spec("dormancy.no_login_30d")
+        quarterly = type(spec)(**{**spec.__dict__, "repeat": "quarterly"})
+
+        q3 = dedupe_key(quarterly, 1, 1, datetime(2026, 8, 1, tzinfo=timezone.utc), False)
+        q4 = dedupe_key(quarterly, 1, 1, datetime(2026, 11, 1, tzinfo=timezone.utc), False)
+
+        assert q3 != q4
+        assert q3.endswith(":2026-Q3")
+        assert q4.endswith(":2026-Q4")
+
+    def test_dry_run_keys_are_namespaced(self):
+        spec = get_spec("activation.first_course_d1")
+        assert dedupe_key(spec, 1, 1, NOW, True).startswith("dryrun:")
+        assert not dedupe_key(spec, 1, 1, NOW, False).startswith("dryrun:")
+
+
+class TestDryRun:
+    async def test_dry_run_writes_a_row_and_sends_nothing(
+        self, db, activation_org, sender
+    ):
+        stats = await run_nudges(db, now=NOW, dry_run=True)
+
+        sender.assert_not_called()
+        assert stats.sent == 0
+        assert stats.by_nudge == {"activation.first_course_d1": 1}
+
+        rows = await _ledger(db)
+        assert len(rows) == 1
+        assert rows[0].status == NudgeSendStatus.DRY_RUN
+        assert rows[0].sent_at is None
+
+    async def test_dry_run_works_with_the_kill_switch_off(
+        self, db, activation_org, sender, monkeypatch
+    ):
+        """Rehearsing against production must not require arming the system."""
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_ENABLED", "false")
+
+        stats = await run_nudges(db, now=NOW, dry_run=True)
+        assert stats.by_nudge == {"activation.first_course_d1": 1}
+
+
+class TestSuppression:
+    async def test_unverified_admins_are_never_mailed(
+        self, db, activation_org, verified_admin, sender
+    ):
+        verified_admin.email_verified = False
+        db.add(verified_admin)
+        await db.commit()
+
+        stats = await run_nudges(db, now=NOW)
+
+        assert stats.sent == 0
+        sender.assert_not_called()
+
+    async def test_opted_out_admins_are_skipped(
+        self, db, activation_org, verified_admin, sender
+    ):
+        await set_lifecycle_opt_out(db, verified_admin.id)
+
+        stats = await run_nudges(db, now=NOW)
+
+        assert stats.sent == 0
+        assert stats.skipped_optout == 1
+        sender.assert_not_called()
+
+    async def test_inactive_orgs_are_skipped(
+        self, db, activation_org, sender
+    ):
+        from src.db.organization_config import OrganizationConfig
+
+        db.add(
+            OrganizationConfig(
+                org_id=activation_org.id,
+                config={"config_version": "2.0", "plan": "free", "active": False},
+                creation_date=_stored(0),
+                update_date=_stored(0),
+            )
+        )
+        await db.commit()
+
+        stats = await run_nudges(db, now=NOW)
+
+        assert stats.sent == 0
+        assert stats.skipped_inactive_org == 1
+
+    async def test_an_org_that_came_back_on_its_own_is_left_alone(
+        self, db, activation_org, sender
+    ):
+        db.add(
+            Course(
+                id=99,
+                name="Just Started",
+                description="",
+                public=False,
+                published=False,
+                open_to_contributors=False,
+                org_id=activation_org.id,
+                course_uuid="course_new",
+                creation_date=_stored(0.1),
+                update_date=_stored(0.1),
+            )
+        )
+        await db.commit()
+
+        stats = await run_nudges(db, now=NOW)
+        assert stats.sent == 0
+
+
+class TestFrequencyCap:
+    async def test_weekly_cap_blocks_further_sends(
+        self, db, activation_org, verified_admin, sender
+    ):
+        for index in range(2):
+            db.add(
+                NudgeSend(
+                    nudge_id=f"other.nudge_{index}",
+                    dedupe_key=f"other.nudge_{index}:1:1",
+                    org_id=activation_org.id,
+                    user_id=verified_admin.id,
+                    status=NudgeSendStatus.SENT,
+                    claimed_at=NOW - timedelta(days=5),
+                    sent_at=NOW - timedelta(days=5),
+                )
+            )
+        await db.commit()
+
+        stats = await run_nudges(db, now=NOW)
+
+        assert stats.sent == 0
+        assert stats.skipped_cap == 1
+
+    async def test_recent_send_enforces_a_minimum_gap(
+        self, db, activation_org, verified_admin, sender
+    ):
+        """One email yesterday is under the weekly cap but still too soon."""
+        db.add(
+            NudgeSend(
+                nudge_id="other.nudge",
+                dedupe_key="other.nudge:1:1",
+                org_id=activation_org.id,
+                user_id=verified_admin.id,
+                status=NudgeSendStatus.SENT,
+                claimed_at=NOW - timedelta(hours=6),
+                sent_at=NOW - timedelta(hours=6),
+            )
+        )
+        await db.commit()
+
+        stats = await run_nudges(db, now=NOW)
+
+        assert stats.sent == 0
+        assert stats.skipped_cap == 1
+
+    async def test_old_sends_do_not_count_against_the_cap(
+        self, db, activation_org, verified_admin, sender
+    ):
+        db.add(
+            NudgeSend(
+                nudge_id="other.nudge",
+                dedupe_key="other.nudge:1:1",
+                org_id=activation_org.id,
+                user_id=verified_admin.id,
+                status=NudgeSendStatus.SENT,
+                claimed_at=NOW - timedelta(days=30),
+                sent_at=NOW - timedelta(days=30),
+            )
+        )
+        await db.commit()
+
+        stats = await run_nudges(db, now=NOW)
+        assert stats.sent == 1
+
+    async def test_failed_sends_do_not_count_against_the_cap(
+        self, db, activation_org, verified_admin, sender
+    ):
+        db.add(
+            NudgeSend(
+                nudge_id="other.nudge",
+                dedupe_key="other.nudge:1:1",
+                org_id=activation_org.id,
+                user_id=verified_admin.id,
+                status=NudgeSendStatus.FAILED,
+                claimed_at=NOW - timedelta(hours=1),
+                sent_at=None,
+            )
+        )
+        await db.commit()
+
+        stats = await run_nudges(db, now=NOW)
+        assert stats.sent == 1
+
+
+class TestBudget:
+    async def test_max_sends_stops_the_run(self, db, activation_org, sender):
+        stats = await run_nudges(db, now=NOW, max_sends=0)
+
+        assert stats.sent == 0
+        assert stats.budget_exhausted is True
+        sender.assert_not_called()
+
+    async def test_deferred_candidates_are_not_claimed(
+        self, db, activation_org, sender
+    ):
+        """Budget exhaustion must leave them eligible tomorrow, not burn them."""
+        await run_nudges(db, now=NOW, max_sends=0)
+        assert await _ledger(db) == []
+
+        stats = await run_nudges(db, now=NOW, max_sends=10)
+        assert stats.sent == 1
+
+
+class TestProviderFailure:
+    async def test_failure_is_recorded_and_does_not_raise(
+        self, db, activation_org, sender
+    ):
+        """`_send_notification_email` returns False on a provider failure; one
+        bad address must not take down the batch."""
+        sender.return_value = False
+
+        stats = await run_nudges(db, now=NOW)
+
+        assert stats.failed == 1
+        assert stats.sent == 0
+
+        rows = await _ledger(db)
+        assert rows[0].status == NudgeSendStatus.FAILED
+        assert rows[0].sent_at is None
+        assert rows[0].error
+
+
+class TestSeeding:
+    async def test_seed_suppresses_without_sending(self, db, activation_org, sender):
+        stats = await run_nudges(db, now=NOW, seed=True)
+
+        sender.assert_not_called()
+        assert stats.sent == 0
+
+        rows = await _ledger(db)
+        assert len(rows) == 1
+        assert rows[0].status == NudgeSendStatus.SUPPRESSED
+
+    async def test_seeded_keys_are_permanently_consumed(
+        self, db, activation_org, sender
+    ):
+        """The point of seeding: switching the system on must not fire a
+        backlog of everything that happens to be true that day."""
+        await run_nudges(db, now=NOW, seed=True)
+        stats = await run_nudges(db, now=NOW)
+
+        assert stats.sent == 0
+        sender.assert_not_called()
+
+
+class TestBackfillGuard:
+    @pytest.fixture
+    async def legacy_org(self, db, org, verified_admin):
+        """An org from long before this system existed, quiet for 32 days —
+        inside the dormancy window and far outside every other track's."""
+        org.creation_date = _stored(400)
+        org.update_date = _stored(32)
+        db.add(org)
+        db.add(
+            Course(
+                id=50,
+                name="Old Course",
+                description="",
+                public=True,
+                published=True,
+                open_to_contributors=False,
+                org_id=org.id,
+                course_uuid="course_old",
+                creation_date=_stored(390),
+                update_date=_stored(32),
+            )
+        )
+        await db.commit()
+        return org
+
+    async def test_backfill_off_excludes_preexisting_orgs(
+        self, db, legacy_org, sender, monkeypatch
+    ):
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_START_DATE", "2026-07-01")
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_BACKFILL_MODE", "off")
+
+        stats = await run_nudges(db, now=NOW)
+
+        assert stats.sent == 0
+        assert stats.skipped_backfill >= 1
+
+    async def test_winback_mode_admits_only_the_dormancy_track(
+        self, db, legacy_org, sender, monkeypatch
+    ):
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_START_DATE", "2026-07-01")
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_BACKFILL_MODE", "winback")
+
+        stats = await run_nudges(db, now=NOW)
+
+        assert stats.sent == 1
+        assert stats.by_nudge == {"dormancy.no_login_30d": 1}
+
+    async def test_no_start_date_treats_every_org_as_new(
+        self, db, legacy_org, sender, monkeypatch
+    ):
+        monkeypatch.delenv("LEARNHOUSE_NUDGES_START_DATE", raising=False)
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_BACKFILL_MODE", "off")
+
+        stats = await run_nudges(db, now=NOW)
+        assert stats.sent == 1
+
+    async def test_unparseable_start_date_is_ignored(self, monkeypatch):
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_START_DATE", "not-a-date")
+        assert runner_module.start_date() is None
+
+    async def test_start_date_without_a_zone_is_read_as_utc(self, monkeypatch):
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_START_DATE", "2026-07-01")
+        parsed = runner_module.start_date()
+        assert parsed is not None and parsed.tzinfo is not None
+
+
+class TestEnvHelpers:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [("true", True), ("1", True), ("YES", True), ("off", False), ("", False)],
+    )
+    def test_flag_parsing(self, monkeypatch, value, expected):
+        monkeypatch.setenv("LEARNHOUSE_TEST_FLAG", value)
+        assert runner_module._flag("LEARNHOUSE_TEST_FLAG") is expected
+
+    def test_flag_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("LEARNHOUSE_TEST_FLAG", raising=False)
+        assert runner_module._flag("LEARNHOUSE_TEST_FLAG", True) is True
+
+    def test_int_env_falls_back_on_garbage(self, monkeypatch):
+        monkeypatch.setenv("LEARNHOUSE_TEST_INT", "not-a-number")
+        assert runner_module._int_env("LEARNHOUSE_TEST_INT", 42) == 42
+
+    def test_stats_serialise(self):
+        stats = RunStats()
+        stats.record("a.b")
+        stats.record("a.b")
+        assert stats.as_dict()["by_nudge"] == {"a.b": 2}

--- a/apps/api/src/tests/services/test_nudges_runner.py
+++ b/apps/api/src/tests/services/test_nudges_runner.py
@@ -530,3 +530,93 @@ class TestEnvHelpers:
         stats.record("a.b")
         stats.record("a.b")
         assert stats.as_dict()["by_nudge"] == {"a.b": 2}
+
+
+class TestRepeatKeys:
+    def test_monthly_repeat_keys_by_month(self):
+        spec = get_spec("dormancy.no_login_30d")
+        monthly = type(spec)(**{**spec.__dict__, "repeat": "monthly"})
+
+        july = dedupe_key(monthly, 1, 1, datetime(2026, 7, 5, tzinfo=timezone.utc), False)
+        august = dedupe_key(monthly, 1, 1, datetime(2026, 8, 5, tzinfo=timezone.utc), False)
+
+        assert july.endswith(":2026-07")
+        assert august.endswith(":2026-08")
+
+    def test_full_backfill_mode_admits_every_track(self, monkeypatch):
+        """Documented as unsupported, but it exists as an escape hatch and
+        must do what it says."""
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_BACKFILL_MODE", "full")
+        spec = get_spec("activation.first_course_d1")
+        snapshot = type(
+            "S", (), {"created_at": NOW - timedelta(days=400)}
+        )()
+        assert runner_module._backfill_allows(
+            spec, snapshot, NOW - timedelta(days=30)
+        ) is True
+
+
+class TestWhiteLabelling:
+    async def test_org_logo_is_used_when_the_org_has_one(
+        self, db, activation_org, sender
+    ):
+        activation_org.logo_image = "logo.png"
+        db.add(activation_org)
+        await db.commit()
+
+        await run_nudges(db, now=NOW)
+
+        assert sender.call_args.kwargs["logo_url"] == (
+            "https://api.test/content/orgs/org_test/logos/logo.png"
+        )
+
+    async def test_no_logo_leaves_the_default_mark(self, db, activation_org, sender):
+        await run_nudges(db, now=NOW)
+        assert sender.call_args.kwargs["logo_url"] is None
+
+
+class TestBudgetMidOrganization:
+    async def test_budget_stops_between_admins_of_one_org(
+        self, db, org, admin_role, verified_admin, sender
+    ):
+        """The inner loop needs its own budget check — an org with several
+        admins could otherwise overrun the cap on a single iteration."""
+        from datetime import datetime as dt
+
+        from src.db.user_organizations import UserOrganization
+        from src.db.users import User
+
+        org.creation_date = _stored(1.5)
+        org.update_date = _stored(1.5)
+        db.add(org)
+
+        for index in range(2, 5):
+            db.add(
+                User(
+                    id=index + 10,
+                    username=f"admin{index}",
+                    first_name="Admin",
+                    last_name="Two",
+                    email=f"admin{index}@test.com",
+                    password="x",
+                    user_uuid=f"user_admin{index}",
+                    email_verified=True,
+                    creation_date=str(dt.now()),
+                    update_date=str(dt.now()),
+                )
+            )
+            db.add(
+                UserOrganization(
+                    user_id=index + 10,
+                    org_id=org.id,
+                    role_id=admin_role.id,
+                    creation_date=str(dt.now()),
+                    update_date=str(dt.now()),
+                )
+            )
+        await db.commit()
+
+        stats = await run_nudges(db, now=NOW, max_sends=2)
+
+        assert stats.sent == 2
+        assert stats.budget_exhausted is True

--- a/apps/api/src/tests/services/test_nudges_runner.py
+++ b/apps/api/src/tests/services/test_nudges_runner.py
@@ -40,6 +40,27 @@ async def _fake_base_url(org_slug, db_session=None, org_id=None):
     return f"https://{org_slug}.test"
 
 
+@pytest.fixture(autouse=True)
+async def _seeded_ledger(db, org):
+    """Pin the activation boundary in the past.
+
+    The boundary is derived from the earliest ledger row, so an empty ledger
+    means every org predates the system. Production pins it by running
+    `nudges-seed`; the tests pin it here so their orgs count as new.
+    """
+    db.add(
+        NudgeSend(
+            nudge_id="bootstrap",
+            dedupe_key="bootstrap:0:0",
+            org_id=org.id,
+            user_id=1,
+            status=NudgeSendStatus.SUPPRESSED,
+            claimed_at=NOW - timedelta(days=400),
+        )
+    )
+    await db.commit()
+
+
 @pytest.fixture
 def sender():
     """Patch the provider call and record what would go out."""
@@ -72,7 +93,9 @@ async def activation_org(db, org, verified_admin):
 
 
 async def _ledger(db):
-    return (await db.execute(select(NudgeSend))).scalars().all()
+    """Ledger rows written by the run under test, excluding the bootstrap row."""
+    rows = (await db.execute(select(NudgeSend))).scalars().all()
+    return [r for r in rows if r.nudge_id != "bootstrap"]
 
 
 class TestGates:
@@ -445,9 +468,9 @@ class TestSeeding:
 class TestBackfillGuard:
     @pytest.fixture
     async def legacy_org(self, db, org, verified_admin):
-        """An org from long before this system existed, quiet for 32 days —
-        inside the dormancy window and far outside every other track's."""
-        org.creation_date = _stored(400)
+        """An org from long before this system existed, quiet for 32 days."""
+        # Older than the boundary the autouse fixture pinned.
+        org.creation_date = _stored(500)
         org.update_date = _stored(32)
         db.add(org)
         db.add(
@@ -460,7 +483,7 @@ class TestBackfillGuard:
                 open_to_contributors=False,
                 org_id=org.id,
                 course_uuid="course_old",
-                creation_date=_stored(390),
+                creation_date=_stored(490),
                 update_date=_stored(32),
             )
         )
@@ -470,7 +493,6 @@ class TestBackfillGuard:
     async def test_backfill_off_excludes_preexisting_orgs(
         self, db, legacy_org, sender, monkeypatch
     ):
-        monkeypatch.setenv("LEARNHOUSE_NUDGES_START_DATE", "2026-07-01")
         monkeypatch.setenv("LEARNHOUSE_NUDGES_BACKFILL_MODE", "off")
 
         stats = await run_nudges(db, now=NOW)
@@ -478,34 +500,60 @@ class TestBackfillGuard:
         assert stats.sent == 0
         assert stats.skipped_backfill >= 1
 
-    async def test_winback_mode_admits_only_the_dormancy_track(
+    async def test_winback_mode_admits_the_winback_tracks(
         self, db, legacy_org, sender, monkeypatch
     ):
-        monkeypatch.setenv("LEARNHOUSE_NUDGES_START_DATE", "2026-07-01")
         monkeypatch.setenv("LEARNHOUSE_NUDGES_BACKFILL_MODE", "winback")
 
         stats = await run_nudges(db, now=NOW)
 
         assert stats.sent == 1
-        assert stats.by_nudge == {"dormancy.no_login_30d": 1}
+        assert set(stats.by_nudge) <= {
+            "dormancy.no_login_30d",
+            "reactivation.opener",
+        }
 
-    async def test_no_start_date_treats_every_org_as_new(
-        self, db, legacy_org, sender, monkeypatch
-    ):
-        monkeypatch.delenv("LEARNHOUSE_NUDGES_START_DATE", raising=False)
-        monkeypatch.setenv("LEARNHOUSE_NUDGES_BACKFILL_MODE", "off")
+    async def test_full_mode_admits_everything(self, db, legacy_org, sender, monkeypatch):
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_BACKFILL_MODE", "full")
 
         stats = await run_nudges(db, now=NOW)
         assert stats.sent == 1
 
-    async def test_unparseable_start_date_is_ignored(self, monkeypatch):
-        monkeypatch.setenv("LEARNHOUSE_NUDGES_START_DATE", "not-a-date")
-        assert runner_module.start_date() is None
 
-    async def test_start_date_without_a_zone_is_read_as_utc(self, monkeypatch):
-        monkeypatch.setenv("LEARNHOUSE_NUDGES_START_DATE", "2026-07-01")
-        parsed = runner_module.start_date()
-        assert parsed is not None and parsed.tzinfo is not None
+class TestActivationBoundary:
+    """The pre-existing/new boundary is derived from the ledger, not configured."""
+
+    async def test_the_earliest_ledger_row_is_the_boundary(self, db):
+        from src.services.nudges.runner import activation_date
+
+        # The autouse fixture pinned it 400 days back.
+        assert (await activation_date(db)) == NOW - timedelta(days=400)
+
+    async def test_an_empty_ledger_means_everything_predates_the_system(self, db):
+        """Nothing has run here yet, so no org can be "new". That is what makes
+        `nudges-seed` a real prerequisite rather than a suggestion."""
+        from sqlmodel import delete
+
+        from src.services.nudges.runner import activation_date
+
+        await db.execute(delete(NudgeSend))
+        await db.commit()
+
+        boundary = await activation_date(db)
+        assert boundary > NOW - timedelta(days=1)
+
+    async def test_seeding_pins_the_boundary(self, db, activation_org, sender):
+        """`nudges-seed` writes rows, so seeding is what fixes the date — there
+        is no separate value to set, and none to get wrong."""
+        from sqlmodel import delete
+
+        from src.services.nudges.runner import activation_date
+
+        await db.execute(delete(NudgeSend))
+        await db.commit()
+
+        await run_nudges(db, now=NOW, seed=True)
+        assert (await activation_date(db)) == NOW
 
 
 class TestEnvHelpers:
@@ -520,10 +568,6 @@ class TestEnvHelpers:
     def test_flag_default_when_unset(self, monkeypatch):
         monkeypatch.delenv("LEARNHOUSE_TEST_FLAG", raising=False)
         assert runner_module._flag("LEARNHOUSE_TEST_FLAG", True) is True
-
-    def test_int_env_falls_back_on_garbage(self, monkeypatch):
-        monkeypatch.setenv("LEARNHOUSE_TEST_INT", "not-a-number")
-        assert runner_module._int_env("LEARNHOUSE_TEST_INT", 42) == 42
 
     def test_stats_serialise(self):
         stats = RunStats()
@@ -622,36 +666,6 @@ class TestBudgetMidOrganization:
         assert stats.budget_exhausted is True
 
 
-class TestSlotsInTheRun:
-    async def test_an_org_outside_the_current_slot_is_deferred(
-        self, db, activation_org, sender, monkeypatch
-    ):
-        """Spreading the day's mail across slots keeps a single burst from
-        looking like a blast to spam filters — and means a bad send reaches a
-        fraction of the list before anyone notices."""
-        monkeypatch.setenv("LEARNHOUSE_NUDGES_SLOTS", "6")
-        # org id 1 belongs to slot 1; run during slot 0.
-        stats = await run_nudges(db, now=NOW.replace(hour=0))
-
-        assert stats.sent == 0
-        assert stats.skipped_slot == 1
-        sender.assert_not_called()
-
-    async def test_the_org_sends_when_its_slot_comes_round(
-        self, db, activation_org, sender, monkeypatch
-    ):
-        monkeypatch.setenv("LEARNHOUSE_NUDGES_SLOTS", "6")
-        stats = await run_nudges(db, now=NOW.replace(hour=1))
-
-        assert stats.sent == 1
-        assert stats.skipped_slot == 0
-
-    async def test_stats_expose_the_deferred_count(self, db, activation_org, sender, monkeypatch):
-        monkeypatch.setenv("LEARNHOUSE_NUDGES_SLOTS", "6")
-        stats = await run_nudges(db, now=NOW.replace(hour=0))
-        assert stats.as_dict()["skipped_slot"] == 1
-
-
 class TestStatStripReachesTheEmail:
     async def test_content_nudge_carries_its_figures(self, db, org, verified_admin, sender):
         from src.db.courses.courses import Course
@@ -702,3 +716,17 @@ class TestStatStripReachesTheEmail:
         await run_nudges(db, now=NOW, only="content.course_draft_d3")
 
         assert sender.call_args.kwargs["stats"] == [("chapters", 0), ("lessons", 2)]
+
+
+class TestPreexistingEdgeCase:
+    def test_an_org_with_no_parseable_creation_date_is_not_preexisting(self):
+        """A malformed date must not silently move an org into the winback
+        tracks — treat it as new and let day_max do the bounding."""
+        from src.services.nudges.runner import _is_preexisting
+        from src.services.nudges.snapshot import OrgSnapshot
+
+        snap = OrgSnapshot(
+            org_id=1, org_slug="a", org_name="A", plan="free", lang="en",
+            now=NOW, created_at=None,
+        )
+        assert _is_preexisting(snap, NOW) is False

--- a/apps/api/src/tests/services/test_nudges_scheduler.py
+++ b/apps/api/src/tests/services/test_nudges_scheduler.py
@@ -1,0 +1,264 @@
+"""Tests for the in-app daily tick and the first-run auto-seed.
+
+Together these are what let the feature work from a deploy alone, with no cron
+to schedule and no command to remember to run first.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.services.nudges import scheduler
+
+NOW = datetime(2026, 7, 28, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class TestNextRunTiming:
+    def test_waits_until_this_morning_when_still_early(self):
+        early = NOW.replace(hour=3)
+        seconds = scheduler._seconds_until_next_run(early)
+        assert seconds == pytest.approx((scheduler.RUN_AT_HOUR_UTC - 3) * 3600)
+
+    def test_rolls_to_tomorrow_once_the_hour_has_passed(self):
+        late = NOW.replace(hour=20)
+        seconds = scheduler._seconds_until_next_run(late)
+        assert 0 < seconds <= 24 * 3600
+
+    def test_exactly_on_the_hour_waits_a_full_day(self):
+        """Otherwise a pod restarting at 09:00 would run again immediately."""
+        on_hour = NOW.replace(hour=scheduler.RUN_AT_HOUR_UTC, minute=0, second=0, microsecond=0)
+        assert scheduler._seconds_until_next_run(on_hour) == 24 * 3600
+
+
+class TestDayLock:
+    async def test_first_pod_claims_the_day(self, monkeypatch):
+        client = type("R", (), {"set": lambda self, *a, **k: True})()
+        monkeypatch.setattr("src.core.redis.get_redis_client", lambda: client)
+
+        assert await scheduler._claim_day(NOW) is True
+
+    async def test_second_pod_is_turned_away(self, monkeypatch):
+        client = type("R", (), {"set": lambda self, *a, **k: None})()
+        monkeypatch.setattr("src.core.redis.get_redis_client", lambda: client)
+
+        assert await scheduler._claim_day(NOW) is False
+
+    async def test_absent_redis_still_runs(self, monkeypatch):
+        """The ledger already guarantees a nudge is sent once, so running
+        without the lock is wasteful rather than wrong — and silently doing
+        nothing would be worse."""
+        monkeypatch.setattr("src.core.redis.get_redis_client", lambda: None)
+
+        assert await scheduler._claim_day(NOW) is True
+
+    async def test_a_broken_redis_still_runs(self, monkeypatch):
+        def explode():
+            raise RuntimeError("redis down")
+
+        monkeypatch.setattr("src.core.redis.get_redis_client", explode)
+
+        assert await scheduler._claim_day(NOW) is True
+
+    def test_the_lock_is_scoped_to_the_day(self):
+        assert scheduler._lock_key(NOW) != scheduler._lock_key(NOW + timedelta(days=1))
+        assert scheduler._lock_key(NOW) == scheduler._lock_key(NOW.replace(hour=23))
+
+
+class TestStartGating:
+    @pytest.fixture(autouse=True)
+    def _clean(self, monkeypatch):
+        monkeypatch.delenv("LEARNHOUSE_NUDGES_NO_SCHEDULER", raising=False)
+        scheduler._task = None
+        yield
+        scheduler._task = None
+
+    def test_does_not_start_when_the_feature_is_off(self, monkeypatch):
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_ENABLED", "false")
+        scheduler.start_scheduler()
+        assert scheduler._task is None
+
+    def test_does_not_start_outside_saas(self, monkeypatch):
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_ENABLED", "true")
+        monkeypatch.setattr(
+            "src.core.deployment_mode.get_deployment_mode", lambda: "oss"
+        )
+        scheduler.start_scheduler()
+        assert scheduler._task is None
+
+    def test_can_be_opted_out_of(self, monkeypatch):
+        """For deployments that would rather drive the CLI from their own cron."""
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_ENABLED", "true")
+        monkeypatch.setattr(
+            "src.core.deployment_mode.get_deployment_mode", lambda: "saas"
+        )
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_NO_SCHEDULER", "1")
+        scheduler.start_scheduler()
+        assert scheduler._task is None
+
+    async def test_starts_when_enabled_on_saas(self, monkeypatch):
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_ENABLED", "true")
+        monkeypatch.setattr(
+            "src.core.deployment_mode.get_deployment_mode", lambda: "saas"
+        )
+        scheduler.start_scheduler()
+        assert scheduler._task is not None
+        await scheduler.stop_scheduler()
+        assert scheduler._task is None
+
+    async def test_stopping_when_never_started_is_harmless(self):
+        await scheduler.stop_scheduler()
+
+
+class TestRunOnce:
+    async def test_reports_a_seeding_run_distinctly(self, monkeypatch, caplog):
+        from src.services.nudges.runner import RunStats
+
+        stats = RunStats()
+        stats.auto_seeded = True
+
+        monkeypatch.setattr(
+            "src.services.nudges.runner.run_nudges", AsyncMock(return_value=stats)
+        )
+        with patch("src.core.events.database._async_session_factory"):
+            with caplog.at_level("INFO"):
+                await scheduler._run_once()
+
+        assert "seeded" in caplog.text
+
+
+class TestAutoSeed:
+    async def test_the_first_run_seeds_instead_of_sending(
+        self, db, org, admin_role, admin_user, monkeypatch
+    ):
+        """No prerequisite command: the first run consumes the backlog itself,
+        so switching the feature on cannot fire a year of accumulated state."""
+        from sqlmodel import select
+
+        from src.db.nudges import NudgeSend, NudgeSendStatus
+        from src.db.users import User
+        from src.services.nudges import runner as runner_module
+        from src.services.nudges.runner import run_nudges
+
+        org.creation_date = str((NOW - timedelta(days=1.5)).replace(tzinfo=None))
+        org.update_date = org.creation_date
+        db.add(org)
+        row = (await db.execute(select(User).where(User.id == admin_user.id))).scalars().first()
+        row.email_verified = True
+        db.add(row)
+        await db.commit()
+
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_ENABLED", "true")
+        monkeypatch.setattr(runner_module, "get_deployment_mode", lambda: "saas")
+
+        with patch("src.services.nudges.runner.send_nudge_email") as sender:
+            stats = await run_nudges(db, now=NOW)
+
+        assert stats.auto_seeded is True
+        assert stats.sent == 0
+        sender.assert_not_called()
+
+        rows = (await db.execute(select(NudgeSend))).scalars().all()
+        assert rows and all(r.status == NudgeSendStatus.SUPPRESSED for r in rows)
+
+    async def test_the_second_run_sends_normally(
+        self, db, org, admin_role, admin_user, monkeypatch
+    ):
+        from sqlmodel import select
+
+        from src.db.users import User
+        from src.services.nudges import runner as runner_module
+        from src.services.nudges.runner import run_nudges
+
+        org.creation_date = str((NOW - timedelta(days=1.5)).replace(tzinfo=None))
+        org.update_date = org.creation_date
+        db.add(org)
+        row = (await db.execute(select(User).where(User.id == admin_user.id))).scalars().first()
+        row.email_verified = True
+        db.add(row)
+        await db.commit()
+
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_ENABLED", "true")
+        monkeypatch.setattr(runner_module, "get_deployment_mode", lambda: "saas")
+        monkeypatch.setattr(
+            runner_module.links, "org_base_url", AsyncMock(return_value="https://a.test")
+        )
+        monkeypatch.setattr(
+            runner_module, "get_media_base_url", lambda _r=None: "https://api.test"
+        )
+
+        with patch("src.services.nudges.runner.send_nudge_email") as sender:
+            first = await run_nudges(db, now=NOW)
+            # A day later, a newly-eligible org is reached normally.
+            second = await run_nudges(db, now=NOW + timedelta(days=1))
+
+        assert first.auto_seeded is True
+        assert second.auto_seeded is False
+        assert sender.call_count == second.sent
+
+
+class TestLoop:
+    async def test_one_tick_claims_the_day_and_runs(self, monkeypatch):
+        import asyncio
+
+        monkeypatch.setattr(scheduler, "_seconds_until_next_run", lambda _now: 0)
+        monkeypatch.setattr(scheduler, "_claim_day", AsyncMock(return_value=True))
+        ran = AsyncMock()
+        monkeypatch.setattr(scheduler, "_run_once", ran)
+
+        task = asyncio.create_task(scheduler._loop())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert ran.await_count >= 1
+
+    async def test_a_pod_that_loses_the_lock_does_not_run(self, monkeypatch):
+        import asyncio
+
+        monkeypatch.setattr(scheduler, "_seconds_until_next_run", lambda _now: 0)
+        monkeypatch.setattr(scheduler, "_claim_day", AsyncMock(return_value=False))
+        ran = AsyncMock()
+        monkeypatch.setattr(scheduler, "_run_once", ran)
+
+        task = asyncio.create_task(scheduler._loop())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        ran.assert_not_awaited()
+
+    async def test_a_failed_run_does_not_kill_the_loop(self, monkeypatch, caplog):
+        """Otherwise the feature stops silently until the next deploy."""
+        import asyncio
+
+        monkeypatch.setattr(scheduler, "_seconds_until_next_run", lambda _now: 0)
+        monkeypatch.setattr(scheduler, "_claim_day", AsyncMock(return_value=True))
+        monkeypatch.setattr(
+            scheduler, "_run_once", AsyncMock(side_effect=RuntimeError("db gone"))
+        )
+
+        with caplog.at_level("ERROR"):
+            task = asyncio.create_task(scheduler._loop())
+            await asyncio.sleep(0.05)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert "will retry tomorrow" in caplog.text
+
+    async def test_run_once_reports_a_normal_run(self, monkeypatch, caplog):
+        from src.services.nudges.runner import RunStats
+
+        stats = RunStats()
+        stats.sent = 3
+        monkeypatch.setattr(
+            "src.services.nudges.runner.run_nudges", AsyncMock(return_value=stats)
+        )
+        with patch("src.core.events.database._async_session_factory"):
+            with caplog.at_level("INFO"):
+                await scheduler._run_once()
+
+        assert "sent=3" in caplog.text

--- a/apps/api/src/tests/services/test_nudges_scheduler.py
+++ b/apps/api/src/tests/services/test_nudges_scheduler.py
@@ -262,3 +262,35 @@ class TestLoop:
                 await scheduler._run_once()
 
         assert "sent=3" in caplog.text
+
+    async def test_cancelling_mid_run_stops_the_loop(self, monkeypatch):
+        """Shutdown must actually stop it — the cancellation has to propagate
+        rather than be swallowed by the retry handler."""
+        import asyncio
+
+        started = asyncio.Event()
+
+        async def slow_run():
+            started.set()
+            await asyncio.sleep(10)
+
+        monkeypatch.setattr(scheduler, "_seconds_until_next_run", lambda _now: 0)
+        monkeypatch.setattr(scheduler, "_claim_day", AsyncMock(return_value=True))
+        monkeypatch.setattr(scheduler, "_run_once", slow_run)
+
+        task = asyncio.create_task(scheduler._loop())
+        await asyncio.wait_for(started.wait(), timeout=1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    async def test_a_broken_start_never_stops_the_api_booting(self, monkeypatch):
+        """This runs during application startup; a background email job must
+        not be able to prevent the service coming up."""
+        monkeypatch.setattr(
+            "src.services.nudges.runner.nudges_enabled",
+            lambda: (_ for _ in ()).throw(RuntimeError("config exploded")),
+        )
+        scheduler._task = None
+        scheduler.start_scheduler()
+        assert scheduler._task is None

--- a/apps/api/src/tests/services/test_nudges_tokens.py
+++ b/apps/api/src/tests/services/test_nudges_tokens.py
@@ -1,0 +1,85 @@
+"""Tests for src/services/nudges/tokens.py."""
+
+import pytest
+
+from src.services.nudges import tokens as tokens_module
+from src.services.nudges.tokens import (
+    CATEGORY_LIFECYCLE,
+    make_unsubscribe_token,
+    verify_unsubscribe_token,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_secret_cache():
+    """The signing key is lru_cached; clear it around tests that swap config."""
+    tokens_module._unsub_secret.cache_clear()
+    yield
+    tokens_module._unsub_secret.cache_clear()
+
+
+class TestRoundTrip:
+    def test_token_verifies_back_to_the_same_uuid(self):
+        token = make_unsubscribe_token("user_abc123")
+        assert verify_unsubscribe_token(token) == "user_abc123"
+
+    def test_token_is_url_safe(self):
+        # Base64url + a hex signature: nothing here needs percent-encoding, so
+        # the link survives mail clients that rewrite URLs.
+        token = make_unsubscribe_token("user_abc123")
+        assert all(c.isalnum() or c in "-_." for c in token)
+
+    def test_distinct_users_get_distinct_tokens(self):
+        assert make_unsubscribe_token("user_a") != make_unsubscribe_token("user_b")
+
+    def test_uuid_with_padding_characters_round_trips(self):
+        # b64 padding is stripped at mint time and restored on verify; a uuid
+        # whose length lands on each padding case must survive.
+        for uuid in ("a", "ab", "abc", "abcd"):
+            assert verify_unsubscribe_token(make_unsubscribe_token(uuid)) == uuid
+
+
+class TestRejection:
+    def test_tampered_payload_is_rejected(self):
+        token = make_unsubscribe_token("user_abc123")
+        payload, _, signature = token.rpartition(".")
+        forged = make_unsubscribe_token("user_victim").split(".")[0]
+        assert verify_unsubscribe_token(f"{forged}.{signature}") is None
+
+    def test_tampered_signature_is_rejected(self):
+        token = make_unsubscribe_token("user_abc123")
+        payload, _, signature = token.rpartition(".")
+        flipped = ("0" if signature[0] != "0" else "1") + signature[1:]
+        assert verify_unsubscribe_token(f"{payload}.{flipped}") is None
+
+    @pytest.mark.parametrize(
+        "garbage",
+        ["", "no-dot", ".", "..", "!!!.abc", "abc.", ".abc"],
+    )
+    def test_malformed_tokens_return_none(self, garbage):
+        assert verify_unsubscribe_token(garbage) is None
+
+    def test_non_utf8_payload_returns_none(self):
+        # A b64 blob that decodes to invalid UTF-8 must not raise.
+        assert verify_unsubscribe_token("_____w.deadbeef") is None
+
+    def test_token_from_another_category_is_rejected(self):
+        token = make_unsubscribe_token("user_abc123", category="product_updates")
+        assert verify_unsubscribe_token(token, category=CATEGORY_LIFECYCLE) is None
+
+    def test_rotated_secret_invalidates_existing_tokens(self, monkeypatch):
+        token = make_unsubscribe_token("user_abc123")
+        tokens_module._unsub_secret.cache_clear()
+
+        real_config = tokens_module.get_learnhouse_config()
+
+        class _Rotated:
+            security_config = type(
+                "S", (), {"auth_jwt_secret_key": "a-completely-different-secret"}
+            )()
+
+            def __getattr__(self, name):
+                return getattr(real_config, name)
+
+        monkeypatch.setattr(tokens_module, "get_learnhouse_config", lambda: _Rotated())
+        assert verify_unsubscribe_token(token) is None

--- a/apps/api/src/tests/services/test_nudges_translations.py
+++ b/apps/api/src/tests/services/test_nudges_translations.py
@@ -42,7 +42,9 @@ class TestCoverage:
         misleading signal that the nudge still ships."""
         known = {spec.id for spec in NUDGE_CATALOG}
         for key in ENGLISH:
-            if key.startswith("nudge.common."):
+            # `common` and `stat` are shared across the catalog rather than
+            # belonging to any one nudge.
+            if key.startswith(("nudge.common.", "nudge.stat.")):
                 continue
             nudge_id = ".".join(key.split(".")[1:3])
             assert nudge_id in known, f"orphaned copy: {key}"

--- a/apps/api/src/tests/services/test_nudges_translations.py
+++ b/apps/api/src/tests/services/test_nudges_translations.py
@@ -1,0 +1,153 @@
+"""Tests for the nudge copy bundles.
+
+Two classes of bug are worth catching mechanically here: a locale that drifts
+out of sync with the English source, and a translator writing a plan name or a
+limit into a string where a placeholder belongs.
+"""
+
+import re
+import string
+
+import pytest
+
+from src.security.features_utils.plans import PLAN_HIERARCHY
+from src.services.email.nudge_translations import NUDGE_TRANSLATIONS
+from src.services.email.translations import EMAIL_TRANSLATIONS, SUPPORTED_LANGUAGES, t
+from src.services.nudges.catalog import NUDGE_CATALOG
+
+ENGLISH = NUDGE_TRANSLATIONS["en"]
+
+
+def _placeholders(template: str) -> set[str]:
+    return {
+        field
+        for _text, field, _spec, _conv in string.Formatter().parse(template)
+        if field
+    }
+
+
+class TestCoverage:
+    def test_every_supported_locale_has_a_bundle(self):
+        assert set(NUDGE_TRANSLATIONS) == set(SUPPORTED_LANGUAGES)
+
+    def test_every_nudge_has_the_keys_it_needs(self):
+        for spec in NUDGE_CATALOG:
+            for part in ("subject", "heading", "body"):
+                assert f"nudge.{spec.id}.{part}" in ENGLISH, spec.id
+            if spec.has_cta:
+                assert f"nudge.{spec.id}.cta" in ENGLISH, spec.id
+
+    def test_no_orphaned_copy(self):
+        """Copy for a nudge that no longer exists is dead weight and a
+        misleading signal that the nudge still ships."""
+        known = {spec.id for spec in NUDGE_CATALOG}
+        for key in ENGLISH:
+            if key.startswith("nudge.common."):
+                continue
+            nudge_id = ".".join(key.split(".")[1:3])
+            assert nudge_id in known, f"orphaned copy: {key}"
+
+    @pytest.mark.parametrize("locale", sorted(NUDGE_TRANSLATIONS))
+    def test_locale_matches_the_english_key_set(self, locale):
+        assert set(NUDGE_TRANSLATIONS[locale]) == set(ENGLISH)
+
+    def test_bundles_are_merged_into_the_shared_translations(self):
+        for locale, strings in NUDGE_TRANSLATIONS.items():
+            for key in strings:
+                assert key in EMAIL_TRANSLATIONS[locale]
+
+
+class TestPlaceholders:
+    @pytest.mark.parametrize("locale", sorted(NUDGE_TRANSLATIONS))
+    def test_placeholders_match_english(self, locale):
+        """A dropped placeholder silently loses the reader's course name; an
+        invented one raises at render time."""
+        for key, english in ENGLISH.items():
+            translated = NUDGE_TRANSLATIONS[locale][key]
+            assert _placeholders(translated) == _placeholders(english), (
+                f"{locale}:{key}"
+            )
+
+    def test_only_known_placeholders_are_used(self):
+        allowed = {"org_name", "course_name", "plan_name", "next_plan"}
+        for key, template in ENGLISH.items():
+            assert _placeholders(template) <= allowed, key
+
+    @pytest.mark.parametrize("locale", sorted(NUDGE_TRANSLATIONS))
+    def test_every_string_renders(self, locale):
+        values = dict(
+            org_name="Acme",
+            course_name="Intro to Welding",
+            plan_name="free",
+            next_plan="personal",
+        )
+        for key in ENGLISH:
+            rendered = t(locale, key, **values)
+            assert "{" not in rendered, f"{locale}:{key}"
+            assert rendered != key
+
+
+class TestPlanDataIsNeverHardcoded:
+    """Plan names and limits move. The emails are the last place anyone
+    remembers to update, so they must not contain either."""
+
+    def test_english_source_has_no_literal_plan_names(self):
+        """Checked on English only, deliberately.
+
+        English is the source every locale translates from, so a hardcoded
+        tier name can only enter here. Running the same check across all
+        twenty locales produces false positives instead of findings — "pro"
+        is the ordinary German word for "per" ("eines pro Thema"), and
+        "standard" is a normal word in most of these languages.
+
+        Translations are protected by a stronger invariant anyway: placeholder
+        parity (above) means a locale cannot drop `{plan_name}` or
+        `{next_plan}` without failing.
+        """
+        tiers = [p for p in PLAN_HIERARCHY if p != "free"]
+        for key, value in ENGLISH.items():
+            lowered = value.lower()
+            for tier in tiers:
+                assert not re.search(rf"\b{re.escape(tier)}\b", lowered), (
+                    f"{key} hardcodes the plan name {tier!r}"
+                )
+
+    def test_plan_aware_prose_uses_placeholders(self):
+        """Prose that talks about a plan must name it dynamically.
+
+        Scoped to subject/heading/body: a button reading "See plans" mentions
+        plans without naming one, which is exactly right for a CTA.
+        """
+        for key, value in ENGLISH.items():
+            if key.endswith(".cta"):
+                continue
+            if "plan" in value.lower():
+                assert _placeholders(value) & {"plan_name", "next_plan"}, key
+
+    def test_no_bare_limit_digits(self):
+        """A number like "10 members" goes wrong the moment the config
+        changes, and is wrong for five of the six plans on the day it ships."""
+        for key, value in ENGLISH.items():
+            assert not re.search(r"\d+\s*(members?|courses?|credits?)", value), key
+
+
+class TestTone:
+    def test_no_emoji_in_copy(self):
+        """These go to teachers and trainers; an emoji subject line reads as
+        marketing and lands in the promotions tab."""
+        emoji = re.compile("[\U0001f300-\U0001faff☀-➿]")
+        for locale, strings in NUDGE_TRANSLATIONS.items():
+            for key, value in strings.items():
+                assert not emoji.search(value), f"{locale}:{key}"
+
+    def test_subjects_are_not_shouted(self):
+        for locale, strings in NUDGE_TRANSLATIONS.items():
+            for key, value in strings.items():
+                if key.endswith(".subject"):
+                    assert "!" not in value, f"{locale}:{key}"
+
+    def test_final_emails_say_so(self):
+        """Announcing the last message in a sequence earns more goodwill than
+        any subject-line trick — and it is a promise the catalog keeps."""
+        assert "last" in ENGLISH["nudge.activation.last_call_d30.heading"].lower()
+        assert "last" in ENGLISH["nudge.dormancy.no_login_60d.subject"].lower()

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -928,7 +928,7 @@ wheels = [
 
 [[package]]
 name = "learnhouse-api"
-version = "1.3.3"
+version = "1.3.4"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docs/content/self-hosting/configuration/environment-variables.mdx
+++ b/docs/content/self-hosting/configuration/environment-variables.mdx
@@ -18,7 +18,7 @@ optional: the feature stays disabled or uses a runtime fallback when the variabl
 | --- | --- | --- | --- | --- |
 | `LEARNHOUSE_SITE_NAME` | Instance name returned by the API. | string | `LearnHouse` | API |
 | `LEARNHOUSE_SITE_DESCRIPTION` | Short instance description returned by the API. | string | `LearnHouse is an open-source platform tailored for learning experiences.` | API |
-| `LEARNHOUSE_CONTACT_EMAIL` | Contact email for the instance. | email | `hi@learnhouse.app` | API |
+| `LEARNHOUSE_CONTACT_EMAIL` | Contact email for the instance. | email | `hello@learnhouse.app` | API |
 | `LEARNHOUSE_ENV` | Environment label for backend and Sentry reporting. | string | `dev` | API, Web |
 | `LEARNHOUSE_DEVELOPMENT_MODE` | Enables development-only API behavior such as docs routes and EE dev override. | boolean | `false` | API, CLI |
 | `LEARNHOUSE_SAAS` | Enables SaaS deployment mode, plan gating, and platform endpoint warnings. | boolean | `false` | API |


### PR DESCRIPTION
A cron job that sends staged reminder emails to org admins, plus the unsubscribe infrastructure bulk mail needs, new to the repo. Nothing sends until `LEARNHOUSE_NUDGES_ENABLED` is set. It is SaaS-gated too.

New:
- `nudge_send` ledger writes its row before a send is attempted, so a crash loses one email instead of duplicating it. `email_preference` is lazily created; no row means opted in, and transactional mail ignores it.
- Stateless HMAC unsubscribe tokens behind `GET`/`POST /api/v1/emails/unsubscribe`, with `List-Unsubscribe` headers. GET stays side-effect free since scanners prefetch links; POST does the unsubscribe.
- 30 nudges across six tracks, each a per-org predicate. Copy in 20 locales, plus a CLI for dry runs, seeding, and stats.

Guardrails: SaaS gate, kill switch off by default, per-admin frequency caps, active-org suppression, opt-out/unverified skips, a send budget, and dormancy-only backfill for existing orgs.

Additive elsewhere: `send_email` takes an optional `headers` arg, the email URL builders accept a null request, and copy now pulls plan names, limits, and AI credits from `plans.py` at render time.

4778 tests pass (5 pre-existing, unrelated failures); Ruff clean; 98% coverage on new modules.

Rollout: dry run, seed the backlog, then a small max-sends. Non-English locales still need a native-speaker pass.