### PR TITLE
fix(api): return 403 for unconfigured internal pack key guard

### DIFF
--- a/apps/api/src/routers/orgs/packs.py
+++ b/apps/api/src/routers/orgs/packs.py
@@ -1,4 +1,5 @@
 import hmac
+import logging
 import os
 from fastapi import APIRouter, Depends, Header, HTTPException
 from pydantic import BaseModel
@@ -26,14 +27,41 @@ from src.services.packs.packs import (
 # Internal router (platform-key auth)
 # ============================================================================
 
+logger = logging.getLogger(__name__)
+
+# Set the first time a request arrives with LEARNHOUSE_PLATFORM_API_KEY unset, so
+# the misconfiguration is reported once per process instead of on every request.
+_REPORTED_MISSING_PLATFORM_KEY = False
+
+
 async def verify_platform_key(x_platform_key: str = Header(...)):
+    """Fail-closed guard for the internal packs endpoints.
+
+    Mirrors verify_cloud_internal_key in org_plan.py: every rejection is a 403, so
+    a caller cannot tell an unconfigured server from a wrong key.
+
+    Both emptiness checks are load-bearing. hmac.compare_digest(b"", b"") returns
+    True, so dropping either one makes an unconfigured deployment accept every
+    request on all five internal pack endpoints. Comparison is on bytes because
+    compare_digest rejects non-ASCII str, and header values reach us decoded as
+    latin-1 — an arbitrary caller could otherwise trigger a TypeError.
+    """
+    global _REPORTED_MISSING_PLATFORM_KEY
+
     expected_key = os.getenv("LEARNHOUSE_PLATFORM_API_KEY", "")
-    if not expected_key:
-        raise HTTPException(
-            status_code=500,
-            detail="LEARNHOUSE_PLATFORM_API_KEY is not configured on the server",
+    if not expected_key and not _REPORTED_MISSING_PLATFORM_KEY:
+        _REPORTED_MISSING_PLATFORM_KEY = True
+        logger.error(
+            "LEARNHOUSE_PLATFORM_API_KEY is not set on this deployment: every "
+            "internal pack request is rejected, so pack activation and "
+            "active-user overage billing silently do nothing until it is set."
         )
-    if not hmac.compare_digest(x_platform_key, expected_key):
+
+    if (
+        not expected_key
+        or not x_platform_key
+        or not hmac.compare_digest(x_platform_key.encode(), expected_key.encode())
+    ):
         raise HTTPException(status_code=403, detail="Invalid platform API key")
 
 
@@ -65,7 +93,6 @@ class MarkCancelingRequest(BaseModel):
     responses={
         200: {"description": "Pack activated for the organization.", "model": OrgPackRead},
         403: {"description": "Invalid platform API key"},
-        500: {"description": "LEARNHOUSE_PLATFORM_API_KEY is not configured on the server"},
     },
 )
 async def api_activate_pack(
@@ -88,7 +115,6 @@ async def api_activate_pack(
     responses={
         200: {"description": "Pack marked as canceling.", "model": OrgPackRead},
         403: {"description": "Invalid platform API key"},
-        500: {"description": "LEARNHOUSE_PLATFORM_API_KEY is not configured on the server"},
     },
 )
 async def api_mark_pack_canceling(
@@ -111,7 +137,6 @@ async def api_mark_pack_canceling(
     responses={
         200: {"description": "Pack deactivated.", "model": OrgPackRead},
         403: {"description": "Invalid platform API key"},
-        500: {"description": "LEARNHOUSE_PLATFORM_API_KEY is not configured on the server"},
     },
 )
 async def api_deactivate_pack(
@@ -133,7 +158,6 @@ async def api_deactivate_pack(
     responses={
         200: {"description": "All packs deactivated; returns the number of packs affected."},
         403: {"description": "Invalid platform API key"},
-        500: {"description": "LEARNHOUSE_PLATFORM_API_KEY is not configured on the server"},
     },
 )
 async def api_deactivate_all_packs(

--- a/apps/api/src/tests/routers/test_packs_router.py
+++ b/apps/api/src/tests/routers/test_packs_router.py
@@ -67,7 +67,7 @@ class TestInternalPacksRouter:
             else:
                 os.environ["LEARNHOUSE_PLATFORM_API_KEY"] = old
 
-        assert response.status_code == 500
+        assert response.status_code == 403
 
         old = os.environ.get("LEARNHOUSE_PLATFORM_API_KEY")
         os.environ["LEARNHOUSE_PLATFORM_API_KEY"] = "platform-secret"
@@ -75,6 +75,55 @@ class TestInternalPacksRouter:
             response = await client.post(
                 "/api/v1/internal/packs/1/activate",
                 headers={"x-platform-key": "wrong-key"},
+                json={"pack_id": "ai_500", "platform_subscription_id": "sub_123"},
+            )
+        finally:
+            if old is None:
+                os.environ.pop("LEARNHOUSE_PLATFORM_API_KEY", None)
+            else:
+                os.environ["LEARNHOUSE_PLATFORM_API_KEY"] = old
+
+        assert response.status_code == 403
+
+    async def test_unset_key_and_empty_header_is_rejected(self, client):
+        """An unconfigured deployment must never accept a request.
+
+        hmac.compare_digest(b"", b"") is True, so without the emptiness checks in
+        verify_platform_key this exact combination would return 200 and let any
+        caller activate packs on any organization.
+        """
+        old = os.environ.get("LEARNHOUSE_PLATFORM_API_KEY")
+        os.environ.pop("LEARNHOUSE_PLATFORM_API_KEY", None)
+        try:
+            with patch(
+                "src.routers.orgs.packs.activate_pack",
+                return_value=_mock_pack(),
+            ):
+                response = await client.post(
+                    "/api/v1/internal/packs/1/activate",
+                    headers={"x-platform-key": ""},
+                    json={"pack_id": "ai_500", "platform_subscription_id": "sub_123"},
+                )
+        finally:
+            if old is None:
+                os.environ.pop("LEARNHOUSE_PLATFORM_API_KEY", None)
+            else:
+                os.environ["LEARNHOUSE_PLATFORM_API_KEY"] = old
+
+        assert response.status_code == 403
+
+    async def test_non_ascii_key_header_is_rejected(self, client):
+        """A non-ASCII header must be a 403, not an unhandled TypeError -> 500.
+
+        Header values arrive decoded as latin-1 and hmac.compare_digest raises
+        TypeError on non-ASCII str, so the comparison runs on bytes.
+        """
+        old = os.environ.get("LEARNHOUSE_PLATFORM_API_KEY")
+        os.environ["LEARNHOUSE_PLATFORM_API_KEY"] = "platform-secret"
+        try:
+            response = await client.post(
+                "/api/v1/internal/packs/1/activate",
+                headers={"x-platform-key": "clé-invalide".encode("latin-1")},
                 json={"pack_id": "ai_500", "platform_subscription_id": "sub_123"},
             )
         finally:

--- a/docs/content/self-hosting/configuration/environment-variables.mdx
+++ b/docs/content/self-hosting/configuration/environment-variables.mdx
@@ -36,7 +36,7 @@ optional: the feature stays disabled or uses a runtime fallback when the variabl
 | `LEARNHOUSE_CUSTOM_DOMAIN_DEV_MODE` | Skips DNS verification for all custom domains and marks them verified immediately. Development/testing only. | boolean | `false` | API |
 | `LEARNHOUSE_PUBLIC` | Docker build argument that produces a community build by excluding non-community code. | boolean | `false` | Dockerfiles (root, API, Web) |
 | `LEARNHOUSE_PLATFORM_URL` | Base URL for LearnHouse platform links, upgrade URLs, and email allowlist checks. | URL | unset; backend flows fall back to `https://www.learnhouse.app` and the web token-exchange to `https://learnhouse.app` | API, Web |
-| `LEARNHOUSE_PLATFORM_API_KEY` | Shared secret for platform-only internal endpoints such as packs. | secret string | required for SaaS/platform endpoints | API |
+| `LEARNHOUSE_PLATFORM_API_KEY` | Shared secret for platform-only internal endpoints such as packs. When unset, those endpoints reject every request with a 403 and the API logs an error on the first rejected request. | secret string | required for SaaS/platform endpoints | API |
 | `CLOUD_INTERNAL_KEY` | Shared secret for SaaS-internal endpoints (custom-domain sync and the `cloud_internal` router). When unset, those endpoints reject every request and the API logs a startup warning. | secret string | unset; required for SaaS custom-domain provisioning | API |
 
 ## Database, Redis, and collaboration


### PR DESCRIPTION
Every request to the internal pack endpoints returned a 500 (and a Sentry event) when LEARNHOUSE_PLATFORM_API_KEY was unset on a deployment. verify_platform_key in apps/api/src/routers/orgs/packs.py raised before comparing anything, unlike the other two internal-key guards (org_plan, custom_domains), which fold an unset key into a plain 403. The 500 also told an unauthenticated caller whether the server was configured.

All three rejection paths (key unset, client key empty, mismatch) now return 403. The unset-key case logs an error once per process instead of raising on every request. The comparison moved to bytes, since compare_digest raises on non-ASCII strings and header values arrive latin-1 decoded, so a caller could previously force a 500 that way. Removed the now-unreachable 500 from the OpenAPI responses and updated the docs.

Heads up before merging: LEARNHOUSE_PLATFORM_API_KEY is actually unset on the API deployment right now, so active-user overage billing never fires. Set it and confirm the endpoint returns 200 before merging. After this change a missing key stops producing per-request Sentry noise, so the misconfiguration goes quiet instead of loud.

Verified: the existing unset-key test now asserts 403; added regression tests for an empty header and a non-ASCII header. All 14 tests in test_packs_router.py pass, ruff clean.

Fixes LEARNHOUSE-API-83