### PR TITLE
Fix library folder order and misleading certificate copy

### DIFF
--- a/apps/api/src/services/folders/folders.py
+++ b/apps/api/src/services/folders/folders.py
@@ -77,6 +77,55 @@ def _apply_folder_sort(statement, sort_mode: str):
     return statement.order_by(Folder.name.asc())
 
 
+def _item_name(item: FolderContentItem) -> str:
+    """Display name of a resolved item — courses/media expose `name`, some
+    resources only carry a `title`. Lowercased to match the client comparator."""
+    resource = item.resource or {}
+    return str(resource.get("name") or resource.get("title") or "").lower()
+
+
+def _item_date(item: FolderContentItem) -> str:
+    """Creation timestamp of a resolved item, in the same fallback order the
+    client comparator uses (creation_date -> created_at -> update_date).
+    'newest'/'oldest' mean creation date on both sides — every course carries a
+    non-empty update_date, so preferring it would put the API and the browser in
+    permanent disagreement. Timestamps are stored as sortable strings."""
+    resource = item.resource or {}
+    return str(
+        resource.get("creation_date")
+        or resource.get("created_at")
+        or resource.get("update_date")
+        or ""
+    )
+
+
+def _sort_items(
+    items: List[FolderContentItem], sort_mode: str
+) -> List[FolderContentItem]:
+    """Order a folder's CONTENT items by the org's sort mode, mirroring
+    _apply_folder_sort so folders and their content agree.
+
+    FolderContent.position is applied first and Python's sort is stable, so the
+    admin's drag order stays the tiebreaker for the name modes — and is the only
+    key in 'manual' mode. The date modes break ties by name instead, the way the
+    client comparator does (`_dateOf(b) - _dateOf(a) || byName(a, b)`).
+    """
+    items.sort(key=lambda i: i.position)
+    if sort_mode == "manual":
+        return items
+    if sort_mode == "name_desc":
+        items.sort(key=_item_name, reverse=True)
+    elif sort_mode == "newest":
+        items.sort(key=_item_name)
+        items.sort(key=_item_date, reverse=True)
+    elif sort_mode == "oldest":
+        items.sort(key=_item_name)
+        items.sort(key=_item_date)
+    else:  # name_asc (default)
+        items.sort(key=_item_name)
+    return items
+
+
 # ----------------------------------------------------------------------------
 # Resource resolution — folders are polymorphic containers
 # ----------------------------------------------------------------------------
@@ -119,8 +168,14 @@ async def _resolve_items(
     db_session: AsyncSession,
     content_rows: list[FolderContent],
     include_private: bool,
+    sort_mode: str = "manual",
 ) -> List[FolderContentItem]:
-    """Resolve FolderContent rows into typed items, batching per resource type."""
+    """Resolve FolderContent rows into typed items, batching per resource type.
+
+    The resolved items are ordered by the org's sort mode, the same mode the
+    sibling folders are ordered by — otherwise a folder's content would render
+    in a different order than the dashboard shows.
+    """
     registry = _resource_registry()
 
     by_prefix: dict[str, list[str]] = {}
@@ -152,8 +207,7 @@ async def _resolve_items(
                 )
             )
 
-    items.sort(key=lambda i: i.position)
-    return items
+    return _sort_items(items, sort_mode)
 
 
 async def _build_breadcrumbs(db_session: AsyncSession, folder: Folder) -> List[FolderBreadcrumb]:
@@ -222,7 +276,9 @@ async def _folder_to_read(
                 select(FolderContent).where(FolderContent.folder_id == folder.id)
             )
         ).scalars().all()
-        items = await _resolve_items(db_session, list(content_rows), include_private)
+        items = await _resolve_items(
+            db_session, list(content_rows), include_private, sort_mode
+        )
         breadcrumbs = await _build_breadcrumbs(db_session, folder)
 
     return FolderRead(
@@ -598,7 +654,8 @@ async def reorder_folder_content(
 ) -> dict:
     """Persist the manual (admin drag) ordering of a folder's CONTENT items
     (courses, media, …). Position is derived from the array index — matching how
-    `_resolve_folder_content` sorts items by FolderContent.position. Admin only.
+    `_sort_items` orders items by FolderContent.position in 'manual' mode (and
+    uses it as the tiebreaker in every other mode). Admin only.
     """
     from src.db.organizations import Organization
     from src.services.orgs.orgs import rbac_check
@@ -908,7 +965,10 @@ async def get_org_root_items(
             )
         )
     ).scalars().all()
