### PR TITLE
fix(ci): pin bun docker images to 1.3.14 to match lockfile

### DIFF
--- a/.github/workflows/cli-publish.yaml
+++ b/.github/workflows/cli-publish.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version-file: .bun-version
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version-file: .bun-version
 
       # setup-bun restores the toolchain, not the packages.
       - name: Cache bun install cache
@@ -55,7 +55,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version-file: .bun-version
 
       # setup-bun restores the toolchain, not the packages.
       - name: Cache bun install cache

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version-file: .bun-version
 
       # Build the CLI from this repo so the suite installs the self-host with
       # the current CLI (it still pulls the published app image).

--- a/.github/workflows/web-lint.yaml
+++ b/.github/workflows/web-lint.yaml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version-file: .bun-version
       # setup-bun restores the toolchain, not the packages. Without this the
       # web install re-downloads its whole tree on every lint run.
       - name: Cache bun install cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ───────────────────────────────────────────────
 # Stage 1: Frontend dependency install
 # ───────────────────────────────────────────────
-FROM oven/bun:1-alpine AS frontend-deps
+FROM oven/bun:1.3.14-alpine AS frontend-deps
 RUN apk update && apk add --no-cache libc6-compat && rm -rf /var/cache/apk/*
 WORKDIR /app
 
@@ -11,7 +11,7 @@ RUN bun install --frozen-lockfile
 # ───────────────────────────────────────────────
 # Stage 2: Frontend build
 # ───────────────────────────────────────────────
-FROM oven/bun:1-alpine AS frontend-builder
+FROM oven/bun:1.3.14-alpine AS frontend-builder
 WORKDIR /app
 COPY --from=frontend-deps /app/node_modules ./node_modules
 COPY apps/web .
@@ -53,7 +53,7 @@ RUN chmod +x server-wrapper.js
 # ───────────────────────────────────────────────
 # Stage 4: Collab server build
 # ───────────────────────────────────────────────
-FROM oven/bun:1-alpine AS collab-builder
+FROM oven/bun:1.3.14-alpine AS collab-builder
 WORKDIR /app
 
 COPY apps/collab/package.json apps/collab/bun.lock* ./

--- a/apps/collab/Dockerfile
+++ b/apps/collab/Dockerfile
@@ -1,5 +1,5 @@
 # ── Build stage ──────────────────────────────────────────────────────────────
-FROM oven/bun:1-alpine AS builder
+FROM oven/bun:1.3.14-alpine AS builder
 
 WORKDIR /app
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1-alpine AS base
+FROM oven/bun:1.3.14-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps


### PR DESCRIPTION
Every Docker build in CI has been failing with:

```
error: lockfile had changes, but lockfile is frozen
note: overrides in package.json changed since bun.lock was saved
```

Nothing in the repo changed. The Dockerfiles pull `oven/bun:1-alpine`, a floating tag. bun 1.4.0 got published and the tag moved from 1.3.14 to 1.4.0. 1.4 compares the `overrides` field in package.json against a lockfile written by 1.3 differently enough to reject it on `--frozen-lockfile`.

The workflows had the same drift for the same reason: web-lint, e2e, cli-tests and cli-publish all asked setup-bun for `latest`, so they resolved to 1.4.0 too. That is why lint and E2E were failing alongside the image builds — E2E has been red on `dev` for days.

We already pin bun in `.bun-version` (1.3.14), and the lockfiles workflow reads it via `bun-version-file`. Everywhere else was choosing its own version, which is how they drifted. Now one file decides it:

- 5 Dockerfile references pinned to `oven/bun:1.3.14-alpine` (root x3, apps/web, apps/collab)
- 4 workflows switched from `bun-version: latest` to `bun-version-file: .bun-version`

Not upgrading to bun 1.4 here. That needs a regenerated bun.lock, `.bun-version` bumped to match, and the pnpm lockfile kept in step. Should happen deliberately, not as a side effect of a base image moving.

Verified by building `--target frontend-deps` from this Dockerfile: 1113 packages installed, exit 0. Also reproduced the failure directly: `oven/bun:1-alpine` (now 1.4.0) rejects the frozen install, `oven/bun:1.3-alpine` (1.3.14) installs it cleanly.

This unblocks every open PR. They'll need a re-run once this lands.