### PR TITLE
fix(web): wrap activity row labels to survive translation

### DIFF
--- a/apps/web/components/Dashboard/Pages/Course/EditCourseStructure/DraggableElements/ActivityElement.tsx
+++ b/apps/web/components/Dashboard/Pages/Course/EditCourseStructure/DraggableElements/ActivityElement.tsx
@@ -350,9 +350,11 @@ function ActivityElement(props: ActivitiyElementProps) {
                 ) : (
                   <EyeOff size={10} />
                 )}
-                {props.activity.published
-                  ? t('dashboard.courses.structure.activity.status.published')
-                  : t('dashboard.courses.structure.activity.status.draft')}
+                <span>
+                  {props.activity.published
+                    ? t('dashboard.courses.structure.activity.status.published')
+                    : t('dashboard.courses.structure.activity.status.draft')}
+                </span>
               </button>
               <div className="w-px h-5 bg-gray-200/80 mx-1" />
               <div className="flex items-center gap-1">
@@ -474,14 +476,16 @@ function ActivityElement(props: ActivitiyElementProps) {
                 <DropdownMenuContent align="end" className="w-48">
                   <DropdownMenuItem onClick={() => setSelectedActivity(props.activity.id)}>
                     <Pencil size={14} />
-                    {t('dashboard.courses.structure.actions.rename')}
+                    <span>{t('dashboard.courses.structure.actions.rename')}</span>
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem onClick={changePublicStatus} disabled={isPublishing}>
                     {props.activity.published ? <EyeOff size={14} /> : <Globe size={14} />}
-                    {props.activity.published
-                      ? t('dashboard.courses.structure.actions.unpublish')
-                      : t('dashboard.courses.structure.actions.publish')}
+                    <span>
+                      {props.activity.published
+                        ? t('dashboard.courses.structure.actions.unpublish')
+                        : t('dashboard.courses.structure.actions.publish')}
+                    </span>
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
@@ -492,7 +496,7 @@ function ActivityElement(props: ActivitiyElementProps) {
                     className="text-red-600 focus:text-red-600 focus:bg-red-50"
                   >
                     <Trash2 size={14} />
-                    {t('dashboard.courses.structure.bulk_actions.delete')}
+                    <span>{t('dashboard.courses.structure.bulk_actions.delete')}</span>
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>

--- a/apps/web/tests/course-structure-translatable-text.test.mjs
+++ b/apps/web/tests/course-structure-translatable-text.test.mjs
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const DIR = join(
+  import.meta.dir,
+  "../components/Dashboard/Pages/Course/EditCourseStructure/DraggableElements",
+);
+
+/**
+ * Chrome and Edge page translation replaces a text node with a <font> wrapper it
+ * inserts into the DOM. When that text node is a bare sibling of an element,
+ * React's next commit tries to insert before a node that is no longer a child of
+ * the container and throws NotFoundError: Failed to execute 'insertBefore'. The
+ * whole dashboard page unmounts mid-edit.
+ *
+ * Giving every label its own element removes the hazard: the translator swaps
+ * the text inside the span and React's sibling structure stays intact.
+ */
+describe("course structure labels are translation-safe", () => {
+  const files = readdirSync(DIR).filter((name) => name.endsWith(".tsx"));
+
+  test.each(files)("%s has no bare text sibling after an element", (name) => {
+    const lines = readFileSync(join(DIR, name), "utf8").split("\n");
+    const offenders = [];
+
+    for (let i = 1; i < lines.length; i++) {
+      const previous = lines[i - 1].trimEnd();
+      const current = lines[i].trim();
+      // Only a COMPLETED sibling element is the hazard: a self-closing tag or a
+      // closing tag. A line ending in an opening tag means the text is that
+      // element's only child, which the translator handles fine.
+      const previousIsElement =
+        previous.endsWith("/>") || /<\/[A-Za-z][\w.]*>$/.test(previous);
+      const currentIsBareExpression =
+        current.startsWith("{") && !current.startsWith("{/*") && !current.includes("<");
+
+      if (previousIsElement && currentIsBareExpression && current.includes("t(")) {
+        offenders.push(`${name}:${i + 1}: ${current}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Editing course content crashed with "NotFoundError: Failed to execute 'insertBefore' on 'Node'" when the browser's page translation was active, unmounting the page mid-edit. Chrome and Edge translation replaces a text node with a <font> wrapper it inserts itself. Where that text node sits as a bare sibling of an element, React's next commit tries to insert before a node no longer in the container and throws. The activity row had four spots like this: the publish pill and three dropdown items, each an icon followed by a bare label. ChapterElement already wraps its labels in spans, which is why the crash stayed confined to activity rows. The dashboard sets notranslate on its own subtree, but the dropdown renders through a Radix portal to document.body, outside that wrapper, so the attribute never reached these nodes.

Fix: wrap each label in a span. Text stays translatable; the translator swaps what's inside the span, and React's sibling structure holds.

Not touching the shared Radix primitives (dialog, hover-card, tooltip, popover). They render real learner-facing content on public routes, and a blanket translate="no" there would block legitimate translation.

This is a mitigation for browser translation behavior, not a fix to a bug in our rendering logic.

Verified: a test pins the DOM shape for the three affected components, failing on the unfixed file and passing with the change. Lint clean.

Fixes LEARNHOUSE-WEB-5M