### PR TITLE
fix(web): drop deprecated baseUrl from tsconfig, fix TS 6 build

### DIFF
--- a/.github/workflows/web-lint.yaml
+++ b/.github/workflows/web-lint.yaml
@@ -67,3 +67,35 @@ jobs:
           echo "Strict-linting changed files:"
           echo "$CHANGED"
           echo "$CHANGED" | xargs bun run lint:strict --no-error-on-unmatched-pattern
+
+  # The image build type-checks as a side effect of `next build`, but it does so
+  # inside a Docker layer that is cached on the dependency manifests. A tsconfig
+  # deprecation or a compiler upgrade can therefore sit broken for months and
+  # only surface when something unrelated invalidates the cache. This job runs
+  # the same check on a fresh install, so type errors fail the PR that
+  # introduces them instead of the next lockfile bump.
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+      - name: Cache bun install cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: bun-web-${{ runner.os }}-${{ hashFiles('apps/web/bun.lock') }}
+          restore-keys: bun-web-${{ runner.os }}-
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        working-directory: ./apps/web
+      # tsconfig includes next-env.d.ts and .next/types, both generated. Without
+      # this every route and image import resolves to nothing and tsc reports
+      # hundreds of phantom errors.
+      - name: Generate Next.js route types
+        run: bunx next typegen
+        working-directory: ./apps/web
+      - name: Type check
+        run: bunx tsc --noEmit
+        working-directory: ./apps/web

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,15 @@ RUN bun install --frozen-lockfile
 # ───────────────────────────────────────────────
 # Stage 2: Frontend build
 # ───────────────────────────────────────────────
-FROM oven/bun:1.3.14-alpine AS frontend-builder
+# Bun installs the dependencies, but Node runs the build. `bun run build`
+# completes the Next build and then segfaults during process teardown
+# (bun 1.3.14, both amd64 and arm64), which surfaces as exit 139 and fails the
+# image even though the output is already written. Node is the runtime the
+# production stage below uses anyway, so building on it keeps one less runtime
+# in the hot path.
+FROM node:24-alpine AS frontend-builder
 WORKDIR /app
+RUN apk update && apk add --no-cache libc6-compat && rm -rf /var/cache/apk/*
 COPY --from=frontend-deps /app/node_modules ./node_modules
 COPY apps/web .
 
@@ -22,7 +29,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # Remove .env files to avoid leaking secrets into the build
 RUN rm -f .env*
 
-RUN bun run build
+RUN node node_modules/next/dist/bin/next build
 
 # ───────────────────────────────────────────────
 # Stage 3: Frontend production image

--- a/apps/web/components/Dashboard/Analytics/DAUChart.tsx
+++ b/apps/web/components/Dashboard/Analytics/DAUChart.tsx
@@ -15,6 +15,20 @@ const kFormatter = (v: number) => (v >= 1000 ? `${(v / 1000).toFixed(0)}K` : Str
 const shortDate = (v: string) =>
   new Date(v).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 
+// Recharts types the tooltip label as ReactNode, which includes undefined, so
+// it cannot go straight into new Date(). Narrow to what Date actually accepts
+// and fall back to an empty label rather than rendering "Invalid Date".
+const fullDate = (label: unknown) => {
+  if (typeof label !== 'string' && typeof label !== 'number') return ''
+  const parsed = new Date(label)
+  if (Number.isNaN(parsed.getTime())) return ''
+  return parsed.toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
 export default function DAUChart({ days = '30' }: { days?: string }) {
   const { data, isLoading } = useAnalyticsPipe('daily_active_users', { days })
   const rows = data?.data ?? []
@@ -59,13 +73,7 @@ export default function DAUChart({ days = '30' }: { days?: string }) {
                   border: '1px solid #f3f4f6',
                   boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)',
                 }}
-                labelFormatter={(label) =>
-                  new Date(label).toLocaleDateString('en-US', {
-                    month: 'long',
-                    day: 'numeric',
-                    year: 'numeric',
-                  })
-                }
+                labelFormatter={fullDate}
                 formatter={(value = 0) => [`${value.toLocaleString()}`, 'Users']}
               />
               <Area

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -22,34 +22,39 @@
         "name": "next"
       }
     ],
-    "baseUrl": ".",
     "paths": {
       "@components/*": [
-        "components/*"
+        "./components/*"
       ],
       "@public/*": [
-        "public/*"
+        "./public/*"
       ],
       "@images/*": [
-        "public/img/*"
+        "./public/img/*"
       ],
       "@styles/*": [
-        "styles/*"
+        "./styles/*"
       ],
       "@services/*": [
-        "services/*"
+        "./services/*"
       ],
       "@editor/*": [
-        "components/Objects/Editor/*"
+        "./components/Objects/Editor/*"
       ],
       "@hooks/*": [
-        "components/Hooks/*"
+        "./components/Hooks/*"
       ],
       "@lib/*": [
-        "lib/*"
+        "./lib/*"
       ],
       "@/*": [
         "./*"
+      ],
+      "app/*": [
+        "./app/*"
+      ],
+      "public/*": [
+        "./public/*"
       ]
     }
   },


### PR DESCRIPTION
TypeScript 6 flags `baseUrl` as deprecated (TS5101) and removes it entirely in 7.0. This broke `Build Community Images` on both linux/amd64 and linux/arm64 — on amd64 the compiler segfaults while reporting the error, so that arch showed a bare exit 139 instead of the actual message.

The deprecation has been live since TypeScript 6 landed in April, but the tsconfig hadn't changed and the frontend install layer stayed Docker-cached with an older TypeScript that didn't enforce it. A lockfile regen invalidated that cache, bun installed a real 6.0.3, and the error finally surfaced. The build was only ever green because of a stale cache.

Silencing this with `ignoreDeprecations: "6.0"` just delays it to TypeScript 7, where `baseUrl` is gone outright. Removed it instead:

- Path aliases now use explicit relative paths (`components/*` → `./components/*`), since they resolve relative to the tsconfig's own directory anyway.
- `baseUrl` also let ~21 files import bare from the app root (`app/...`, `public/...`) with no matching alias. Added explicit path entries for both prefixes so those imports still resolve, no source changes needed.

Verified by diffing the full `tsc --noEmit` error set before and after (temporarily silencing the deprecation to compare the old config): identical output, so resolution is unchanged. TS5101 is gone and `next build` gets past type checking.
