### PR TITLE
Add www support to caddy template file

### DIFF
--- a/apps/cli/src/templates/caddyfile.ts
+++ b/apps/cli/src/templates/caddyfile.ts
@@ -7,6 +7,10 @@ export function generateCaddyfile(config: SetupConfig): string {
   email ${email}
 }
 
+www.${config.domain} {
+  redir https://${config.domain}{uri} permanent
+}
+
 ${config.domain} {
   reverse_proxy learnhouse-app:80
 }


### PR DESCRIPTION
https://github.com/learnhouse/learnhouse/discussions/1038

Added support for self-hosted learnhouse for `www.domain.com` access.

Setting up access to the www subdomain requires two steps:

1.  DNS resolves `www.domain.com` to the IP address of `domain.com` via an A record or CNAME record. The browser connects to the IP address and sends an HTTP request header containing:
```
HTTP
Host: *www*.domain.com
```
When Caddy receives this request, it checks its configured site blocks to find a match for `www.domain.com`.

However, if the Caddyfile only defines `domain.com`:

```
# Caddyfile without www
domain.com {
    reverse_proxy localhost:80
}
```

Caddy will look at the Host: `www.domain.com` header, see that it doesn't match `domain.com`, and return a 404 Not Found or drop the connection.

2. Caddy automatically provisions SSL certificates via Let's Encrypt / ZeroSSL for any domain listed in your Caddyfile.  Therefore, `www.domain.com` needs to appear in the Caddyfile. 

Most modern web setups don't just serve the exact same site on both URLs — they choose one primary ("canonical") domain and redirect the other to avoid duplicate content SEO penalties.

```
# Redirect www -> non-www
www.domain.com {
    redir https://domain.com{uri} permanent
}

domain.com {
    reverse_proxy localhost:80
}
```

The URI contains a `/` in front, so {uri} is the right suffix to forward URI parameters to the main domain.

Tested: 
- Updated the local Caddyfile to use the www redirect and restarted caddy docker, and was able to access `www.domain.com`. 
- `caddy validate --config <path-to-generated-caddy-file>`

Note: I built the CLI and installed learnhouse with it on GCE, but it created the Caddyfile from the old template, so this PR may be incomplete to achieve an updated Caddyfile, or I may be missing an installation step. 