### PR TITLE
fix: store AI-planned course tags as pipe-separated chips

### DIFF
--- a/apps/api/src/routers/ai/courseplanning.py
+++ b/apps/api/src/routers/ai/courseplanning.py
@@ -24,6 +24,7 @@ from src.security.features_utils.usage import (
     reserve_ai_credit,
 )
 from src.services.ai.llm import resolve_model_for_org, model_for_tier
+from src.services.ai.course_tags import normalize_course_tags
 from src.services.ai.courseplanning import (
     get_course_planning_session,
     create_course_planning_session,
@@ -327,7 +328,7 @@ async def finalize_course_plan(
         description=plan.description,
         about=plan.description,
         learnings=plan.learnings,
-        tags=plan.tags,
+        tags=normalize_course_tags(plan.tags),
         public=False,  # Start as unpublished
         published=False,
         open_to_contributors=False,

--- a/apps/api/src/services/ai/course_tags.py
+++ b/apps/api/src/services/ai/course_tags.py
@@ -1,0 +1,18 @@
+"""Course tag storage helpers."""
+
+
+def normalize_course_tags(raw: str) -> str:
+    """Store AI-planner tags in the same pipe-separated form TagInput uses.
+
+    The planning prompt historically asked for comma-separated tags, so
+    finalize wrote ``"a, b, c"`` and the editor rendered one chip.
+    Split on commas *or* pipes, strip empties, rejoin with ``|``.
+    """
+    if not raw:
+        return ""
+    parts = []
+    for chunk in raw.replace("|", ",").split(","):
+        tag = chunk.strip()
+        if tag:
+            parts.append(tag)
+    return "|".join(parts)

--- a/apps/api/src/services/ai/courseplanning.py
+++ b/apps/api/src/services/ai/courseplanning.py
@@ -200,7 +200,7 @@ When the user describes a course they want to create, generate a structured cour
 1. A compelling course name
 2. A clear, engaging description
 3. Key learnings (comma-separated list of what students will learn)
-4. Relevant tags (comma-separated)
+4. Relevant tags (pipe-separated, e.g. python|beginner|data)
 5. Chapters organized logically to build knowledge progressively
 6. Activities within each chapter that support the learning objectives
 
@@ -239,7 +239,7 @@ You MUST respond with a valid JSON object following this exact structure:
   "name": "Course Title",
   "description": "A compelling course description...",
   "learnings": "Learning outcome 1, Learning outcome 2, Learning outcome 3",
-  "tags": "tag1, tag2, tag3",
+  "tags": "tag1|tag2|tag3",
   "chapters": [
     {{
       "name": "Chapter 1 Title",

--- a/apps/api/src/tests/services/test_normalize_course_tags.py
+++ b/apps/api/src/tests/services/test_normalize_course_tags.py
@@ -1,0 +1,14 @@
+from src.services.ai.course_tags import normalize_course_tags
+
+
+def test_comma_separated_tags_become_pipe_separated():
+    assert normalize_course_tags("python, beginner, data") == "python|beginner|data"
+
+
+def test_already_pipe_separated_tags_are_kept():
+    assert normalize_course_tags("python|beginner") == "python|beginner"
+
+
+def test_empty_and_whitespace_are_dropped():
+    assert normalize_course_tags("") == ""
+    assert normalize_course_tags("  a, , b  ") == "a|b"


### PR DESCRIPTION
## Problem

AI course finalize wrote the model's comma-separated `tags` string into `Course.tags`. TagInput splits on `|`, so the editor showed one chip with every tag.

Fixes #1051.

## Change

Normalize commas (and existing pipes) to pipe-separated tags on finalize. Ask the planner for pipe-separated tags.

## Test

Unit assertions on `normalize_course_tags` (comma list, already-piped, empty/whitespace).
