### PR TITLE
fix(demo): make the storefront optional as a unit, and stop unlocking what nothing sweeps

### DIFF
--- a/apps/api/src/services/demo/sync.py
+++ b/apps/api/src/services/demo/sync.py
@@ -242,10 +242,17 @@ def _demo_org_config() -> dict:
             # Pro already gives unlimited courses/assignments and 500 members;
             # these keep headroom as visitors accumulate.
             "members": {"extra_limit": 500},
-            # Enterprise-only tiers, forced on so nothing is hidden.
-            "audit_logs": {"force_enabled": True},
-            "scorm": {"force_enabled": True},
-            "sso": {"force_enabled": True},
+            # Enterprise tiers the demo can show safely.
+            #
+            # audit_logs, scorm and sso are deliberately NOT here. Every
+            # visitor is an admin of this org, and those three surfaces are
+            # served by Enterprise routers that know nothing about the demo:
+            # they have no is_demo guard, and none of their tables is in the
+            # drift sweep. The audit one is the sharp case — the sync sweeps
+            # UserAuditEvent and the audit router hides other visitors
+            # precisely so one prospect cannot read another's identity, and
+            # force-enabling the Enterprise audit surface would hand it back.
+            # A prospect missing three settings pages is a cheaper loss.
             "analytics_advanced": {"force_enabled": True},
             "custom_domains": {"force_enabled": True},
             # Belt and braces: these are all enabled by pro, but stating them
@@ -261,7 +268,13 @@ def _demo_org_config() -> dict:
             "playgrounds": {"force_enabled": True},
             "podcasts": {"force_enabled": True},
             "webhooks": {"force_enabled": True},
-            "payments": {"force_enabled": True},
+            # Only where the storefront can actually be seeded AND swept.
+            # Turning the feature on while the sweep is off is worse than
+            # having no storefront: every visitor is an admin, so one of them
+            # can point the demo's payments config at their own account and
+            # publish an offer against a bundle course, and nothing would ever
+            # take it down. The next prospect would meet a real checkout.
+            "payments": {"force_enabled": _store_unsupported_reason() is None},
             "api": {"force_enabled": True},
             "seo": {"force_enabled": True},
             "analytics": {"force_enabled": True},
