### PR TITLE
Fix nudge scheduler never running on fast deploy cadences

### DIFF
--- a/apps/api/src/services/nudges/scheduler.py
+++ b/apps/api/src/services/nudges/scheduler.py
@@ -28,6 +28,10 @@ RUN_AT_HOUR_UTC = 9
 # Held for well under a day so a pod that dies mid-run does not block tomorrow.
 _LOCK_TTL_SECONDS = 6 * 60 * 60
 
+# A moment's grace on boot so the run does not compete with startup work, and
+# so a rolling deploy's pods do not all reach the day-lock in the same instant.
+STARTUP_DELAY_SECONDS = 30
+
 _task: Optional[asyncio.Task] = None
 
 
@@ -79,20 +83,33 @@ async def _run_once() -> None:
         )
 
 
+async def _tick() -> None:
+    """Run today's job if nobody has yet."""
+    try:
+        today = datetime.now(timezone.utc)
+        if await _claim_day(today):
+            await _run_once()
+        else:
+            logger.info("Today's nudge run was already handled elsewhere")
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        # A failed run must not kill the loop, or the feature silently stops
+        # until the next deploy.
+        logger.exception("Nudge run failed, will retry tomorrow: %s", exc)
+
+
 async def _loop() -> None:
+    # Try immediately on boot rather than sleeping first. A pod restarts on
+    # every deploy, so a loop that waits for a fixed hour resets its timer each
+    # time — on a daily-or-faster deploy cadence it would never fire at all.
+    # The day-lock and the ledger make an extra attempt free.
+    await asyncio.sleep(STARTUP_DELAY_SECONDS)
+    await _tick()
+
     while True:
-        now = datetime.now(timezone.utc)
-        await asyncio.sleep(_seconds_until_next_run(now))
-        try:
-            today = datetime.now(timezone.utc)
-            if await _claim_day(today):
-                await _run_once()
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            # A failed run must not kill the loop, or the feature silently
-            # stops until the next deploy.
-            logger.exception("Nudge run failed, will retry tomorrow: %s", exc)
+        await asyncio.sleep(_seconds_until_next_run(datetime.now(timezone.utc)))
+        await _tick()
 
 
 def start_scheduler() -> None:
@@ -111,8 +128,13 @@ def start_scheduler() -> None:
         from src.services.nudges.runner import nudges_enabled
 
         if not nudges_enabled():
+            logger.info(
+                "Nudge scheduler idle: LEARNHOUSE_NUDGES_ENABLED is not set"
+            )
             return
-        if get_deployment_mode() != "saas":
+        mode = get_deployment_mode()
+        if mode != "saas":
+            logger.info("Nudge scheduler idle: deployment mode is %r, not 'saas'", mode)
             return
         if os.environ.get("LEARNHOUSE_NUDGES_NO_SCHEDULER"):
             # For deployments that would rather drive the CLI from their own cron.

--- a/apps/api/src/tests/services/test_nudges_scheduler.py
+++ b/apps/api/src/tests/services/test_nudges_scheduler.py
@@ -65,6 +65,28 @@ class TestDayLock:
         assert scheduler._lock_key(NOW) == scheduler._lock_key(NOW.replace(hour=23))
 
 
+class TestIdleLogging:
+    """Silence is what made this undebuggable: an instance that decides not to
+    run must say so."""
+
+    def test_says_so_when_the_flag_is_unset(self, monkeypatch, caplog):
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_ENABLED", "false")
+        scheduler._task = None
+        with caplog.at_level("INFO"):
+            scheduler.start_scheduler()
+        assert "LEARNHOUSE_NUDGES_ENABLED" in caplog.text
+
+    def test_says_so_when_the_deployment_is_not_saas(self, monkeypatch, caplog):
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_ENABLED", "true")
+        monkeypatch.setattr(
+            "src.core.deployment_mode.get_deployment_mode", lambda: "oss"
+        )
+        scheduler._task = None
+        with caplog.at_level("INFO"):
+            scheduler.start_scheduler()
+        assert "not 'saas'" in caplog.text
+
+
 class TestStartGating:
     @pytest.fixture(autouse=True)
     def _clean(self, monkeypatch):
@@ -197,10 +219,51 @@ class TestAutoSeed:
         assert sender.call_count == second.sent
 
 
