### PR TITLE
Add H5P embed block for course activities

### DIFF
--- a/apps/api/src/services/ai/rag/content_extraction.py
+++ b/apps/api/src/services/ai/rag/content_extraction.py
@@ -162,6 +162,17 @@ def _walk_prosemirror_node(node: dict, parts: list[str]) -> None:
             parts.append(f"[{node_type}] {texts}")
         return
 
+    # Handle H5P blocks — embed-only, the interactive content lives on the
+    # author's own H5P host, so the author-supplied title is the only text we
+    # have. Handled explicitly so it does not fall through to the generic
+    # recursion, which would yield nothing for this atom node.
+    if node_type == "blockH5P":
+        attrs = node.get("attrs")
+        title = attrs.get("title") if isinstance(attrs, dict) else None
+        if isinstance(title, str) and title.strip():
+            parts.append(f"[H5P interactive content] {title.strip()}")
+        return
+
     # Handle table
     if node_type == "table":
         for row in _child_nodes(node):

--- a/apps/web/components/Objects/Activities/DynamicCanva/DynamicCanva.tsx
+++ b/apps/web/components/Objects/Activities/DynamicCanva/DynamicCanva.tsx
@@ -33,6 +33,7 @@ import VideoBlock from '@components/Objects/Editor/Extensions/Video/VideoBlock'
 import AudioBlock from '@components/Objects/Editor/Extensions/Audio/AudioBlock'
 import MathEquationBlock from '@components/Objects/Editor/Extensions/MathEquation/MathEquationBlock'
 import PDFBlock from '@components/Objects/Editor/Extensions/PDF/PDFBlock'
+import H5PBlock from '@components/Objects/Editor/Extensions/H5P/H5PBlock'
 import LibraryBlock from '@components/Objects/Editor/Extensions/Library/LibraryBlock'
 import QuizBlock from '@components/Objects/Editor/Extensions/Quiz/QuizBlock'
 import MagicBlock from '@components/Objects/Editor/Extensions/MagicBlocks/MagicBlock'
@@ -141,6 +142,10 @@ function Canva(props: Editor) {
       }),
       PDFBlock.configure({
         editable: true,
+        activity: props.activity,
+      }),
+      H5PBlock.configure({
+        editable: isEditable,
         activity: props.activity,
       }),
       LibraryBlock.configure({

--- a/apps/web/components/Objects/Editor/Editor.tsx
+++ b/apps/web/components/Objects/Editor/Editor.tsx
@@ -32,6 +32,7 @@ import AudioBlock from './Extensions/Audio/AudioBlock'
 import { Eye, Monitor, History, AlertTriangle, RefreshCw, Loader2 } from 'lucide-react'
 import MathEquationBlock from './Extensions/MathEquation/MathEquationBlock'
 import PDFBlock from './Extensions/PDF/PDFBlock'
+import H5PBlock from './Extensions/H5P/H5PBlock'
 import LibraryBlock from './Extensions/Library/LibraryBlock'
 import QuizBlock from './Extensions/Quiz/QuizBlock'
 import { Table } from '@tiptap/extension-table'
@@ -174,6 +175,7 @@ function Editor(props: EditorProps) {
       AudioBlock.configure({ editable: true, activity: stableActivity }),
       MathEquationBlock.configure({ editable: true, activity: stableActivity }),
       PDFBlock.configure({ editable: true, activity: stableActivity }),
+      H5PBlock.configure({ editable: true, activity: stableActivity }),
       LibraryBlock.configure({ editable: true, activity: stableActivity }),
       QuizBlock.configure({ editable: true, activity: stableActivity }),
       Youtube.configure({ controls: true, modestBranding: true }),

--- a/apps/web/components/Objects/Editor/EditorPreview.tsx
+++ b/apps/web/components/Objects/Editor/EditorPreview.tsx
@@ -14,6 +14,7 @@ import VideoBlock from './Extensions/Video/VideoBlock'
 import AudioBlock from './Extensions/Audio/AudioBlock'
 import MathEquationBlock from './Extensions/MathEquation/MathEquationBlock'
 import PDFBlock from './Extensions/PDF/PDFBlock'
+import H5PBlock from './Extensions/H5P/H5PBlock'
 import LibraryBlock from './Extensions/Library/LibraryBlock'
 import QuizBlock from './Extensions/Quiz/QuizBlock'
 import { Table } from '@tiptap/extension-table'
@@ -84,6 +85,10 @@ function EditorPreview({ content, activity }: EditorPreviewProps) {
         activity: activity,
       }),
       PDFBlock.configure({
+        editable: false,
+        activity: activity,
+      }),
+      H5PBlock.configure({
         editable: false,
         activity: activity,
       }),

--- a/apps/web/components/Objects/Editor/Extensions/H5P/H5PBlock.ts
+++ b/apps/web/components/Objects/Editor/Extensions/H5P/H5PBlock.ts
@@ -1,0 +1,63 @@
+import { mergeAttributes, Node } from '@tiptap/core'
+import { ReactNodeViewRenderer } from '@tiptap/react'
+import dynamic from 'next/dynamic'
+
+/*
+ H5P interactive content — EMBED ONLY, by design.
+
+ The H5P core (the player, the editor, the content types) is AGPL-licensed, so
+ vendoring it into LearnHouse would put the whole application under the AGPL.
+ We also do not accept, unpack or serve `.h5p` packages: hosting the runtime is
+ the part that carries the licence obligation, and unpacking author-supplied
+ archives is a file-handling risk we have no reason to take.
+
+ So there is no authoring integration here, and there never was one removed.
+ The author creates the content on their own H5P host (H5P.com, Lumi, or a
+ self-hosted Drupal/Moodle/WordPress site), pastes the embed URL, and we render
+ it in a sandboxed iframe. The content — and its licence — stays on their host.
+*/
+
+const H5PBlockComponent = dynamic(() => import('./H5PBlockComponent'), {
+  ssr: false,
+})
+
+export default Node.create({
+  name: 'blockH5P',
+  group: 'block',
+  draggable: true,
+  atom: true,
+
+  addAttributes() {
+    return {
+      h5pUrl: {
+        default: '',
+      },
+      // Kept in sync with the host's H5P.Resizer postMessage, so the frame
+      // opens at roughly the right size next time instead of jumping.
+      height: {
+        default: 400,
+      },
+      // Used for the iframe title attribute (a11y) and as the text this block
+      // contributes to search/RAG indexing.
+      title: {
+        default: '',
+      },
+    }
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'block-h5p',
+      },
+    ]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['block-h5p', mergeAttributes(HTMLAttributes)]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(H5PBlockComponent as any)
+  },
+})

