### PR TITLE
fix(api): make logging actually work, stop nudges eating their own send budget

### DIFF
--- a/apps/api/src/core/events/events.py
+++ b/apps/api/src/core/events/events.py
@@ -6,7 +6,7 @@ from config.config import LearnHouseConfig, get_learnhouse_config
 from src.core.events.autoinstall import auto_install
 from src.core.events.content import check_content_directory
 from src.core.events.database import close_database, connect_to_db
-from src.core.events.logs import create_logs_dir
+from src.core.events.logs import create_logs_dir, init_logging
 from src.core.ee_hooks import run_ee_startup
 
 logger = logging.getLogger(__name__)
@@ -45,6 +45,11 @@ def startup_app(app: FastAPI) -> Callable:
 
         # Connect to database
         await connect_to_db(app)
+
+        # Send application logs to stdout. Until this runs, the root logger
+        # has no handler and Python's fallback drops everything below WARNING,
+        # so every logger.info in the codebase is invisible in production.
+        init_logging()
 
         # Create logs directory
         await create_logs_dir()

--- a/apps/api/src/core/events/logs.py
+++ b/apps/api/src/core/events/logs.py
@@ -1,24 +1,52 @@
 import logging
 import os
+import sys
 
 
 async def create_logs_dir():
     if not os.path.exists("logs"):
         os.mkdir("logs")
 
-# Initiate logging
-async def init_logging():
-    await create_logs_dir()
 
-    # Logging
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        datefmt="%d-%b-%y %H:%M:%S",
-        handlers=[
-            logging.FileHandler("logs/learnhouse.log"),
-            logging.StreamHandler()
-        ]
+def _log_level() -> int:
+    raw = (os.environ.get("LEARNHOUSE_LOG_LEVEL") or "INFO").strip().upper()
+    return getattr(logging, raw, logging.INFO)
+
+
+def init_logging() -> None:
+    """Send application logs to stdout.
+
+    Without this the root logger has no handler, so Python's fallback emits
+    WARNING and above only — every ``logger.info`` in the codebase disappears,
+    including the ones a background job relies on to show it ran at all.
+
+    Deliberately additive rather than ``basicConfig``: uvicorn installs its own
+    handlers on its own loggers, and reconfiguring the root with ``force=True``
+    would tear those down and take the access log with them. Attaching one
+    stream handler to the root leaves uvicorn alone and lets everything that
+    propagates through.
+
+    No file handler. In a container nothing reads ``logs/learnhouse.log`` and
+    it grows until the disk complains; stdout is what the platform collects.
+    """
+    root = logging.getLogger()
+    root.setLevel(_log_level())
+
+    already = any(
+        isinstance(h, logging.StreamHandler) and getattr(h, "_learnhouse", False)
+        for h in root.handlers
     )
+    if already:
+        return
 
-    logging.info("Logging initiated")
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s %(levelname)s %(name)s: %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%S",
+        )
+    )
+    handler._learnhouse = True  # type: ignore[attr-defined]
+    root.addHandler(handler)
+
+    logging.getLogger(__name__).info("Application logging initialised at %s", logging.getLevelName(root.level))

--- a/apps/api/src/services/nudges/delivery.py
+++ b/apps/api/src/services/nudges/delivery.py
@@ -28,10 +28,17 @@ from src.services.nudges.preferences import suppress_address
 logger = logging.getLogger(__name__)
 
 # `last_event` values meaning the address should not be mailed again.
+# Only `complained` suppresses on this path. Polling returns a bare "bounced"
+# with no sub-type, so a full mailbox is indistinguishable from a dead address —
+# and the webhook path refuses to suppress on that for exactly this reason
+# (routers/nudges.py checks bounce.type). Suppressing here would throw away good
+# addresses permanently, with no way to undo it.
 TERMINAL_EVENTS = {
-    "bounced": "bounce",
     "complained": "complaint",
 }
