### PR TITLE
fix(web): make dashboard access consistent instead of list-dependent

### DIFF
--- a/apps/web/components/Security/AdminAuthorization.tsx
+++ b/apps/web/components/Security/AdminAuthorization.tsx
@@ -6,21 +6,16 @@ import { usePathname, useRouter } from 'next/navigation';
 import PageLoading from '@components/Objects/Loaders/PageLoading';
 import { getUriWithOrg } from '@services/config/config';
 import { useOrg } from '@components/Contexts/OrgContext';
+import ErrorUI from '@components/Objects/StyledElements/Error/Error';
 
 type AuthorizationProps = {
   children: React.ReactNode;
   authorizationMode: 'component' | 'page';
 };
 
-const ADMIN_PATHS = [
-  '/dash/org/*',
-  '/dash/org',
-  '/dash/users/*',
-  '/dash/users',
-  '/dash/courses/*',
-  '/dash/courses',
-  '/dash/org/settings/general',
-];
+// This component wraps the whole dashboard layout, so gate all of it: the old
+// allow-list named 3 sections and left /dash plus 10 others open to any member.
+const ADMIN_PATH_PREFIX = '/dash';
 
 const AdminAuthorization: React.FC<AuthorizationProps> = ({ children, authorizationMode }) => {
   const session = useLHSession() as any;
@@ -32,21 +27,11 @@ const AdminAuthorization: React.FC<AuthorizationProps> = ({ children, authorizat
 
   const isUserAuthenticated = useMemo(() => session.status === 'authenticated', [session.status]);
 
-  const checkPathname = useCallback((pattern: string, pathname: string) => {
-    // Ensure the inputs are strings
-    if (typeof pattern !== 'string' || typeof pathname !== 'string') {
-      return false;
-    }
-
-    // Convert pattern to a regex pattern
-    const regexPattern = new RegExp(`^${pattern.replace(/[/.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\*/g, '.*')}$`);
-
-    // Test the pathname against the regex pattern
-    return regexPattern.test(pathname);
-  }, []);
-
-
-  const isAdminPath = useMemo(() => ADMIN_PATHS.some(path => checkPathname(path, pathname)), [pathname, checkPathname]);
+  const isAdminPath = useMemo(() => {
+    if (typeof pathname !== 'string') return false;
+    // The trailing check keeps a hypothetical sibling like /dashboard out.
+    return pathname === ADMIN_PATH_PREFIX || pathname.startsWith(`${ADMIN_PATH_PREFIX}/`);
+  }, [pathname]);
 
   const authorizeUser = useCallback(() => {
     if (loading) {
@@ -62,12 +47,9 @@ const AdminAuthorization: React.FC<AuthorizationProps> = ({ children, authorizat
 
     if (authorizationMode === 'page') {
       if (isAdminPath) {
-        if (isAdmin) {
-          setIsAuthorized(true);
-        } else {
-          setIsAuthorized(false);
-          router.push('/dash');
-        }
+        // No redirect on denial: pushing to /dash raced the render below, so the
+        // message only flashed and the user never learned why.
+        setIsAuthorized(isAdmin);
       } else {
         setIsAuthorized(true);
       }
@@ -89,11 +71,9 @@ const AdminAuthorization: React.FC<AuthorizationProps> = ({ children, authorizat
   }
 
   if (authorizationMode === 'page' && !isAuthorized) {
-    return (
-      <div className="flex justify-center items-center h-screen">
-        <h1 className="text-2xl">You are not authorized to access this page</h1>
-      </div>
-    );
+    // 403 is what classifyError matches to the catalog's `permission` category,
+    // which supplies the copy and the Home / sign out / report actions.
+    return <ErrorUI error={{ status: 403, message: 'admin_only' }} />;
   }
 
   return <>{isAuthorized && children}</>;

--- a/apps/web/components/Security/AdminAuthorization.tsx
+++ b/apps/web/components/Security/AdminAuthorization.tsx
@@ -23,7 +23,11 @@ const AdminAuthorization: React.FC<AuthorizationProps> = ({ children, authorizat
   const pathname = usePathname();
   const router = useRouter();
   const { isAdmin, loading } = useAdminStatus() as any
-  const [isAuthorized, setIsAuthorized] = useState(false);
+  // `null` is "not decided yet", distinct from a decided `false`. The decision
+  // is made in an effect, which runs after the commit — so a `false` initial
+  // state paints the denial page for a frame on every load, including for the
+  // admins about to be let in. Only `false` means denied.
+  const [isAuthorized, setIsAuthorized] = useState<boolean | null>(null);
 
   const isUserAuthenticated = useMemo(() => session.status === 'authenticated', [session.status]);
 
@@ -39,6 +43,10 @@ const AdminAuthorization: React.FC<AuthorizationProps> = ({ children, authorizat
     }
 
     if (!isUserAuthenticated) {
+      // Left undecided on purpose: the /login navigation is in flight, and a
+      // signed-out visitor should not be told they lack permission on the way
+      // out. The loading state below covers the gap.
+      //
       // org can still be null here (its fetch is client-side and may not have
       // landed); getUriWithOrg tolerates an empty slug, dereferencing does not.
       router.push(getUriWithOrg(org?.slug ?? '', '/login'));
@@ -49,12 +57,12 @@ const AdminAuthorization: React.FC<AuthorizationProps> = ({ children, authorizat
       if (isAdminPath) {
         // No redirect on denial: pushing to /dash raced the render below, so the
         // message only flashed and the user never learned why.
-        setIsAuthorized(isAdmin);
+        setIsAuthorized(isAdmin === true);
       } else {
         setIsAuthorized(true);
       }
     } else if (authorizationMode === 'component') {
-      setIsAuthorized(isAdmin);
+      setIsAuthorized(isAdmin === true);
     }
   }, [loading, isUserAuthenticated, isAdmin, isAdminPath, authorizationMode, router]);
 
@@ -62,7 +70,10 @@ const AdminAuthorization: React.FC<AuthorizationProps> = ({ children, authorizat
     authorizeUser();
   }, [authorizeUser]);
 
-  if (loading) {
+  // Undecided counts as loading, but only in page mode — component mode renders
+  // inline (the sidebar, the dashboard home), where a full-screen spinner in
+  // place of the component would be worse than rendering nothing.
+  if (loading || (authorizationMode === 'page' && isAuthorized === null)) {
     return (
       <div className="flex justify-center items-center h-screen">
         <PageLoading />
@@ -70,7 +81,7 @@ const AdminAuthorization: React.FC<AuthorizationProps> = ({ children, authorizat
     );
   }
 
-  if (authorizationMode === 'page' && !isAuthorized) {
+  if (authorizationMode === 'page' && isAuthorized === false) {
     // 403 is what classifyError matches to the catalog's `permission` category,
     // which supplies the copy and the Home / sign out / report actions.
     return <ErrorUI error={{ status: 403, message: 'admin_only' }} />;

--- a/apps/web/tests/admin-authorization-denial.test.mjs
+++ b/apps/web/tests/admin-authorization-denial.test.mjs
@@ -1,9 +1,12 @@
-// Two faults this pins down:
+// Three faults this pins down:
 //
 // 1. ADMIN_PATHS named 3 sections while AdminAuthorization wraps the whole dash
 //    layout, so /dash and 10 other sections were reachable by any member.
 // 2. Denial set isAuthorized(false) *and* router.push('/dash'), so the message
 //    flashed for a frame and the user was bounced with no explanation.
+// 3. isAuthorized started at `false` while the decision is made in an effect,
+//    which runs after the commit — so the denial surface painted for a frame on
+//    every load, admins included.
 
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
@@ -70,5 +73,39 @@ describe("denial explains itself instead of bouncing", () => {
     const classified = classifyError({ status: 403, message: "admin_only" });
     expect(classified.category.kind).toBe("permission");
     expect(classified.category.resolutions).toContain("home");
+  });
+});
+
+describe("the denial surface cannot paint before the decision is made", () => {
+  test("authorization starts undecided rather than denied", () => {
+    expect(SOURCE).toContain("useState<boolean | null>(null)");
+  });
+
+  test("undecided shows the loader, and only in page mode", () => {
+    // Component mode renders inline (sidebar, dashboard home), where a
+    // full-screen spinner would be worse than rendering nothing.
+    expect(SOURCE).toContain("authorizationMode === 'page' && isAuthorized === null");
+  });
+
+  test("only a decided false reaches ErrorUI", () => {
+    // The regression this guards: `!isAuthorized` reads the undecided null as a
+    // denial, which is exactly the frame that used to flash.
+    const errorUI = SOURCE.indexOf("<ErrorUI");
+    const guard = SOURCE.lastIndexOf("if (authorizationMode === 'page'", errorUI);
+    expect(errorUI).toBeGreaterThan(-1);
+    expect(guard).toBeGreaterThan(-1);
+
+    expect(SOURCE.slice(guard, errorUI)).toContain("isAuthorized === false");
+  });
+
+  test("a signed-out visitor is never told they lack permission", () => {
+    // The unauthenticated branch returns without deciding, so the loader holds
+    // the screen while the /login navigation is in flight.
+    const start = SOURCE.indexOf("if (!isUserAuthenticated)");
+    const end = SOURCE.indexOf("if (authorizationMode === 'page')", start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    expect(SOURCE.slice(start, end)).not.toContain("setIsAuthorized");
   });
 });

--- a/apps/web/tests/admin-authorization-denial.test.mjs
+++ b/apps/web/tests/admin-authorization-denial.test.mjs
@@ -1,0 +1,74 @@
+// Two faults this pins down:
+//
+// 1. ADMIN_PATHS named 3 sections while AdminAuthorization wraps the whole dash
+//    layout, so /dash and 10 other sections were reachable by any member.
+// 2. Denial set isAuthorized(false) *and* router.push('/dash'), so the message
+//    flashed for a frame and the user was bounced with no explanation.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { classifyError } from "../lib/errors/classify.ts";
+
+const COMPONENT_DIR = join(import.meta.dir, "..", "components", "Security");
+const SOURCE = readFileSync(join(COMPONENT_DIR, "AdminAuthorization.tsx"), "utf8");
+
+// Mirrors the component's isAdminPath so the gate can be exercised directly.
+const PREFIX = "/dash";
+const isAdminPath = (pathname) =>
+  pathname === PREFIX || pathname.startsWith(`${PREFIX}/`);
+
+describe("every dash section is gated", () => {
+  // The sections that exist under app/orgs/[orgslug]/dash. Only 3 were listed
+  // before; the rest fell through to the "not an admin path" branch.
+  const SECTIONS = [
+    "analytics", "assignments", "boards", "communities", "courses",
+    "developers", "library", "onboarding", "org", "payments",
+    "playgrounds", "podcasts", "users",
+  ];
+
+  test("/dash itself is gated", () => {
+    expect(isAdminPath("/dash")).toBe(true);
+  });
+
+  test.each(SECTIONS)("/dash/%s is gated", (section) => {
+    expect(isAdminPath(`/dash/${section}`)).toBe(true);
+    expect(isAdminPath(`/dash/${section}/nested/page`)).toBe(true);
+  });
+
+  test("paths outside the dashboard are untouched", () => {
+    for (const p of ["/", "/home", "/explore", "/dashboard", "/orgs/acme/course/x"]) {
+      expect(isAdminPath(p)).toBe(false);
+    }
+  });
+});
+
+describe("denial explains itself instead of bouncing", () => {
+  test("the page-mode branch contains no redirect", () => {
+    // Scoped to the page-mode block: router.push is still correct elsewhere
+    // (unauthenticated → /login), so a file-wide search would miss a regression.
+    const start = SOURCE.indexOf("if (authorizationMode === 'page')");
+    const end = SOURCE.indexOf("authorizationMode === 'component'", start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    expect(SOURCE.slice(start, end)).not.toContain("router.push");
+  });
+
+  test("an unauthenticated visitor is still redirected to login", () => {
+    expect(SOURCE).toContain("'/login'");
+  });
+
+  test("renders the shared error surface, not a bare heading", () => {
+    expect(SOURCE).toContain("<ErrorUI");
+    expect(SOURCE).not.toContain("You are not authorized to access this page");
+  });
+
+  test("the error it passes classifies as a permission problem", () => {
+    // Without a `permission` match the user gets the generic fallback copy.
+    const classified = classifyError({ status: 403, message: "admin_only" });
+    expect(classified.category.kind).toBe("permission");
+    expect(classified.category.resolutions).toContain("home");
+  });
+});


### PR DESCRIPTION
Fixes #1007

Two faults in `AdminAuthorization`, which wraps the whole dashboard layout.

### 1. Most of the dashboard was not gated

`ADMIN_PATHS` listed three sections while the component guards all of `/dash`, and the `else` branch authorized anything unlisted. So `/dash` itself and ten more sections rendered for any org member: `analytics`, `onboarding`, `payments`, `library`, `developers`, `boards`, `podcasts`, `playgrounds`, `assignments`, `communities`.

The role data already answers who belongs here — `isAdmin` reads `rights.dashboard.action_access`, and on a default install `User` is the one role without it:

| Role | `dashboard.action_access` | `organizations.action_update` |
|---|---|---|
| Admin | `true` | `true` |
| Maintainer | `true` | `false` |
| Instructor | `true` | `false` |
| User | **`false`** | `false` |

The gate just wasn't asking for the paths that needed it, so this replaces the allow-list with the `/dash` prefix. **The existing tiering is what decides access, and it is unchanged:** an Instructor still reaches the dashboard, and `canManageOrg` still hides org settings and billing from them — the distinction `useAdminStatus` documents as *"an editor/maintainer may reach the dashboard, but only an org admin manages the organization and its billing"*.

### 2. A denial flashed and bounced

```tsx
setIsAuthorized(false);
router.push('/dash');
```

The first line renders the message, the second navigates away from it in the same pass — so it showed for a frame and the user ended up back on the dashboard with no idea why. Denial now stays on the page and renders through the shared error surface, so it gets the catalog's `permission` copy and its Home / sign out / report actions instead of a bare `<h1>` with nowhere to go.

The redirect that *should* happen is untouched: an unauthenticated visitor still goes to `/login`.

### Testing

`apps/web/tests/admin-authorization-denial.test.mjs` — 19 assertions:

- every `/dash` section is gated, including nested paths
- paths outside the dashboard are unaffected (`/`, `/home`, `/explore`, `/dashboard`, org course routes)
- the page-mode branch contains no `router.push` (scoped to that branch, so the legitimate `/login` redirect cannot mask a regression)
- the value passed to `ErrorUI` classifies as `permission`, so the copy is the specific one rather than the generic fallback

Checked against a local `dev` checkout: the reported behaviour reproduces there, and role rights are as tabled above (read from the seeded `role` rows). The `Instructor`-still-reaches-the-dashboard path follows from `isAdmin` being unchanged rather than from a manual pass, so it is worth a second look during review.

Screenshots of the original behaviour are in #1007.
