### PR TITLE
Fix session invalidation on password change and logout

### DIFF
--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -1046,7 +1046,18 @@ async def logout(
     ``get_current_user`` via a Redis blocklist, so stolen tokens cannot
     outlive logout simply by being replayed outside the browser.
     """
+    # Identify the session from either credential. A caller that presents only
+    # the refresh cookie is still logging out a real session, and refusing it
+    # meant the revocation below never ran — a proxy that forwarded one cookie
+    # and not the other silently turned every logout into cookie-clearing only.
     token = extract_jwt_from_request(request)
+    payload = decode_jwt(token) if token else None
+    if not payload or not payload.get("sub"):
+        refresh_token = request.cookies.get(JWT_REFRESH_COOKIE_NAME)
+        if refresh_token:
+            payload = decode_refresh_token(refresh_token) or payload
+            token = token or refresh_token
+
     if not token:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -1056,7 +1067,6 @@ async def logout(
 
     # Best-effort resolve the user to revoke every session they have across
     # devices (not just the one tied to this cookie).
-    payload = decode_jwt(token)
     if payload and payload.get("sub"):
         try:
             user_record = await security_get_user(

--- a/apps/api/src/services/users/users.py
+++ b/apps/api/src/services/users/users.py
@@ -704,12 +704,29 @@ async def update_user_password(
 
     # Update user
     user.password = security_hash_password(form.new_password)
+    # SECURITY: stamp the change so every token minted before it is rejected by
+    # get_current_user and /auth/refresh. Without this, a session stolen before
+    # the password change survives it for the full refresh-token lifetime — the
+    # reset-code flow already stamps it, this one did not.
+    user.password_changed_at = datetime.now(timezone.utc).replace(tzinfo=None)
     user.update_date = str(datetime.now())
 
     # Update user in database
     db_session.add(user)
     await db_session.commit()
     await db_session.refresh(user)
+
+    # Belt-and-braces: also push the Redis revocation cutoff so tokens without
+    # an ``iat`` (pre-upgrade) die too. Never block the password change on it.
+    if user.id is not None:
+        try:
+            # Imported here: src.security.auth imports this module, so a
+            # top-level import would be circular.
+            from src.security.auth import revoke_user_sessions_before
+
+            revoke_user_sessions_before(user.id)
+        except Exception:
+            pass
 
     user = UserRead.model_validate(user)
 

--- a/apps/api/src/tests/security/test_logout_revocation_credentials.py
+++ b/apps/api/src/tests/security/test_logout_revocation_credentials.py
@@ -1,0 +1,106 @@
+"""
+``DELETE /auth/logout`` must revoke server-side sessions whenever it can name
+the user — from the access token or from the refresh cookie.
+
+It used to accept the access credential only. A caller presenting just the
+refresh cookie got a 401, ``revoke_user_sessions_before`` never ran, and the
+logout degraded to clearing cookies in the browser while every issued token
+stayed live until natural expiry. Nothing failed loudly. These tests pin the
+behaviour to the backend so it cannot regress on a client-side change.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException, Response
+
+from src.routers.auth import logout
+from src.security.auth import (
+    JWT_COOKIE_NAME,
+    JWT_REFRESH_COOKIE_NAME,
+    create_access_token,
+    create_refresh_token,
+)
+from starlette.requests import Request
+
+
+def _request_with_cookies(**cookies) -> Request:
+    cookie_header = "; ".join(f"{name}={value}" for name, value in cookies.items())
+    headers = [(b"cookie", cookie_header.encode())] if cookie_header else []
+    return Request(
+        {
+            "type": "http",
+            "method": "DELETE",
+            "path": "/api/v1/auth/logout",
+            "headers": headers,
+            "query_string": b"",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_logout_revokes_with_access_cookie_only(db, admin_user):
+    request = _request_with_cookies(
+        **{JWT_COOKIE_NAME: create_access_token({"sub": admin_user.email})}
+    )
+
+    with patch("src.routers.auth.revoke_user_sessions_before") as revoke:
+        await logout(request, Response(), db)
+
+    revoke.assert_called_once_with(admin_user.id)
+
+
+@pytest.mark.asyncio
+async def test_logout_revokes_with_refresh_cookie_only(db, admin_user):
+    """The half that broke: only the refresh cookie reaches the backend."""
+    request = _request_with_cookies(
+        **{JWT_REFRESH_COOKIE_NAME: create_refresh_token({"sub": admin_user.email})}
+    )
+
+    with patch("src.routers.auth.revoke_user_sessions_before") as revoke:
+        await logout(request, Response(), db)
+
+    revoke.assert_called_once_with(admin_user.id)
+
+
+@pytest.mark.asyncio
+async def test_logout_revokes_with_both_cookies(db, admin_user):
+    request = _request_with_cookies(
+        **{
+            JWT_COOKIE_NAME: create_access_token({"sub": admin_user.email}),
+            JWT_REFRESH_COOKIE_NAME: create_refresh_token({"sub": admin_user.email}),
+        }
+    )
+
+    with patch("src.routers.auth.revoke_user_sessions_before") as revoke:
+        await logout(request, Response(), db)
+
+    revoke.assert_called_once_with(admin_user.id)
+
+
+@pytest.mark.asyncio
+async def test_logout_falls_back_to_refresh_when_access_token_is_junk(db, admin_user):
+    """An expired or malformed access cookie must not shadow a usable refresh
+    cookie — otherwise the most common real-world logout (stale access token)
+    is exactly the one that skips revocation."""
+    request = _request_with_cookies(
+        **{
+            JWT_COOKIE_NAME: "not-a-jwt",
+            JWT_REFRESH_COOKIE_NAME: create_refresh_token({"sub": admin_user.email}),
+        }
+    )
+
+    with patch("src.routers.auth.revoke_user_sessions_before") as revoke:
+        await logout(request, Response(), db)
+
+    revoke.assert_called_once_with(admin_user.id)
+
+
+@pytest.mark.asyncio
+async def test_logout_without_any_credential_is_unauthenticated(db):
+    with patch("src.routers.auth.revoke_user_sessions_before") as revoke:
+        with pytest.raises(HTTPException) as exc:
+            await logout(_request_with_cookies(), Response(), db)
+
+    assert exc.value.status_code == 401
+    revoke.assert_not_called()

--- a/apps/api/src/tests/security/test_password_change_session_invalidation.py
+++ b/apps/api/src/tests/security/test_password_change_session_invalidation.py
@@ -1,0 +1,109 @@
+"""
+Regression coverage for CWE-613 on the self-service password change.
+
+``PUT /users/change_password/{user_id}`` used to rewrite the hash and nothing
+else: it never stamped ``password_changed_at``, so a token stolen before the
+change kept working for its full lifetime (and its refresh token kept minting
+new ones for 30 days). The reset-code flow already stamped it; this path did
+not. Both the stamp and the Redis revocation cutoff are pinned here, because
+either one silently failing restores the vulnerability.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from src.db.users import User, UserUpdatePassword
+from src.security.security import security_hash_password
+from src.services.users.users import update_user_password
+
+
+@pytest.mark.asyncio
+async def test_password_change_stamps_password_changed_at(
+    mock_request, db, admin_user
+):
+    user = await db.get(User, admin_user.id)
+    user.password = security_hash_password("old-password")
+    user.password_changed_at = None
+    db.add(user)
+    await db.commit()
+
+    before = datetime.now(timezone.utc).replace(tzinfo=None)
+
+    await update_user_password(
+        mock_request,
+        db,
+        admin_user,
+        admin_user.id,
+        UserUpdatePassword(
+            old_password="old-password",
+            new_password="NewPassword123!",
+        ),
+    )
+
+    refreshed = await db.get(User, admin_user.id)
+    assert refreshed is not None
+    assert refreshed.password_changed_at is not None, (
+        "password_changed_at must be stamped — get_current_user and "
+        "/auth/refresh use it to reject tokens minted before the change"
+    )
+    assert refreshed.password_changed_at >= before
+
+
+@pytest.mark.asyncio
+async def test_password_change_revokes_existing_sessions(
+    mock_request, db, admin_user
+):
+    user = await db.get(User, admin_user.id)
+    user.password = security_hash_password("old-password")
+    db.add(user)
+    await db.commit()
+
+    with patch(
+        "src.security.auth.revoke_user_sessions_before", return_value=True
+    ) as revoke:
+        await update_user_password(
+            mock_request,
+            db,
+            admin_user,
+            admin_user.id,
+            UserUpdatePassword(
+                old_password="old-password",
+                new_password="NewPassword123!",
+            ),
+        )
+
+    revoke.assert_called_once_with(admin_user.id)
+
+
+@pytest.mark.asyncio
+async def test_password_change_survives_revocation_store_failure(
+    mock_request, db, admin_user
+):
+    """Redis being down must not block the password change — the DB stamp is
+    the load-bearing half of the fix."""
+    user = await db.get(User, admin_user.id)
+    user.password = security_hash_password("old-password")
+    user.password_changed_at = None
+    db.add(user)
+    await db.commit()
+
+    with patch(
+        "src.security.auth.revoke_user_sessions_before",
+        side_effect=RuntimeError("redis down"),
+    ):
+        result = await update_user_password(
+            mock_request,
+            db,
+            admin_user,
+            admin_user.id,
+            UserUpdatePassword(
+                old_password="old-password",
+                new_password="NewPassword123!",
+            ),
+        )
+
+    assert result.id == admin_user.id
+    refreshed = await db.get(User, admin_user.id)
+    assert refreshed is not None and refreshed.password_changed_at is not None

--- a/apps/web/app/api/auth/[...path]/route.ts
+++ b/apps/web/app/api/auth/[...path]/route.ts
@@ -209,8 +209,22 @@ async function proxyRequest(
     // Best-effort backend token invalidation
     try {
       const logoutHeaders: HeadersInit = {}
+      // Both cookies must go: the backend identifies the session to revoke from
+      // LH_access (Authorization header or the LH_access cookie — never
+      // LH_refresh), so sending only the refresh cookie made every logout 401
+      // and skipped server-side revocation entirely.
+      const logoutCookieParts: string[] = []
+      if (accessToken?.value) {
+        logoutCookieParts.push(`${ACCESS_TOKEN_COOKIE}=${accessToken.value}`)
+      }
       if (refreshToken?.value) {
-        logoutHeaders['Cookie'] = `${REFRESH_TOKEN_COOKIE}=${refreshToken.value}`
+        logoutCookieParts.push(`${REFRESH_TOKEN_COOKIE}=${refreshToken.value}`)
+      }
+      if (logoutCookieParts.length > 0) {
+        logoutHeaders['Cookie'] = logoutCookieParts.join('; ')
+      }
+      if (authHeader) {
+        logoutHeaders['Authorization'] = authHeader
       }
       // Backend logout is DELETE /auth/logout — using POST returned 405 and
       // silently skipped server-side session revocation, so revoked tokens


### PR DESCRIPTION
Password change didn't invalidate existing sessions, and logout didn't revoke them either.

- `update_user_password` never stamped `password_changed_at`, so the checks that already reject tokens issued before a password change had nothing to enforce. Now it's stamped, plus a best-effort Redis revocation cutoff (wrapped so a Redis outage can't block the password change).
- `DELETE /auth/logout` only looked at the access token/cookie, so a request with just the refresh cookie 401'd before any session got revoked.
- The web logout proxy only forwarded the refresh cookie, causing that 401.

Logout now falls back to the refresh cookie when there's no valid access credential, and the web proxy forwards both.

Note: changing your password now ends your own current session immediately (the account settings UI already prompts re-login).

Added 8 tests under `apps/api/src/tests/security/`. Full API suite: 5500 passed, 1 pre-existing unrelated failure, 14 skipped. Web typecheck is clean on the changed route; web unit tests aren't in CI and weren't run.