+
+# Seen but not acted on. Recorded so the ledger shows what happened.
+OBSERVED_EVENTS = {"bounced", "delivered", "sent", "opened", "clicked"}
 
 # Wait before judging a message. A receiving server retries a transient failure
 # for a while, and a message read too early can look bounced when it is only
@@ -46,9 +53,18 @@ MAX_PER_RUN = 500
 
 
 async def _last_event(provider_id: str) -> Optional[str]:
-    """Ask the provider what became of one message."""
+    """Ask the provider what became of one message.
+
+    The key is set here rather than assumed: `resend.api_key` is otherwise
+    only assigned inside the send path, and this runs *before* the send loop —
+    so in a one-shot CLI process every lookup would 401, be swallowed per row,
+    and report zero checked while bounces went unnoticed.
+    """
     import resend
 
+    from config.config import get_learnhouse_config
+
+    resend.api_key = get_learnhouse_config().mailing_config.resend_api_key
     email = await asyncio.to_thread(resend.Emails.get, provider_id)
     if isinstance(email, dict):
         return email.get("last_event")
@@ -99,6 +115,11 @@ async def reconcile_delivery(
             address = (row.meta or {}).get("email")
             if address and await suppress_address(db_session, address, reason):
                 suppressed += 1
+
+        # A delayed message has not finished failing yet; leaving it unchecked
+        # means the bounce that lands at hour 60 is still seen.
+        if str(event or "").lower() == "delivery_delayed":
+            continue
 
         row.delivery_checked = True
         db_session.add(row)

--- a/apps/api/src/services/nudges/runner.py
+++ b/apps/api/src/services/nudges/runner.py
@@ -78,29 +78,56 @@ def backfill_mode() -> str:
 
 
 async def _ledger_has_rows(db_session: AsyncSession) -> bool:
+    """Whether a real run has happened here.
+
+    Dry-run rows are excluded: a rehearsal must not convince the system it has
+    already started, which would suppress the auto-seed and pin the boundary at
+    the rehearsal's timestamp.
+    """
     return (
-        await db_session.execute(select(func.count()).select_from(NudgeSend))
+        await db_session.execute(
+            select(func.count())
+            .select_from(NudgeSend)
+            .where(NudgeSend.status != NudgeSendStatus.DRY_RUN)
+        )
     ).scalar_one() > 0
 
 
-async def activation_date(db_session: AsyncSession) -> datetime:
+async def activation_date(
+    db_session: AsyncSession, now: Optional[datetime] = None
+) -> datetime:
     """When this system started running here.
 
-    Orgs created before it are "pre-existing" and only the winback tracks may
-    reach them. Derived from the ledger rather than configured: the first row —
-    written by `nudges-seed`, or by the first live send — *is* the boundary,
-    so there is no date to remember to set and no way to set it wrongly.
+    Orgs created before it are "pre-existing" and reachable only by the winback
+    tracks. An explicit `LEARNHOUSE_NUDGES_ACTIVATION_DATE` wins; otherwise it
+    falls back to the ledger's first real row.
 
-    An empty ledger means nothing has run here yet, so every existing org
-    predates the system and only the winback tracks may reach it. Running
-    `nudges-seed` is what pins the boundary and lets ordinary tracks start
-    applying to organizations created from then on.
+    Deriving it from the ledger alone was a mistake worth naming: the first run
+    wrote the row *and* read it, so the boundary was whatever instant the job
+    happened to start, and nothing could ever move an organization out of the
+    pre-existing set afterwards. Making it configurable means the operator can
+    place the line deliberately — including in the past, to treat existing
+    organizations as ordinary.
     """
+    raw = (os.environ.get("LEARNHOUSE_NUDGES_ACTIVATION_DATE") or "").strip()
+    if raw:
+        try:
+            parsed = datetime.fromisoformat(raw)
+            return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+        except ValueError:
+            logger.warning(
+                "Ignoring unparseable LEARNHOUSE_NUDGES_ACTIVATION_DATE: %r", raw
+            )
+
     earliest = (
-        await db_session.execute(select(func.min(NudgeSend.claimed_at)))
+        await db_session.execute(
+            select(func.min(NudgeSend.claimed_at)).where(
+                NudgeSend.status != NudgeSendStatus.DRY_RUN
+            )
+        )
     ).scalar_one_or_none()
     if earliest is None:
-        return datetime.now(timezone.utc)
+        return now or datetime.now(timezone.utc)
     return earliest if earliest.tzinfo else earliest.replace(tzinfo=timezone.utc)
 
 
@@ -118,6 +145,7 @@ class RunStats:
     # True when this run seeded the backlog rather than sending, which happens
     # once, automatically, the first time the job runs anywhere.
     auto_seeded: bool = False
+    seeded: int = 0
     by_nudge: dict = field(default_factory=dict)
 
     def record(self, nudge_id: str) -> None:
@@ -135,11 +163,19 @@ class RunStats:
             "skipped_inactive_org": self.skipped_inactive_org,
             "budget_exhausted": self.budget_exhausted,
             "auto_seeded": self.auto_seeded,
+            "seeded": self.seeded,
             "by_nudge": dict(sorted(self.by_nudge.items())),
         }
 
 
