### PR TITLE
fix(import): compare the zip entry file-type nibble exactly for symlinks (#1055)

### DIFF
--- a/apps/api/src/services/courses/transfer/import_service.py
+++ b/apps/api/src/services/courses/transfer/import_service.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import time
 import zipfile
 from datetime import datetime
@@ -60,11 +61,6 @@ MAX_ENTRY_SIZE = 250 * 1024 * 1024
 # Max entry count inside the archive. Prevents inode exhaustion / "zip of zero-
 # byte files" attacks even when the compression ratio looks innocent.
 MAX_ENTRY_COUNT = 20000
-
-# Zip central-directory external-attribute mask for symbolic links, in the
-# upper 16 bits (Unix mode). 0xA000 is S_IFLNK. Matching the convention used
-# by zipfile authors, we bail out on any entry whose mode includes this flag.
-_ZIP_SYMLINK_MODE = 0xA000 << 16
 
 # temp_id is always a uuid4 minted by analyze_import_package, but it comes back
 # from the client on the import call, where it is joined into filesystem paths.
@@ -297,7 +293,14 @@ async def analyze_import_package(
                 # SECURITY: reject symlink entries outright — even a contained
                 # symlink can be followed by later entries to write outside
                 # the extract directory.
-                if info.external_attr & _ZIP_SYMLINK_MODE:
+                #
+                # Zip keeps the entry's Unix mode in the upper 16 bits of
+                # external_attr. The file-type nibble there has to be compared
+                # against S_IFLNK exactly: S_IFLNK (0o120000) and S_IFREG
+                # (0o100000) share a bit, so a plain `& S_IFLNK` test also
+                # matches every ordinary file that carries a real mode — which
+                # is every file any Unix zip tool writes.
+                if stat.S_ISLNK(info.external_attr >> 16):
                     raise HTTPException(
                         status_code=400,
                         detail=(

--- a/apps/api/src/tests/services/test_import_service.py
+++ b/apps/api/src/tests/services/test_import_service.py
@@ -554,6 +554,60 @@ class TestImportHelpers:
         assert "symlink" in exc.value.detail.lower()
 
     @pytest.mark.asyncio
+    async def test_analyze_import_package_accepts_entries_with_unix_modes(
+        self, db, org, admin_user, mock_request, tmp_path, monkeypatch
+    ):
+        """
+        True negative for the F-10 symlink guard: S_IFREG entries are files.
+
+        Every Unix zip tool (Info-Zip, Finder's "Compress", zipfile when given
+        an explicit ZipInfo) records the real mode in the upper 16 bits of
+        external_attr, so ordinary files arrive carrying S_IFREG. Those must
+        pass the guard — otherwise the export -> edit -> re-zip -> re-import
+        round trip dies on the first regular file in the archive.
+        """
+        _set_import_temp_dir(monkeypatch, tmp_path)
+
+        manifest = {
+            "version": "2.0.0",
+            "format": "learnhouse-course-export",
+            "courses": [{"course_uuid": "course-1", "path": "course-1"}],
+        }
+        files = {
+            "manifest.json": json.dumps(manifest).encode(),
+            "course-1/course.json": json.dumps(
+                {"course_uuid": "course-1", "name": "Imported Course"}
+            ).encode(),
+            # Finder's "Compress" ships AppleDouble sidecars alongside the real
+            # entries; they are plain files too and must not trip the guard.
+            "__MACOSX/._manifest.json": b"\x00\x05\x16\x07",
+        }
+
+        buf = BytesIO()
+        with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_STORED) as z:
+            dir_info = zipfile.ZipInfo("course-1/")
+            dir_info.external_attr = 0o040755 << 16  # S_IFDIR | rwxr-xr-x
+            dir_info.create_system = 3  # unix
+            z.writestr(dir_info, "")
+            for name, content in files.items():
+                info = zipfile.ZipInfo(name)
+                info.external_attr = 0o100644 << 16  # S_IFREG | rw-r--r--
+                info.create_system = 3  # unix
+                z.writestr(info, content)
+
+        with patch(
+            "src.services.courses.transfer.import_service.check_resource_access",
+            new_callable=AsyncMock,
+        ):
+            result = await analyze_import_package(
+                mock_request, _upload_file(buf.getvalue()), org.id, admin_user, db
+            )
+
+        assert result.version == "2.0.0"
+        assert [course.course_uuid for course in result.courses] == ["course-1"]
+        assert os.path.exists(tmp_path / result.temp_id / "extracted" / "manifest.json")
+
+    @pytest.mark.asyncio
     async def test_analyze_import_package_handles_unexpected_errors(
         self,
         db,


### PR DESCRIPTION
## Summary

- `analyze_import_package` rejected uploaded course packages with `Invalid package: symlink entry '<file>' is not allowed` for archives that contain no symlinks at all.
- The symlink guard tested the Unix mode with a bitwise AND against `S_IFLNK` (`_ZIP_SYMLINK_MODE = 0xA000 << 16`). `S_IFLNK` (`0o120000`) and `S_IFREG` (`0o100000`) share the `0o100000` bit, so the test was true for **every** regular file that carries a real Unix mode — i.e. every file written by Info-Zip, Finder's "Compress", `ditto`, or `zipfile` with an explicit `ZipInfo`. Directory entries slipped through only because `S_IFDIR` (`0o040000`) happens not to overlap the mask, which is why the reported error always named a file.
- Net effect: the export → edit → re-zip → re-import round trip failed on the first regular entry in the archive. Packages produced by LearnHouse's own exporter still worked because `ZipFile.writestr` with a plain string arcname stores `0o600 << 16` and never sets `S_IFREG`.
- The fix compares the `S_IFMT` file-type nibble exactly instead of masking, so only real symlinks are rejected and every other file type is classified correctly.

## Changes

- `apps/api/src/services/courses/transfer/import_service.py`: replaced the `info.external_attr & _ZIP_SYMLINK_MODE` test with `stat.S_ISLNK(info.external_attr >> 16)`, which is `S_IFMT(mode) == S_IFLNK` — an exact type comparison rather than an overlapping mask. The `_ZIP_SYMLINK_MODE` constant is gone (nothing else referenced it) and the comment now records why the nibble has to be compared exactly. The guard is no weaker: a genuine `S_IFLNK` entry is still rejected with the same 400, and the extraction loop never calls `os.symlink` in any case.
- `apps/api/src/tests/services/test_import_service.py`: added `test_analyze_import_package_accepts_entries_with_unix_modes`, the true-negative companion to the existing `test_analyze_import_package_rejects_symlink_entry`. It builds a package whose entries carry real Unix modes (`0o100644 << 16` for files, `0o040755 << 16` for the directory, `create_system = 3`) including a `__MACOSX/._*` AppleDouble sidecar, and asserts the analysis succeeds. On `dev` it fails with the exact reported error, `symlink entry 'manifest.json' is not allowed`.

Happy to switch to a named `_S_IFMT_MASK` / `_ZIP_SYMLINK_TYPE` constant pair as the issue suggests if you'd prefer that over calling `stat.S_ISLNK` directly.

Fixes #1055