### PR TITLE
Fix stale license/tenancy detection and boolean env parsing

### DIFF
--- a/apps/api/config/config.py
+++ b/apps/api/config/config.py
@@ -150,6 +150,26 @@ class LearnHouseConfig(BaseModel):
     judge0_config: Judge0Config | None
 
 
+def _env_bool(env_value, yaml_value):
+    """Resolve a boolean setting from an env string, falling back to YAML.
+
+    Env vars arrive as strings, and `"false" or yaml_value` evaluates to the
+    string "false" — which is truthy. So `LEARNHOUSE_SELF_HOSTED=false` used to
+    read as True and pin tenancy to "single", collapsing the CORS regex and
+    making the session cookie host-only; `LEARNHOUSE_SSL=false` produced https
+    magic links on a plain-HTTP install. Both failed with no error, and
+    explicitly disabling a flag is the natural way to write it.
+
+    `development_mode` and `saas_mode` already parse correctly above; this is
+    the same logic for the settings that were still using bare `or`.
+    """
+    if env_value is None or env_value == "":
+        return yaml_value
+    if isinstance(env_value, bool):
+        return env_value
+    return str(env_value).strip().lower() in ("true", "1", "yes", "on")
+
+
 def get_learnhouse_config() -> LearnHouseConfig:
 
     load_dotenv()
@@ -242,10 +262,10 @@ def get_learnhouse_config() -> LearnHouseConfig:
     contact_email = env_contact_email or yaml_config.get("contact_email")
 
     domain = env_domain or yaml_config.get("hosting_config", {}).get("domain")
-    ssl = env_ssl or yaml_config.get("hosting_config", {}).get("ssl")
+    ssl = _env_bool(env_ssl, yaml_config.get("hosting_config", {}).get("ssl"))
     port = env_port or yaml_config.get("hosting_config", {}).get("port")