-def dedupe_key(spec: NudgeSpec, org_id: int, user_id: int, now: datetime, dry_run: bool) -> str:
+def dedupe_key(
+    spec: NudgeSpec,
+    org_id: int,
+    user_id: int,
+    now: datetime,
+    dry_run: bool,
+    seed: bool = False,
+) -> str:
     """The idempotency boundary.
 
     A dry run uses a separate namespace so a rehearsal never consumes the key
@@ -150,7 +186,13 @@ def dedupe_key(spec: NudgeSpec, org_id: int, user_id: int, now: datetime, dry_ru
         key = f"{key}:{now.year}-Q{(now.month - 1) // 3 + 1}"
     elif spec.repeat == "monthly":
         key = f"{key}:{now.year}-{now.month:02d}"
-    return f"dryrun:{key}" if dry_run else key
+    if dry_run:
+        return f"dryrun:{key}"
+    if seed:
+        # Seeding must not spend the key the real send needs. Suppressing the
+        # backlog is about not firing it today, not about never firing it.
+        return f"seed:{key}"
+    return key
 
 
 def _is_preexisting(snapshot: OrgSnapshot, cutoff: datetime) -> bool:
@@ -363,7 +405,7 @@ async def run_nudges(
     stats = RunStats()
     now = now or datetime.now(timezone.utc)
     max_sends = max_sends if max_sends is not None else DEFAULT_MAX_SENDS
-    cutoff = await activation_date(db_session)
+    cutoff = await activation_date(db_session, now=now)
 
     if not force and get_deployment_mode() != "saas":
         logger.info("Nudges skipped: deployment mode is not saas")
@@ -377,13 +419,31 @@ async def run_nudges(
     # keys for everything that happens to be true today, so switching the
     # system on cannot fire a backlog accumulated over the org's whole life.
     # Doing it automatically means there is no prerequisite step to forget.
-    if not seed and not dry_run and not await _ledger_has_rows(db_session):
+    # Only an unscoped run may seed: seeding from `--org-id` or `--only` would
+    # pin the global boundary while consuming one org's keys, leaving every
+    # other organization both unseeded and permanently pre-existing.
+    if (
+        not seed
+        and not dry_run
+        and org_id is None
+        and only is None
+        and not await _ledger_has_rows(db_session)
+    ):
         logger.info("First nudge run here — seeding the backlog instead of sending")
         seeded = await run_nudges(
             db_session, seed=True, now=now, org_id=org_id, force=True
         )
         seeded.auto_seeded = True
         return seeded
+
+    logger.info(
+        "Nudge run starting: mode=%s cutoff=%s weekly_cap=%s max_sends=%s%s",
+        backfill_mode(),
+        cutoff.isoformat(),
+        WEEKLY_CAP,
+        max_sends,
+        " [dry-run]" if dry_run else (" [seed]" if seed else ""),
+    )
 
     # Ask the provider what became of recent messages before sending more.
     # This is what lets bounces and complaints be noticed without a webhook.
@@ -392,12 +452,28 @@ async def run_nudges(
 
         await reconcile_delivery(db_session, now=now)
     except Exception as exc:
+        # reconcile_delivery commits on the shared session; a failure mid-commit
+        # leaves it needing a rollback, and without one the first _claim raises
+        # PendingRollbackError and takes the whole run down.
         logger.warning("Delivery reconcile skipped: %s", exc)
+        try:
+            await db_session.rollback()
+        except Exception:
+            pass
 
     media_base = get_media_base_url(None)
 
+    preexisting = 0
+    considered_orgs = 0
+
     async for snapshot in iter_snapshots(db_session, now=now, org_id=org_id):
-        if stats.sent >= max_sends:
+        considered_orgs += 1
+        if _is_preexisting(snapshot, cutoff):
+            preexisting += 1
+        # Counted against attempts, not successes: a run where every send fails
+        # would otherwise never trip the fuse and would burn a once-forever key
+        # for every eligible organization in one pass.
+        if stats.sent + stats.failed >= max_sends:
             stats.budget_exhausted = True
             logger.info("Nudge budget of %s reached; deferring the rest", max_sends)
             break
@@ -426,7 +502,7 @@ async def run_nudges(
         )
 
         for admin in admins:
-            if stats.sent >= max_sends:
+            if stats.sent + stats.failed >= max_sends:
                 stats.budget_exhausted = True
                 break
 
@@ -458,7 +534,9 @@ async def run_nudges(
                     stats.skipped_backfill += 1
                     continue
 
-                key = dedupe_key(spec, snapshot.org_id, admin.user_id, now, dry_run)
+                key = dedupe_key(
+                    spec, snapshot.org_id, admin.user_id, now, dry_run, seed
+                )
                 row = await _claim(
                     db_session, spec, snapshot, admin, key, now, dry_run or seed
                 )
@@ -470,6 +548,8 @@ async def run_nudges(
                     row.status = NudgeSendStatus.SUPPRESSED
                     db_session.add(row)
                     await db_session.commit()
+                    stats.seeded += 1
+                    stats.record(spec.id)
                     break
 
                 if dry_run:
@@ -521,4 +601,10 @@ async def run_nudges(
                 await db_session.commit()
                 break
 
+    logger.info(
+        "Nudge run finished: %s orgs scanned, %s predate the system | %s",
+        considered_orgs,
+        preexisting,
+        stats.as_dict(),
+    )
     return stats

--- a/apps/api/src/tests/core/test_core_events.py
+++ b/apps/api/src/tests/core/test_core_events.py
@@ -133,23 +133,62 @@ async def test_create_logs_dir_creates_missing_directory(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_init_logging_configures_logging(monkeypatch):
-    calls = []
+def test_init_logging_attaches_a_stdout_handler():
+    """Until this runs the root logger has no handler, so Python's fallback
+    drops everything below WARNING and every logger.info in the codebase is
+    invisible in production."""
+    root = logging.getLogger()
+    before = list(root.handlers)
+    try:
+        root.handlers = []
+        logs.init_logging()
 
-    async def create_logs_dir():
-        calls.append("create")
+        ours = [h for h in root.handlers if getattr(h, "_learnhouse", False)]
+        assert len(ours) == 1
+        assert isinstance(ours[0], logging.StreamHandler)
+        assert root.level == logging.INFO
+    finally:
+        root.handlers = before
 
-    monkeypatch.setattr(logs, "create_logs_dir", create_logs_dir)
-    monkeypatch.setattr(logs.logging, "FileHandler", lambda *args, **kwargs: object())
-    monkeypatch.setattr(logs.logging, "StreamHandler", lambda *args, **kwargs: object())
-    monkeypatch.setattr(logs.logging, "basicConfig", lambda **kwargs: calls.append(kwargs))
-    monkeypatch.setattr(logs.logging, "info", lambda message: calls.append(message))
 
-    await logs.init_logging()
+def test_init_logging_is_idempotent():
+    """Startup can run more than once in a process; a second call must not
+    double every log line."""
+    root = logging.getLogger()
+    before = list(root.handlers)
+    try:
+        root.handlers = []
+        logs.init_logging()
+        logs.init_logging()
+        assert len([h for h in root.handlers if getattr(h, "_learnhouse", False)]) == 1
+    finally:
+        root.handlers = before
 
-    assert calls[0] == "create"
-    assert calls[1]["level"] == logging.INFO
-    assert calls[-1] == "Logging initiated"
+
+def test_init_logging_honours_an_explicit_level(monkeypatch):
+    monkeypatch.setenv("LEARNHOUSE_LOG_LEVEL", "WARNING")
+    root = logging.getLogger()
+    before, before_level = list(root.handlers), root.level
+    try:
+        root.handlers = []
+        logs.init_logging()
+        assert root.level == logging.WARNING
+    finally:
+        root.handlers, root.level = before, before_level
+
+
+def test_init_logging_leaves_uvicorn_handlers_alone():
+    """basicConfig(force=True) would tear these down and take the access log
+    with it."""
+    root = logging.getLogger()
+    before = list(root.handlers)
+    sentinel = logging.NullHandler()
+    try:
+        root.handlers = [sentinel]
+        logs.init_logging()
+        assert sentinel in root.handlers
+    finally:
+        root.handlers = before
 
 
 def test_is_ee_available(monkeypatch):

--- a/apps/api/src/tests/core/test_core_events_runtime.py
+++ b/apps/api/src/tests/core/test_core_events_runtime.py
@@ -167,26 +167,6 @@ async def test_content_and_logs_helpers(monkeypatch, tmp_path):
     await logs_events.create_logs_dir()
     assert mkdir_calls == ["logs"]
 
-    basic_config_calls = []
-    info_calls = []
-
-    async def fake_create_logs_dir():
-        return None
-
-    monkeypatch.setattr(logs_events, "create_logs_dir", fake_create_logs_dir)
-    monkeypatch.setattr(logs_events.logging, "FileHandler", lambda path: f"file:{path}")
-    monkeypatch.setattr(logs_events.logging, "StreamHandler", lambda: "stream")
-    monkeypatch.setattr(
-        logs_events.logging,
-        "basicConfig",
-        lambda **kwargs: basic_config_calls.append(kwargs),
-    )
-    monkeypatch.setattr(logs_events.logging, "info", lambda message: info_calls.append(message))
-
-    await logs_events.init_logging()
-
-    assert basic_config_calls and basic_config_calls[0]["handlers"] == ["file:logs/learnhouse.log", "stream"]
-    assert info_calls == ["Logging initiated"]
 
 
 @pytest.mark.asyncio

--- a/apps/api/src/tests/services/test_nudges_delivery.py
+++ b/apps/api/src/tests/services/test_nudges_delivery.py
@@ -56,10 +56,8 @@ async def _pref(db, user_id):
 
 
 class TestOutcomes:
-    @pytest.mark.parametrize(
-        "event,reason", [("bounced", "bounce"), ("complained", "complaint")]
-    )
-    async def test_a_failed_message_suppresses_the_address(
+    @pytest.mark.parametrize("event,reason", [("complained", "complaint")])
+    async def test_a_complaint_suppresses_the_address(
         self, db, sent_row, admin_user, event, reason
     ):
         sent_row()
@@ -74,7 +72,37 @@ class TestOutcomes:
         pref = await _pref(db, admin_user.id)
         assert pref.suppressed is True and pref.suppressed_reason == reason
 
-    @pytest.mark.parametrize("event", ["delivered", "sent", "opened", "delivery_delayed"])
+    async def test_a_polled_bounce_does_not_suppress(self, db, sent_row, admin_user):
+        """Polling returns a bare "bounced" with no sub-type, so a full mailbox
+        is indistinguishable from a dead address. The webhook path refuses to
+        suppress on that; this path must too, because suppression is one-way."""
+        sent_row()
+        await db.commit()
+
+        with patch(
+            "src.services.nudges.delivery._last_event",
+            AsyncMock(return_value="bounced"),
+        ):
+            result = await reconcile_delivery(db, now=NOW)
+
+        assert result == {"checked": 1, "suppressed": 0}
+        assert await _pref(db, admin_user.id) is None
+
+    async def test_a_delayed_message_stays_under_watch(self, db, sent_row):
+        """It has not finished failing yet — marking it checked would mean the
+        bounce that lands at hour 60 is never seen."""
+        sent_row()
+        await db.commit()
+
+        with patch(
+            "src.services.nudges.delivery._last_event",
+            AsyncMock(return_value="delivery_delayed"),
+        ):
+            result = await reconcile_delivery(db, now=NOW)
+
+        assert result == {"checked": 0, "suppressed": 0}
+
+    @pytest.mark.parametrize("event", ["delivered", "sent", "opened"])
     async def test_a_healthy_message_suppresses_nothing(
         self, db, sent_row, admin_user, event
     ):
@@ -182,7 +210,8 @@ class TestFailureHandling:
         assert result == {"checked": 0, "suppressed": 0}
 
         with patch(
-            "src.services.nudges.delivery._last_event", AsyncMock(return_value="bounced")
+            "src.services.nudges.delivery._last_event",
+            AsyncMock(return_value="complained"),
         ):
             retried = await reconcile_delivery(db, now=NOW)
         assert retried["suppressed"] == 1
@@ -194,7 +223,8 @@ class TestFailureHandling:
         await db.commit()
 
         with patch(
-            "src.services.nudges.delivery._last_event", AsyncMock(return_value="bounced")
+            "src.services.nudges.delivery._last_event",
+            AsyncMock(return_value="complained"),
         ):
             result = await reconcile_delivery(db, now=NOW)
 
@@ -277,4 +307,40 @@ class TestReconcileInsideARun:
         await db.commit()
 
         stats = await runner_module.run_nudges(db, now=NOW)
+        assert stats.failed == 0
+
+
+class TestReconcileFailureLeavesTheSessionUsable:
+    async def test_a_reconcile_that_breaks_the_session_does_not_kill_the_run(
+        self, db, org, monkeypatch
+    ):
+        """reconcile_delivery commits on the caller's session. Without a
+        rollback here, the first _claim raises PendingRollbackError — which
+        _claim does not catch — and the whole run dies on one bad lookup."""
+        from src.services.nudges import runner as runner_module
+
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_ENABLED", "true")
+        monkeypatch.setattr(runner_module, "get_deployment_mode", lambda: "saas")
+
+        async def poison(session, **kwargs):
+            raise RuntimeError("commit blew up mid-transaction")
+
+        monkeypatch.setattr(
+            "src.services.nudges.delivery.reconcile_delivery", poison
+        )
+        db.add(
+            NudgeSend(
+                nudge_id="bootstrap",
+                dedupe_key="bootstrap:0:0",
+                org_id=org.id,
+                user_id=1,
+                status=NudgeSendStatus.SUPPRESSED,
+                claimed_at=NOW - timedelta(days=400),
+            )
+        )
+        await db.commit()
+
+        stats = await runner_module.run_nudges(db, now=NOW)
+
+        # The run completed rather than dying on the poisoned session.
         assert stats.failed == 0

--- a/apps/api/src/tests/services/test_nudges_runner.py
+++ b/apps/api/src/tests/services/test_nudges_runner.py
@@ -453,16 +453,22 @@ class TestSeeding:
         assert len(rows) == 1
         assert rows[0].status == NudgeSendStatus.SUPPRESSED
 
-    async def test_seeded_keys_are_permanently_consumed(
+    async def test_seeding_holds_back_today_without_spending_the_key(
         self, db, activation_org, sender
     ):
-        """The point of seeding: switching the system on must not fire a
-        backlog of everything that happens to be true that day."""
-        await run_nudges(db, now=NOW, seed=True)
-        stats = await run_nudges(db, now=NOW)
+        """Seeding stops the backlog firing *today*. It must not consume the
+        key forever: the seed writes under a `seed:` namespace so the live send
+        still has its own, which is what lets an org be reached once the gates
+        are opened later."""
+        seeded = await run_nudges(db, now=NOW, seed=True)
+        assert seeded.seeded == 1
 
-        assert stats.sent == 0
-        sender.assert_not_called()
+        rows = await _ledger(db)
+        assert all(r.dedupe_key.startswith("seed:") for r in rows)
+
+        stats = await run_nudges(db, now=NOW)
+        assert stats.sent == 1
+        assert sender.call_count == 1
 
 
 class TestBackfillGuard:
@@ -730,3 +736,136 @@ class TestPreexistingEdgeCase:
             now=NOW, created_at=None,
         )
         assert _is_preexisting(snap, NOW) is False
+
+
+class TestExplicitActivationDate:
+    """The boundary was derived from the ledger's own first row, so the first
+    run wrote it and read it — the cutoff became whatever instant the job
+    happened to start, and no org could ever leave the pre-existing set."""
+
+    async def test_an_explicit_date_wins(self, db, monkeypatch):
+        from src.services.nudges.runner import activation_date
+
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_ACTIVATION_DATE", "2020-01-01")
+        boundary = await activation_date(db, now=NOW)
+
+        assert boundary.year == 2020
+        assert boundary.tzinfo is not None
+
+    async def test_a_past_date_makes_existing_orgs_ordinary(
+        self, db, activation_org, sender, monkeypatch
+    ):
+        """The operator's escape hatch: place the line before the fleet and
+        every org is treated as new."""
+        from src.services.nudges.runner import _is_preexisting, activation_date
+        from src.services.nudges.eligibility import build_snapshots
+
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_ACTIVATION_DATE", "2000-01-01")
+        cutoff = await activation_date(db, now=NOW)
+        snap = (await build_snapshots(db, [activation_org], now=NOW))[0]
+
+        assert _is_preexisting(snap, cutoff) is False
+
+    async def test_garbage_falls_back_to_the_ledger(self, db, monkeypatch):
+        from src.services.nudges.runner import activation_date
+
+        monkeypatch.setenv("LEARNHOUSE_NUDGES_ACTIVATION_DATE", "not-a-date")
+        assert (await activation_date(db, now=NOW)) == NOW - timedelta(days=400)
+
+    async def test_dry_run_rows_do_not_pin_the_boundary(self, db, monkeypatch):
+        """A rehearsal must not convince the system it has already started."""
+        from sqlmodel import delete
+
+        from src.services.nudges.runner import _ledger_has_rows, activation_date
+
+        monkeypatch.delenv("LEARNHOUSE_NUDGES_ACTIVATION_DATE", raising=False)
+        await db.execute(delete(NudgeSend))
+        db.add(
+            NudgeSend(
+                nudge_id="x.y",
+                dedupe_key="dryrun:x.y:1:1",
+                org_id=1,
+                user_id=1,
+                status=NudgeSendStatus.DRY_RUN,
+                claimed_at=NOW - timedelta(days=5),
+            )
+        )
+        await db.commit()
+
+        assert await _ledger_has_rows(db) is False
+        assert (await activation_date(db, now=NOW)) == NOW
+
+
+class TestScopedRunsNeverSeed:
+    async def test_an_org_scoped_run_on_an_empty_ledger_does_not_seed(
+        self, db, activation_org, sender
+    ):
+        """Seeding from --org-id would pin the global boundary while consuming
+        one org's keys, stranding every other org as permanently pre-existing."""
+        from sqlmodel import delete
+
+        await db.execute(delete(NudgeSend))
+        await db.commit()
+
+        stats = await run_nudges(db, now=NOW, org_id=activation_org.id)
+        assert stats.auto_seeded is False
+
+    async def test_a_spec_scoped_run_does_not_seed(self, db, activation_org, sender):
+        from sqlmodel import delete
+
+        await db.execute(delete(NudgeSend))
+        await db.commit()
+
+        stats = await run_nudges(db, now=NOW, only="activation.first_course_d1")
+        assert stats.auto_seeded is False
+
+
+class TestBudgetCountsAttempts:
+    async def test_failures_consume_the_budget(
+        self, db, org, admin_role, verified_admin, sender
+    ):
+        """Counting only successes meant a broken provider could burn a
+        once-forever key for every eligible org in a single pass — the fuse
+        could never trip because nothing ever succeeded."""
+        from datetime import datetime as dt
+
+        from src.db.user_organizations import UserOrganization
+        from src.db.users import User
+
+        org.creation_date = _stored(1.5)
+        org.update_date = _stored(1.5)
+        db.add(org)
+        for index in range(2, 6):
+            db.add(
+                User(
+                    id=index + 20,
+                    username=f"a{index}",
+                    first_name="A",
+                    last_name=str(index),
+                    email=f"a{index}@test.com",
+                    password="x",
+                    user_uuid=f"user_a{index}",
+                    email_verified=True,
+                    creation_date=str(dt.now()),
+                    update_date=str(dt.now()),
+                )
+            )
+            db.add(
+                UserOrganization(
+                    user_id=index + 20,
+                    org_id=org.id,
+                    role_id=admin_role.id,
+                    creation_date=str(dt.now()),
+                    update_date=str(dt.now()),
+                )
+            )
+        await db.commit()
+
+        sender.return_value = False
+        stats = await run_nudges(db, now=NOW, max_sends=2)
+
+        # Stopped after two attempts rather than working through all five.
+        assert stats.failed == 2
+        assert stats.sent == 0
+        assert stats.budget_exhausted is True
+        assert sender.call_count == 2