-    return await _resolve_items(db_session, list(content_rows), include_private=include_private)
+    sort_mode = await _get_folders_sort_mode(db_session, int(org_id))
+    return await _resolve_items(
+        db_session, list(content_rows), include_private=include_private, sort_mode=sort_mode
+    )
 
 
 async def add_org_root_content(

--- a/apps/api/src/tests/services/test_folders_ordering_service.py
+++ b/apps/api/src/tests/services/test_folders_ordering_service.py
@@ -7,6 +7,8 @@ Targets the newly-added ordering surface:
   - _get_folders_sort_mode / _apply_folder_sort : the five sort modes read from
     organization_config general.folders.sort_mode (service lines ~38-76), as
     applied inside get_folders(...) and the subfolder query in _folder_to_read.
+  - _sort_items : the same five modes applied to a folder's CONTENT items, via
+    get_folder(...) and the org-library-root listing get_org_root_items(...).
 
 The reorder admin gate (rbac_check) is exercised both for the pass path
 (patched no-op) and the 403 reject path (patched to raise), mirroring how the
@@ -25,10 +27,13 @@ from src.db.folders.folders import (
     FolderOrder,
     FolderUpdateOrder,
 )
+from src.db.courses.courses import Course
 from src.db.folders.folder_content import FolderContent
 from src.db.organization_config import OrganizationConfig
 from src.services.folders.folders import (
+    get_folder,
     get_folders,
+    get_org_root_items,
     reorder_folders,
     reorder_folder_content,
 )
@@ -359,8 +364,9 @@ class TestGetFoldersSortModes:
 
 
 async def _mk_content(db, org, folder, resource_uuid, position=0):
+    """Link a resource into a folder — pass folder=None for the library root."""
     row = FolderContent(
-        folder_id=folder.id,
+        folder_id=folder.id if folder is not None else None,
         resource_uuid=resource_uuid,
         org_id=org.id,
         position=position,
@@ -524,3 +530,247 @@ class TestFolderRouterDelegation:
         svc.assert_awaited_once()
         # Delegation passes the unwrapped resource_uuids list.
         assert svc.await_args.args[2] == ["course_a", "media_b"]
+
+
+# ---------------------------------------------------------------------------
+# Folder CONTENT ordering — items follow the org sort_mode, not just position
+# ---------------------------------------------------------------------------
+
+
+async def _mk_course(db, org, name, creation_date=None, public=True, update_date=None):
+    c = Course(
+        name=name,
+        description="",
+        public=public,
+        published=True,
+        open_to_contributors=False,
+        org_id=org.id,
+        course_uuid=f"course_{name.replace(' ', '_')}",
+        creation_date=creation_date or str(datetime.now()),
+        update_date=update_date or str(datetime.now()),
+    )
+    db.add(c)
+    await db.commit()
+    await db.refresh(c)
+    return c
+
+
+class TestFolderContentSortModes:
+    """A folder's items (courses/media) must come back in the same order the
+    org's sort_mode gives its folders — the dashboard and the public library
+    both render the API order, so this is the single source of truth."""
+
+    async def _seed(self, db, org):
+        """Names, creation dates and drag positions deliberately disagree so
+        every mode yields a distinct order."""
+        base = datetime(2020, 1, 1, 12, 0, 0)
+        folder = await _mk_folder(db, org, "Content")
+        # Creation order (oldest -> newest): Zeta, Alpha, Mango
+        await _mk_course(db, org, "Zeta", creation_date=str(base))
+        await _mk_course(db, org, "Alpha", creation_date=str(base + timedelta(days=1)))
+        await _mk_course(db, org, "Mango", creation_date=str(base + timedelta(days=2)))
+        # Drag order: Mango, Zeta, Alpha
+        await _mk_content(db, org, folder, "course_Mango", 0)
+        await _mk_content(db, org, folder, "course_Zeta", 1)
+        await _mk_content(db, org, folder, "course_Alpha", 2)
+        return folder
+
+    async def _item_names(self, db, folder, admin_user, mock_request):
+        with patch(
+            "src.services.folders.folders.check_resource_access",
+            new_callable=AsyncMock,
+        ):
+            read = await get_folder(mock_request, folder.folder_uuid, admin_user, db)
+        return [i.resource["name"] for i in read.items]
+
+    @pytest.mark.asyncio
+    async def test_items_sorted_name_asc(self, db, org, admin_user, mock_request):
+        folder = await self._seed(db, org)
+        await _set_sort_mode(db, org, "name_asc")
+        names = await self._item_names(db, folder, admin_user, mock_request)
+        assert names == ["Alpha", "Mango", "Zeta"]
+
+    @pytest.mark.asyncio
+    async def test_items_sorted_name_desc(self, db, org, admin_user, mock_request):
+        folder = await self._seed(db, org)
+        await _set_sort_mode(db, org, "name_desc")
+        names = await self._item_names(db, folder, admin_user, mock_request)
+        assert names == ["Zeta", "Mango", "Alpha"]
+
+    @pytest.mark.asyncio
+    async def test_items_sorted_newest(self, db, org, admin_user, mock_request):
+        folder = await self._seed(db, org)
+        await _set_sort_mode(db, org, "newest")
+        names = await self._item_names(db, folder, admin_user, mock_request)
+        assert names == ["Mango", "Alpha", "Zeta"]
+
+    @pytest.mark.asyncio
+    async def test_items_sorted_oldest(self, db, org, admin_user, mock_request):
+        folder = await self._seed(db, org)
+        await _set_sort_mode(db, org, "oldest")
+        names = await self._item_names(db, folder, admin_user, mock_request)
+        assert names == ["Zeta", "Alpha", "Mango"]
+
+    @pytest.mark.asyncio
+    async def test_items_manual_keeps_drag_positions(
+        self, db, org, admin_user, mock_request
+    ):
+        folder = await self._seed(db, org)
+        await _set_sort_mode(db, org, "manual")
+        names = await self._item_names(db, folder, admin_user, mock_request)
+        # FolderContent.position order: Mango(0), Zeta(1), Alpha(2)
+        assert names == ["Mango", "Zeta", "Alpha"]
+
+    @pytest.mark.asyncio
+    async def test_items_default_to_name_asc_without_config(
+        self, db, org, admin_user, mock_request
+    ):
+        """The regression this guards: with no config row and every position
+        still 0, items came back in arbitrary DB row order."""
+        folder = await _mk_folder(db, org, "Content")
+        await _mk_course(db, org, "Zeta")
+        await _mk_course(db, org, "Alpha")
+        await _mk_course(db, org, "Mango")
+        for uuid in ("course_Zeta", "course_Alpha", "course_Mango"):
+            await _mk_content(db, org, folder, uuid, 0)
+        names = await self._item_names(db, folder, admin_user, mock_request)
+        assert names == ["Alpha", "Mango", "Zeta"]
+
+    @pytest.mark.asyncio
+    async def test_date_modes_use_creation_date_not_update_date(
+        self, db, org, admin_user, mock_request
+    ):
+        """'newest'/'oldest' mean CREATION date on both sides of the wire.
+
+        Every course row carries a non-empty update_date and editing a course
+        bumps only that field, so seeding the two in opposite orders is the
+        normal case — if the service ever preferred update_date it would order
+        every edited library differently than the client comparator
+        (apps/web/lib/library/sort.ts::_dateOf) re-renders it.
+        """
+        base = datetime(2020, 1, 1, 12, 0, 0)
+        folder = await _mk_folder(db, org, "Content")
+        # Creation order (oldest -> newest): Zeta, Alpha, Mango
+        # Update order is the exact reverse: Mango, Alpha, Zeta
+        await _mk_course(
+            db, org, "Zeta",
+            creation_date=str(base),
+            update_date=str(base + timedelta(days=30)),
+        )
+        await _mk_course(
+            db, org, "Alpha",
+            creation_date=str(base + timedelta(days=1)),
+            update_date=str(base + timedelta(days=20)),
+        )
+        await _mk_course(
+            db, org, "Mango",
+            creation_date=str(base + timedelta(days=2)),
+            update_date=str(base + timedelta(days=10)),
+        )
+        for uuid in ("course_Mango", "course_Zeta", "course_Alpha"):
+            await _mk_content(db, org, folder, uuid, 0)
+
+        await _set_sort_mode(db, org, "newest")
+        assert await self._item_names(db, folder, admin_user, mock_request) == [
+            "Mango", "Alpha", "Zeta",
+        ]
+
+        await _set_sort_mode(db, org, "oldest")
+        assert await self._item_names(db, folder, admin_user, mock_request) == [
+            "Zeta", "Alpha", "Mango",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_date_ties_break_by_name_like_the_client(
+        self, db, org, admin_user, mock_request
+    ):
+        """Same creation date -> name decides, matching the client's
+        `_dateOf(b) - _dateOf(a) || byName(a, b)`."""
+        same = str(datetime(2020, 1, 1, 12, 0, 0))
+        folder = await _mk_folder(db, org, "Content")
+        await _mk_course(db, org, "Zeta", creation_date=same)
+        await _mk_course(db, org, "Alpha", creation_date=same)
+        # Drag order puts Zeta first, so a position tiebreak would keep it there.
+        await _mk_content(db, org, folder, "course_Zeta", 0)
+        await _mk_content(db, org, folder, "course_Alpha", 1)
+
+        await _set_sort_mode(db, org, "newest")
+        assert await self._item_names(db, folder, admin_user, mock_request) == [
+            "Alpha", "Zeta",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_position_breaks_ties_between_equal_names(
+        self, db, org, admin_user, mock_request
+    ):
+        """Same display name -> the admin's drag order still decides."""
+        folder = await _mk_folder(db, org, "Content")
+        for uuid in ("course_same_1", "course_same_2"):
+            db.add(
+                Course(
+                    name="Same",
+                    description="",
+                    public=True,
+                    published=True,
+                    open_to_contributors=False,
+                    org_id=org.id,
+                    course_uuid=uuid,
+                    creation_date=str(datetime.now()),
+                    update_date=str(datetime.now()),
+                )
+            )
+        await db.commit()
+        await _mk_content(db, org, folder, "course_same_2", 0)
+        await _mk_content(db, org, folder, "course_same_1", 1)
+        await _set_sort_mode(db, org, "name_asc")
+        with patch(
+            "src.services.folders.folders.check_resource_access",
+            new_callable=AsyncMock,
+        ):
+            read = await get_folder(mock_request, folder.folder_uuid, admin_user, db)
+        assert [i.resource_uuid for i in read.items] == [
+            "course_same_2",
+            "course_same_1",
+        ]
+
+
+class TestOrgRootItemsSortModes:
+    """The library-root listing had no sort-mode lookup at all — it must order
+    its items by the same mode as everything else."""
+
+    async def _seed_root(self, db, org):
+        base = datetime(2020, 1, 1, 12, 0, 0)
+        await _mk_course(db, org, "Zeta", creation_date=str(base))
+        await _mk_course(db, org, "Alpha", creation_date=str(base + timedelta(days=1)))
+        await _mk_course(db, org, "Mango", creation_date=str(base + timedelta(days=2)))
+        # Drag order at the root: Mango, Zeta, Alpha
+        await _mk_content(db, org, None, "course_Mango", 0)
+        await _mk_content(db, org, None, "course_Zeta", 1)
+        await _mk_content(db, org, None, "course_Alpha", 2)
+
+    async def _root_names(self, db, org, admin_user, mock_request):
+        items = await get_org_root_items(mock_request, str(org.id), admin_user, db)
+        return [i.resource["name"] for i in items]
+
+    @pytest.mark.asyncio
+    async def test_root_items_sorted_name_asc(self, db, org, admin_user, mock_request):
+        await self._seed_root(db, org)
+        await _set_sort_mode(db, org, "name_asc")
+        names = await self._root_names(db, org, admin_user, mock_request)
+        assert names == ["Alpha", "Mango", "Zeta"]
+
+    @pytest.mark.asyncio
+    async def test_root_items_sorted_newest(self, db, org, admin_user, mock_request):
+        await self._seed_root(db, org)
+        await _set_sort_mode(db, org, "newest")
+        names = await self._root_names(db, org, admin_user, mock_request)
+        assert names == ["Mango", "Alpha", "Zeta"]
+
+    @pytest.mark.asyncio
+    async def test_root_items_manual_keeps_drag_positions(
+        self, db, org, admin_user, mock_request
+    ):
+        await self._seed_root(db, org)
+        await _set_sort_mode(db, org, "manual")
+        names = await self._root_names(db, org, admin_user, mock_request)
+        assert names == ["Mango", "Zeta", "Alpha"]

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/library/LibraryClient.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/library/LibraryClient.tsx
@@ -9,6 +9,8 @@ import FeatureGate from '@components/Dashboard/Shared/FeatureGate/FeatureGate'
 import { useOrg } from '@components/Contexts/OrgContext'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
 import { queryKeys } from '@/lib/query/keys'
+import { sortLibrary } from '@lib/library/sort'
+import { type FolderSortMode } from '@components/Dashboard/Library/FolderSortDropdown'
 import { getOrgFolders, getOrgRootItems } from '@services/folders/folders'
 import { FolderSimple } from '@phosphor-icons/react'
 import { FolderCard, LibraryItemCard } from './library-cards'
@@ -34,8 +36,17 @@ function LibraryClient({ orgslug }: { orgslug: string }) {
 
   // Folders are a transparent, optional layer: a fetch failure must degrade to
   // an empty state rather than blanking the page or blocking course discovery.
-  const folders = Array.isArray(data) ? data : []
-  const rootItems = Array.isArray(rootItemsData) ? rootItemsData : []
+  // Same org-level sort mode the dashboard reads, so learners see the library in
+  // the exact order an admin arranged it in. Until the org config is actually
+  // here, 'manual' trusts the API order rather than assuming A→Z.
+  const sortMode: FolderSortMode = org
+    ? org?.config?.config?.general?.folders?.sort_mode ?? 'name_asc'
+    : 'manual'
+  const { folders, items: rootItems } = sortLibrary(
+    Array.isArray(data) ? data : [],
+    Array.isArray(rootItemsData) ? rootItemsData : [],
+    sortMode
+  )
 
   useTrackView(
     AnalyticsEvent.LibraryViewed,

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/library/folder/[folderid]/FolderClient.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/library/folder/[folderid]/FolderClient.tsx
@@ -7,7 +7,10 @@ import GeneralWrapperStyled from '@components/Objects/StyledElements/Wrappers/Ge
 import FeatureGate from '@components/Dashboard/Shared/FeatureGate/FeatureGate'
 import { Breadcrumbs } from '@components/Objects/Breadcrumbs/Breadcrumbs'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
+import { useOrg } from '@components/Contexts/OrgContext'
 import { queryKeys } from '@/lib/query/keys'
+import { sortLibrary } from '@lib/library/sort'
+import { type FolderSortMode } from '@components/Dashboard/Library/FolderSortDropdown'
 import { getFolderById, removeFolderPrefix } from '@services/folders/folders'
 import { getUriWithOrg } from '@services/config/config'
 import { shareFolderLink } from '@components/Dashboard/Library/shareFolder'
@@ -24,8 +27,18 @@ function FolderClient({
 }) {
   const { t } = useTranslation()
   const session = useLHSession() as any
+  const org = useOrg() as any
   const access_token = session?.data?.tokens?.access_token
   const folderUuid = `folder_${folderid}`
+
+  // Same org-level sort mode the dashboard reads, so learners see the folder in
+  // the exact order an admin arranged it in. The folder query is independent of
+  // the org query, so the content can arrive first — until the org config is
+  // actually here, 'manual' keeps the (already correctly sorted) API order
+  // instead of flashing A→Z or destroying a manual-mode drag order.
+  const sortMode: FolderSortMode = org
+    ? org?.config?.config?.general?.folders?.sort_mode ?? 'name_asc'
+    : 'manual'
 
   const { data: folder, isLoading } = useQuery({
     queryKey: queryKeys.folders.detail(folderUuid),
@@ -58,8 +71,11 @@ function FolderClient({
     )
   }
 
-  const subfolders = folder?.subfolders || []
-  const items = folder?.items || []
+  const { folders: subfolders, items } = sortLibrary(
+    folder?.subfolders || [],
+    folder?.items || [],
+    sortMode
+  )
   const breadcrumbs = folder?.breadcrumbs || []
   const isEmpty = subfolders.length === 0 && items.length === 0
 

--- a/apps/web/components/Dashboard/Library/LibraryHeader.tsx
+++ b/apps/web/components/Dashboard/Library/LibraryHeader.tsx
@@ -122,41 +122,10 @@ export default function LibraryHeader({
   )
 }
 
-// Name/date accessors that work for both folders and content items (courses,
-// media, …). Items carry their display fields under `.resource`.
-const _nameOf = (x: any) =>
-  (x?.name ?? x?.resource?.name ?? x?.resource?.title ?? x?.title ?? '').toString().toLowerCase()
-const _dateOf = (x: any) => {
-  const raw =
-    x?.creation_date ?? x?.created_at ?? x?.update_date ??
-    x?.resource?.update_date ?? x?.resource?.creation_date ?? x?.resource?.created_at ?? ''
-  const t = raw ? Date.parse(raw) : NaN
-  return Number.isNaN(t) ? 0 : t
-}
-
-/**
- * Apply the selected sort mode to the visible library content, CLIENT-SIDE, so
- * it reorders folders AND items (courses/media) instantly and consistently.
- *
- * 'manual' is intentionally a no-op here: folders already arrive ordered by their
- * persisted `order` from the server, and drag-reordering mutates the array in
- * place — re-sorting by the (optimistically stale) `order` field would fight the
- * drag. So manual mode trusts the incoming order.
- */
-export function sortLibrary(folders: any[], items: any[], mode: FolderSortMode) {
-  if (mode === 'manual') return { folders, items }
-  const byName = (a: any, b: any) => _nameOf(a).localeCompare(_nameOf(b))
-  const cmp = (a: any, b: any) => {
-    switch (mode) {
-      case 'name_desc': return byName(b, a)
-      case 'newest': return _dateOf(b) - _dateOf(a) || byName(a, b)
-      case 'oldest': return _dateOf(a) - _dateOf(b) || byName(a, b)
-      case 'name_asc':
-      default: return byName(a, b)
-    }
-  }
-  return { folders: [...folders].sort(cmp), items: [...items].sort(cmp) }
-}
+// The sort comparator lives in @lib/library/sort so the public learner views can
+// reuse it without importing this (client, i18n-bound) component. Re-exported
+// here so existing dashboard imports keep working.
+export { sortLibrary } from '@lib/library/sort'
 
 // Shared client-side filtering used by both root and folder views.
 const _RESOURCE_TYPES = ['podcasts', 'communities', 'boards', 'playgrounds']

--- a/apps/web/components/Hooks/useCourseCertification.tsx
+++ b/apps/web/components/Hooks/useCourseCertification.tsx
@@ -1,0 +1,51 @@
+'use client'
+import { useQuery } from '@tanstack/react-query'
+import { queryKeys } from '@/lib/query/keys'
+import { useOrg } from '@components/Contexts/OrgContext'
+import { useLHSession } from '@components/Contexts/LHSessionContext'
+import { getCourseCertifications } from '@services/courses/certifications'
+import { getCourseCertificationStatus } from '@/lib/certifications/enabled'
+import type { CourseCertificationStatus } from '@/lib/certifications/enabled'
+
+/**
+ * Does this course award a certificate?
+ *
+ * Learner-facing surfaces use this to avoid promising a certificate the course
+ * never had. Only `isEnabled === false && isUnknown === false` means "no
+ * certification" — while the answer is loading or the request failed, callers
+ * must keep showing whatever they show today.
+ */
+export function useCourseCertification(course_uuid?: string) {
+  const org = useOrg() as any
+  const session = useLHSession() as any
+  const access_token = session?.data?.tokens?.access_token
+
+  // Call sites pass the uuid with or without the `course_` prefix; the API and
+  // the dashboard's cache entry both use the prefixed form.
+  const prefixed_uuid = course_uuid
+    ? `course_${course_uuid.replace('course_', '')}`
+    : ''
+
+  // Wait for the session before asking: an anonymous request on a private
+  // course gets a 403, which would cache an 'unknown' answer for the whole
+  // staleTime even though the user is signed in.
+  const isSessionReady = session?.status !== 'loading'
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: queryKeys.certifications.byCourse(prefixed_uuid),
+    queryFn: () =>
+      getCourseCertifications(prefixed_uuid, org.id, null, access_token),
+    enabled: !!prefixed_uuid && !!org?.id && isSessionReady,
+    staleTime: 60_000,
+  })
+
+  const status: CourseCertificationStatus = getCourseCertificationStatus(data)
+
+  return {
+    status,
+    isEnabled: status === 'enabled',
+    isUnknown: status === 'unknown',
+    isLoading,
+    error,
+  }
+}

--- a/apps/web/components/Pages/Activity/CourseEndView.tsx
+++ b/apps/web/components/Pages/Activity/CourseEndView.tsx
@@ -10,6 +10,7 @@ import { useWindowSize } from 'usehooks-ts';
 import { useOrg } from '@components/Contexts/OrgContext';
 import { useLHSession } from '@components/Contexts/LHSessionContext';
 import { getUserCertificates } from '@services/courses/certifications';
+import { useCourseCertification } from '@components/Hooks/useCourseCertification';
 import CertificatePreview from '@components/Dashboard/Pages/Course/EditCourseCertification/CertificatePreview';
 import {
   downloadCertificateNodeAsPdf,
@@ -46,6 +47,17 @@ const CourseEndView: React.FC<CourseEndViewProps> = ({
   // The visible copy is fluid (max-w-2xl and narrower on mobile), so capturing
   // it directly would make the exported file depend on the viewer's screen.
   const certificateCaptureRef = useRef<HTMLDivElement>(null);
+
+  // Certificate copy is hidden only when this course definitively has no
+  // certification. While the answer is loading — or if the request failed —
+  // we keep the certificate UI, so a blip never tells a certified course's
+  // students that no certificate is coming.
+  const {
+    isEnabled: certificationEnabled,
+    isUnknown: certificationUnknown,
+    isLoading: isLoadingCertificationStatus,
+  } = useCourseCertification(courseUuid);
+  const showCertificateUI = certificationEnabled || certificationUnknown;
 
   // Recipient's display name for the certificate (full name -> username ->
   // session user). Empty when unknown so the "Presented to" line is skipped.
@@ -104,6 +116,10 @@ const CourseEndView: React.FC<CourseEndViewProps> = ({
     const fetchUserCertificate = async () => {
       if (!isCourseCompleted) return;
 
+      // Nothing to fetch until we know the course certifies at all, and
+      // nothing to fetch ever if it does not.
+      if (isLoadingCertificationStatus || !showCertificateUI) return;
+
       if (!session?.data?.tokens?.access_token) {
         setCertificateError(t('auth.authenticate_to_contribute')); // Reusing an auth error key
         return;
@@ -137,7 +153,7 @@ const CourseEndView: React.FC<CourseEndViewProps> = ({
     };
 
     fetchUserCertificate();
-  }, [isCourseCompleted, courseUuid, session?.data?.tokens?.access_token, org?.id]);
+  }, [isCourseCompleted, courseUuid, session?.data?.tokens?.access_token, org?.id, isLoadingCertificationStatus, showCertificateUI]);
 
   // Generate the PDF from the SAME <CertificatePreview> the learner sees.
   //
@@ -270,7 +286,10 @@ const CourseEndView: React.FC<CourseEndViewProps> = ({
             {t('certificate.dedication_message')}
           </p>
 
-          {isLoadingCertificate ? (
+          {/* Courses without certification skip this block entirely — no
+              spinner, no "no certificate" box for something never offered. */}
+          {showCertificateUI && (
+            isLoadingCertificate || isLoadingCertificationStatus ? (
             <div className="flex items-center justify-center py-8">
               <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
               <span className="ms-3 text-gray-600">{t('certificate.loading_certificate')}</span>
@@ -327,6 +346,7 @@ const CourseEndView: React.FC<CourseEndViewProps> = ({
                 {t('certificate.no_certificate_available')}
               </p>
             </div>
+            )
           )}
 
           <div className="pt-6">
@@ -401,7 +421,9 @@ const CourseEndView: React.FC<CourseEndViewProps> = ({
           )}
           
           <p className="text-gray-500">
-            {t('courses.keep_going_description')}
+            {showCertificateUI
+              ? t('courses.keep_going_description')
+              : t('courses.keep_going_description_no_certificate')}
           </p>
 
           <div className="pt-6">

--- a/apps/web/components/Pages/Courses/ActivityIndicators.tsx
+++ b/apps/web/components/Pages/Courses/ActivityIndicators.tsx
@@ -7,6 +7,7 @@ import { getUriWithOrg } from '@services/config/config'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useTranslation } from 'react-i18next'
+import { useCourseCertification } from '@components/Hooks/useCourseCertification'
 
 interface Props {
   course: any
@@ -305,6 +306,13 @@ function ActivityIndicators(props: Props) {
   const enableNavigation = props.enableNavigation || false
   const router = useRouter()
 
+  // The trophy promises a certificate, so it only makes sense on a course that
+  // actually has certification. A definitive "no certification" hides it; a
+  // pending or failed lookup leaves it as it is today.
+  const { isEnabled: certificationEnabled, isUnknown: certificationUnknown } =
+    useCourseCertification(props.course_uuid)
+  const showCertificationBadge = certificationEnabled || certificationUnknown
+
   const done_activity_style = 'bg-teal-500 hover:bg-teal-600'
   const black_activity_style = 'bg-zinc-200/80 hover:bg-zinc-300'
   const current_activity_style = 'bg-gray-500 animate-pulse hover:bg-gray-600'
@@ -460,11 +468,13 @@ function ActivityIndicators(props: Props) {
           </div>
         </div>
 
-        <CertificationBadge
-          courseid={courseid}
-          orgslug={orgslug}
-          isCompleted={isCourseCompleted}
-        />
+        {showCertificationBadge && (
+          <CertificationBadge
+            courseid={courseid}
+            orgslug={orgslug}
+            isCompleted={isCourseCompleted}
+          />
+        )}
 
         {enableNavigation && (
           <button
@@ -583,11 +593,13 @@ function ActivityIndicators(props: Props) {
           })}
 
           {/* Certification Badge */}
-          <CertificationBadge
-            courseid={courseid}
-            orgslug={orgslug}
-            isCompleted={isCourseCompleted}
-          />
+          {showCertificationBadge && (
+            <CertificationBadge
+              courseid={courseid}
+              orgslug={orgslug}
+              isCompleted={isCourseCompleted}
+            />
+          )}
         </div>
 
         {enableNavigation && (

--- a/apps/web/components/Pages/Trail/TrailCourseCard.tsx
+++ b/apps/web/components/Pages/Trail/TrailCourseCard.tsx
@@ -7,6 +7,7 @@ import { getCourseThumbnailMediaDirectory } from '@services/media/media'
 import { revalidateTags } from '@services/utils/ts/requests'
 import { useLHSession } from '@components/Contexts/LHSessionContext'
 import { getUserCertificates } from '@services/courses/certifications'
+import { useCourseCertification } from '@components/Hooks/useCourseCertification'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
@@ -47,6 +48,19 @@ function TrailCourseCard(props: TrailCourseCardProps) {
   const [isLoadingCertificate, setIsLoadingCertificate] = useState(false)
   const queryClient = useQueryClient()
 
+  // Only a definitive "this course has no certification" hides the certificate
+  // row; a pending or failed lookup keeps the existing behaviour. Asked for only
+  // at 100% — that is the only progress where anything below consumes it, and a
+  // trail of N unfinished courses must not fire N certification requests.
+  const {
+    isEnabled: certificationEnabled,
+    isUnknown: certificationUnknown,
+    isLoading: isLoadingCertificationStatus,
+  } = useCourseCertification(
+    course_progress === 100 ? props.course.course_uuid : undefined
+  )
+  const showCertificateUI = certificationEnabled || certificationUnknown
+
   const handleMouseEnter = () => {
     queryClient.prefetchQuery({
       queryKey: queryKeys.courses.meta(courseid),
@@ -67,6 +81,7 @@ function TrailCourseCard(props: TrailCourseCardProps) {
   useEffect(() => {
     const fetchCourseCertificate = async () => {
       if (!access_token || course_progress < 100 || !org?.id) return;
+      if (isLoadingCertificationStatus || !showCertificateUI) return;
 
       setIsLoadingCertificate(true);
       try {
@@ -87,7 +102,7 @@ function TrailCourseCard(props: TrailCourseCardProps) {
     };
 
     fetchCourseCertificate();
-  }, [access_token, course_progress, props.course.course_uuid, org?.id]);
+  }, [access_token, course_progress, props.course.course_uuid, org?.id, isLoadingCertificationStatus, showCertificateUI]);
 
   useEffect(() => { }, [props.course, org])
 
@@ -172,12 +187,12 @@ function TrailCourseCard(props: TrailCourseCardProps) {
         <div className="pt-1.5 flex items-center justify-between border-t border-gray-100">
           {/* Certificate or Progress indicator */}
           {course_progress === 100 ? (
-            isLoadingCertificate ? (
+            showCertificateUI && (isLoadingCertificate || isLoadingCertificationStatus) ? (
               <div className="flex items-center gap-1.5 text-gray-400">
                 <div className="animate-spin rounded-full h-3 w-3 border-b-2 border-yellow-500"></div>
                 <span className="text-[10px] font-bold uppercase tracking-wider">{t('common.loading')}</span>
               </div>
-            ) : courseCertificate ? (
+            ) : showCertificateUI && courseCertificate ? (
               <div className="flex items-center gap-1.5 text-yellow-600">
                 <Award size={12} />
                 <span className="text-[10px] font-bold uppercase tracking-wider">{t('certificate.certificate')}</span>
@@ -195,7 +210,7 @@ function TrailCourseCard(props: TrailCourseCardProps) {
             </div>
           )}
 
-          {course_progress === 100 && courseCertificate ? (
+          {course_progress === 100 && showCertificateUI && courseCertificate ? (
             <Link
               href={getUriWithOrg(props.orgslug, `/certificates/${courseCertificate.certificate_user.user_certification_uuid}/verify`)}
               target="_blank"

--- a/apps/web/lib/certifications/enabled.ts
+++ b/apps/web/lib/certifications/enabled.ts
@@ -1,0 +1,31 @@
+/**
+ * Whether a course actually hands out a certificate.
+ *
+ * A course has certification ON when a Certifications row exists for it and
+ * OFF when it does not — the dashboard toggle creates and deletes that row.
+ * `getCourseCertifications()` goes through `getResponseMetadata`, which returns
+ * `{ success, data, status }` and swallows parse errors, so a failed request
+ * looks like a successful one with a non-list `data` (an error body) or
+ * `success: false`. Those cases are NOT "no certification": they are "we don't
+ * know yet", and the learner UI must keep its certificate copy rather than
+ * telling a certified course's students that nothing is coming.
+ */
+
+export type CourseCertificationStatus = 'enabled' | 'disabled' | 'unknown'
+
+export type CourseCertificationsResponse =
+  | {
+      success?: boolean
+      data?: any
+      status?: number
+    }
+  | null
+  | undefined
+
+export function getCourseCertificationStatus(
+  response: CourseCertificationsResponse
+): CourseCertificationStatus {
+  if (!response || response.success !== true) return 'unknown'
+  if (!Array.isArray(response.data)) return 'unknown'
+  return response.data.length > 0 ? 'enabled' : 'disabled'
+}

--- a/apps/web/lib/library/sort.ts
+++ b/apps/web/lib/library/sort.ts
@@ -1,0 +1,49 @@
+import type { FolderSortMode } from '@components/Dashboard/Library/FolderSortDropdown'
+
+/*
+ The library sort comparator, shared by the dashboard views and the public
+ learner views so both render a folder's subfolders and content in the exact
+ same order the org's sort_mode describes. Framework-free on purpose: no React,
+ no i18n, nothing but the arrays it is handed.
+*/
+
+// Name/date accessors that work for both folders and content items (courses,
+// media, …). Items carry their display fields under `.resource`.
+export const _nameOf = (x: any) =>
+  (x?.name ?? x?.resource?.name ?? x?.resource?.title ?? x?.title ?? '').toString().toLowerCase()
+// 'newest'/'oldest' mean CREATION date, the same field the API sorts folders by
+// (Folder.creation_date) and items by (_item_date in services/folders/folders.py).
+// `update_date` is only a last resort: an item has no top-level date fields, so
+// preferring it would silently re-sort every edited course away from the API order.
+export const _dateOf = (x: any) => {
+  const raw =
+    x?.creation_date ?? x?.created_at ??
+    x?.resource?.creation_date ?? x?.resource?.created_at ??
+    x?.update_date ?? x?.resource?.update_date ?? ''
+  const t = raw ? Date.parse(raw) : NaN
+  return Number.isNaN(t) ? 0 : t
+}
+
+/**
+ * Apply the selected sort mode to the visible library content, CLIENT-SIDE, so
+ * it reorders folders AND items (courses/media) instantly and consistently.
+ *
+ * 'manual' is intentionally a no-op here: folders already arrive ordered by their
+ * persisted `order` from the server, and drag-reordering mutates the array in
+ * place — re-sorting by the (optimistically stale) `order` field would fight the
+ * drag. So manual mode trusts the incoming order.
+ */
+export function sortLibrary(folders: any[], items: any[], mode: FolderSortMode) {
+  if (mode === 'manual') return { folders, items }
+  const byName = (a: any, b: any) => _nameOf(a).localeCompare(_nameOf(b))
+  const cmp = (a: any, b: any) => {
+    switch (mode) {
+      case 'name_desc': return byName(b, a)
+      case 'newest': return _dateOf(b) - _dateOf(a) || byName(a, b)
+      case 'oldest': return _dateOf(a) - _dateOf(b) || byName(a, b)
+      case 'name_asc':
+      default: return byName(a, b)
+    }
+  }
+  return { folders: [...folders].sort(cmp), items: [...items].sort(cmp) }
+}

--- a/apps/web/locales/ar.json
+++ b/apps/web/locales/ar.json
@@ -526,6 +526,7 @@
     "successfully_completed": "لقد أكملت بنجاح",
     "keep_going": "استمر في العمل الجيد! 💪",
     "keep_going_description": "أنت تبلي بلاءً حسناً! أكمل الأنشطة المتبقية للحصول على شهادة الإكمال.",
+    "keep_going_description_no_certificate": "أنت تبلي بلاءً حسناً! أكمل الأنشطة المتبقية لإنهاء الدورة.",
     "making_great_progress": "أنت تحرز تقدماً رائعاً في",
     "continue_learning": "مواصلة التعلم",
     "back_to_course": "العودة للدورة",

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -524,6 +524,7 @@
     "successfully_completed": "You've successfully completed",
     "keep_going": "Keep Going! 💪",
     "keep_going_description": "You're doing great! Complete the remaining activities to unlock your course completion certificate.",
+    "keep_going_description_no_certificate": "You're doing great! Complete the remaining activities to finish the course.",
     "making_great_progress": "You're making great progress in",
     "continue_learning": "Continue Learning",
     "back_to_course": "Back to Course",

--- a/apps/web/tests/certification-enabled.test.mjs
+++ b/apps/web/tests/certification-enabled.test.mjs
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getCourseCertificationStatus,
+} from "../lib/certifications/enabled.ts";
+
+describe("getCourseCertificationStatus", () => {
+  test("reports enabled when the course has a certification row", () => {
+    expect(
+      getCourseCertificationStatus({
+        success: true,
+        status: 200,
+        data: [{ certification_uuid: "certification_1", config: {} }],
+      })
+    ).toBe("enabled");
+  });
+
+  test("reports disabled when the course has no certification row", () => {
+    expect(
+      getCourseCertificationStatus({ success: true, status: 200, data: [] })
+    ).toBe("disabled");
+  });
+
+  test("reports unknown when the request failed", () => {
+    expect(
+      getCourseCertificationStatus({
+        success: false,
+        status: 403,
+        data: { detail: "Forbidden" },
+      })
+    ).toBe("unknown");
+  });
+
+  test("reports unknown when a 200 carries something other than a list", () => {
+    expect(
+      getCourseCertificationStatus({ success: true, status: 200, data: null })
+    ).toBe("unknown");
+  });
+
+  test("reports unknown when there is no answer yet", () => {
+    expect(getCourseCertificationStatus(undefined)).toBe("unknown");
+    expect(getCourseCertificationStatus(null)).toBe("unknown");
+  });
+});

--- a/apps/web/tests/library-sort.test.mjs
+++ b/apps/web/tests/library-sort.test.mjs
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+
+import { sortLibrary } from "../lib/library/sort.ts";
+
+// Content items carry their display fields under `.resource` — courses expose
+// `name`, some resources only a `title`.
+const item = (resource_uuid, resource) => ({ resource_uuid, resource });
+const names = (list) => list.map((x) => x.name ?? x.resource?.name ?? x.resource?.title);
+
+describe("sortLibrary", () => {
+  test("name_asc sorts folders and items alphabetically", () => {
+    const folders = [{ name: "Zeta" }, { name: "Alpha" }, { name: "Mango" }];
+    const items = [
+      item("course_z", { name: "Zebra course" }),
+      item("media_a", { title: "Anatomy slides" }),
+      item("course_m", { name: "Mango course" }),
+    ];
+
+    const sorted = sortLibrary(folders, items, "name_asc");
+
+    expect(names(sorted.folders)).toEqual(["Alpha", "Mango", "Zeta"]);
+    expect(names(sorted.items)).toEqual([
+      "Anatomy slides",
+      "Mango course",
+      "Zebra course",
+    ]);
+  });
+
+  test("name_asc is the default for an unknown mode", () => {
+    const items = [item("course_b", { name: "B" }), item("course_a", { name: "A" })];
+    expect(names(sortLibrary([], items, "wat").items)).toEqual(["A", "B"]);
+  });
+
+  test("name_desc reverses the alphabetical order", () => {
+    const folders = [{ name: "Alpha" }, { name: "Zeta" }];
+    const items = [
+      item("media_a", { title: "Anatomy slides" }),
+      item("course_z", { name: "Zebra course" }),
+    ];
+
+    const sorted = sortLibrary(folders, items, "name_desc");
+
+    expect(names(sorted.folders)).toEqual(["Zeta", "Alpha"]);
+    expect(names(sorted.items)).toEqual(["Zebra course", "Anatomy slides"]);
+  });
+
+  test("name sorting is case-insensitive across name and title fields", () => {
+    const items = [
+      item("course_c", { name: "cherry" }),
+      item("media_b", { title: "Banana" }),
+      item("course_a", { name: "Apple" }),
+    ];
+    expect(names(sortLibrary([], items, "name_asc").items)).toEqual([
+      "Apple",
+      "Banana",
+      "cherry",
+    ]);
+  });
+
+  test("newest puts the most recently created first", () => {
+    const items = [
+      item("course_old", { name: "Old", creation_date: "2020-01-01T12:00:00Z" }),
+      item("course_new", { name: "New", creation_date: "2024-06-01T12:00:00Z" }),
+      item("course_mid", { name: "Mid", creation_date: "2022-03-01T12:00:00Z" }),
+    ];
+    expect(names(sortLibrary([], items, "newest").items)).toEqual([
+      "New",
+      "Mid",
+      "Old",
+    ]);
+  });
+
+  test("oldest puts the earliest created first", () => {
+    const folders = [
+      { name: "New", creation_date: "2024-06-01T12:00:00Z" },
+      { name: "Old", creation_date: "2020-01-01T12:00:00Z" },
+    ];
+    expect(names(sortLibrary(folders, [], "oldest").folders)).toEqual([
+      "Old",
+      "New",
+    ]);
+  });
+
+  test("newest uses the resource's creation date, not its last update", () => {
+    // The real API payload: every course row carries BOTH dates, and editing a
+    // course bumps update_date only. Preferring update_date here would put the
+    // browser in permanent disagreement with the API's own newest/oldest order.
+    const items = [
+      item("course_old", {
+        name: "Old",
+        creation_date: "2020-01-01T12:00:00Z",
+        update_date: "2024-12-01T12:00:00Z", // edited yesterday, still the oldest
+      }),
+      item("course_new", {
+        name: "New",
+        creation_date: "2024-06-01T12:00:00Z",
+        update_date: "2024-06-02T12:00:00Z",
+      }),
+      item("course_mid", {
+        name: "Mid",
+        creation_date: "2022-03-01T12:00:00Z",
+        update_date: "2022-03-02T12:00:00Z",
+      }),
+    ];
+
+    expect(names(sortLibrary([], items, "newest").items)).toEqual([
+      "New",
+      "Mid",
+      "Old",
+    ]);
+    expect(names(sortLibrary([], items, "oldest").items)).toEqual([
+      "Old",
+      "Mid",
+      "New",
+    ]);
+  });
+
+  test("update_date is only used when no creation date exists", () => {
+    const items = [
+      item("media_b", { title: "B", update_date: "2024-06-01T12:00:00Z" }),
+      item("media_a", { title: "A", update_date: "2020-01-01T12:00:00Z" }),
+    ];
+    expect(names(sortLibrary([], items, "newest").items)).toEqual(["B", "A"]);
+  });
+
+  test("date sorting falls back to name when timestamps tie", () => {
+    const items = [
+      item("course_b", { name: "Bravo", creation_date: "2024-06-01T12:00:00Z" }),
+      item("course_a", { name: "Alpha", creation_date: "2024-06-01T12:00:00Z" }),
+    ];
+    expect(names(sortLibrary([], items, "newest").items)).toEqual([
+      "Alpha",
+      "Bravo",
+    ]);
+  });
+
+  test("manual returns the input arrays untouched", () => {
+    const folders = [{ name: "Zeta" }, { name: "Alpha" }];
+    const items = [item("course_z", { name: "Zebra" }), item("course_a", { name: "Apple" })];
+
+    const sorted = sortLibrary(folders, items, "manual");
+
+    // Same order AND the same array references — the drag order is trusted.
+    expect(sorted.folders).toBe(folders);
+    expect(sorted.items).toBe(items);
+    expect(names(sorted.folders)).toEqual(["Zeta", "Alpha"]);
+    expect(names(sorted.items)).toEqual(["Zebra", "Apple"]);
+  });
+
+  test("sorting does not mutate the arrays it is given", () => {
+    const folders = [{ name: "Zeta" }, { name: "Alpha" }];
+    sortLibrary(folders, [], "name_asc");
+    expect(names(folders)).toEqual(["Zeta", "Alpha"]);
+  });
+
+  test("a numbered module list sorts the way an admin expects", () => {
+    // The real-world case: zero-padded module numbers keep 10 after 09, and the
+    // unnumbered final item lands where its name puts it.
+    const items = [
+      item("course_10", { name: "10 Module — Wrap up" }),
+      item("course_02", { name: "02 Module — Basics" }),
+      item("course_fin", { name: "Final Assessment" }),
+      item("course_01", { name: "01 Module — Intro" }),
+      item("course_09", { name: "09 Module — Review" }),
+    ];
+
+    expect(names(sortLibrary([], items, "name_asc").items)).toEqual([
+      "01 Module — Intro",
+      "02 Module — Basics",
+      "09 Module — Review",
+      "10 Module — Wrap up",
+      "Final Assessment",
+    ]);
+  });
+});


### PR DESCRIPTION
Two unrelated fixes.

Folder order: the public library page could show a different course order than the dashboard. The API sorted a folder's content by `FolderContent.position` only, ignoring the org's `sort_mode` it already applies to folders themselves. Nobody had drag-ordered anything yet, so every position was 0 and order fell back to raw DB row order. The comparator now lives in `apps/web/lib/library/sort.ts`, shared by the dashboard and both public library views (`LibraryHeader` re-exports it, so dashboard imports don't change). Also fixed newest/oldest to key off creation date consistently, since it previously preferred `update_date`, which no API sort uses. Public views now trust server order while org config is loading instead of assuming A-Z.

Certificate copy: the progress screen, trophy badge, and trail card inferred "has a certificate" from the learner's certificate row, not from whether the course has certification enabled. A course with certification off still promised or warned about one. Added a `useCourseCertification` hook; copy is hidden only on a definitive "no certification" answer, so a loading or failed lookup keeps current behavior.

Tests: `library-sort.test.mjs`, `certification-enabled.test.mjs`, new pytest ordering cases.

Verified: ruff/eslint/tsc clean, folders pytest suite and new bun tests pass. Not run: full API suite, manual browser pass.