### PR TITLE
fix(ai): make course-plan tags a list, join to pipe at finalize

### DIFF
--- a/apps/api/src/routers/ai/courseplanning.py
+++ b/apps/api/src/routers/ai/courseplanning.py
@@ -327,7 +327,7 @@ async def finalize_course_plan(
         description=plan.description,
         about=plan.description,
         learnings=plan.learnings,
-        tags=plan.tags,
+        tags="|".join(plan.tags),
         public=False,  # Start as unpublished
         published=False,
         open_to_contributors=False,

--- a/apps/api/src/services/ai/courseplanning.py
+++ b/apps/api/src/services/ai/courseplanning.py
@@ -200,7 +200,7 @@ When the user describes a course they want to create, generate a structured cour
 1. A compelling course name
 2. A clear, engaging description
 3. Key learnings (comma-separated list of what students will learn)
-4. Relevant tags (comma-separated)
+4. Relevant tags (as a JSON array of short strings, e.g. ["python", "beginners"])
 5. Chapters organized logically to build knowledge progressively
 6. Activities within each chapter that support the learning objectives
 
@@ -239,7 +239,7 @@ You MUST respond with a valid JSON object following this exact structure:
   "name": "Course Title",
   "description": "A compelling course description...",
   "learnings": "Learning outcome 1, Learning outcome 2, Learning outcome 3",
-  "tags": "tag1, tag2, tag3",
+  "tags": ["tag1", "tag2", "tag3"],
   "chapters": [
     {{
       "name": "Chapter 1 Title",

--- a/apps/api/src/services/ai/schemas/courseplanning.py
+++ b/apps/api/src/services/ai/schemas/courseplanning.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from typing import Optional, List, Dict, Literal
 
 
@@ -31,8 +31,21 @@ class CoursePlan(BaseModel):
     name: str
     description: str
     learnings: str = ""
-    tags: str = ""
+    tags: list[str] = []
     chapters: List[ChapterPlan] = []
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def _coerce_tags(cls, v):
+        # The prompt asks for a JSON array, but a stray generation (or an
+        # older client) may still send a delimited string. Accept either and
+        # normalize to a clean list, so tags never 422 the finalize call. The
+        # storage separator (pipe) is finalize's job, not the model's.
+        if v is None:
+            return []
+        if isinstance(v, str):
+            v = v.replace("|", ",").split(",")
+        return [t.strip() for t in v if isinstance(t, str) and t.strip()]
 
 
 class CoursePlanningMessage(BaseModel):

--- a/apps/api/src/tests/services/test_courseplanning_tags.py
+++ b/apps/api/src/tests/services/test_courseplanning_tags.py
@@ -1,0 +1,48 @@
+"""Course-plan tag coercion.
+
+Course tags are stored PIPE-separated and the web TagInput splits on `|`.
+The planning prompt now asks the model for a JSON array, and CoursePlan
+coerces that to a clean list. finalize then joins with `|`.
+
+The bug this guards against: the model used to emit `"a, b, c"` (comma
+string), finalize stored it verbatim, and the UI rendered ONE chip. So
+the negative case here is a stray comma string: it must still coerce to
+separate tags, not a single blob.
+"""
+
+from src.services.ai.schemas.courseplanning import CoursePlan
+
+
+def _plan(tags):
+    return CoursePlan(name="n", description="d", tags=tags)
+
+
+def _stored(tags):
+    # How finalize_course_plan writes tags onto the Course row.
+    return "|".join(_plan(tags).tags)
+
+
+def test_list_input_is_trimmed_and_blanks_dropped():
+    assert _plan(["python", "  beginners  ", ""]).tags == ["python", "beginners"]
+
+
+def test_stored_form_is_pipe_separated():
+    assert _stored(["python", "web"]) == "python|web"
+
+
+def test_comma_string_still_splits():
+    # Guard the actual bug: a comma string (old model output) must NOT
+    # become one tag. If this fails, the UI shows a single chip again.
+    assert _plan("python, web, apis").tags == ["python", "web", "apis"]
+    assert _stored("python, web") == "python|web"
+
+
+def test_pipe_string_is_accepted():
+    # Idempotent: feeding the stored form back in round-trips.
+    assert _plan("a|b|c").tags == ["a", "b", "c"]
+
+
+def test_empty_and_none_are_empty():
+    assert _plan("").tags == []
+    assert _plan(None).tags == []
+    assert _stored([]) == ""

--- a/apps/web/services/ai/courseplanning.ts
+++ b/apps/web/services/ai/courseplanning.ts
@@ -37,7 +37,7 @@ export interface CoursePlan {
   name: string
   description: string
   learnings: string
-  tags: string
+  tags: string[]
   chapters: ChapterPlan[]
 }
 


### PR DESCRIPTION
Fixes #1051

## What

AI-generated courses stored their tags comma-joined, so the course editor showed one chip holding every tag instead of one chip per tag.

## Why it happened

Course tags are stored pipe-separated and the web TagInput splits on `|`. But the planning prompt told the model to return tags "comma-separated", and `finalize_course_plan` wrote that string to the Course row as-is. The UI saw no `|`, so it made a single chip.

## The fix

Stop making the model emit a delimited string at all. Tags are a list.

- Prompt asks for a JSON array (`["python", "beginners"]`). Arrays are the one shape LLMs serialize reliably.
- `CoursePlan.tags` is now `list[str]` with a `mode="before"` validator that still accepts a stray delimited string (comma or pipe), trims, and drops blanks, so a regressed generation can't 422 finalize.
- `finalize` owns the storage encoding: `"|".join(plan.tags)`. The pipe separator lives in one place that knows the DB format and never appears in a prompt again.
- Web `CoursePlan.tags` typed `string[]` to match. Nothing on the web reads the field, it only rides through to finalize.

### Alternative rejected

Just changing the prompt to say "pipe-separated" moves the fragility rather than fixing it. Models drift back to commas, spaces, or "and" no matter what delimiter you name, so a prose contract for a machine boundary stays brittle. A list removes the separator from the model's job entirely.

## Validation

- Unit: `test_courseplanning_tags.py` pins the guarantee (list trims and drops blanks, stored form is pipe-joined) and the negative case (a comma string still splits into separate tags, not one chip).
- End to end against a running instance: the planner returned tags as a JSON array and the course row stored `a|b|c` in Postgres; posting finalize with tags as a comma string still stored the pipe form.
- UI: the editor's Tags field renders one chip per tag.

No new ruff findings versus the base. No manifest changes, so lockfiles are untouched.