### PR TITLE
fix(api): stop paging on rejected email recipients

### DIFF
--- a/apps/api/src/services/email/utils.py
+++ b/apps/api/src/services/email/utils.py
@@ -360,6 +360,26 @@ def _is_transient_email_error(exc: BaseException) -> bool:
     )
 
 
+def _is_recipient_rejected(exc: BaseException) -> bool:
+    """True only when the provider rejected the RECIPIENT address itself.
+
+    A bad address supplied by a caller (a provisioning integration creating
+    accounts on example.com, a typo in an admin-entered email) is a property of
+    that address: retrying cannot help, and it is not an incident worth paging
+    on. Everything else stays at error level, because it means mail is broken
+    for everyone — an unverified sending domain (invalid_from_address), an empty
+    subject or body from a template regression (missing_required_field), an
+    auth failure, a rate limit, a 5xx, or a non-JSON body from an intermediary
+    (application_error). Classifying on the bare 4xx status would sweep all of
+    those into silence, so we require positive evidence: a validation error that
+    names the `to` field.
+    """
+    if str(getattr(exc, "error_type", "")).lower() != "validation_error":
+        return False
+    message = str(exc).lower()
+    return "`to`" in message or "to field" in message
+
+
 def _send_email_resend(
     sender: str,
     to: str,
@@ -386,7 +406,10 @@ def _send_email_resend(
                 logger.warning("Resend email to %s failed (%s), retrying once", to, e)
                 time.sleep(_RESEND_RETRY_DELAY_SECONDS)
                 continue
-            logger.error("Resend email failed to %s: %s", to, e, exc_info=True)
+            if _is_recipient_rejected(e):
+                logger.warning("Resend rejected the recipient address %s: %s", to, e)
+            else:
+                logger.error("Resend email failed to %s: %s", to, e, exc_info=True)
             raise HTTPException(status_code=503, detail="Email service temporarily unavailable")
 
 

--- a/apps/api/src/tests/services/test_email_utils_service.py
+++ b/apps/api/src/tests/services/test_email_utils_service.py
@@ -8,6 +8,8 @@ import pytest
 from fastapi import HTTPException
 from starlette.requests import Request
 
+import resend.exceptions as resend_exceptions
+
 from src.services.email.utils import (
     _is_allowed_base_url,
     get_base_url_from_request,
@@ -362,6 +364,77 @@ class TestEmailUtilsService:
             with pytest.raises(HTTPException) as exc_info:
                 send_email("to@test.com", "Subject", "<p>Body</p>")
         assert exc_info.value.status_code == 503
+
+    def test_recipient_rejection_logs_warning_not_error(self):
+        """A provider rejection of the address itself must not page.
+
+        It still raises 503 — only the log level changes, so nothing downstream
+        of send_email sees different behavior.
+        """
+        rejection = resend_exceptions.ValidationError(
+            message=(
+                "Invalid `to` field. Please use our testing email address "
+                "instead of domains like `example.com`."
+            ),
+            error_type="validation_error",
+            code=400,
+        )
+        with patch(
+            "src.services.email.utils.get_learnhouse_config",
+            return_value=_config(email_provider="resend", resend_api_key="key"),
+        ), patch(
+            "src.services.email.utils.resend.Emails.send",
+            side_effect=rejection,
+        ), patch("src.services.email.utils.logger") as mock_logger:
+            with pytest.raises(HTTPException) as exc_info:
+                send_email("nobody@example.com", "Subject", "<p>Body</p>")
+
+        assert exc_info.value.status_code == 503
+        mock_logger.error.assert_not_called()
+        mock_logger.warning.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            resend_exceptions.ApplicationError(
+                message="Something went wrong", error_type="application_error", code=500
+            ),
+            resend_exceptions.RateLimitError(
+                message="Too many requests", error_type="rate_limit_exceeded", code=429
+            ),
+            resend_exceptions.InvalidApiKeyError(
+                message="Invalid API key", error_type="invalid_api_key", code=403
+            ),
+            resend_exceptions.MissingRequiredFieldsError(
+                message="Missing `subject` field",
+                error_type="missing_required_field",
+                code=422,
+            ),
+            resend_exceptions.ValidationError(
+                message="Invalid `from` field. The domain is not verified.",
+                error_type="validation_error",
+                code=400,
+            ),
+        ],
+    )
+    def test_deployment_wide_failures_still_log_error(self, failure):
+        """Anything that is not a recipient rejection keeps paging.
+
+        These are our-side or provider-side faults that break mail for every
+        user, so they must stay at error level even though several carry a 4xx.
+        """
+        with patch(
+            "src.services.email.utils.get_learnhouse_config",
+            return_value=_config(email_provider="resend", resend_api_key="key"),
+        ), patch(
+            "src.services.email.utils.resend.Emails.send",
+            side_effect=failure,
+        ), patch("src.services.email.utils.logger") as mock_logger:
+            with pytest.raises(HTTPException) as exc_info:
+                send_email("to@test.com", "Subject", "<p>Body</p>")
+
+        assert exc_info.value.status_code == 503
+        mock_logger.error.assert_called_once()
 
     def test_send_email_smtp_exception_raises_503(self):
         smtp_client = Mock()


### PR DESCRIPTION
Creating a user with an unroutable email address (bad provisioning data, a typo'd invite) fired a Sentry error with a full stack trace. The email provider rejects these with a validation error naming the `to` field, which fell into the generic except branch in apps/api/src/services/email/utils.py, logged at error level, and the logging integration turns any error record into a Sentry event. No retry or operator action changes the outcome of a bad address.

Recipient rejections now log at warning level. Everything else still pages: unverified sending domain, a template regression that empties the subject, auth failures, rate limits, a non-JSON body from something in front of the provider. Those mean mail is broken for everyone. Classification requires positive evidence, a validation error naming `to`, not the bare status code, so none of those get swept into silence by mistake. The call still raises 503 with the same detail; nothing changes for callers or the frontend error catalog.

Verified: new test confirms a recipient rejection logs a warning, not an error, and still raises 503; a parametrized test confirms application errors, rate limits, invalid API keys, missing fields, and invalid-from-address failures still log at error. 114 email tests pass, ruff clean.

Fixes LEARNHOUSE-API-84