### PR TITLE
fix(web): make the dash sidebar scroll so its bottom items stay reachable

### DIFF
--- a/apps/web/app/orgs/[orgslug]/dash/ClientAdminLayout.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/ClientAdminLayout.tsx
@@ -33,7 +33,7 @@ function ClientAdminLayout({
                             this node", taking the whole page with it. The dashboard is
                             already translated by i18n, so opting it out costs nothing.
                             Public course pages stay translatable. */}
-                        <div translate="no" className="notranslate flex flex-col lg:flex-row">
+                        <div translate="no" className="notranslate flex flex-col lg:flex-row min-h-screen bg-[#f8f8f8]">
                             {!isMobile && <DashLeftMenu />}
                             <div className="flex flex-col w-full min-w-0 relative isolate pb-24 lg:pb-0">
                                 {children}

--- a/apps/web/components/Dashboard/Menus/DashLeftMenu.tsx
+++ b/apps/web/components/Dashboard/Menus/DashLeftMenu.tsx
@@ -313,7 +313,7 @@ function DashLeftMenu() {
 
       {/* Search trigger — replaced by the onboarding progress in this slot until
           setup is complete (then the search box returns). */}
-      <div className={cn('px-3', showOnboarding ? 'pt-2' : 'pt-3')}>
+      <div className={cn('px-3 shrink-0', showOnboarding ? 'pt-2' : 'pt-3')}>
         {showOnboarding ? (
           <OnboardingSidebarBox />
         ) : (
@@ -321,10 +321,12 @@ function DashLeftMenu() {
         )}
       </div>
 
-      {/* Main Navigation - Vertically Centered */}
-      <div className="flex-1 flex flex-col justify-center py-4 px-3">
+      {/* Main Navigation — scrolls once the list outgrows the viewport.
+          Centered with `my-auto`, not `justify-center`: the latter would push
+          the first items above scroll origin, out of reach. */}
+      <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain flex flex-col py-4 px-3">
         <AdminAuthorization authorizationMode="component">
-          <div className="space-y-1">
+          <div className="space-y-1 my-auto">
             <MenuLink
               href="/dash"
               icon={<House size={20} weight="fill" />}


### PR DESCRIPTION
Fixes #1005.

On every `/dash/*` page the bottom of the left sidebar — Analytics, Language, Help, the organization switcher and the user menu — is pushed off-screen and cannot be scrolled to, and a white band is painted below the dashboard content.

### Root cause

Two symptoms, one origin: an `h-screen` sidebar in an auto-height flex row.

**Sidebar bottom unreachable.** `DashLeftMenu.tsx:242` makes the nav root `flex flex-col … h-screen sticky top-0`, and the navigation list at line 325 was `flex-1 flex flex-col justify-center py-4 px-3` — no `min-h-0`, no scroll region. A `flex-1` child defaults to `min-height: auto`, so it will not shrink below its content height. Once the item list outgrows the viewport it overflows the `h-screen` root and pushes the `shrink-0` bottom section past the fold, where nothing can scroll to it. This is reachable in practice whenever an org has most feature toggles on, or on a shorter viewport.

**White band.** The same overflow made the document's scroll height come from the sidebar, while the content column in `ClientAdminLayout.tsx:36` had no minimum height — pages using `h-full` resolve to `auto` against an auto-height parent. `bg-[#f8f8f8]` was therefore painted only to content height, leaving the bare `<body>` background (white, `globals.css:312`) showing below.

### The change

Four class changes across two files:

- `DashLeftMenu.tsx` — `min-h-0 overflow-y-auto overscroll-contain` on the nav region so it scrolls independently, and `shrink-0` on the search/onboarding slot so it cannot be squeezed.
- `ClientAdminLayout.tsx` — `min-h-screen bg-[#f8f8f8]` on the layout row so short pages never expose the bare body.

One deliberate detail: centering moved from `justify-center` on the container to `my-auto` on the list. In a scroll container `justify-center` pushes the first items above scroll origin, where `scrollTop` cannot reach them — that would trade an unreachable bottom for an unreachable top. Auto margins collapse to zero once content overflows, so the list stays centered when it fits and scrolls cleanly when it does not.

`overscroll-contain` keeps scroll from chaining to the page when the sidebar list reaches its end.

### Scope

- Fixes both the expanded and collapsed sidebar states — the change is on the shared container, and the collapsed state renders the same items.
- The mobile menu was not affected by the bug (it is portalled to `document.body` and its panel already sets `max-h-[52vh] overflow-y-auto`), but it does benefit from the layout change, since `DashLeftMenu` is not rendered on mobile and `min-h-screen` plus the background is what removes the white band there.
- `Watermark` was ruled out as the white overlay: it is `fixed bottom-8 right-8` and only a small pill.

### Testing

- `npx eslint` clean on both touched files.
- `npx tsc --noEmit` reports only a pre-existing `tsconfig.json` `baseUrl` deprecation warning, unrelated to this change.
- `/dash/courses` renders (200) with the change applied.

The diagnosis is from the CSS box model and the component tree rather than a measured render — I don't have browser automation set up locally, so a quick eyeball at a short viewport height (and with most feature toggles enabled) would be worth it before merging.

### Not included

Several dash pages set `h-screen` on their own root (`payments/[subpage]`, `users/settings/[subpage]`, `courses/course/[courseuuid]/[subpage]`, `boards`, `podcasts`, `users/analytics`). They size against the now `min-h-screen` parent and are unchanged in behaviour, but the mix of `h-screen`/`h-full` across dashboard pages is inconsistent and looked worth normalising separately rather than widening this fix.