### PR DESCRIPTION
Nudges were running daily but sending almost nothing, and none of it showed up in logs. Follow-up to #1002 and #1027.

- `init_logging()` was defined but never called, so the root logger had no handler and everything below WARNING was silently dropped in production — not nudge-specific, this affected every `logger.info` call in the codebase. Now called at startup with a single stdout handler (not `basicConfig`, which would tear down uvicorn's handlers and the access log with them). Dropped the unused file handler. Level configurable via `LEARNHOUSE_LOG_LEVEL`.
- The activation boundary was derived from the job's own dedupe rows, so the first run wrote it and then read it back — the cutoff was just whatever instant the job first started, and no org could ever cross it after that. Now configurable via `LEARNHOUSE_NUDGES_ACTIVATION_DATE`. Dry-run rows no longer set it, and scoped runs (`--org-id`/`--only`) can no longer trigger the auto-seed.
- Seeded rows now use their own dedupe namespace instead of consuming the real send key, so holding an email back once no longer blocks it forever.
- The per-run budget counted successes instead of attempts, so a run where every send failed could burn a dedupe key for every eligible org without ever tripping the fuse.
- Delivery reconcile: fixed a missing API key that made every lookup 401 silently, stopped bounces without a sub-type from suppressing, kept delayed messages under watch instead of marking them checked, and rolled back on a broken session instead of taking the whole run down.
- Added run-level logging (mode, cutoff, caps, budget, org counts, stats) so this is observable going forward.

Doesn't change who receives email — `LEARNHOUSE_NUDGES_BACKFILL_MODE` still defaults off. It makes the system observable and stops it from destroying its own future sends.

Testing: full API suite passes (5 pre-existing failures unrelated to this change, verified against clean tree). Ruff clean.