### PR TITLE
fix(cache): version instance-info key, finish #1015 follow-ups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,11 @@ COPY ./apps/api/docker-entrypoint.sh /app/api/docker-entrypoint.sh
 COPY ./docker/start.sh /app/start.sh
 RUN chmod +x /app/api/docker-entrypoint.sh /app/start.sh
 
-ENV PORT=8000 LEARNHOUSE_PORT=9000 COLLAB_PORT=4000 HOSTNAME=0.0.0.0 LEARNHOUSE_OSS=true NEXT_PUBLIC_LEARNHOUSE_OSS=true
+# PYTHONDONTWRITEBYTECODE: the image ships read-only source and gains nothing
+# from writing .pyc files back into it. It also keeps __pycache__ out of the
+# enterprise tree, where stale bytecode could otherwise shadow a source file
+# that verifies clean against the signed manifest.
+ENV PORT=8000 LEARNHOUSE_PORT=9000 COLLAB_PORT=4000 HOSTNAME=0.0.0.0 LEARNHOUSE_OSS=true NEXT_PUBLIC_LEARNHOUSE_OSS=true PYTHONDONTWRITEBYTECODE=1
 
 EXPOSE 80 9000 4000
 

--- a/apps/api/config/config.py
+++ b/apps/api/config/config.py
@@ -163,11 +163,13 @@ def _env_bool(env_value, yaml_value):
     `development_mode` and `saas_mode` already parse correctly above; this is
     the same logic for the settings that were still using bare `or`.
     """
-    if env_value is None or env_value == "":
-        return yaml_value
-    if isinstance(env_value, bool):
-        return env_value
-    return str(env_value).strip().lower() in ("true", "1", "yes", "on")
+    value = yaml_value if env_value is None or env_value == "" else env_value
+    if value is None or isinstance(value, bool):
+        return value
+    # YAML gives a real bool for `ssl: false` but a string for `ssl: "false"`,
+    # and the quoted form is easy to write by accident. Parse both sides the
+    # same way rather than only fixing the env side.
+    return str(value).strip().lower() in ("true", "1", "yes", "on")
 
 
 _yaml_cache: dict = {}

--- a/apps/api/src/routers/instance.py
+++ b/apps/api/src/routers/instance.py
@@ -49,8 +49,11 @@ async def get_instance_info(db_session: AsyncSession = Depends(get_db_session)):
     # can flip mid-runtime (a heartbeat recovering, a revocation landing), and
     # baking those into a 600s blob meant an operator who fixed a bad license
     # key watched /instance/info keep reporting mode "oss" for ten minutes and
-    # concluded the fix had not worked. Both fields are cheap — an attribute
-    # read on module-global state.
+    # concluded the fix had not worked.
+    #
+    # This is not free — get_deployment_mode() resolves the whole config, which
+    # is why config.yaml parsing is memoised. Measured at ~0.2ms per request
+    # against ~26ms before that memoisation.
     cached = get_cached_instance_info()
     if cached is not None:
         return {**cached, **_live_fields(cached.get("tenancy", "single"))}

--- a/apps/api/src/routers/instance.py
+++ b/apps/api/src/routers/instance.py
@@ -3,7 +3,6 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from src.db.organizations import Organization
 from src.core.events.database import get_db_session
-from src.core.ee_hooks import is_multi_org_allowed
 from src.core.deployment_mode import get_deployment_mode
 from src.services.orgs.cache import get_cached_instance_info, set_cached_instance_info
 from config.config import get_learnhouse_config

--- a/apps/api/src/services/orgs/cache.py
+++ b/apps/api/src/services/orgs/cache.py
@@ -19,6 +19,17 @@ CACHE_TTL_ORG_CONFIG = 120     # org config — same TTL as slug
 
 _KEY_PREFIX = "org_cache"
 
+# Versioned: the cached payload's SHAPE changed when `mode` and
+# `multi_org_enabled` moved out of it and became per-request. Deploys are
+# rolling, so old and new pods share this Redis for the length of a rollout.
+# On the old key an old pod would read the new trimmed blob and return it
+# verbatim, giving clients an /instance/info response with no `mode` at all —
+# which the frontend proxy writes into the LH_mode cookie, and which then
+# reads back as "oss". EE surfaces and the SaaS billing guard would switch off
+# fleet-wide for up to the cache TTL. Bumping the key means neither version
+# ever sees the other's payload; the stale key simply expires.
+_INSTANCE_INFO_KEY = f"{_KEY_PREFIX}:instance_info:v2"
+
 
 def get_cached_org_config(org_id: int) -> Optional[dict]:
     """Return cached org config for an org_id, or None."""
@@ -98,7 +109,7 @@ def get_cached_instance_info() -> Optional[dict]:
     if r is None:
         return None
     try:
-        raw = r.get(f"{_KEY_PREFIX}:instance_info")
+        raw = r.get(_INSTANCE_INFO_KEY)
         if raw:
             return json.loads(raw)
     except Exception:
@@ -112,6 +123,6 @@ def set_cached_instance_info(data: dict) -> None:
     if r is None:
         return
     try:
-        r.setex(f"{_KEY_PREFIX}:instance_info", CACHE_TTL_INSTANCE_INFO, json.dumps(data))
+        r.setex(_INSTANCE_INFO_KEY, CACHE_TTL_INSTANCE_INFO, json.dumps(data))
     except Exception:
         logger.debug("Instance info cache write failed", exc_info=True)

--- a/apps/api/src/tests/routers/test_instance_router.py
+++ b/apps/api/src/tests/routers/test_instance_router.py
@@ -104,9 +104,6 @@ class TestInstanceRouter:
             "src.routers.instance.get_deployment_mode",
             return_value="saas",
         ), patch(
-            "src.routers.instance.is_multi_org_allowed",
-            return_value=True,
-        ), patch(
             "src.routers.instance.set_cached_instance_info",
         ) as mock_set_cache:
             response = await client.get("/api/v1/instance/info")
@@ -138,9 +135,6 @@ class TestInstanceRouter:
         ), patch(
             "src.routers.instance.get_deployment_mode",
             return_value="ee",
-        ), patch(
-            "src.routers.instance.is_multi_org_allowed",
-            return_value=True,
         ), patch(
             "src.routers.instance.set_cached_instance_info",
         ):
@@ -175,9 +169,6 @@ class TestInstanceRouter:
             ), patch(
                 "src.routers.instance.get_deployment_mode",
                 return_value="oss",
-            ), patch(
-                "src.routers.instance.is_multi_org_allowed",
-                return_value=False,
             ), patch(
                 "src.routers.instance.set_cached_instance_info",
             ):

--- a/apps/api/src/tests/routers/test_instance_router.py
+++ b/apps/api/src/tests/routers/test_instance_router.py
@@ -50,6 +50,43 @@ class TestInstanceRouter:
         assert body["mode"] == "oss"  # live, overrides the stale cached value
         assert body["multi_org_enabled"] is False
 
+    async def test_license_derived_fields_are_never_cached(self, client, db, org):
+        """What gets written to Redis must not carry `mode`.
+
+        Deploys are rolling and the cache is shared, so any pod running older
+        code will return a cached blob verbatim. If these fields are ever put
+        back into the stored payload, that pod serves a stale `mode` — and if
+        they are stored under a key an older build also reads, it serves a
+        response missing `mode` entirely.
+        """
+        stored = {}
+
+        config = SimpleNamespace(
+            hosting_config=SimpleNamespace(frontend_domain="localhost:3000", tenancy="multi")
+        )
+        with patch("src.routers.instance.get_cached_instance_info", return_value=None), patch(
+            "src.routers.instance.set_cached_instance_info", side_effect=lambda d: stored.update(d)
+        ), patch("src.routers.instance.get_learnhouse_config", return_value=config), patch(
+            "src.routers.instance.get_deployment_mode", return_value="saas"
+        ):
+            response = await client.get("/api/v1/instance/info")
+
+        assert response.status_code == 200
+        assert "mode" not in stored
+        assert "multi_org_enabled" not in stored
+        # ...but the response the client actually receives still has both.
+        assert response.json()["mode"] == "saas"
+        assert response.json()["multi_org_enabled"] is True
+
+    async def test_instance_info_cache_key_is_versioned(self):
+        """The key must not collide with the pre-change payload shape."""
+        from src.services.orgs.cache import _INSTANCE_INFO_KEY
+
+        assert _INSTANCE_INFO_KEY.endswith(":v2"), (
+            "bump the key version whenever the cached instance-info shape changes, "
+            "or a rolling deploy will have two builds reading one payload"
+        )
+
     async def test_get_instance_info_builds_response(self, client, db, org):
         config = SimpleNamespace(
             hosting_config=SimpleNamespace(

--- a/apps/api/src/tests/services/test_org_usage_cache_service.py
+++ b/apps/api/src/tests/services/test_org_usage_cache_service.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException
 
 from src.db.organization_config import OrganizationConfig
 from src.services.orgs import cache as org_cache
+from src.services.orgs.cache import _INSTANCE_INFO_KEY
 from src.services.orgs import uploads as org_uploads
 from src.services.orgs import usage as org_usage
 
@@ -46,14 +47,14 @@ class TestOrgCacheHelpers:
             org_cache.set_cached_instance_info({"instance": "cached"})
 
         redis_client.get.assert_any_call("org_cache:slug:cached-org")
-        redis_client.get.assert_any_call("org_cache:instance_info")
+        redis_client.get.assert_any_call(_INSTANCE_INFO_KEY)
         redis_client.setex.assert_any_call(
             "org_cache:slug:cached-org",
             org_cache.CACHE_TTL_ORG_SLUG,
             '{"slug": "cached-org"}',
         )
         redis_client.setex.assert_any_call(
-            "org_cache:instance_info",
+            _INSTANCE_INFO_KEY,
             org_cache.CACHE_TTL_INSTANCE_INFO,
             '{"instance": "cached"}',
         )

--- a/apps/api/src/tests/services/test_orgs_cache_service.py
+++ b/apps/api/src/tests/services/test_orgs_cache_service.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 from src.services.orgs import cache as cache_module
 from src.services.orgs.cache import (
+    _INSTANCE_INFO_KEY,
     get_cached_org_config,
     invalidate_org_config_cache,
     set_cached_org_config,
@@ -160,7 +161,7 @@ class TestInstanceInfoCache:
         with patch("src.services.orgs.cache.get_redis_client", return_value=r):
             set_cached_instance_info({"version": "2.0"})
         r.setex.assert_called_once_with(
-            "org_cache:instance_info",
+            _INSTANCE_INFO_KEY,
             cache_module.CACHE_TTL_INSTANCE_INFO,
             json.dumps({"version": "2.0"}),
         )

--- a/docs/content/self-hosting/configuration/environment-variables.mdx
+++ b/docs/content/self-hosting/configuration/environment-variables.mdx
@@ -27,7 +27,7 @@ optional: the feature stays disabled or uses a runtime fallback when the variabl
 | `LEARNHOUSE_TENANCY` | Selects `single` host tenancy or `multi` subdomain tenancy. Multi-tenancy requires EE or SaaS mode. | enum: `single`, `multi` | `single` unless inferred as multi-tenant | API, EE CLI |
 | `LEARNHOUSE_DOMAIN` | Public domain used for org routing, cookie decisions, and custom-domain CNAME targets. Include the port for local development. | hostname | `localhost:3000` | API, CLI |
 | `LEARNHOUSE_FRONTEND_DOMAIN` | Frontend host used by the API when it needs the public frontend domain separately from the backend host. | hostname | `localhost:3000` | API, EE CLI |
-| `LEARNHOUSE_SSL` | Backend-side SSL flag for generated URLs and hosting config. | boolean | `false` | API |
+| `LEARNHOUSE_SSL` | Backend-side SSL flag: picks `https` vs `http` for generated links (password reset, email verification, invites, magic links, SSO redirect, media URLs). Accepts `true`/`1`/`yes`/`on` (case-insensitive); anything else is off. Previously any non-empty value enabled it, including the string `false` — check your value before upgrading. | boolean | `false` | API |
 | `LEARNHOUSE_PORT` | Backend port. Local config defaults to `1338`; the production CLI template emits `9000`. | integer | `1338` locally, `9000` in generated Docker installs | API, CLI, API container |
 | `LEARNHOUSE_ALLOWED_ORIGINS` | Comma-separated CORS allowlist. | CSV of URLs | `http://localhost:3000,http://localhost:3001` | API |
 | `LEARNHOUSE_ALLOWED_REGEXP` | Additional CORS origin regex used by multi-tenant deployments. | regex string | `\b((?:https?://)[^\s/$.?#].[^\s]*)\b` | API |


### PR DESCRIPTION
Heads up: #1015 merged mid-stream with only 3 of its commits, so dev currently has the cache shape change without its safety fix, plus a failing lint. These four commits close the gap.

- fix(cache): version the instance-info key. #1015 trimmed the cached /instance/info payload but kept the same Redis key. During a rolling deploy, a pod on old code can serve that trimmed value with no `mode` field, which the frontend writes into the LH_mode cookie, flipping it to OSS mode until the entry expires. Bumping the key avoids the overlap. Also sets `PYTHONDONTWRITEBYTECODE=1` in the image.
- fix(lint): drop the now-unused `is_multi_org_allowed` import. ruff's been failing on dev since #1015 merged.
- fix(config): parse YAML-side boolean strings in `_env_bool`. A quoted `ssl: "false"` in config.yaml still evaluated truthy after #1015's env-side fix.
- docs(config): document the LEARNHOUSE_SSL parsing change and fix an inaccurate cost comment.

Tests: full API suite, 4483 passed / 10 skipped (4 Ollama failures pre-existing on dev, unrelated). ruff clean. Added coverage for the trimmed payload and versioned key.

Note: if your deployment sets LEARNHOUSE_SSL to anything other than `true`/`1`/`yes`/`on`, check it before deploying. It now parses as off, where previously any non-empty value counted as on.