+class TestRunsOnBoot:
+    async def test_it_runs_without_waiting_for_the_scheduled_hour(self, monkeypatch):
+        """A pod restarts on every deploy. A loop that sleeps until a fixed
+        hour resets that timer each time, so on a daily-or-faster deploy
+        cadence it would never fire at all."""
+        import asyncio
+
+        monkeypatch.setattr(scheduler, "STARTUP_DELAY_SECONDS", 0)
+        monkeypatch.setattr(scheduler, "_seconds_until_next_run", lambda _now: 3600)
+        monkeypatch.setattr(scheduler, "_claim_day", AsyncMock(return_value=True))
+        ran = AsyncMock()
+        monkeypatch.setattr(scheduler, "_run_once", ran)
+
+        task = asyncio.create_task(scheduler._loop())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        ran.assert_awaited_once()
+
+    async def test_a_restart_does_not_send_twice(self, monkeypatch):
+        """The day-lock is what makes running on every boot free."""
+        import asyncio
+
+        monkeypatch.setattr(scheduler, "STARTUP_DELAY_SECONDS", 0)
+        monkeypatch.setattr(scheduler, "_seconds_until_next_run", lambda _now: 3600)
+        monkeypatch.setattr(scheduler, "_claim_day", AsyncMock(return_value=False))
+        ran = AsyncMock()
+        monkeypatch.setattr(scheduler, "_run_once", ran)
+
+        task = asyncio.create_task(scheduler._loop())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        ran.assert_not_awaited()
+
+
 class TestLoop:
     async def test_one_tick_claims_the_day_and_runs(self, monkeypatch):
         import asyncio
 
+        monkeypatch.setattr(scheduler, "STARTUP_DELAY_SECONDS", 0)
         monkeypatch.setattr(scheduler, "_seconds_until_next_run", lambda _now: 0)
         monkeypatch.setattr(scheduler, "_claim_day", AsyncMock(return_value=True))
         ran = AsyncMock()
@@ -217,6 +280,7 @@ class TestLoop:
     async def test_a_pod_that_loses_the_lock_does_not_run(self, monkeypatch):
         import asyncio
 
+        monkeypatch.setattr(scheduler, "STARTUP_DELAY_SECONDS", 0)
         monkeypatch.setattr(scheduler, "_seconds_until_next_run", lambda _now: 0)
         monkeypatch.setattr(scheduler, "_claim_day", AsyncMock(return_value=False))
         ran = AsyncMock()
@@ -234,6 +298,7 @@ class TestLoop:
         """Otherwise the feature stops silently until the next deploy."""
         import asyncio
 
+        monkeypatch.setattr(scheduler, "STARTUP_DELAY_SECONDS", 0)
         monkeypatch.setattr(scheduler, "_seconds_until_next_run", lambda _now: 0)
         monkeypatch.setattr(scheduler, "_claim_day", AsyncMock(return_value=True))
         monkeypatch.setattr(
@@ -274,6 +339,7 @@ class TestLoop:
             started.set()
             await asyncio.sleep(10)
 
+        monkeypatch.setattr(scheduler, "STARTUP_DELAY_SECONDS", 0)
         monkeypatch.setattr(scheduler, "_seconds_until_next_run", lambda _now: 0)
         monkeypatch.setattr(scheduler, "_claim_day", AsyncMock(return_value=True))
         monkeypatch.setattr(scheduler, "_run_once", slow_run)


### PR DESCRIPTION
`_loop()` slept until the next scheduled hour before doing anything. On a deploy cadence faster than that sleep, pods restart before the first run ever lands, so the job never fires. The tables and migration from #1002 shipped fine, but the scheduler itself stayed dormant.

- Run shortly after boot (30s delay), then continue on the daily cadence. Repeat attempts are free: the Redis day-lock and the ledger's unique dedupe key already guarantee at-most-once.
- Extracted the run into `_tick()` so boot and cadence share one path.
- `start_scheduler()` had three early-return paths; two logged nothing (kill switch unset, deployment not SaaS). A silently idle instance looked identical to a working one. Both now log which setting caused it.

Tests: boot-time run without waiting for the scheduled hour, a restart doesn't double-send (covers the day-lock), both idle paths log their reason. Ruff clean, 100% coverage on the changed file. Full suite passes aside from pre-existing live-model test failures unrelated to this change.

Relevant files: `apps/api/src/services/nudges/scheduler.py` and its test file.