@@ -2140,6 +2153,60 @@ async def _sync_playground(
 
 # --- store ------------------------------------------------------------------
 
+def _store_unsupported_reason() -> Optional[str]:
+    """Why this build cannot host the demo storefront, or None if it can.
+
+    The storefront is the only part of the demo whose models live in the
+    Enterprise tree, which ships on its own release cadence. So this asks what
+    the build in front of us can actually do instead of assuming, and names the
+    gap when it cannot: an older Enterprise release is not a fault, and is not a
+    community install either, and one undifferentiated "skipped" line cost a
+    debugging round trip while somebody watched a demo refuse to build.
+
+    Both store steps ask the same question here so they can never disagree
+    about whether the storefront exists — the seeding skipping while the drift
+    sweep carried on is exactly how the second production failure happened.
+    """
+    from src.core.deployment_mode import get_deployment_mode
+
+    if get_deployment_mode() == "oss":
+        return "payments are unavailable in oss mode"
+
+    try:
+        from ee.db.payments.payments import (  # type: ignore[import-not-found]
+            PaymentProviderEnum,
+        )
+        from ee.db.payments.payments_enrollments import (  # type: ignore[import-not-found]
+            PaymentsEnrollment,
+        )
+    except ImportError as exc:
+        return (
+            f"payments models unavailable ({exc}) — expected on a community install"
+        )
+
+    # CUSTOM means "this organization drives its own enrolments", the only
+    # provider that takes no money. STRIPE would be a real checkout somebody
+    # could complete inside a sandbox anyone can enter as an admin, so without
+    # CUSTOM there is nothing safe to configure.
+    if not hasattr(PaymentProviderEnum, "CUSTOM"):
+        return (
+            "this Enterprise build's PaymentProviderEnum has no CUSTOM provider "
+            f"(has: {', '.join(p.name for p in PaymentProviderEnum)}), and the "
+            "demo will not point a storefront at a real payment provider"
+        )
+
+    # The drift sweep matches seeded enrolments by uuid. Older builds have the
+    # table without that column, and discovering it halfway through the sweep
+    # is what stopped the demo provisioning the second time.
+    if not hasattr(PaymentsEnrollment, "enrollment_uuid"):
+        return (
+            "this Enterprise build's PaymentsEnrollment has no enrollment_uuid, "
+            "so seeded enrolments could not be tracked or swept"
+        )
+
+    return None
+
+
 async def _sync_store(
     db_session: AsyncSession,
     bundle: Bundle,
@@ -2161,17 +2228,13 @@ async def _sync_store(
     if not store.offers:
         return
 
-    # "Can I import the models?" is not the same question as "is this feature
-    # on?". Payments is in EE_ONLY_FEATURES, so resolve_feature blocks it
-    # outright in oss mode — including on a machine that has the ee/ tree
-    # present but no active licence, where the import below would succeed.
-    # Seeding there produces a storefront the rest of the application refuses
-    # to serve, and payments tables on an install whose schema has no
-    # migration for them.
-    from src.core.deployment_mode import get_deployment_mode
-
-    if get_deployment_mode() == "oss":
-        logger.info("Demo store skipped: payments unavailable in oss mode.")
+    # One question, asked in one place: can this build host the storefront at
+    # all? "Can I import the models?" is not the same as "is this feature on
+    # and complete?" — payments is Enterprise-gated, and an Enterprise tree can
+    # be present, importable, and still older than the demo needs.
+    unsupported = _store_unsupported_reason()
+    if unsupported:
+        logger.info("Demo store skipped: %s.", unsupported)
         return
 
     try:
@@ -2206,24 +2269,6 @@ async def _sync_store(
         )
         return
 
-    # The storefront needs a provider that takes no money. CUSTOM means "this
-    # organization drives its own enrolments through the public API", which is
-    # exactly the demo's situation; STRIPE would be a real checkout somebody
-    # could complete in a shared sandbox.
-    #
-    # It is a newer member of the enum than the payments tables themselves, so
-    # an Enterprise build can have the models and not this value — which is not
-    # a community install and not a fault, just an older Enterprise release.
-    # Seeding a storefront without it is not an option, so the step is skipped
-    # and says why.
-    if not hasattr(PaymentProviderEnum, "CUSTOM"):
-        logger.info(
-            "Demo store skipped: this Enterprise build's PaymentProviderEnum "
-            "has no CUSTOM provider (has: %s), and the demo will not configure "
-            "a storefront against a real payment provider.",
-            ", ".join(p.name for p in PaymentProviderEnum),
-        )
-        return
 
     stats.steps.append("store")
 
@@ -2568,7 +2613,23 @@ async def _delete_drift(
     await _delete_unowned_org_drift(db_session, org, registry, stats)
     await _delete_certification_drift(db_session, org, registry, stats)
     await _delete_visitor_progress_drift(db_session, org, registry, stats)
-    await _delete_store_drift(db_session, org, registry, stats)
+    # Same treatment as the seeding step, and for the same reason: this is the
+    # other half of the storefront, it touches the same Enterprise models, and
+    # a version skew here must cost the storefront rather than the demo. The
+    # capability gate above should already have stopped it, but the gate can
+    # only know about the gaps we have met so far — this covers the next one.
+    #
+    # A savepoint rather than a bare try: a statement failing mid-sweep aborts
+    # the surrounding transaction on Postgres, and every later phase would then
+    # fail on "current transaction is aborted".
+    try:
+        async with db_session.begin_nested():
+            await _delete_store_drift(db_session, org, registry, stats)
+    except Exception as exc:
+        stats.steps.append("store-drift:failed")
+        logger.exception(
+            "Demo store drift sweep failed; continuing without it: %s", exc
+        )
 
     # Users who are not registry-owned demo students and hold no membership are
     # not touched here: visitors are real accounts that exist outside the demo.
@@ -2950,11 +3011,12 @@ async def _delete_store_drift(
     Groups are matched by primary key rather than uuid: PaymentsGroup has no
     uuid column, so the registry stores a synthetic one.
     """
-    # Same gate as the seeding step: in oss mode there is no storefront to
-    # sweep, and the tables may not exist even where the models import.
-    from src.core.deployment_mode import get_deployment_mode
-
-    if get_deployment_mode() == "oss":
+    # The same gate the seeding step uses. Asking a different question here is
+    # what broke production: the seeding skipped itself on an older Enterprise
+    # build while this sweep went ahead and referenced a column that build does
+    # not have.
+    unsupported = _store_unsupported_reason()
+    if unsupported:
         return
 
     try:

--- a/apps/api/src/tests/services/test_demo_drift.py
+++ b/apps/api/src/tests/services/test_demo_drift.py
@@ -438,3 +438,171 @@ async def test_a_storefront_failure_does_not_cost_the_whole_demo(db, monkeypatch
     ).scalar_one()
     assert courses == 6, "the catalogue is incomplete"
     assert "store:failed" in stats.steps, "the failure was not recorded"
+
+
+async def test_a_storefront_drift_failure_does_not_cost_the_whole_demo(db, monkeypatch):
+    """The other half of the storefront, and the second production outage.
+
+    The seeding step was guarded after the first failure; this sweep was not,
+    and it referenced a column the Enterprise release in production does not
+    have. Both halves touch the same separately-released models, so both have
+    to fail the same way: without the storefront, not without the demo.
+    """
+    from src.services.demo import sync as sync_module
+
+    async def _explode(*args, **kwargs):
+        raise AttributeError("enrollment_uuid")
+
+    monkeypatch.setattr(sync_module, "_delete_store_drift", _explode)
+
+    stats = await sync_demo(db, today=EPOCH_DAY)
+
+    org = (
+        await db.execute(select(Organization).where(Organization.is_demo.is_(True)))
+    ).scalars().first()
+    assert org is not None, "the demo was not built"
+
+    courses = (
+        await db.execute(
+            select(func.count()).select_from(Course).where(Course.org_id == org.id)
+        )
+    ).scalar_one()
+    assert courses == 6
+    assert "store-drift:failed" in stats.steps
+
+
+def test_both_store_steps_ask_the_same_capability_question():
+    """They disagreed once, and the demo stopped provisioning because of it.
+
+    The seeding skipped itself on an older Enterprise build while the drift
+    sweep went ahead and referenced a column that build does not have.
+    """
+    import inspect
+
+    from src.services.demo import sync as sync_module
+
+    for fn in (sync_module._sync_store, sync_module._delete_store_drift):
+        source = inspect.getsource(fn)
+        assert "_store_unsupported_reason()" in source, (
+            f"{fn.__name__} does not use the shared storefront capability gate"
+        )
+
+
+# ---------------------------------------------------------------------------
+# the storefront capability gate
+#
+# This is the code that decides whether a build can host the storefront, and
+# it exists for an environment CI does not have: an Enterprise tree, present
+# and importable, but older than the demo needs. Both production failures lived
+# in exactly that gap, so the decision is tested here against stand-in modules
+# rather than left to the next deploy to evaluate.
+# ---------------------------------------------------------------------------
+
+def _fake_ee(monkeypatch, *, provider_members, enrolment_attrs):
+    """Install a stand-in Enterprise payments package for one test."""
+    import sys
+    import types
+    from enum import Enum
+
+    provider = Enum("PaymentProviderEnum", provider_members, type=str)
+    enrolment = type("PaymentsEnrollment", (), dict(enrolment_attrs))
+
+    payments = types.ModuleType("ee.db.payments.payments")
+    payments.PaymentProviderEnum = provider
+    enrolments = types.ModuleType("ee.db.payments.payments_enrollments")
+    enrolments.PaymentsEnrollment = enrolment
+
+    for name, module in (
+        ("ee", types.ModuleType("ee")),
+        ("ee.db", types.ModuleType("ee.db")),
+        ("ee.db.payments", types.ModuleType("ee.db.payments")),
+        ("ee.db.payments.payments", payments),
+        ("ee.db.payments.payments_enrollments", enrolments),
+    ):
+        monkeypatch.setitem(sys.modules, name, module)
+
+    # The gate asks the deployment first; the suite pins oss.
+    monkeypatch.setattr(
+        "src.core.deployment_mode.get_deployment_mode", lambda: "saas"
+    )
+
+
+def test_the_gate_refuses_a_community_install(monkeypatch):
+    """No payments package at all — normal, and not a fault."""
+    import sys
+
+    from src.services.demo.sync import _store_unsupported_reason
+
+    monkeypatch.setattr(
+        "src.core.deployment_mode.get_deployment_mode", lambda: "saas"
+    )
+    for name in list(sys.modules):
+        if name == "ee" or name.startswith("ee."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setattr(sys, "path", [p for p in sys.path if "ee" not in p])
+
+    reason = _store_unsupported_reason()
+    assert reason is not None
+    assert "community install" in reason
+
+
+def test_the_gate_refuses_a_build_without_the_custom_provider(monkeypatch):
+    """Production's build. STRIPE would be a checkout somebody could complete."""
+    from src.services.demo.sync import _store_unsupported_reason
+
+    _fake_ee(
+        monkeypatch,
+        provider_members={"STRIPE": "stripe"},
+        enrolment_attrs={"enrollment_uuid": "x"},
+    )
+
+    reason = _store_unsupported_reason()
+    assert reason is not None
+    assert "CUSTOM" in reason
+    assert "STRIPE" in reason, "the message should name what the build does have"
+
+
+def test_the_gate_refuses_a_build_without_enrollment_uuid(monkeypatch):
+    """The second production failure: the sweep matches enrolments by uuid."""
+    from src.services.demo.sync import _store_unsupported_reason
+
+    _fake_ee(
+        monkeypatch,
+        provider_members={"STRIPE": "stripe", "CUSTOM": "custom"},
+        enrolment_attrs={},
+    )
+
+    reason = _store_unsupported_reason()
+    assert reason is not None
+    assert "enrollment_uuid" in reason
+
+
+def test_the_gate_allows_a_complete_build(monkeypatch):
+    """Everything present: the storefront is seeded and swept as before."""
+    from src.services.demo.sync import _store_unsupported_reason
+
+    _fake_ee(
+        monkeypatch,
+        provider_members={"STRIPE": "stripe", "CUSTOM": "custom"},
+        enrolment_attrs={"enrollment_uuid": "x"},
+    )
+
+    assert _store_unsupported_reason() is None
+
+
+def test_the_gate_refuses_oss_regardless_of_what_is_installed(monkeypatch):
+    """Payments is Enterprise-gated, so an oss deployment has no storefront."""
+    from src.services.demo.sync import _store_unsupported_reason
+
+    _fake_ee(
+        monkeypatch,
+        provider_members={"STRIPE": "stripe", "CUSTOM": "custom"},
+        enrolment_attrs={"enrollment_uuid": "x"},
+    )
+    monkeypatch.setattr(
+        "src.core.deployment_mode.get_deployment_mode", lambda: "oss"
+    )
+
+    reason = _store_unsupported_reason()
+    assert reason is not None
+    assert "oss mode" in reason

--- a/apps/api/src/tests/services/test_demo_sync.py
+++ b/apps/api/src/tests/services/test_demo_sync.py
@@ -219,8 +219,10 @@ async def test_demo_runs_on_pro_with_everything_unlocked(db, synced):
     ).scalars().first()
 
     assert config.config["plan"] == "pro"
-    # The tiers pro itself withholds must be forced on.
-    for enterprise_only in ("audit_logs", "scorm", "sso"):
+    # The tiers pro itself withholds, and that the demo can safely serve.
+    # audit_logs, scorm and sso are excluded on purpose — see
+    # test_the_demo_does_not_unlock_what_it_cannot_clean_up.
+    for enterprise_only in ("analytics_advanced", "custom_domains"):
         assert config.config["overrides"][enterprise_only]["force_enabled"] is True
 
 
@@ -258,15 +260,71 @@ async def test_every_showcase_feature_resolves_as_available(db, synced):
     assert not unavailable, f"hidden from the demo: {unavailable}"
 
 
-async def test_enterprise_only_features_follow_the_deployment_not_the_config(db, synced):
-    """sso / audit_logs / payments / scorm are gated by deployment mode.
+async def test_the_demo_does_not_unlock_what_it_cannot_clean_up(db, synced):
+    """Three Enterprise surfaces are deliberately left off.
 
-    The demo config force-enables them, but resolve_feature refuses them
-    outright in OSS mode — a platform rule the demo neither can nor should
-    defeat. The suite pins OSS (conftest sets LEARNHOUSE_DISABLE_EE), so this
-    documents where the ceiling actually is: on a SaaS or EE deployment the
-    same config makes them available, and on a self-hosted OSS install they
-    stay hidden however the demo is configured.
+    audit_logs, scorm and sso are served by Enterprise routers that know
+    nothing about the demo: no is_demo guard, and none of their tables in the
+    drift sweep. Every visitor is an admin of this shared org, so turning them
+    on would publish surfaces nothing reverts — and the audit one would hand
+    back exactly the visitor identities the audit router was taught to hide.
+
+    A prospect losing three settings pages is the cheaper loss, and this test
+    is what stops somebody restoring them for completeness.
+    """
+    from src.db.organization_config import OrganizationConfig
+
+    org = (
+        await db.execute(select(Organization).where(Organization.is_demo.is_(True)))
+    ).scalars().first()
+    config = (
+        await db.execute(
+            select(OrganizationConfig).where(OrganizationConfig.org_id == org.id)
+        )
+    ).scalars().first()
+
+    overrides = config.config["overrides"]
+    for feature in ("audit_logs", "scorm", "sso"):
+        assert feature not in overrides, (
+            f"{feature} is force-enabled but nothing sweeps what it creates"
+        )
+
+
+async def test_payments_is_only_unlocked_where_the_storefront_can_be_swept(db, synced):
+    """The feature follows the build's capability, not a hardcoded True.
+
+    Regression test for a hole opened while fixing another: the storefront
+    seeding and its drift sweep were both switched off on an Enterprise build
+    too old to support them, while the payments feature stayed force-enabled.
+    That combination is worse than no storefront — a visitor-admin could point
+    the demo's payments config at their own account and publish an offer, and
+    nothing would ever take it down.
+    """
+    from src.db.organization_config import OrganizationConfig
+    from src.services.demo.sync import _store_unsupported_reason
+
+    org = (
+        await db.execute(select(Organization).where(Organization.is_demo.is_(True)))
+    ).scalars().first()
+    config = (
+        await db.execute(
+            select(OrganizationConfig).where(OrganizationConfig.org_id == org.id)
+        )
+    ).scalars().first()
+
+    unlocked = config.config["overrides"]["payments"]["force_enabled"]
+    assert unlocked is (_store_unsupported_reason() is None)
+
+    # The suite pins oss mode, where there is no storefront to sweep.
+    assert unlocked is False
+
+
+async def test_enterprise_only_features_follow_the_deployment_not_the_config(db, synced):
+    """Deployment mode has the last word, whatever the config asks for.
+
+    The suite pins OSS (conftest sets LEARNHOUSE_DISABLE_EE), so this documents
+    where the ceiling actually is: an Enterprise-only feature stays unavailable
+    on a self-hosted OSS install however the demo is configured.
     """
     from src.core.deployment_mode import EE_ONLY_FEATURES
     from src.db.organization_config import OrganizationConfig
@@ -281,11 +339,6 @@ async def test_enterprise_only_features_follow_the_deployment_not_the_config(db,
         )
     ).scalars().first()
 
-    # The config asks for them...
-    for feature in ("audit_logs", "scorm", "sso"):
-        assert config.config["overrides"][feature]["force_enabled"] is True
-
-    # ...and the deployment mode still has the last word.
     for feature in EE_ONLY_FEATURES:
         resolved = resolve_feature(feature, config.config, org.id)
         assert resolved["available"] is False


### PR DESCRIPTION
Follow-up to #1040, which fixed the first symptom. This fixes the class, and closes a hole #1040 opened.

The demo failed to provision in production twice, both times referencing something the Enterprise release running there does not have: `PaymentProviderEnum.CUSTOM`, then `PaymentsEnrollment.enrollment_uuid`.

Rather than wait for a third, I asked the running build what it actually provides and checked every Enterprise symbol the demo touches against it. **The complete list of gaps is those two.** Every other model attribute and enum value the storefront uses — offers, groups, resources, enrolments, and the three enums the bundle's values are parsed into — is present.

So this isn't another attribute check:

**One capability gate**, asked by both the seeding step and the drift sweep. Asking different questions in the two halves is exactly how the second failure happened: #1040 taught the seeding to skip itself, and the sweep carried on into a column that build lacks.

**The drift sweep runs in a savepoint**, like the seeding already did, so a future gap costs the storefront rather than the demo. A savepoint rather than a bare `try` because a statement failing mid-sweep aborts the surrounding transaction on Postgres, and every later phase would then fail on "current transaction is aborted".

**`payments` is force-enabled only where the storefront can be seeded *and* swept.** This is the part worth reviewing, and it is the hole #1040 left open: switching the seeding off while leaving the feature on is worse than having no storefront. Every visitor is an admin of this shared org, so one could point the demo's payments config at their own account, publish an offer against a bundle course, and nothing would ever take it down. The next prospect would meet a real checkout.

**`audit_logs`, `scorm` and `sso` are no longer force-enabled.** They're served by Enterprise routers that know nothing about the demo — no `is_demo` guard, and none of their tables in the drift sweep. The audit one is sharp: this feature sweeps `UserAuditEvent` and teaches the audit router to hide other visitors so one prospect can't read another's identity, and force-enabling the Enterprise audit surface hands that straight back. A prospect missing three settings pages is the cheaper loss.

Tests cover the guarantee rather than the two symbols: the demo still builds when either store half raises, both halves are asserted to consult the same gate, and the payments override is asserted to track capability rather than a hardcoded `True`.

Expected after deploy: the demo comes up **without a storefront** on the current Enterprise release, everything else intact. It returns by itself once a release carrying `CUSTOM` and `enrollment_uuid` ships — no further change here.