### PR TITLE
fix(api): drop unused import breaking ruff on dev

### DIFF
--- a/apps/api/src/routers/instance.py
+++ b/apps/api/src/routers/instance.py
@@ -3,7 +3,6 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from src.db.organizations import Organization
 from src.core.events.database import get_db_session
-from src.core.ee_hooks import is_multi_org_allowed
 from src.core.deployment_mode import get_deployment_mode
 from src.services.orgs.cache import get_cached_instance_info, set_cached_instance_info
 from config.config import get_learnhouse_config

--- a/apps/api/src/tests/routers/test_instance_router.py
+++ b/apps/api/src/tests/routers/test_instance_router.py
@@ -67,9 +67,6 @@ class TestInstanceRouter:
             "src.routers.instance.get_deployment_mode",
             return_value="saas",
         ), patch(
-            "src.routers.instance.is_multi_org_allowed",
-            return_value=True,
-        ), patch(
             "src.routers.instance.set_cached_instance_info",
         ) as mock_set_cache:
             response = await client.get("/api/v1/instance/info")
@@ -101,9 +98,6 @@ class TestInstanceRouter:
         ), patch(
             "src.routers.instance.get_deployment_mode",
             return_value="ee",
-        ), patch(
-            "src.routers.instance.is_multi_org_allowed",
-            return_value=True,
         ), patch(
             "src.routers.instance.set_cached_instance_info",
         ):
@@ -138,9 +132,6 @@ class TestInstanceRouter:
             ), patch(
                 "src.routers.instance.get_deployment_mode",
                 return_value="oss",
-            ), patch(
-                "src.routers.instance.is_multi_org_allowed",
-                return_value=False,
             ), patch(
                 "src.routers.instance.set_cached_instance_info",
             ):


### PR DESCRIPTION
Ruff is failing on dev, blocking every backend PR. `apps/api/src/routers/instance.py` imports `is_multi_org_allowed` but only references it in a docstring — `_live_fields` resolves the deployment mode itself now. Removed the import and the three now-pointless mock patches of that name in the instance router tests.

Verified: ruff clean across `apps/api`, all 692 tests in `apps/api/src/tests/routers` pass.