--- a/apps/web/components/Objects/Editor/Extensions/H5P/H5PBlockComponent.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/H5P/H5PBlockComponent.tsx
@@ -1,0 +1,266 @@
+import { NodeViewWrapper } from '@tiptap/react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { PuzzlePiece, Link as LinkIcon, PencilSimple, X, WarningCircle } from '@phosphor-icons/react'
+import { useEditorProvider } from '@components/Contexts/Editor/EditorContext'
+import { useTranslation } from 'react-i18next'
+import { normalizeH5PUrl, type H5PUrlErrorReason } from '@/lib/media/h5pUrl'
+
+// Matches the `height` attribute default on the H5PBlock node.
+const DEFAULT_HEIGHT = 400
+// The host controls the number in the resize message, so clamp it before it
+// reaches a style attribute.
+const MIN_HEIGHT = 120
+const MAX_HEIGHT = 4000
+// Only persist a resize once it has actually moved, so a noisy host does not
+// flood the document with attribute updates.
+const HEIGHT_PERSIST_THRESHOLD = 16
+
+const ERROR_KEYS: Record<H5PUrlErrorReason, string> = {
+  empty: 'editor.blocks.h5p_block.errors.empty',
+  unparseable: 'editor.blocks.h5p_block.errors.unparseable',
+  unsupported_protocol: 'editor.blocks.h5p_block.errors.unsupported_protocol',
+}
+
+function clampHeight(value: number): number {
+  return Math.round(Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, value)))
+}
+
+function H5PBlockComponent(props: any) {
+  const { t } = useTranslation()
+  const editorState = useEditorProvider() as any
+  const isEditable = editorState?.isEditable
+
+  const [h5pUrl, setH5pUrl] = useState<string>(props.node.attrs.h5pUrl || '')
+  const [title, setTitle] = useState<string>(props.node.attrs.title || '')
+  const [frameHeight, setFrameHeight] = useState<number>(
+    clampHeight(Number(props.node.attrs.height) || DEFAULT_HEIGHT)
+  )
+  const [isEditing, setIsEditing] = useState(false)
+  const [urlDraft, setUrlDraft] = useState<string>(props.node.attrs.h5pUrl || '')
+  const [titleDraft, setTitleDraft] = useState<string>(props.node.attrs.title || '')
+  const [error, setError] = useState<string | null>(null)
+
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const persistedHeightRef = useRef<number>(
+    clampHeight(Number(props.node.attrs.height) || DEFAULT_HEIGHT)
+  )
+  // The node-view props object is new on every render; keep the writer in a
+  // ref so the message listener is attached once, not on each render.
+  const updateAttributesRef = useRef(props.updateAttributes)
+  useEffect(() => {
+    updateAttributesRef.current = props.updateAttributes
+  })
+
+  const frameTitle = title || t('editor.blocks.h5p_block.default_title')
+
+  // H5P's standard resizer posts {context:'h5p', action:'resize', scrollHeight}
+  // to the parent window. Anything can postMessage at us, so we only act on a
+  // message whose source is this very iframe, with the exact shape we expect,
+  // and a height we clamp ourselves.
+  useEffect(() => {
+    if (!h5pUrl) return
+
+    const handleMessage = (event: MessageEvent) => {
+      const frame = iframeRef.current
+      if (!frame || !event.source || event.source !== frame.contentWindow) return
+
+      let payload: any = event.data
+      if (typeof payload === 'string') {
+        try {
+          payload = JSON.parse(payload)
+        } catch {
+          return
+        }
+      }
+      if (!payload || typeof payload !== 'object') return
+      if (payload.context !== 'h5p' || payload.action !== 'resize') return
+
+      const raw = Number(payload.scrollHeight)
+      if (!Number.isFinite(raw) || raw <= 0) return
+
+      const next = clampHeight(raw)
+      setFrameHeight(next)
+
+      if (isEditable && Math.abs(next - persistedHeightRef.current) > HEIGHT_PERSIST_THRESHOLD) {
+        persistedHeightRef.current = next
+        updateAttributesRef.current({ height: next })
+      }
+    }
+
+    window.addEventListener('message', handleMessage)
+    return () => window.removeEventListener('message', handleMessage)
+  }, [h5pUrl, isEditable])
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent) => {
+      event.preventDefault()
+      const result = normalizeH5PUrl(urlDraft)
+      if (!result.ok) {
+        setError(t(ERROR_KEYS[result.reason]))
+        return
+      }
+      const nextTitle = titleDraft.trim()
+      setError(null)
+      setH5pUrl(result.url)
+      setTitle(nextTitle)
+      setUrlDraft(result.url)
+      setIsEditing(false)
+      props.updateAttributes({ h5pUrl: result.url, title: nextTitle })
+    },
+    [urlDraft, titleDraft, props, t]
+  )
+
+  const handleRemove = useCallback(() => {
+    setH5pUrl('')
+    setUrlDraft('')
+    setError(null)
+    setIsEditing(false)
+    props.updateAttributes({ h5pUrl: '' })
+  }, [props])
+
+  const handleStartEditing = useCallback(() => {
+    setUrlDraft(h5pUrl)
+    setTitleDraft(title)
+    setError(null)
+    setIsEditing(true)
+  }, [h5pUrl, title])
+
+  const frame = (
+    <iframe
+      ref={iframeRef}
+      src={h5pUrl}
+      title={frameTitle}
+      className="w-full block border-0 rounded-lg bg-white"
+      style={{ height: `${frameHeight}px` }}
+      /*
+        H5P needs allow-same-origin: its own JavaScript reads resources from
+        its own origin. That means the frame is isolated from US, not from
+        itself — it keeps its own cookies and storage. Which is exactly why
+        this block only ever points at an author-supplied URL on someone
+        else's host and carries no LearnHouse credentials of any kind.
+      */
+      sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-presentation"
+      allow="autoplay; fullscreen; encrypted-media; picture-in-picture"
+      allowFullScreen
+      loading="lazy"
+      referrerPolicy="no-referrer-when-downgrade"
+    />
+  )
+
+  // Read-only with nothing configured: stay quiet rather than render a broken
+  // frame at a learner.
+  if (!isEditable && !h5pUrl) {
+    return <NodeViewWrapper className="block-h5p" />
+  }
+
+  if (!isEditable) {
+    return (
+      <NodeViewWrapper className="block-h5p w-full">
+        <div className="w-full rounded-xl overflow-hidden nice-shadow bg-white">{frame}</div>
+      </NodeViewWrapper>
+    )
+  }
+
+  return (
+    <NodeViewWrapper className="block-h5p w-full">
+      <div className="bg-neutral-50 rounded-xl px-5 py-4 transition-all ease-linear">
+        {/* Header */}
+        <div className="flex items-center justify-between gap-2 mb-3">
+          <div className="flex items-center gap-2">
+            <PuzzlePiece weight="duotone" className="text-neutral-400" size={16} />
+            <span className="uppercase tracking-widest text-xs font-bold text-neutral-400">
+              {t('editor.blocks.h5p')}
+            </span>
+          </div>
+          {h5pUrl && !isEditing && (
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={handleStartEditing}
+                className="p-1.5 rounded-md hover:bg-neutral-200 text-neutral-600 transition-colors"
+                title={t('editor.blocks.h5p_block.edit_content')}
+              >
+                <PencilSimple weight="duotone" size={16} />
+              </button>
+              <button
+                type="button"
+                onClick={handleRemove}
+                className="p-1.5 rounded-md hover:bg-neutral-200 text-neutral-600 hover:text-red-500 transition-colors"
+                title={t('editor.blocks.h5p_block.remove_content')}
+              >
+                <X weight="duotone" size={16} />
+              </button>
+            </div>
+          )}
+        </div>
+
+        {h5pUrl && !isEditing ? (
+          <div className="w-full rounded-lg overflow-hidden nice-shadow bg-white">{frame}</div>
+        ) : (
+          <form onSubmit={handleSubmit} className="bg-white rounded-lg nice-shadow p-4">
+            <p className="text-sm text-neutral-600 mb-1">
+              {t('editor.blocks.h5p_block.description')}
+            </p>
+            <p className="text-xs text-neutral-500 mb-4">
+              {t('editor.blocks.h5p_block.hosted_hint')}
+            </p>
+
+            <div className="relative mb-3">
+              <div className="absolute start-3 top-1/2 -translate-y-1/2 text-neutral-500">
+                <LinkIcon weight="duotone" size={16} />
+              </div>
+              <input
+                type="text"
+                value={urlDraft}
+                onChange={(event) => setUrlDraft(event.target.value)}
+                placeholder={t('editor.blocks.h5p_block.url_placeholder')}
+                aria-label={t('editor.blocks.h5p_block.url_label')}
+                className="w-full ps-10 pe-4 py-2.5 bg-neutral-50 border border-neutral-200 rounded-lg focus:ring-2 focus:ring-neutral-400 focus:border-neutral-400 outline-none transition-all text-sm"
+              />
+            </div>
+
+            <input
+              type="text"
+              value={titleDraft}
+              onChange={(event) => setTitleDraft(event.target.value)}
+              placeholder={t('editor.blocks.h5p_block.title_placeholder')}
+              aria-label={t('editor.blocks.h5p_block.title_label')}
+              className="w-full px-4 py-2.5 mb-3 bg-neutral-50 border border-neutral-200 rounded-lg focus:ring-2 focus:ring-neutral-400 focus:border-neutral-400 outline-none transition-all text-sm"
+            />
+
+            {error && (
+              <div className="mb-3 flex items-center gap-2 text-sm text-red-500 font-medium bg-red-50 rounded-lg p-3">
+                <WarningCircle weight="duotone" size={16} />
+                {error}
+              </div>
+            )}
+
+            <div className="flex justify-end gap-2">
+              {h5pUrl && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setIsEditing(false)
+                    setError(null)
+                  }}
+                  className="px-4 py-2 text-sm text-neutral-600 hover:text-neutral-800 rounded-lg transition-colors"
+                >
+                  {t('editor.blocks.common.cancel')}
+                </button>
+              )}
+              <button
+                type="submit"
+                disabled={!urlDraft.trim()}
+                className="px-4 py-2 bg-neutral-700 hover:bg-neutral-800 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
+              >
+                {t('editor.blocks.common.apply')}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </NodeViewWrapper>
+  )
+}
+
+export default H5PBlockComponent

