### PR TITLE
Gate superadmin dashboard on deployment mode, not a forgeable cookie

### DIFF
--- a/apps/api/src/core/ee_hooks.py
+++ b/apps/api/src/core/ee_hooks.py
@@ -14,7 +14,9 @@ def is_ee_available():
     """
     if os.environ.get("LEARNHOUSE_DISABLE_EE") == "1":
         return False
-    return os.path.exists("ee")
+    # Require the hooks module itself, not merely a directory named "ee":
+    # a directory without it imports nothing, so it is not an EE install.
+    return os.path.isdir("ee") and os.path.isfile(os.path.join("ee", "hooks.py"))
 
 def get_ee_hooks():
     """Safely import and return the EE hooks module if available."""

--- a/apps/api/src/routers/orgs/ai_credits.py
+++ b/apps/api/src/routers/orgs/ai_credits.py
@@ -23,7 +23,7 @@ from src.security.features_utils.usage import (
     set_ai_credits,
 )
 from src.security.org_auth import is_org_member, is_org_admin, enforce_org_mfa
-from src.security.superadmin import is_user_superadmin
+from src.security.superadmin import ensure_ee_superadmin_surface, is_user_superadmin
 
 
 router = APIRouter()
@@ -193,6 +193,7 @@ async def add_org_ai_credits(
     # admin here lets a tenant mint unlimited free AI credits for itself
     # (revenue/quota bypass), so this must be a billing-platform / superadmin
     # operation — same posture as the /set endpoint.
+    ensure_ee_superadmin_surface()
     user_id = resolve_acting_user_id(current_user)
     if not user_id or not await is_user_superadmin(user_id, db_session):
         raise HTTPException(
@@ -259,6 +260,7 @@ async def reset_org_ai_credits(
     # Resetting consumed usage effectively grants free metered AI usage, letting
     # a tenant zero out its own usage at will and bypass the plan's AI quota.
     # This is a billing-platform / superadmin operation (same posture as /set).
+    ensure_ee_superadmin_surface()
     user_id = resolve_acting_user_id(current_user)
     if not user_id or not await is_user_superadmin(user_id, db_session):
         raise HTTPException(
@@ -302,6 +304,7 @@ async def set_org_ai_credits(
     if not org:
         raise HTTPException(status_code=404, detail="Organization not found")
 
+    ensure_ee_superadmin_surface()
     user_id = resolve_acting_user_id(current_user)
     if not user_id or not await is_user_superadmin(user_id, db_session):
         raise HTTPException(status_code=403, detail="Superadmin access required")

--- a/apps/api/src/security/auth.py
+++ b/apps/api/src/security/auth.py
@@ -546,6 +546,14 @@ async def get_current_user(
     # cleanliness" — or every superadmin token will silently fall through
     # to org-token validation and fail.
     if auth_lower.startswith("bearer lh_sa_"):
+        # Superadmin tokens are an Enterprise Edition credential. On an OSS
+        # deployment they can only exist through a lapsed license or a direct
+        # DB insert, so refuse before touching the database. This matters
+        # because SuperadminAPITokenUser is not an APITokenUser subclass and
+        # therefore passes the api-token rejection on core routers.
+        from src.security.superadmin import ensure_ee_superadmin_surface
+
+        ensure_ee_superadmin_surface()
         token = auth_header[7:].strip()  # strip "Bearer "
         sa_user = await validate_superadmin_api_token(token, db_session)
         if sa_user:

--- a/apps/api/src/security/superadmin.py
+++ b/apps/api/src/security/superadmin.py
@@ -7,6 +7,40 @@ from src.db.users import User
 
 logger = logging.getLogger(__name__)
 
+#: Machine-readable body for "this surface is Enterprise Edition only".
+#: The web client matches this exact shape (403 + detail.error === 'ee_required')
+#: in apps/web/components/Admin/EELicenseError.tsx::isEERequiredError.
+#:
+#: Deliberately not the 503 'ee_license_inactive' shape: that one means EE is
+#: installed but its license check is failing, which is transient and worth a
+#: retry. This one means the feature does not exist on this deployment.
+EE_SUPERADMIN_REQUIRED_DETAIL = {
+    "error": "ee_required",
+    "feature": "superadmin",
+    "message": "Enterprise Edition license required.",
+}
+
+
+def ensure_ee_superadmin_surface() -> None:
+    """Block the superadmin surface on OSS deployments.
+
+    Denies only when the mode is definitively 'oss'. Both 'saas' and 'ee' pass
+    through untouched — never invert this to ``!= 'ee'``, which would 403 the
+    live SaaS deployment.
+
+    The import is lazy so the mode is resolved per request rather than frozen
+    when the dependency is constructed, and to stay clear of the
+    rbac -> superadmin -> auth -> users -> rbac import cycle this module
+    already works around.
+    """
+    from src.core.deployment_mode import get_deployment_mode
+
+    if get_deployment_mode() == 'oss':
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=dict(EE_SUPERADMIN_REQUIRED_DETAIL),
+        )
+
 
 async def is_user_superadmin(user_id: int, db_session: AsyncSession) -> bool:
     """Check if a user is a superadmin by querying the database directly."""
@@ -51,6 +85,14 @@ async def require_superadmin(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Authentication required",
         )
+
+    # Defense in depth. The EE superadmin routers are already mounted behind
+    # their own OSS check, so on those routes this never fires — it is here so
+    # that any core route which adopts require_superadmin later inherits the
+    # gate instead of quietly shipping a superadmin surface to OSS.
+    # Ordered after the 401 so anonymous callers still get 401, and before the
+    # principal-type branches so OSS never reveals which principals would pass.
+    ensure_ee_superadmin_surface()
 
     # Org-scoped API tokens are never superadmins, regardless of who minted them.
     if isinstance(current_user, APITokenUser):

--- a/apps/api/src/tests/conftest.py
+++ b/apps/api/src/tests/conftest.py
@@ -15,6 +15,18 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 # Set testing environment variable to use SQLite (must be before any app imports)
 os.environ["TESTING"] = "true"
 
+# Pin the deployment mode to 'oss' for the whole suite.
+#
+# Unpinned, get_deployment_mode() resolves against the filesystem: 'oss' in CI
+# (no ee/ checkout) but potentially 'ee' on a developer machine with the
+# apps/api/ee symlink. That divergence hides EE-gating regressions locally.
+# Going through LEARNHOUSE_DISABLE_EE rather than patching
+# get_deployment_mode is deliberate — several modules import that symbol at
+# load time, so a patch would reach only the lazy importers and leave the
+# suite split-brained, silently relaxing the SaaS plan gates that key off the
+# same function. Tests that need 'saas' or 'ee' patch it explicitly.
+os.environ["LEARNHOUSE_DISABLE_EE"] = "1"
+
 # Set a valid JWT secret key for tests (must be at least 32 characters)
 os.environ["LEARNHOUSE_AUTH_JWT_SECRET_KEY"] = (
     "test-secret-key-for-unit-tests-32chars!"

--- a/apps/api/src/tests/core/test_core_events.py
+++ b/apps/api/src/tests/core/test_core_events.py
@@ -157,10 +157,16 @@ def test_is_ee_available(monkeypatch):
     assert ee_hooks.is_ee_available() is False
 
     monkeypatch.delenv("LEARNHOUSE_DISABLE_EE", raising=False)
-    monkeypatch.setattr(ee_hooks.os.path, "exists", lambda path: True)
+    monkeypatch.setattr(ee_hooks.os.path, "isdir", lambda path: True)
+    monkeypatch.setattr(ee_hooks.os.path, "isfile", lambda path: True)
     assert ee_hooks.is_ee_available() is True
 
-    monkeypatch.setattr(ee_hooks.os.path, "exists", lambda path: False)
+    # A directory named "ee" with no hooks.py imports nothing, so it does not
+    # count as EE being available.
+    monkeypatch.setattr(ee_hooks.os.path, "isfile", lambda path: False)
+    assert ee_hooks.is_ee_available() is False
+
+    monkeypatch.setattr(ee_hooks.os.path, "isdir", lambda path: False)
     assert ee_hooks.is_ee_available() is False
 
 

--- a/apps/api/src/tests/core/test_core_events_runtime.py
+++ b/apps/api/src/tests/core/test_core_events_runtime.py
@@ -337,7 +337,8 @@ async def test_periodic_migration_cleanup(monkeypatch, caplog):
 
 def test_ee_hooks_availability_and_loading(monkeypatch, caplog):
     monkeypatch.delenv("LEARNHOUSE_DISABLE_EE", raising=False)
-    monkeypatch.setattr(ee_hooks.os.path, "exists", lambda path: path == "ee")
+    monkeypatch.setattr(ee_hooks.os.path, "isdir", lambda path: path == "ee")
+    monkeypatch.setattr(ee_hooks.os.path, "isfile", lambda path: True)
     assert ee_hooks.is_ee_available() is True
 
     monkeypatch.setenv("LEARNHOUSE_DISABLE_EE", "1")
@@ -345,7 +346,7 @@ def test_ee_hooks_availability_and_loading(monkeypatch, caplog):
     assert ee_hooks.get_ee_hooks() is None
 
     monkeypatch.delenv("LEARNHOUSE_DISABLE_EE", raising=False)
-    monkeypatch.setattr(ee_hooks.os.path, "exists", lambda path: True)
+    monkeypatch.setattr(ee_hooks.os.path, "isdir", lambda path: True)
     monkeypatch.setattr(ee_hooks.importlib.util, "find_spec", lambda name: None)
     assert ee_hooks.get_ee_hooks() is None
 

--- a/apps/api/src/tests/core/test_deployment_mode.py
+++ b/apps/api/src/tests/core/test_deployment_mode.py
@@ -78,3 +78,21 @@ def test_get_deployment_mode_fails_closed_for_hooks_without_license_check():
         patch("src.core.deployment_mode.get_ee_hooks", return_value=hooks),
     ):
         assert get_deployment_mode() == "oss"
+
+
+def test_empty_ee_dir_does_not_count_as_ee_available(tmp_path, monkeypatch):
+    """A directory named "ee" with no hooks.py is not an EE install.
+
+    get_deployment_mode() already fails closed on a hooks module it cannot
+    load, but is_ee_available() is consulted on its own elsewhere, so it
+    should not claim EE is present either.
+    """
+    from src.core.ee_hooks import is_ee_available
+
+    monkeypatch.delenv("LEARNHOUSE_DISABLE_EE", raising=False)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "ee").mkdir()
+    assert is_ee_available() is False
+
+    (tmp_path / "ee" / "hooks.py").write_text("")
+    assert is_ee_available() is True

--- a/apps/api/src/tests/routers/test_ai_credits_router.py
+++ b/apps/api/src/tests/routers/test_ai_credits_router.py
@@ -34,6 +34,19 @@ async def client(app):
         yield c
 
 
+@pytest.fixture(autouse=True)
+def ee_mode():
+    """Run this module against the self-hosted-EE baseline.
+
+    The credit mutators are superadmin-only and therefore Enterprise-only. The
+    suite pins 'oss' globally (see conftest), which would 403 them before any
+    of the behaviour under test runs. Tests that specifically want OSS patch
+    the same target again — the inner patch wins.
+    """
+    with patch("src.core.deployment_mode.get_deployment_mode", return_value="ee"):
+        yield
+
+
 class TestAICreditsRouter:
     async def test_org_member_and_admin_wrappers(self, db, org):
         with patch(
@@ -232,3 +245,41 @@ class TestAICreditsRouter:
                 json={"amount": -1},
             )
         assert response.status_code == 400
+
+
+class TestAICreditsOSSGate:
+    """The credit mutators are Enterprise-only; the read endpoint is not."""
+
+    async def test_mutators_403_in_oss(self, client, org):
+        with patch("src.core.deployment_mode.get_deployment_mode", return_value="oss"):
+            for path, payload in (
+                (f"/api/v1/orgs/{org.id}/ai-credits/add", {"amount": 10}),
+                (f"/api/v1/orgs/{org.id}/ai-credits/reset", {}),
+                (f"/api/v1/orgs/{org.id}/ai-credits/set", {"amount": 10}),
+            ):
+                response = await client.post(path, json=payload)
+                assert response.status_code == 403, path
+                assert response.json()["detail"]["error"] == "ee_required", path
+
+    async def test_get_still_works_in_oss(self, client, org):
+        # Regression guard: three non-admin billing and usage surfaces read
+        # this endpoint. Gating it would break org billing in every mode.
+        with patch("src.core.deployment_mode.get_deployment_mode", return_value="oss"), patch(
+            "src.routers.orgs.ai_credits.verify_user_is_org_member",
+            new_callable=AsyncMock,
+            return_value=True,
+        ), patch(
+            "src.routers.orgs.ai_credits.get_ai_credits_summary",
+            return_value={
+                "plan": "free",
+                "base_credits": 100,
+                "purchased_credits": 0,
+                "total_credits": 100,
+                "used_credits": 0,
+                "remaining_credits": 100,
+                "mode": "v1",
+            },
+        ):
+            response = await client.get(f"/api/v1/orgs/{org.id}/ai-credits")
+        assert response.status_code == 200
+        assert response.json()["remaining_credits"] == 100

--- a/apps/api/src/tests/security/test_get_current_user_provenance.py
+++ b/apps/api/src/tests/security/test_get_current_user_provenance.py
@@ -72,7 +72,11 @@ class TestProvenancePublished:
         sa_user = SimpleNamespace(id=0, is_superadmin=True)
         req = _request(auth="Bearer lh_sa_faketoken")
 
-        with patch("src.security.auth.validate_superadmin_api_token", return_value=sa_user):
+        # Superadmin tokens are an EE credential and are refused outright in
+        # 'oss', which the suite pins globally. Run this against EE.
+        with patch(
+            "src.core.deployment_mode.get_deployment_mode", return_value="ee"
+        ), patch("src.security.auth.validate_superadmin_api_token", return_value=sa_user):
             result = await get_current_user(req, db)
 
         assert result is sa_user

--- a/apps/api/src/tests/security/test_security_runtime.py
+++ b/apps/api/src/tests/security/test_security_runtime.py
@@ -141,7 +141,11 @@ class TestSuperadminRuntime:
             user_uuid="user_2",
         )
 
-        with patch("src.security.superadmin.is_user_superadmin", return_value=False):
+        # 'ee' is the self-hosted-EE baseline; the suite pins 'oss' globally,
+        # which would trip the EE gate before the superadmin flag is read.
+        with patch(
+            "src.core.deployment_mode.get_deployment_mode", return_value="ee"
+        ), patch("src.security.superadmin.is_user_superadmin", return_value=False):
             with pytest.raises(HTTPException) as exc_info:
                 await require_superadmin(current_user=current_user, db_session=Mock(spec=Session))
 
@@ -160,7 +164,9 @@ class TestSuperadminRuntime:
         )
         db_session = Mock(spec=Session)
 
-        with patch("src.security.superadmin.is_user_superadmin", return_value=True) as mock_is_superadmin:
+        with patch(
+            "src.core.deployment_mode.get_deployment_mode", return_value="ee"
+        ), patch("src.security.superadmin.is_user_superadmin", return_value=True) as mock_is_superadmin:
             result = await require_superadmin(current_user=current_user, db_session=db_session)
 
         assert result == current_user

--- a/apps/api/src/tests/security/test_superadmin.py
+++ b/apps/api/src/tests/security/test_superadmin.py
@@ -115,7 +115,11 @@ class TestRequireSuperadmin:
             email="plain@test.com",
             user_uuid="user_plain30",
         )
+        # 'ee' is the self-hosted-EE baseline: the suite pins 'oss' globally
+        # (see conftest), which would trip the EE gate before this assertion.
         with patch(
+            "src.core.deployment_mode.get_deployment_mode", return_value="ee"
+        ), patch(
             "src.security.superadmin.is_user_superadmin",
             new=AsyncMock(return_value=False),
         ):
@@ -134,6 +138,8 @@ class TestRequireSuperadmin:
             user_uuid="user_sadmin31",
         )
         with patch(
+            "src.core.deployment_mode.get_deployment_mode", return_value="ee"
+        ), patch(
             "src.security.superadmin.is_user_superadmin",
             new=AsyncMock(return_value=True),
         ):

--- a/apps/api/src/tests/security/test_superadmin_ee_gate.py
+++ b/apps/api/src/tests/security/test_superadmin_ee_gate.py
@@ -1,0 +1,104 @@
+"""
+Tests for the Enterprise Edition gate on the superadmin surface.
+
+The contract these pin down:
+  - OSS deployments get 403 with a machine-readable `ee_required` detail that
+    the web client matches on.
+  - SaaS and EE are completely unaffected. Those two cases are the SEV guard —
+    a gate written as `!= 'ee'` instead of `== 'oss'` would 403 live SaaS.
+  - Anonymous callers still get 401, not 403, so the gate never becomes an
+    authentication oracle.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.db.users import AnonymousUser, PublicUser
+from src.security.superadmin import (
+    EE_SUPERADMIN_REQUIRED_DETAIL,
+    ensure_ee_superadmin_surface,
+    require_superadmin,
+)
+
+
+def _mode(value):
+    return patch("src.core.deployment_mode.get_deployment_mode", return_value=value)
+
+
+def _superadmin_user():
+    return PublicUser(
+        id=90,
+        username="sadmin",
+        first_name="Super",
+        last_name="Admin",
+        email="sadmin90@test.com",
+        user_uuid="user_sadmin90",
+    )
+
+
+class TestEnsureEESuperadminSurface:
+    def test_oss_raises_403_with_ee_required_detail(self):
+        with _mode("oss"):
+            with pytest.raises(HTTPException) as exc_info:
+                ensure_ee_superadmin_surface()
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail["error"] == "ee_required"
+        assert exc_info.value.detail["feature"] == "superadmin"
+
+    @pytest.mark.parametrize("mode", ["saas", "ee"])
+    def test_saas_and_ee_pass_through(self, mode):
+        with _mode(mode):
+            assert ensure_ee_superadmin_surface() is None
+
+    def test_detail_is_not_the_503_license_shape(self):
+        # The web client keys two different banners off these two shapes.
+        # Unifying them would silently break isEERequiredError.
+        assert EE_SUPERADMIN_REQUIRED_DETAIL["error"] != "ee_license_inactive"
+
+    def test_raised_detail_is_a_copy(self):
+        # A handler mutating exc.detail must not poison the module constant.
+        with _mode("oss"):
+            with pytest.raises(HTTPException) as exc_info:
+                ensure_ee_superadmin_surface()
+        exc_info.value.detail["error"] = "mutated"
+        assert EE_SUPERADMIN_REQUIRED_DETAIL["error"] == "ee_required"
+
+
+class TestRequireSuperadminEEGate:
+    async def test_oss_blocks_superadmin(self, db):
+        with _mode("oss"), patch(
+            "src.security.superadmin.is_user_superadmin",
+            new=AsyncMock(return_value=True),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await require_superadmin(current_user=_superadmin_user(), db_session=db)
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail["error"] == "ee_required"
+
+    @pytest.mark.parametrize("mode", ["saas", "ee"])
+    async def test_saas_and_ee_unaffected(self, db, mode):
+        user = _superadmin_user()
+        with _mode(mode), patch(
+            "src.security.superadmin.is_user_superadmin",
+            new=AsyncMock(return_value=True),
+        ):
+            result = await require_superadmin(current_user=user, db_session=db)
+        assert result is user
+
+    async def test_anonymous_still_401_in_oss(self, db):
+        # Ordering regression test: the gate sits after the 401 branch.
+        with _mode("oss"):
+            with pytest.raises(HTTPException) as exc_info:
+                await require_superadmin(current_user=AnonymousUser(), db_session=db)
+        assert exc_info.value.status_code == 401
+
+    async def test_oss_blocks_before_touching_the_database(self, db):
+        checker = AsyncMock(return_value=True)
+        with _mode("oss"), patch(
+            "src.security.superadmin.is_user_superadmin", new=checker
+        ):
+            with pytest.raises(HTTPException):
+                await require_superadmin(current_user=_superadmin_user(), db_session=db)
+        checker.assert_not_awaited()

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -1,6 +1,12 @@
 import type { Metadata } from 'next'
 import AdminProviders from './providers'
 import React from 'react'
+import { fetchInstanceMode, isSuperadminSurfaceBlocked } from '@lib/eeGate'
+import EERequiredScreen from '@components/Security/EERequiredScreen'
+
+// The gate is resolved per request. An ISR-cached result would outlive a
+// licence change, and this layout is what decides whether /admin exists.
+export const dynamic = 'force-dynamic'
 
 export const metadata: Metadata = {
   title: {
@@ -9,10 +15,18 @@ export const metadata: Metadata = {
   },
 }
 
-export default function AdminRootLayout({
+// Wraps everything under /admin, including /admin/login, which sits outside
+// the (dashboard) route group and was previously ungated. Returning the screen
+// here short-circuits AdminProviders, so OSS never bootstraps a session or
+// renders the login form.
+export default async function AdminRootLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
+  if (isSuperadminSurfaceBlocked(await fetchInstanceMode())) {
+    return <EERequiredScreen />
+  }
+
   return <AdminProviders>{children}</AdminProviders>
 }

--- a/apps/web/components/Admin/EELicenseError.tsx
+++ b/apps/web/components/Admin/EELicenseError.tsx
@@ -26,13 +26,60 @@ export function isEELicenseInactiveError(err: unknown): err is { status: 503; de
   )
 }
 
+/** Shape of the FastAPI detail for a surface that only exists in EE. */
+interface EERequiredDetail {
+  error: 'ee_required'
+  feature: string
+  message: string
+}
+
+/**
+ * Detect the Enterprise-only 403 raised by
+ * `apps/api/src/security/superadmin.py::ensure_ee_superadmin_surface`.
+ *
+ * Distinct from `isEELicenseInactiveError` (503): that one means EE is
+ * installed but its license check is failing, which is transient. This one
+ * means the feature does not exist on this deployment, which is permanent —
+ * so it must not be presented as something to retry or reconfigure.
+ */
+export function isEERequiredError(err: unknown): err is { status: 403; detail: EERequiredDetail } {
+  if (!err || typeof err !== 'object') return false
+  const e = err as { status?: unknown; detail?: unknown }
+  if (e.status !== 403) return false
+  const d = e.detail
+  return (
+    !!d &&
+    typeof d === 'object' &&
+    (d as { error?: unknown }).error === 'ee_required'
+  )
+}
+
 /**
  * Render a clear banner when an EE-gated endpoint returns 503 with the
- * `ee_license_inactive` detail. Falls back to a generic error banner for any
- * other thrown error. Returns null when there's no error to show.
+ * `ee_license_inactive` detail, or 403 with `ee_required`. Falls back to a
+ * generic error banner for any other thrown error. Returns null when there's
+ * no error to show.
  */
 export default function EELicenseError({ error }: { error: unknown }) {
   if (!error) return null
+  if (isEERequiredError(error)) {
+    return (
+      <div className="rounded-2xl border border-sky-400/20 bg-sky-400/[0.06] p-5 my-4">
+        <div className="flex items-start gap-3">
+          <Warning size={20} weight="fill" className="text-sky-300 mt-0.5 shrink-0" />
+          <div className="min-w-0">
+            <div className="text-sm font-semibold text-sky-200">
+              Enterprise Edition license required
+            </div>
+            <p className="text-xs text-sky-200/80 mt-1.5 leading-relaxed">
+              This endpoint is part of LearnHouse Enterprise Edition and is not
+              available on this deployment.
+            </p>
+          </div>
+        </div>
+      </div>
+    )
+  }
   if (isEELicenseInactiveError(error)) {
     return (
       <div className="rounded-2xl border border-amber-400/20 bg-amber-400/[0.06] p-5 my-4">

--- a/apps/web/components/Security/EERequiredScreen.tsx
+++ b/apps/web/components/Security/EERequiredScreen.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+
+/**
+ * Full-page message for a surface that only exists in Enterprise Edition.
+ *
+ * Kept separate from EELicenseError, which is an inline banner for a failing
+ * licence check and names environment variables and pod logs — operator
+ * debugging detail that does not belong on a page any anonymous visitor to an
+ * OSS deployment can load.
+ */
+export default function EERequiredScreen() {
+  return (
+    <div className="flex justify-center items-center min-h-screen bg-[#0f0f10] px-6">
+      <div className="text-center max-w-md">
+        <h1 className="text-2xl font-bold text-white mb-2">
+          Enterprise Edition license required
+        </h1>
+        <p className="text-white/50 text-sm leading-relaxed">
+          The superadmin dashboard is part of LearnHouse Enterprise Edition and
+          is not available on this deployment.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/Security/SuperadminAuthorization.tsx
+++ b/apps/web/components/Security/SuperadminAuthorization.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState, useCallback, useMemo } from 'react'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
 import { useRouter } from 'next/navigation'
 import PageLoading from '@components/Objects/Loaders/PageLoading'
-import { getDeploymentMode } from '@services/config/config'
 
 type SuperadminAuthorizationProps = {
   children: React.ReactNode
@@ -16,6 +15,7 @@ const SuperadminAuthorization: React.FC<SuperadminAuthorizationProps> = ({
   const router = useRouter()
   const [isAuthorized, setIsAuthorized] = useState(false)
   const [isChecking, setIsChecking] = useState(true)
+  const [isRedirecting, setIsRedirecting] = useState(false)
 
   const isUserAuthenticated = useMemo(
     () => session.status === 'authenticated',
@@ -26,16 +26,14 @@ const SuperadminAuthorization: React.FC<SuperadminAuthorizationProps> = ({
     if (session.status === 'loading') return
 
     if (!isUserAuthenticated) {
+      // Keep the loader up through the navigation rather than releasing it
+      // into a false "Access Denied" flash.
+      setIsRedirecting(true)
       router.push('/admin/login')
       return
     }
 
-    const isSuperadmin = session?.data?.user?.is_superadmin === true
-    if (isSuperadmin) {
-      setIsAuthorized(true)
-    } else {
-      setIsAuthorized(false)
-    }
+    setIsAuthorized(session?.data?.user?.is_superadmin === true)
     setIsChecking(false)
   }, [session.status, isUserAuthenticated, session?.data?.user?.is_superadmin, router])
 
@@ -43,7 +41,7 @@ const SuperadminAuthorization: React.FC<SuperadminAuthorizationProps> = ({
     checkAuth()
   }, [checkAuth])
 
-  if (session.status === 'loading' || isChecking) {
+  if (session.status === 'loading' || isChecking || isRedirecting) {
     return (
       <div className="flex justify-center items-center h-screen">
         <PageLoading />
@@ -51,19 +49,12 @@ const SuperadminAuthorization: React.FC<SuperadminAuthorizationProps> = ({
     )
   }
 
-  if (getDeploymentMode() === 'oss') {
-    return (
-      <div className="flex justify-center items-center h-screen bg-[#0f0f10]">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold text-white mb-2">Not Available in OSS Mode</h1>
-          <p className="text-white/50">
-            The superadmin dashboard is not available in OSS deployments.
-          </p>
-        </div>
-      </div>
-    )
-  }
-
+  // No deployment-mode check here. app/admin/layout.tsx resolves the mode
+  // server-side and renders the licence screen before this component mounts.
+  // The previous check ran on a client-side value and failed closed, which
+  // could hide the dashboard from legitimate operators during a transient
+  // backend failure. Two gates with opposite failure directions is worse
+  // than one.
   if (!isAuthorized) {
     return (
       <div className="flex justify-center items-center h-screen bg-[#0f0f10]">

--- a/apps/web/lib/eeGate.ts
+++ b/apps/web/lib/eeGate.ts
@@ -1,0 +1,39 @@
+import 'server-only'
+import { getServerAPIUrl } from '@services/config/config'
+
+export type InstanceMode = 'saas' | 'oss' | 'ee'
+
+/**
+ * The whole gate policy, in one pure function so it can be tested directly.
+ *
+ * Blocks only on a definitive 'oss'. A null mode means the lookup failed, and
+ * that renders the dashboard: failing closed would lock real SaaS superadmins
+ * out of /admin during any brief API blip — which is exactly when they need
+ * it. The API-side check is what actually enforces this; the web gate exists
+ * to show a clean message instead of dead chrome.
+ */
+export function isSuperadminSurfaceBlocked(mode: InstanceMode | null): boolean {
+  return mode === 'oss'
+}
+
+/**
+ * Resolve the deployment mode without trusting anything client-supplied.
+ *
+ * Deliberately not lib/saas.ts::getInstanceMode(), which prefers a value the
+ * client can influence. The URL here comes from server env, never from the
+ * request, so nothing on this path is caller-controlled.
+ */
+export async function fetchInstanceMode(): Promise<InstanceMode | null> {
+  try {
+    const res = await fetch(`${getServerAPIUrl()}instance/info`, {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(4000),
+    })
+    if (!res.ok) return null
+    const info = await res.json()
+    const mode = info?.mode
+    return mode === 'saas' || mode === 'oss' || mode === 'ee' ? mode : null
+  } catch {
+    return null
+  }
+}

--- a/apps/web/tests/admin-ee-gate.test.mjs
+++ b/apps/web/tests/admin-ee-gate.test.mjs
@@ -1,0 +1,36 @@
+// Contract tests for the superadmin surface's EE gate.
+//
+// The failure direction here is the whole point. Blocking on anything other
+// than a definitive 'oss' would show live SaaS superadmins a licence screen
+// during an API blip — precisely when they need the dashboard. If someone
+// later "hardens" this into a fail-closed check, these fail.
+
+import { describe, expect, test } from "bun:test";
+
+// `server-only` is a Next build-time alias rather than an installed package, so
+// it has to be stubbed before importing any module that declares it.
+import { mock } from "bun:test";
+mock.module("server-only", () => ({}));
+
+const { isSuperadminSurfaceBlocked } = await import("../lib/eeGate.ts");
+
+describe("isSuperadminSurfaceBlocked", () => {
+  test("blocks OSS", () => {
+    expect(isSuperadminSurfaceBlocked("oss")).toBe(true);
+  });
+
+  test("never blocks SaaS", () => {
+    expect(isSuperadminSurfaceBlocked("saas")).toBe(false);
+  });
+
+  test("never blocks self-hosted EE", () => {
+    expect(isSuperadminSurfaceBlocked("ee")).toBe(false);
+  });
+
+  test("fails open when the mode is unknown", () => {
+    // null means the instance/info lookup failed or timed out. Rendering the
+    // dashboard is deliberate: the API-side check still denies every request,
+    // so the worst case is empty panels rather than a locked-out operator.
+    expect(isSuperadminSurfaceBlocked(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
The superadmin dashboard is now gated to Enterprise Edition. OSS deployments get a clear "Enterprise Edition license required" screen instead of a dashboard that can't actually work.

The check moved server-side. It previously relied on a client-side signal that couldn't be trusted.

- API: a shared guard in `apps/api/src/security/superadmin.py` returns 403 with a machine-readable `ee_required` detail. It applies to the superadmin dependency, the AI-credit mutators, and superadmin token auth. The read-only AI-credits endpoint stays open since org billing and usage pages depend on it.
- Web: `app/admin/layout.tsx` now decides server-side and covers `/admin/login`, which was previously outside the gated route group. Added a new `EERequiredScreen`, and `EELicenseError` now detects the new 403 separately from the existing 503 case.
- Also tightened deployment-mode resolution to fail closed, and fixed a loading-state bug in `SuperadminAuthorization` where logged-out visitors never landed on the right screen.

Tests added on both sides, suite green.

Touches some of the same files as #1015 (merged); rebased on top of it.