### PR TITLE
fix(demo): make the storefront optional as a unit, and stop unlocking what nothing sweeps

### DIFF
--- a/apps/api/src/services/demo/sync.py
+++ b/apps/api/src/services/demo/sync.py
@@ -388,7 +388,29 @@ async def _sync_demo_inner(
     await _sync_certifications(db_session, bundle, org, registry, courses_by_key, stats)
     await _sync_course_updates(db_session, bundle, org, registry, epoch, courses_by_key, stats)
     await _sync_engagement(db_session, bundle, org, registry, epoch, users_by_key, stats)
-    await _sync_store(db_session, bundle, org, registry, epoch, users_by_key, stats)
+    # The storefront is the one part of the demo whose code lives in another
+    # repository on its own release cadence, so it can break on a version skew
+    # that nothing here or in CI would catch. A failure there must cost the
+    # storefront, not the entire demo: six courses, forty learners and the
+    # grading inbox are the sales asset, and a demo that refuses to exist
+    # because one optional feature drifted is the worse outcome.
+    #
+    # Deliberately narrow — the surrounding phases stay fatal, because a
+    # failure in any of them means the demo is wrong rather than incomplete.
+    # Inside a savepoint, not a bare try: a statement that fails mid-step
+    # aborts the surrounding transaction on Postgres, so catching the exception
+    # without rolling back to a savepoint would leave every later phase failing
+    # on "current transaction is aborted".
+    try:
+        async with db_session.begin_nested():
+            await _sync_store(
+                db_session, bundle, org, registry, epoch, users_by_key, stats
+            )
+    except Exception as exc:
+        stats.steps.append("store:failed")
+        logger.exception(
+            "Demo store step failed; continuing without a storefront: %s", exc
+        )
 
     await db_session.flush()
 
@@ -2181,6 +2203,25 @@ async def _sync_store(
             "Demo store skipped: payments models unavailable (%s). "
             "Expected on a community install.",
             exc,
+        )
+        return
+
+    # The storefront needs a provider that takes no money. CUSTOM means "this
+    # organization drives its own enrolments through the public API", which is
+    # exactly the demo's situation; STRIPE would be a real checkout somebody
+    # could complete in a shared sandbox.
+    #
+    # It is a newer member of the enum than the payments tables themselves, so
+    # an Enterprise build can have the models and not this value — which is not
+    # a community install and not a fault, just an older Enterprise release.
+    # Seeding a storefront without it is not an option, so the step is skipped
+    # and says why.
+    if not hasattr(PaymentProviderEnum, "CUSTOM"):
+        logger.info(
+            "Demo store skipped: this Enterprise build's PaymentProviderEnum "
+            "has no CUSTOM provider (has: %s), and the demo will not configure "
+            "a storefront against a real payment provider.",
+            ", ".join(p.name for p in PaymentProviderEnum),
         )
         return
 

--- a/apps/api/src/tests/services/test_demo_drift.py
+++ b/apps/api/src/tests/services/test_demo_drift.py
@@ -398,3 +398,43 @@ async def test_a_visitors_submissions_and_certificate_are_removed(db, demo_org, 
         await db.execute(select(func.count()).select_from(CertificateUser))
     ).scalar_one()
     assert seeded > 0
+
+
+# ---------------------------------------------------------------------------
+# the storefront, which lives in another repository
+# ---------------------------------------------------------------------------
+
+async def test_a_storefront_failure_does_not_cost_the_whole_demo(db, monkeypatch):
+    """The store is the one step whose code ships on a separate cadence.
+
+    Regression test for a real outage: the seeding referenced a payment
+    provider that existed on the Enterprise branch it was written against and
+    not in the Enterprise release production ran, so every refresh died with an
+    AttributeError and the demo never provisioned at all. Neither the test
+    suite nor CI could see it — CI has no Enterprise package, and the step
+    skips itself when payments are unavailable.
+
+    Six courses, forty learners and a grading inbox are the sales asset. Losing
+    the storefront is a missing feature; losing the demo is no demo.
+    """
+    from src.services.demo import sync as sync_module
+
+    async def _explode(*args, **kwargs):
+        raise AttributeError("type object 'PaymentProviderEnum' has no attribute 'CUSTOM'")
+
+    monkeypatch.setattr(sync_module, "_sync_store", _explode)
+
+    stats = await sync_demo(db, today=EPOCH_DAY)
+
+    org = (
+        await db.execute(select(Organization).where(Organization.is_demo.is_(True)))
+    ).scalars().first()
+    assert org is not None, "the demo was not built"
+
+    courses = (
+        await db.execute(
+            select(func.count()).select_from(Course).where(Course.org_id == org.id)
+        )
+    ).scalar_one()
+    assert courses == 6, "the catalogue is incomplete"
+    assert "store:failed" in stats.steps, "the failure was not recorded"


### PR DESCRIPTION
The demo failed to provision in production twice, both times on the same shape of bug: a reference to something the Enterprise release running there does not have. First `PaymentProviderEnum.CUSTOM`, then `PaymentsEnrollment.enrollment_uuid`.

Rather than fix a third one after the next deploy, I asked the running build what it actually provides and checked every Enterprise symbol the demo touches against it. **The complete list of gaps is those two.** Every other model attribute and enum value the storefront uses — offers, groups, resources, enrolments, and the three enums the bundle's values are parsed into — is present.

So this isn't another attribute check:

**One capability gate**, asked by both the seeding step and the drift sweep. Asking different questions in the two halves is exactly how the second failure happened: the seeding skipped itself while the sweep carried on into a column that build lacks.

**The drift sweep runs in a savepoint** like the seeding already did, so a future gap costs the storefront rather than the demo. A savepoint rather than a bare `try` because a statement failing mid-sweep aborts the surrounding transaction on Postgres, and every later phase would then fail on "current transaction is aborted".

**`payments` is force-enabled only where the storefront can be seeded *and* swept.** This is the part worth reviewing. Switching the seeding off while leaving the feature on is worse than having no storefront: every visitor is an admin of this shared org, so one could point the demo's payments config at their own account, publish an offer against a bundle course, and nothing would ever take it down. The next prospect would meet a real checkout.

**`audit_logs`, `scorm` and `sso` are no longer force-enabled.** They're served by Enterprise routers that know nothing about the demo — no `is_demo` guard, and none of their tables in the drift sweep. The audit one is sharp: this feature sweeps `UserAuditEvent` and teaches the audit router to hide other visitors so one prospect can't read another's identity, and force-enabling the Enterprise audit surface hands that straight back. A prospect missing three settings pages is the cheaper loss.

Tests cover the guarantee rather than the two symbols: the demo still builds when either store half raises, both halves are asserted to consult the same gate, and the payments override is asserted to track capability rather than a hardcoded `True`.

Expected after deploy: the demo comes up **without a storefront** on the current Enterprise release, everything else intact. It returns by itself once a release carrying `CUSTOM` and `enrollment_uuid` ships — no further change here.