--- a/apps/web/components/Objects/Editor/Extensions/SlashCommands/slashCommandsConfig.tsx
+++ b/apps/web/components/Objects/Editor/Extensions/SlashCommands/slashCommandsConfig.tsx
@@ -21,6 +21,7 @@ import {
   ListOrdered,
   MousePointerClick,
   Pilcrow,
+  Puzzle,
   RotateCw,
   Sigma,
   Table,
@@ -256,6 +257,17 @@ export const slashCommands: SlashCommandItem[] = [
     keywords: ['quiz', 'question', 'test', 'interactive'],
     command: (editor) => {
       editor.chain().focus().insertContent({ type: 'blockQuiz' }).run()
+    },
+  },
+  {
+    id: 'h5p',
+    title: 'H5P',
+    description: 'Embed interactive H5P content by URL',
+    icon: <Puzzle size={18} />,
+    category: 'interactive',
+    keywords: ['h5p', 'interactive', 'embed', 'lumi', 'moodle', 'hvp', 'activity'],
+    command: (editor) => {
+      editor.chain().focus().insertContent({ type: 'blockH5P' }).run()
     },
   },
   {

--- a/apps/web/components/Objects/Editor/editorPreload.ts
+++ b/apps/web/components/Objects/Editor/editorPreload.ts
@@ -9,6 +9,7 @@ const COMPONENT_LOADERS: Record<string, () => Promise<unknown>> = {
   blockMathEquation: () =>
     import('./Extensions/MathEquation/MathEquationBlockComponent'),
   blockPDF: () => import('./Extensions/PDF/PDFBlockComponent'),
+  blockH5P: () => import('./Extensions/H5P/H5PBlockComponent'),
   blockLibrary: () => import('./Extensions/Library/LibraryBlockComponent'),
   blockQuiz: () => import('./Extensions/Quiz/QuizBlockComponent'),
   blockEmbed: () => import('./Extensions/EmbedObjects/EmbedObjectsComponent'),

--- a/apps/web/lib/media/h5pUrl.ts
+++ b/apps/web/lib/media/h5pUrl.ts
@@ -1,0 +1,137 @@
+/*
+ Normalize a pasted H5P embed URL.
+
+ We never host H5P ourselves (see the comment on the blockH5P extension), so
+ whatever the author pastes has to be turned into something an <iframe> can
+ load as-is. Hosts hand out a few different shapes: a content page URL, a
+ ready-made embed URL, or a whole <iframe> snippet.
+
+ There is deliberately NO host allowlist — self-hosted H5P (Drupal, Moodle,
+ WordPress) is the common case and an allowlist would break every one of them.
+ The only hard rule is the scheme: http/https, so `javascript:`, `data:` and
+ `file:` can never reach the iframe src.
+
+ Pure functions, no React — unit tested in apps/web/tests/h5p-url.test.mjs.
+*/
+
+export type H5PUrlErrorReason =
+  | 'empty'
+  | 'unparseable'
+  | 'unsupported_protocol'
+
+export type H5PUrlResult =
+  | { ok: true; url: string }
+  | { ok: false; reason: H5PUrlErrorReason }
+
+const IFRAME_SRC_QUOTED = /<iframe[^>]*\ssrc\s*=\s*("([^"]*)"|'([^']*)')/i
+const IFRAME_SRC_BARE = /<iframe[^>]*\ssrc\s*=\s*([^\s>]+)/i
+
+/** Minimal HTML entity decode — embed snippets ship `&amp;` inside the src. */
+function decodeEntities(value: string): string {
+  return value
+    .replace(/&quot;/gi, '"')
+    .replace(/&#0*39;/g, "'")
+    .replace(/&apos;/gi, "'")
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&amp;/gi, '&')
+}
+
+/**
+ * Pull the src out of a full `<iframe …>` snippet. Returns null when the input
+ * is not an iframe snippet, so callers can treat it as a plain URL.
+ */
+export function extractIframeSrc(input: string): string | null {
+  if (!input || !/<iframe/i.test(input)) return null
+  const quoted = input.match(IFRAME_SRC_QUOTED)
+  if (quoted) {
+    const value = quoted[2] !== undefined ? quoted[2] : quoted[3]
+    return value ? decodeEntities(value.trim()) : null
+  }
+  const bare = input.match(IFRAME_SRC_BARE)
+  if (bare && bare[1]) return decodeEntities(bare[1].trim())
+  return null
+}
+
+/** True when the URL already points at an H5P embed endpoint. */
+function looksLikeEmbedUrl(url: URL): boolean {
+  const path = url.pathname.replace(/\/+$/, '').toLowerCase()
+  if (path.endsWith('/embed') || path.includes('/embed/')) return true
+  if (path.endsWith('/embed.php')) return true
+  // WordPress plugin: /wp-admin/admin-ajax.php?action=h5p_embed&id=1
+  if ((url.searchParams.get('action') || '').toLowerCase() === 'h5p_embed') return true
+  // Generic ?embed=1 / ?embed=true style used by several self-hosted setups
+  if (url.searchParams.has('embed')) return true
+  return false
+}
+
+/** `https://x.h5p.com/content/<id>` → its `/embed` form. */
+function toH5PComEmbed(url: URL): URL {
+  const host = url.hostname.toLowerCase()
+  if (host !== 'h5p.com' && !host.endsWith('.h5p.com')) return url
+  const segments = url.pathname.split('/').filter(Boolean)
+  if (segments.length === 2 && segments[0].toLowerCase() === 'content') {
+    const next = new URL(url.toString())
+    next.pathname = `/content/${segments[1]}/embed`
+    return next
+  }
+  return url
+}
+
+/**
+ * Turn author input into an iframe-ready H5P embed URL.
+ *
+ * Accepts a content page URL, an embed URL, a schemeless URL, or a pasted
+ * `<iframe>` snippet. Returns a discriminated result instead of throwing so
+ * the UI can show the reason.
+ */
+export function normalizeH5PUrl(input: string): H5PUrlResult {
+  if (typeof input !== 'string') return { ok: false, reason: 'empty' }
+
+  const trimmed = input.trim()
+  if (!trimmed) return { ok: false, reason: 'empty' }
+
+  let candidate = extractIframeSrc(trimmed) ?? trimmed
+  candidate = candidate.trim()
+  if (!candidate) return { ok: false, reason: 'unparseable' }
+
+  // A URL never contains raw whitespace; this catches pasted prose early.
+  if (/\s/.test(candidate)) return { ok: false, reason: 'unparseable' }
+
+  const hasScheme =
+    /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(candidate) || candidate.startsWith('//')
+  if (candidate.startsWith('//')) {
+    candidate = `https:${candidate}`
+  } else if (!hasScheme) {
+    candidate = `https://${candidate}`
+  }
+
+  let parsed: URL
+  try {
+    parsed = new URL(candidate)
+  } catch {
+    return { ok: false, reason: 'unparseable' }
+  }
+
+  // The whole point of this module: nothing but http(s) reaches the iframe.
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { ok: false, reason: 'unsupported_protocol' }
+  }
+  if (!parsed.hostname) return { ok: false, reason: 'unparseable' }
+
+  // A bare word ("hello") parses fine once we prefix https://, which would
+  // leave the author staring at a dead frame. Require a dotted host unless
+  // they typed a scheme themselves — intranet hosts like
+  // `http://h5p-server/h5p/embed/1` stay valid that way.
+  const isDotted = parsed.hostname.includes('.')
+  const isLocal = parsed.hostname === 'localhost' || parsed.hostname.startsWith('[')
+  if (!hasScheme && !isDotted && !isLocal) {
+    return { ok: false, reason: 'unparseable' }
+  }
+
+  if (looksLikeEmbedUrl(parsed)) {
+    return { ok: true, url: parsed.toString() }
+  }
+
+  return { ok: true, url: toH5PComEmbed(parsed).toString() }
+}

--- a/apps/web/locales/ar.json
+++ b/apps/web/locales/ar.json
@@ -4568,6 +4568,7 @@
       "image": "صورة",
       "video": "فيديو",
       "pdf": "مستند PDF",
+      "h5p": "محتوى H5P التفاعلي",
       "youtube": "فيديو يوتيوب",
       "quiz": "اختبار تفاعلي",
       "math": "معادلة رياضية (LaTeX)",
@@ -4656,6 +4657,22 @@
         "document_title": "مستند PDF",
         "expand_pdf": "توسيع PDF",
         "download_pdf": "تحميل PDF"
+      },
+      "h5p_block": {
+        "default_title": "محتوى H5P تفاعلي",
+        "description": "الصق رابط التضمين الخاص بنشاط H5P لعرضه هنا.",
+        "hosted_hint": "يبقى المحتوى على خادم H5P الخاص بك (H5P.com أو Lumi أو موقع Drupal أو Moodle أو WordPress مستضاف ذاتيًا). يمكنك لصق رابط التضمين أو مقتطف iframe كاملاً كما يقدمه المزوّد.",
+        "url_label": "رابط تضمين H5P",
+        "url_placeholder": "https://your-team.h5p.com/content/123456/embed",
+        "title_label": "العنوان",
+        "title_placeholder": "العنوان (يُستخدم لإمكانية الوصول والبحث)",
+        "edit_content": "تعديل محتوى H5P",
+        "remove_content": "إزالة محتوى H5P",
+        "errors": {
+          "empty": "أدخل رابط تضمين H5P.",
+          "unparseable": "لا يبدو هذا رابطًا صالحًا. الصق رابط التضمين أو مقتطف iframe من مزوّد H5P.",
+          "unsupported_protocol": "يمكن تضمين روابط http و https فقط."
+        }
       },
       "quiz_block": {
         "all_correct": "جميع الإجابات صحيحة!",

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -5023,6 +5023,7 @@
       "image": "Image",
       "video": "Video",
       "pdf": "PDF Document",
+      "h5p": "H5P Interactive Content",
       "youtube": "YouTube Video",
       "quiz": "Interactive Quiz",
       "math": "Math Equation (LaTeX)",
@@ -5079,6 +5080,22 @@
         "document_title": "PDF Document",
         "expand_pdf": "Expand PDF",
         "download_pdf": "Download PDF"
+      },
+      "h5p_block": {
+        "default_title": "H5P interactive content",
+        "description": "Paste the embed URL of an H5P activity to show it here.",
+        "hosted_hint": "The content stays on your own H5P host (H5P.com, Lumi, or a self-hosted Drupal, Moodle or WordPress site). You can paste the embed URL or the whole iframe snippet the host gives you.",
+        "url_label": "H5P embed URL",
+        "url_placeholder": "https://your-team.h5p.com/content/123456/embed",
+        "title_label": "Title",
+        "title_placeholder": "Title (used for accessibility and search)",
+        "edit_content": "Edit H5P content",
+        "remove_content": "Remove H5P content",
+        "errors": {
+          "empty": "Enter an H5P embed URL.",
+          "unparseable": "That does not look like a valid URL. Paste the embed URL or iframe snippet from your H5P host.",
+          "unsupported_protocol": "Only http and https URLs can be embedded."
+        }
       },
       "quiz_block": {
         "all_correct": "All answers are correct!",

--- a/apps/web/tests/h5p-url.test.mjs
+++ b/apps/web/tests/h5p-url.test.mjs
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+
+import { extractIframeSrc, normalizeH5PUrl } from "../lib/media/h5pUrl.ts";
+
+describe("normalizeH5PUrl — H5P.com", () => {
+  test("content page URL becomes its embed form", () => {
+    const result = normalizeH5PUrl("https://team.h5p.com/content/1291234567890123456");
+    expect(result.ok).toBe(true);
+    expect(result.url).toBe("https://team.h5p.com/content/1291234567890123456/embed");
+  });
+
+  test("trailing slash on the content page is handled", () => {
+    const result = normalizeH5PUrl("https://team.h5p.com/content/123/");
+    expect(result.ok).toBe(true);
+    expect(result.url).toBe("https://team.h5p.com/content/123/embed");
+  });
+
+  test("already-embed URL passes through unchanged", () => {
+    const url = "https://team.h5p.com/content/1291234567890123456/embed";
+    expect(normalizeH5PUrl(url)).toEqual({ ok: true, url });
+  });
+
+  test("query string on a content URL is preserved", () => {
+    const result = normalizeH5PUrl("https://team.h5p.com/content/123?lang=fr");
+    expect(result.url).toBe("https://team.h5p.com/content/123/embed?lang=fr");
+  });
+});
+
+describe("normalizeH5PUrl — self-hosted shapes", () => {
+  test("Drupal/standalone /h5p/embed/<id> passes through", () => {
+    const url = "https://learning.example.org/h5p/embed/42";
+    expect(normalizeH5PUrl(url)).toEqual({ ok: true, url });
+  });
+
+  test("Moodle /h5p/embed.php passes through", () => {
+    const url = "https://moodle.example.org/h5p/embed.php?url=https%3A%2F%2Fmoodle.example.org%2Ffile.h5p";
+    expect(normalizeH5PUrl(url)).toEqual({ ok: true, url });
+  });
+
+  test("WordPress admin-ajax h5p_embed passes through", () => {
+    const url = "https://example.org/wp-admin/admin-ajax.php?action=h5p_embed&id=7";
+    expect(normalizeH5PUrl(url)).toEqual({ ok: true, url });
+  });
+
+  test("?embed=1 style passes through", () => {
+    const url = "https://example.org/interactive/quiz?embed=1";
+    expect(normalizeH5PUrl(url)).toEqual({ ok: true, url });
+  });
+
+  test("http is kept as-is, not upgraded", () => {
+    const url = "http://intranet.example.org/h5p/embed/3";
+    expect(normalizeH5PUrl(url)).toEqual({ ok: true, url });
+  });
+
+  test("an unrecognised https URL is passed through rather than mangled", () => {
+    const url = "https://example.org/some/other/path";
+    expect(normalizeH5PUrl(url)).toEqual({ ok: true, url });
+  });
+});
+
+describe("normalizeH5PUrl — iframe snippets", () => {
+  test("extracts src from a full iframe snippet", () => {
+    const snippet =
+      '<iframe src="https://team.h5p.com/content/123/embed" width="1090" height="694" frameborder="0" allowfullscreen="allowfullscreen" allow="autoplay *; geolocation *"></iframe>';
+    expect(normalizeH5PUrl(snippet)).toEqual({
+      ok: true,
+      url: "https://team.h5p.com/content/123/embed",
+    });
+  });
+
+  test("decodes &amp; inside a snippet src", () => {
+    const snippet = "<iframe src='https://example.org/h5p/embed/9?a=1&amp;b=2'></iframe>";
+    expect(normalizeH5PUrl(snippet)).toEqual({
+      ok: true,
+      url: "https://example.org/h5p/embed/9?a=1&b=2",
+    });
+  });
+
+  test("a snippet pointing at a content page is still normalized to /embed", () => {
+    const snippet = '<iframe width="800" src="https://team.h5p.com/content/55"></iframe>';
+    expect(normalizeH5PUrl(snippet).url).toBe("https://team.h5p.com/content/55/embed");
+  });
+
+  test("extractIframeSrc returns null for a plain URL", () => {
+    expect(extractIframeSrc("https://example.org/h5p/embed/1")).toBeNull();
+  });
+
+  test("a javascript: src inside a snippet is still rejected", () => {
+    const snippet = `<iframe src="javascript:alert(1)"></iframe>`;
+    expect(normalizeH5PUrl(snippet)).toEqual({
+      ok: false,
+      reason: "unsupported_protocol",
+    });
+  });
+});
+
+describe("normalizeH5PUrl — rejections", () => {
+  test("javascript: is rejected", () => {
+    expect(normalizeH5PUrl("javascript:alert(document.cookie)")).toEqual({
+      ok: false,
+      reason: "unsupported_protocol",
+    });
+  });
+
+  test("data: is rejected", () => {
+    expect(normalizeH5PUrl("data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==")).toEqual({
+      ok: false,
+      reason: "unsupported_protocol",
+    });
+  });
+
+  test("file: is rejected", () => {
+    expect(normalizeH5PUrl("file:///etc/passwd").ok).toBe(false);
+  });
+
+  test("empty and whitespace-only input is rejected", () => {
+    expect(normalizeH5PUrl("")).toEqual({ ok: false, reason: "empty" });
+    expect(normalizeH5PUrl("   ")).toEqual({ ok: false, reason: "empty" });
+    expect(normalizeH5PUrl(null)).toEqual({ ok: false, reason: "empty" });
+  });
+
+  test("garbage input is rejected", () => {
+    expect(normalizeH5PUrl("this is not a url").ok).toBe(false);
+    expect(normalizeH5PUrl("hello").ok).toBe(false);
+    expect(normalizeH5PUrl("https://").ok).toBe(false);
+  });
+});
+
+describe("normalizeH5PUrl — schemeless input", () => {
+  test("schemeless host gets https://", () => {
+    expect(normalizeH5PUrl("team.h5p.com/content/123")).toEqual({
+      ok: true,
+      url: "https://team.h5p.com/content/123/embed",
+    });
+  });
+
+  test("protocol-relative input gets https:", () => {
+    expect(normalizeH5PUrl("//example.org/h5p/embed/4")).toEqual({
+      ok: true,
+      url: "https://example.org/h5p/embed/4",
+    });
+  });
+
+  test("surrounding whitespace is trimmed", () => {
+    expect(normalizeH5PUrl("  https://example.org/h5p/embed/5  ").url).toBe(
+      "https://example.org/h5p/embed/5"
+    );
+  });
+});

--- a/docs/content/platform/editor/_meta.json
+++ b/docs/content/platform/editor/_meta.json
@@ -1,4 +1,5 @@
 {
   "index": "Overview",
-  "blocks": "Blocks"
+  "blocks": "Blocks",
+  "h5p": "H5P"
 }

--- a/docs/content/platform/editor/blocks.mdx
+++ b/docs/content/platform/editor/blocks.mdx
@@ -21,6 +21,7 @@ import {
   MathOperations,
   Cards,
   FlowArrow,
+  PuzzlePiece,
   Tag,
   Info,
   Warning,
@@ -74,6 +75,7 @@ The LearnHouse editor supports a wide range of block types for building rich cou
   <Block icon={MathOperations} name="Math Equation" description="Render mathematical notation using LaTeX syntax." />
   <Block icon={Cards} name="Flip Card" description="Flashcard for learning and memorization." />
   <Block icon={FlowArrow} name="Scenarios" description="Interactive branching scenarios with choices." />
+  <Block icon={PuzzlePiece} name="H5P" description="Embed interactive H5P content hosted on your own H5P provider." />
 </ul>
 
 ## UI Blocks

--- a/docs/content/platform/editor/h5p.mdx
+++ b/docs/content/platform/editor/h5p.mdx
@@ -1,0 +1,41 @@
+# H5P Interactive Content
+
+The **H5P** block puts an interactive H5P activity — a course presentation, an interactive video, a drag-and-drop, a branching scenario — inside a course page. Type `/` in the editor and pick **H5P**, then paste the embed URL of the activity.
+
+## Embed only
+
+LearnHouse does not host H5P. There is no upload field for `.h5p` packages and no H5P authoring tool built into the editor. You create the content on an H5P host you control, and the block renders it in a sandboxed iframe.
+
+That means:
+
+- The activity, its media and its user data stay on your H5P host.
+- Learner progress inside the activity is tracked by that host, not by LearnHouse.
+- If the host is unreachable, the block shows nothing — there is no local copy.
+
+## Why we do not bundle H5P
+
+The H5P core — the player, the editor and the content types — is licensed under the **AGPL**. Shipping it inside LearnHouse would put LearnHouse itself under the AGPL, which does not match the licence the project is distributed under. Embedding a page that someone else serves carries no such obligation, so embedding is what the block does.
+
+## Supported hosts
+
+Anything that hands you an H5P embed URL works. There is no allowlist of domains, precisely so that self-hosted installs keep working:
+
+- **H5P.com** — the hosted service. Use the *Embed* link under an activity, or paste the content page URL and the block converts it.
+- **Lumi** — export to a web page and host it yourself, then paste that URL.
+- **Drupal** with the H5P module — `https://your-site/h5p/embed/<id>`.
+- **Moodle** with H5P activities — `https://your-site/h5p/embed.php?url=...`.
+- **WordPress** with the H5P plugin — the `admin-ajax.php?action=h5p_embed&id=<id>` URL from the *Embed* button.
+
+You can paste either the URL or the entire `<iframe …>` snippet the host gives you; the block pulls the `src` out of the snippet for you.
+
+Only `http` and `https` URLs are accepted. Anything else is rejected with an error before it reaches the page.
+
+## Sizing
+
+H5P activities report their own height to the page they are embedded in, and the block listens for that message and resizes the frame to match. The height is remembered with the block, so the activity opens at roughly the right size the next time the page loads.
+
+## Notes for administrators
+
+- Your H5P host must allow being framed. If it sends `X-Frame-Options: DENY` or a restrictive `Content-Security-Policy: frame-ancestors`, the block will stay blank — allow your LearnHouse domain on the H5P side.
+- Serve the H5P host over HTTPS. A plain-HTTP frame inside an HTTPS course page is blocked by the browser as mixed content.
+- The frame is sandboxed and carries no LearnHouse session or credentials.

--- a/docs/content/platform/editor/index.mdx
+++ b/docs/content/platform/editor/index.mdx
@@ -12,3 +12,4 @@ LearnHouse includes a block-based WYSIWYG editor for creating course content. Th
 ## Learn More
 
 - [Available Blocks](/platform/editor/blocks) — See all the block types you can use.
+- [H5P Interactive Content](/platform/editor/h5p) — Embed H5P activities hosted on your own H5P provider.


### PR DESCRIPTION
The editor now has a block for embedding H5P interactive content. Authors paste an embed URL or a full iframe snippet (what most H5P hosts hand out) and it renders inside a course activity.

It's embed-only by design. H5P's core is AGPL, so nothing is vendored, no .h5p package gets unpacked or served here. The block just sandboxes an iframe pointed at content the author already hosts.

What's in this:
- URL normalizer that handles content-page URLs, embed URLs, schemeless input, and pasted iframe snippets, rejecting anything but http/https.
- No host allowlist. Self-hosted H5P on Drupal, Moodle, WordPress is the normal case, and an allowlist would break all of them. Sandboxing carries the security weight instead.
- iframe sandbox attributes, plus a resize listener that only accepts messages from the block's own contentWindow with the expected shape and a clamped height.
- Server-side content extraction now has an explicit case for the H5P node, so it contributes a title instead of falling through as unknown.
- Docs on supported H5P hosts and the licensing rationale.

Tested: 23 unit tests on the URL normalizer, plus 18 adversarial payloads (javascript:, data:, file:, vbscript:, blob:, encoded/mixed-case variants, and iframe-wrapped versions of each), all rejected, no false positives on legitimate URLs.
