### PR TITLE
Add toolbar button for H5P blocks

### DIFF
--- a/apps/web/components/Objects/Editor/Toolbar/ToolbarButtons.tsx
+++ b/apps/web/components/Objects/Editor/Toolbar/ToolbarButtons.tsx
@@ -22,6 +22,7 @@ import {
   Link,
   ListBullets,
   ListNumbers,
+  PuzzlePiece,
   Rows,
   RowsPlusBottom,
   SealQuestion,
@@ -453,6 +454,23 @@ export const ToolbarButtons = React.memo(({ editor }: any) => {
           aria-label={t('editor.blocks.quiz')}
         >
           <SealQuestion size={15} weight="fill" />
+        </div>
+      </ToolTip>
+      <ToolTip content={t('editor.blocks.h5p')}>
+        <div
+          className="editor-tool-btn editor-tool-btn-interactive"
+          onClick={() =>
+            editor
+              .chain()
+              .focus()
+              .insertContent({
+                type: 'blockH5P',
+              })
+              .run()
+          }
+          aria-label={t('editor.blocks.h5p')}
+        >
+          <PuzzlePiece size={15} weight="fill" />
         </div>
       </ToolTip>
       <div className="relative inline-block shrink-0">


### PR DESCRIPTION
H5P blocks shipped in #1045, but the only way to insert one was typing `/h5p` in the slash-command menu. Every other interactive block (image, video, audio, YouTube, math, PDF, library, quiz) has both a toolbar button and a slash command; H5P was missing the button.

Adds it to `ToolbarButtons.tsx`, next to quiz in the interactive group, inserting the same `blockH5P` node the slash command already uses.

- Icon is phosphor's `PuzzlePiece`. Phosphor has no plain `Puzzle` icon; the slash menu's `Puzzle` comes from `lucide-react`, a separate package.
- Reuses the `editor.blocks.h5p` translation key from #1045, so no locale changes.

One file, about 18 lines. Lint clean on the file. Not manually tested in a running editor.