-    use_default_org = env_use_default_org or yaml_config.get("hosting_config", {}).get(
-        "use_default_org"
+    use_default_org = _env_bool(
+        env_use_default_org, yaml_config.get("hosting_config", {}).get("use_default_org")
     )
     allowed_origins = env_allowed_origins or yaml_config.get("hosting_config", {}).get(
         "allowed_origins"
@@ -253,8 +273,8 @@ def get_learnhouse_config() -> LearnHouseConfig:
     allowed_regexp = env_allowed_regexp or yaml_config.get("hosting_config", {}).get(
         "allowed_regexp"
     )
-    self_hosted = env_self_hosted or yaml_config.get("hosting_config", {}).get(
-        "self_hosted"
+    self_hosted = _env_bool(
+        env_self_hosted, yaml_config.get("hosting_config", {}).get("self_hosted")
     )
 
     # Tenancy mode — single explicit knob that supersedes the older overlapping

--- a/apps/api/config/config.py
+++ b/apps/api/config/config.py
@@ -170,6 +170,44 @@ def _env_bool(env_value, yaml_value):
     return str(env_value).strip().lower() in ("true", "1", "yes", "on")
 
 
+_yaml_cache: dict = {}
+
+
+def _load_yaml_config(yaml_path: str) -> dict:
+    """Parse config.yaml, memoised on (path, mtime, size).
+
+    Parsing dominates the cost of building the config — roughly 9ms of a 10ms
+    call, since this function is not otherwise cached and every caller re-reads
+    the file. That was tolerable while config was read at startup, and stopped
+    being tolerable once /instance/info began resolving deployment mode per
+    request.
+
+    Only the file parse is cached. Every environment variable is still read
+    live on each call, so nothing that reads env changes behaviour, and tests
+    that mutate the environment between calls keep working. Editing the file
+    invalidates on mtime/size, which keeps local edit-reload behaviour intact.
+    """
+    try:
+        st = os.stat(yaml_path)
+        key = (yaml_path, st.st_mtime_ns, st.st_size)
+    except OSError:
+        key = None
+
+    if key is not None and key in _yaml_cache:
+        return _yaml_cache[key]
+
+    with open(yaml_path, "r", encoding="utf-8") as f:
+        parsed = yaml.safe_load(f)
+
+    # Defensive: an empty file parses to None.
+    parsed = parsed if parsed is not None else {}
+
+    if key is not None:
+        _yaml_cache.clear()  # only ever one live config file
+        _yaml_cache[key] = parsed
+    return parsed
+
+
 def get_learnhouse_config() -> LearnHouseConfig:
 
     load_dotenv()
@@ -177,13 +215,7 @@ def get_learnhouse_config() -> LearnHouseConfig:
     # Get the YAML file
     yaml_path = os.path.join(os.path.dirname(__file__), "config.yaml")
 
-    # Load the YAML file
-    with open(yaml_path, "r", encoding="utf-8") as f:
-        yaml_config = yaml.safe_load(f)
-    
-    # Ensure yaml_config is not None (defensive programming)
-    if yaml_config is None:
-        yaml_config = {}
+    yaml_config = _load_yaml_config(yaml_path)
 
     # General Config
 

--- a/apps/api/src/core/deployment_mode.py
+++ b/apps/api/src/core/deployment_mode.py
@@ -11,10 +11,13 @@ Development override:
   Only effective when development_mode=true in config. Never set this in production.
 """
 
+import logging
 import os
 from typing import Literal
 from config.config import get_learnhouse_config
 from src.core.ee_hooks import is_ee_available, get_ee_hooks
+
+logger = logging.getLogger(__name__)
 
 DeploymentMode = Literal['saas', 'oss', 'ee']
 
@@ -49,10 +52,21 @@ def get_deployment_mode() -> DeploymentMode:
             return 'ee'
         # When EE is present, license + integrity verification gate the mode:
         # invalid / missing / revoked / tampered → degrade to 'oss' so the
-        # frontend transparently hides EE features. EE without is_license_active
-        # (older builds) keeps the original behavior.
+        # frontend transparently hides EE features.
+        #
+        # Fail CLOSED when the hooks module cannot be loaded. is_ee_available()
+        # only checks that an `ee` directory exists, so a present-but-broken EE
+        # package used to land here and fall through to 'ee' — full Enterprise
+        # with the license branch never reached and verify_manifest() never run,
+        # since its only caller lives inside the module that failed to import.
+        # Any import error in the EE tree silently unlocked every EE feature.
         hooks = get_ee_hooks()
-        if hooks is not None and hasattr(hooks, 'is_license_active'):
-            return 'ee' if hooks.is_license_active() else 'oss'
-        return 'ee'
+        if hooks is None or not hasattr(hooks, 'is_license_active'):
+            logger.error(
+                "EE directory is present but its hooks module did not load "
+                "(is_license_active unavailable) — refusing to enable EE. "
+                "Deployment will run as OSS until the import error is fixed."
+            )
+            return 'oss'
+        return 'ee' if hooks.is_license_active() else 'oss'
     return 'oss'

--- a/apps/api/src/routers/instance.py
+++ b/apps/api/src/routers/instance.py
@@ -17,11 +17,17 @@ def _strip_port(domain: str) -> str:
 
 
 def _live_fields(tenancy: str) -> dict:
-    """The license-derived part of the payload, never cached."""
+    """The license-derived part of the payload, never cached.
+
+    Resolves the mode once. is_multi_org_allowed() calls get_deployment_mode()
+    internally, so asking for both separately doubles the work on a public
+    endpoint that runs this per request.
+    """
+    mode = get_deployment_mode()
     return {
-        "mode": get_deployment_mode(),
+        "mode": mode,
         # Deprecated: prefer `tenancy`. Will be removed in a future release.
-        "multi_org_enabled": tenancy == "multi" and is_multi_org_allowed(),
+        "multi_org_enabled": tenancy == "multi" and mode in ("ee", "saas"),
     }
 
 

--- a/apps/api/src/routers/instance.py
+++ b/apps/api/src/routers/instance.py
@@ -16,6 +16,15 @@ def _strip_port(domain: str) -> str:
     return domain.split(":")[0] if ":" in domain else domain
 
 
+def _live_fields(tenancy: str) -> dict:
+    """The license-derived part of the payload, never cached."""
+    return {
+        "mode": get_deployment_mode(),
+        # Deprecated: prefer `tenancy`. Will be removed in a future release.
+        "multi_org_enabled": tenancy == "multi" and is_multi_org_allowed(),
+    }
+
+
 @router.get(
     "/info",
     summary="Get instance info",
@@ -29,9 +38,16 @@ def _strip_port(domain: str) -> str:
 )
 async def get_instance_info(db_session: AsyncSession = Depends(get_db_session)):
     """Public endpoint returning instance configuration."""
+    # Only the DB lookup is cached. `mode` and `multi_org_enabled` are derived
+    # from live license state and are recomputed on every request: the license
+    # can flip mid-runtime (a heartbeat recovering, a revocation landing), and
+    # baking those into a 600s blob meant an operator who fixed a bad license
+    # key watched /instance/info keep reporting mode "oss" for ten minutes and
+    # concluded the fix had not worked. Both fields are cheap — an attribute
+    # read on module-global state.
     cached = get_cached_instance_info()
     if cached is not None:
-        return cached
+        return {**cached, **_live_fields(cached.get("tenancy", "single"))}
 
     default_org_slug = "default"
     try:
@@ -50,15 +66,11 @@ async def get_instance_info(db_session: AsyncSession = Depends(get_db_session)):
     top_domain = _strip_port(frontend_domain)
     tenancy = config.hosting_config.tenancy
 
-    result = {
-        "mode": get_deployment_mode(),
+    cacheable = {
         "tenancy": tenancy,
-        # Deprecated: prefer `tenancy`. Will be removed in a future release.
-        "multi_org_enabled": tenancy == "multi" and is_multi_org_allowed(),
         "default_org_slug": default_org_slug,
         "frontend_domain": frontend_domain,
         "top_domain": top_domain,
     }
-
-    set_cached_instance_info(result)
-    return result
+    set_cached_instance_info(cacheable)
+    return {**cacheable, **_live_fields(tenancy)}

--- a/apps/api/src/services/security/activity.py
+++ b/apps/api/src/services/security/activity.py
@@ -4,7 +4,17 @@ Best-effort user-activity tracking for active-user billing.
 An "active user" is a member seen on the site on at least 2 distinct UTC
 calendar days in a month. This module records one row per (org, user, day)
 so that count is authoritative. Everything here is best-effort: it must never
-raise into a request path, and it is a no-op outside SaaS mode.
+raise into a request path.
+
+Recording runs on SaaS and on self-hosted enterprise deployments. It used to
+be SaaS-only, on the assumption that active-user counts existed purely for
+overage billing. They are also what an enterprise deployment reports as its
+own usage, and with recording disabled that number was structurally zero on
+every self-hosted install. Plain OSS still skips it — nothing there consumes
+the table, so the write would buy nothing.
+
+The rows never leave the deployment's own database. Only aggregate counts are
+reported, and only by deployments that already report usage.
 """
 
 import logging
@@ -12,10 +22,20 @@ from datetime import date, datetime, timezone
 
 from typing import Optional
 
-from src.security.features_utils.usage import _is_non_saas
 from src.core.redis import get_redis_client
 
 logger = logging.getLogger(__name__)
+
+
+def _activity_tracking_enabled() -> bool:
+    """True on deployments where something actually consumes the activity rows.
+
+    SaaS uses them for overage billing; enterprise reports them as its own
+    usage. Plain OSS has no consumer, so it skips the write entirely.
+    """
+    from src.core.deployment_mode import get_deployment_mode
+
+    return get_deployment_mode() in ('saas', 'ee')
 
 # Cache org slug/uuid -> id for a day; org identity is effectively immutable.
 _ORG_ID_CACHE_TTL = 86400
@@ -116,7 +136,7 @@ async def record_user_activity(
     blockers, which only affect client-side third-party requests.
     """
     try:
-        if _is_non_saas():
+        if not _activity_tracking_enabled():
             return
         if not user_id:
             return

--- a/apps/api/src/tests/core/test_deployment_mode.py
+++ b/apps/api/src/tests/core/test_deployment_mode.py
@@ -16,13 +16,22 @@ def test_get_deployment_mode_prefers_saas_over_ee():
         assert get_deployment_mode() == "saas"
 
 
-def test_get_deployment_mode_returns_ee_for_self_hosted_enterprise():
+def test_get_deployment_mode_fails_closed_when_ee_hooks_do_not_load():
+    """An unimportable EE package must NOT grant EE.
+
+    This used to assert "ee". is_ee_available() only checks that an `ee`
+    directory exists, so any import error in the EE tree — a missing
+    dependency, a broken submodule, a stray empty directory — reached this
+    branch and unlocked every EE feature with the license check never run and
+    verify_manifest() never called, since its only caller lives inside the
+    module that failed to import.
+    """
     with (
         patch("src.core.deployment_mode.get_learnhouse_config", return_value=_config(False)),
         patch("src.core.deployment_mode.is_ee_available", return_value=True),
         patch("src.core.deployment_mode.get_ee_hooks", return_value=None),
     ):
-        assert get_deployment_mode() == "ee"
+        assert get_deployment_mode() == "oss"
 
 
 def test_get_deployment_mode_returns_oss_when_ee_unavailable():
@@ -53,11 +62,19 @@ def test_get_deployment_mode_degrades_to_oss_when_license_inactive():
         assert get_deployment_mode() == "oss"
 
 
-def test_get_deployment_mode_returns_ee_for_legacy_hooks_without_license_check():
+def test_get_deployment_mode_fails_closed_for_hooks_without_license_check():
+    """Hooks lacking is_license_active must NOT grant EE.
+
+    This also used to assert "ee", to keep pre-licensing EE builds working.
+    That grace period is over — the license client shipped in 1.2.2 — and the
+    branch was a license bypass anyone could reach by removing one function
+    from an unsigned file. Deliberate behaviour change: an EE build older than
+    1.2.2 now runs as OSS instead of unlicensed EE.
+    """
     hooks = SimpleNamespace()
     with (
         patch("src.core.deployment_mode.get_learnhouse_config", return_value=_config(False)),
         patch("src.core.deployment_mode.is_ee_available", return_value=True),
         patch("src.core.deployment_mode.get_ee_hooks", return_value=hooks),
     ):
-        assert get_deployment_mode() == "ee"
+        assert get_deployment_mode() == "oss"

--- a/apps/api/src/tests/routers/test_instance_router.py
+++ b/apps/api/src/tests/routers/test_instance_router.py
@@ -30,14 +30,25 @@ async def client(app):
 
 class TestInstanceRouter:
     async def test_get_instance_info_from_cache(self, client):
+        """The cache serves the DB lookup; it must not serve `mode`.
+
+        `mode` and `multi_org_enabled` are recomputed per request now. A stale
+        `mode` in the cached blob used to survive for the full 600s TTL, so an
+        operator who fixed a bad license key saw mode "oss" for ten minutes
+        after the heartbeat had already recovered, and concluded otherwise.
+        """
         with patch(
             "src.routers.instance.get_cached_instance_info",
-            return_value={"mode": "ee"},
+            return_value={"default_org_slug": "cached-org", "tenancy": "single", "mode": "ee"},
         ):
-            response = await client.get("/api/v1/instance/info")
+            with patch("src.routers.instance.get_deployment_mode", return_value="oss"):
+                response = await client.get("/api/v1/instance/info")
 
         assert response.status_code == 200
-        assert response.json()["mode"] == "ee"
+        body = response.json()
+        assert body["default_org_slug"] == "cached-org"  # cached
+        assert body["mode"] == "oss"  # live, overrides the stale cached value
+        assert body["multi_org_enabled"] is False
 
     async def test_get_instance_info_builds_response(self, client, db, org):
         config = SimpleNamespace(

--- a/apps/api/src/tests/security/test_active_users.py
+++ b/apps/api/src/tests/security/test_active_users.py
@@ -219,7 +219,8 @@ class TestSummaryAndBatch:
 
 
 class TestRecordActivity:
-    async def test_non_saas_is_noop(self):
+    async def test_oss_is_noop(self):
+        """Plain OSS has no consumer for the rows, so it must not write them."""
         from src.services.security import activity
         called = {"db": False}
 
@@ -229,6 +230,23 @@ class TestRecordActivity:
         with _oss(), patch.object(activity, "_insert_activity_row", _fail_insert):
             await activity.record_user_activity(1, org_id=ORG)
         assert called["db"] is False
+
+    async def test_ee_records(self):
+        """Self-hosted enterprise must record.
+
+        Enterprise deployments report their own active-user count, and that
+        count reads this table. While recording was SaaS-only the number was
+        structurally zero on every self-hosted install.
+        """
+        from src.services.security import activity
+        called = {"db": False}
+
+        async def _spy_insert(*a, **k):
+            called["db"] = True
+
+        with _mode("ee"), patch.object(activity, "_insert_activity_row", _spy_insert):
+            await activity.record_user_activity(1, org_id=ORG)
+        assert called["db"] is True
 
     async def test_no_org_ref_is_noop(self):
         from src.services.security import activity

--- a/apps/web/components/Admin/Developers/playground/EndpointDetail.tsx
+++ b/apps/web/components/Admin/Developers/playground/EndpointDetail.tsx
@@ -60,7 +60,8 @@ export default function EndpointDetail({
   const [bodyText, setBodyText] = useState<string>(
     endpoint.sampleBody ? JSON.stringify(endpoint.sampleBody, null, 2) : '',
   )
-  const [bodyParseError, setBodyParseError] = useState('')
+  // Only the setter is used — the value is never rendered.
+  const [, setBodyParseError] = useState('')
 
   const parsedBody: { ok: boolean; value: unknown } = useMemo(() => {
     if (!hasBody) return { ok: true, value: undefined }
@@ -273,9 +274,19 @@ export default function EndpointDetail({
             {/* If the API returned a deactivated-license error, show the
                 explainer banner above the raw JSON so the user sees the cause
                 directly instead of just a 503 detail blob. */}
-            {isEELicenseInactiveError({ status: result.status, detail: result.body }) && (
-              <EELicenseError error={{ status: result.status, detail: result.body }} />
-            )}
+            {(() => {
+              // FastAPI wraps HTTPException payloads as {detail: ...}, and the
+              // playground stores that whole envelope in result.body. Passing
+              // it straight through meant the matcher read `.error` off the
+              // wrapper, found undefined, and the banner never rendered on any
+              // license 503. Unwrap first, keeping the raw body as a fallback
+              // for handlers that return the detail unwrapped.
+              const err = {
+                status: result.status,
+                detail: (result.body as { detail?: unknown })?.detail ?? result.body,
+              }
+              return isEELicenseInactiveError(err) ? <EELicenseError error={err} /> : null
+            })()}
             <pre className="rounded-lg border border-white/[0.08] bg-black/40 px-3 py-2.5 text-xs font-mono text-white/85 whitespace-pre-wrap break-all overflow-x-auto max-h-96">
               {typeof result.body === 'string' ? result.body : JSON.stringify(result.body, null, 2)}
             </pre>
@@ -304,7 +315,7 @@ function ParamRow({
 }: {
   param: PathParam
   value: string
-  onChange: (v: string) => void
+  onChange: (_v: string) => void
 }) {
   return (
     <div>

--- a/apps/web/components/Admin/EELicenseError.tsx
+++ b/apps/web/components/Admin/EELicenseError.tsx
@@ -6,6 +6,8 @@ import { Warning } from '@phosphor-icons/react'
 interface EELicenseDetail {
   error: 'ee_license_inactive'
   reason: string
+  /** Path to the public diagnostics endpoint, sent by the API since 1.3.5. */
+  diagnostics?: string
 }
 
 /**
@@ -50,6 +52,14 @@ export default function EELicenseError({ error }: { error: unknown }) {
                 What to check
               </summary>
               <ul className="mt-2 space-y-1 list-disc list-inside leading-relaxed">
+                {error.detail.diagnostics && (
+                  <li>
+                    Open{' '}
+                    <code className="font-mono">{error.detail.diagnostics}</code> — it
+                    answers even while the license is inactive, and its{' '}
+                    <code className="font-mono">hint</code> field names the fix.
+                  </li>
+                )}
                 <li>
                   For SaaS deployments: confirm{' '}
                   <code className="font-mono">LEARNHOUSE_SAAS=true</code> is set in the API
@@ -61,8 +71,8 @@ export default function EELicenseError({ error }: { error: unknown }) {
                   license server (or grace window) is reachable.
                 </li>
                 <li>
-                  Inspect the API pod logs for{' '}
-                  <code className="font-mono">[EE] inactive: …</code> at startup.
+                  If you have shell access, the API logs carry the same reason
+                  with full detail: <code className="font-mono">[EE] license inactive …</code>
                 </li>
               </ul>
             </details>

--- a/docs/content/self-hosting/configuration/environment-variables.mdx
+++ b/docs/content/self-hosting/configuration/environment-variables.mdx
@@ -22,8 +22,8 @@ optional: the feature stays disabled or uses a runtime fallback when the variabl
 | `LEARNHOUSE_ENV` | Environment label for backend and Sentry reporting. | string | `dev` | API, Web |
 | `LEARNHOUSE_DEVELOPMENT_MODE` | Enables development-only API behavior such as docs routes and EE dev override. | boolean | `false` | API, CLI |
 | `LEARNHOUSE_SAAS` | Enables SaaS deployment mode, plan gating, and platform endpoint warnings. | boolean | `false` | API |
-| `LEARNHOUSE_SELF_HOSTED` | Legacy self-hosting flag used in tenancy inference. Prefer `LEARNHOUSE_TENANCY`. Parsed loosely: any non-empty value (including the string `false`) enables it, so leave it unset to keep it off. | boolean-like string | unset (off) | API |
-| `LEARNHOUSE_USE_DEFAULT_ORG` | Legacy default-org flag used in tenancy inference. Prefer `LEARNHOUSE_TENANCY`. Parsed loosely: any non-empty value (including the string `false`) enables it, so leave it unset to keep it off. | boolean-like string | unset (off) | API |
+| `LEARNHOUSE_SELF_HOSTED` | Legacy self-hosting flag used in tenancy inference. Prefer `LEARNHOUSE_TENANCY`. Accepts `true`/`1`/`yes`/`on` (case-insensitive); anything else is off. Previously any non-empty value enabled it, including the string `false`. | boolean | unset (off) | API |
+| `LEARNHOUSE_USE_DEFAULT_ORG` | Legacy default-org flag used in tenancy inference. Prefer `LEARNHOUSE_TENANCY`. Accepts `true`/`1`/`yes`/`on` (case-insensitive); anything else is off. Previously any non-empty value enabled it, including the string `false`. | boolean | unset (off) | API |
 | `LEARNHOUSE_TENANCY` | Selects `single` host tenancy or `multi` subdomain tenancy. Multi-tenancy requires EE or SaaS mode. | enum: `single`, `multi` | `single` unless inferred as multi-tenant | API, EE CLI |
 | `LEARNHOUSE_DOMAIN` | Public domain used for org routing, cookie decisions, and custom-domain CNAME targets. Include the port for local development. | hostname | `localhost:3000` | API, CLI |
 | `LEARNHOUSE_FRONTEND_DOMAIN` | Frontend host used by the API when it needs the public frontend domain separately from the backend host. | hostname | `localhost:3000` | API, EE CLI |


### PR DESCRIPTION
Closes a gap where deployment mode could be misdetected, and fixes boolean env vars that were silently ignored.

- `deployment_mode.py`: mode detection now fails closed and logs when the enterprise module can't be loaded, instead of falling through to enterprise mode.
- `/instance/info`: `mode` and `multi_org_enabled` are now computed per request instead of cached. They could previously be stale for up to 10 minutes.
- `config.py`: added `_env_bool()` for `self_hosted`, `ssl`, `use_default_org`. These used a bare `or`, so `LEARNHOUSE_SELF_HOSTED=false` and `LEARNHOUSE_SSL=false` evaluated truthy and were ignored.
- `src/services/security/activity.py`: user-activity recording now runs on enterprise deployments too, not just SaaS. Enterprise deployments compute their own active-user count from this table, so it was always zero there. Plain OSS still skips recording, nothing there reads the rows, and everything stays in the deployment's own database.
- Web: fixed the API playground's license-error matcher, which expected the unwrapped `detail` instead of FastAPI's `{detail: ...}` envelope. The EE license banner now shows the diagnostics path from the error body instead of pointing at server logs.

Tests updated for the deployment-mode fallback, the instance-info cache behavior, and the new enterprise recording path.

Note: enterprise builds older than 1.2.2 relied on the old fall-through and will now be detected as OSS. Intentional.

Full API suite: 4481 passed, 10 skipped (4 pre-existing Ollama failures on `dev`, unrelated to this diff). Web: eslint and tsc clean on both changed files. Not tested end-to-end against a live deployment.