### PR TITLE
perf(scorm): recompress proxy responses since fetch strips gzip

### DIFF
--- a/apps/web/ee/app/api/scorm/[...path]/route.ts
+++ b/apps/web/ee/app/api/scorm/[...path]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getAPIUrl } from '@services/config/config'
+import { bodyWasDecoded, canRecompress } from '../../../../services/scorm/proxyCompression'
 
 /**
  * Proxy route for SCORM content
@@ -23,25 +24,6 @@ const FORWARDED_RESPONSE_HEADERS = [
   'etag',
   'last-modified',
 ]
-
-/**
- * Whether `fetch` decompressed the upstream body underneath us.
- *
- * The API gzips every response over 1000 bytes, and undici's `fetch`
- * transparently decodes it — but leaves the upstream `content-length` (the
- * COMPRESSED size) on the response headers. Forwarding that header alongside
- * the decompressed body tells the browser to stop reading early, which
- * truncates every SCORM asset big enough to be gzipped: `modernizr.js` and
- * `scriptLoader.js` die on `Uncaught SyntaxError: Unexpected end of input`,
- * while files under the gzip threshold load fine.
- *
- * We do not forward `content-encoding` either, so the bytes and the headers
- * agree: no encoding, and a length only when it still describes the body.
- */
-function bodyWasDecoded(response: Response): boolean {
-  const encoding = response.headers.get('content-encoding')?.trim().toLowerCase()
-  return !!encoding && encoding !== 'identity'
-}
 
 export async function GET(
   request: NextRequest,
@@ -118,8 +100,23 @@ export async function GET(
       headers.set('cache-control', 'private, max-age=3600, must-revalidate')
     }
 
+    // Re-compress what the API had already compressed and `fetch` unpacked on
+    // the way in, so the browser hop is not the one that carries the raw bytes.
+    // `vary` goes on every response, compressed or not: the body now depends on
+    // the request's accept-encoding, and a cache that missed that would serve
+    // gzip to a client that cannot read it.
+    headers.set('vary', 'accept-encoding')
+
+    let body = response.body
+    if (body && canRecompress(response, request.headers.get('accept-encoding'))) {
+      body = body.pipeThrough(new CompressionStream('gzip'))
+      headers.set('content-encoding', 'gzip')
+      // The length of the plaintext no longer describes what goes out.
+      headers.delete('content-length')
+    }
+
     // Stream the body through (200 or 206 for Range responses)
-    return new NextResponse(response.body, {
+    return new NextResponse(body, {
       status: response.status,
       headers,
     })

--- a/apps/web/ee/services/scorm/proxyCompression.ts
+++ b/apps/web/ee/services/scorm/proxyCompression.ts
@@ -1,0 +1,75 @@
+/**
+ * Compression decisions for the SCORM content proxy.
+ *
+ * The proxy exists so SCORM assets are same-origin with the player, which means
+ * every file in a package — often hundreds of them — crosses this hop. Getting
+ * the encoding wrong here does not fail loudly in one place; it either inflates
+ * the whole package on the slowest leg of the path, or hands the browser bytes
+ * that contradict their headers. Both decisions live here so they can be tested
+ * without a server.
+ */
+
+/**
+ * Whether `fetch` decompressed the upstream body underneath us.
+ *
+ * The API gzips every response over 1000 bytes and undici transparently decodes
+ * it, while leaving the upstream (compressed) `content-length` on the response.
+ * Forwarding that length alongside the decoded body tells the browser to stop
+ * reading early and truncates every asset large enough to have been gzipped.
+ */
+export function bodyWasDecoded(response: Response): boolean {
+  const encoding = response.headers.get('content-encoding')?.trim().toLowerCase()
+  return !!encoding && encoding !== 'identity'
+}
+
+/**
+ * Whether the client asked for gzip and did not then weight it away.
+ *
+ * `accept-encoding: gzip;q=0` is a refusal, not a request, so matching the token
+ * alone is not enough. A `*` covers gzip unless gzip is refused by name.
+ */
+export function acceptsGzip(header: string | null | undefined): boolean {
+  if (!header) return false
+
+  let wildcard = false
+  for (const entry of header.split(',')) {
+    const [rawToken, ...params] = entry.split(';')
+    const token = rawToken.trim().toLowerCase()
+    if (token !== 'gzip' && token !== '*') continue
+
+    const quality = params
+      .map((param) => param.trim().toLowerCase())
+      .find((param) => param.startsWith('q='))
+    const accepted = !quality || Number(quality.slice(2)) > 0
+
+    if (token === 'gzip') return accepted
+    wildcard = accepted
+  }
+
+  return wildcard
+}
+
+/**
+ * Whether this response can be handed back to the browser gzipped.
+ *
+ * When the API compresses a response there is no way to keep the compression
+ * across this hop: undici decodes even when the outgoing request carries an
+ * explicit `accept-encoding: gzip`, while still reporting `content-encoding:
+ * gzip` on the response — so forwarding that header would ship gzip-labelled
+ * plaintext and every text asset would fail with ERR_CONTENT_DECODING_FAILED.
+ * Next does not compress App Router route-handler streams either. Re-compressing
+ * here is what keeps the package from crossing the last mile as raw bytes.
+ *
+ * Only full responses qualify. A 206 body is a slice the browser asked for by
+ * byte offset and its `content-range` describes the identity bytes, so
+ * compressing it would contradict the header.
+ */
+export function canRecompress(
+  response: Response,
+  acceptEncoding: string | null | undefined
+): boolean {
+  if (!bodyWasDecoded(response)) return false
+  if (response.status !== 200) return false
+  if (typeof CompressionStream === 'undefined') return false
+  return acceptsGzip(acceptEncoding)
+}

--- a/apps/web/tests/scorm-proxy-compression.test.mjs
+++ b/apps/web/tests/scorm-proxy-compression.test.mjs
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  acceptsGzip,
+  bodyWasDecoded,
+  canRecompress,
+} from "../ee/services/scorm/proxyCompression.ts";
+
+/**
+ * The SCORM proxy carries every file of a package — hundreds of them — so the
+ * encoding decision it makes is worth more than one asset. Get it too cautious
+ * and megabytes of JS cross the last mile uncompressed; get it wrong and the
+ * browser is handed bytes its headers contradict.
+ */
+
+const gzipped = (status = 200) =>
+  new Response(null, { status, headers: { "content-encoding": "gzip" } });
+
+describe("bodyWasDecoded", () => {
+  test("a compressed upstream response is flagged", () => {
+    expect(bodyWasDecoded(gzipped())).toBe(true);
+  });
+
+  test("no content-encoding means nothing was unpacked", () => {
+    expect(bodyWasDecoded(new Response(null))).toBe(false);
+  });
+
+  test("identity is not compression", () => {
+    const response = new Response(null, {
+      headers: { "content-encoding": "identity" },
+    });
+    expect(bodyWasDecoded(response)).toBe(false);
+  });
+});
+
+describe("acceptsGzip", () => {
+  test("a plain gzip offer is accepted", () => {
+    expect(acceptsGzip("gzip")).toBe(true);
+  });
+
+  test("gzip among other encodings is found", () => {
+    expect(acceptsGzip("br, gzip, deflate")).toBe(true);
+  });
+
+  test("a positive q value is still an offer", () => {
+    expect(acceptsGzip("gzip;q=0.5")).toBe(true);
+  });
+
+  test("gzip weighted to zero is a refusal, not an offer", () => {
+    expect(acceptsGzip("gzip;q=0")).toBe(false);
+    expect(acceptsGzip("br, gzip;q=0")).toBe(false);
+  });
+
+  test("a wildcard covers gzip", () => {
+    expect(acceptsGzip("*")).toBe(true);
+  });
+
+  test("a wildcard does not override gzip refused by name", () => {
+    expect(acceptsGzip("*, gzip;q=0")).toBe(false);
+  });
+
+  test("encodings that merely contain 'gzip' are not gzip", () => {
+    expect(acceptsGzip("x-gzip-ish")).toBe(false);
+  });
+
+  test("a missing or empty header is not an offer", () => {
+    expect(acceptsGzip(null)).toBe(false);
+    expect(acceptsGzip("")).toBe(false);
+  });
+});
+
+describe("canRecompress", () => {
+  test("a decoded 200 for a gzip-capable client is re-compressed", () => {
+    expect(canRecompress(gzipped(), "gzip")).toBe(true);
+  });
+
+  test("a body that was never compressed is left alone", () => {
+    expect(canRecompress(new Response(null), "gzip")).toBe(false);
+  });
+
+  test("a client that cannot read gzip gets plaintext", () => {
+    expect(canRecompress(gzipped(), null)).toBe(false);
+  });
+
+  test("a 206 is left alone — its content-range describes identity bytes", () => {
+    expect(canRecompress(gzipped(206), "gzip")).toBe(false);
+  });
+});
+
+describe("the bytes the browser actually receives", () => {
+  test("a re-compressed stream round-trips back to the original body", async () => {
+    const original = "console.log('scorm');".repeat(500);
+
+    const compressed = new Response(original).body.pipeThrough(
+      new CompressionStream("gzip")
+    );
+    const restored = await new Response(
+      compressed.pipeThrough(new DecompressionStream("gzip"))
+    ).text();
+
+    expect(restored).toBe(original);
+  });
+
+  test("compressing shrinks a typical text asset", async () => {
+    const original = "console.log('scorm');".repeat(500);
+
+    const compressed = await new Response(
+      new Response(original).body.pipeThrough(new CompressionStream("gzip"))
+    ).arrayBuffer();
+
+    expect(compressed.byteLength).toBeLessThan(original.length);
+  });
+});


### PR DESCRIPTION
The SCORM proxy route makes package assets same-origin with the player. The API gzips anything over 1000 bytes, but fetch (undici) decodes that transparently on the way in, and the route doesn't forward content-encoding. Doing so would label plaintext as gzip, and every text asset would fail with ERR_CONTENT_DECODING_FAILED. Next.js route handlers don't compress their own streams either, so the whole package crossed the last hop uncompressed: about 3.3MB of avoidable transfer per load (roughly 0.3s on a fast link, up to 5.3s at 5 Mbps).

Fix: re-compress with CompressionStream('gzip') when the upstream body was decoded, the response is a 200, and the client's accept-encoding allows it (handles q=0 and wildcard values). Vary: accept-encoding is now set on every response, since the body now depends on that header. 206 range responses are left alone, since the body is a byte-offset slice and content-range describes the identity bytes.

The compression decision lives in proxyCompression.ts so it's unit-testable without a server. The same decode-and-forward gap would apply anywhere else this proxy pattern gets used.

17 new tests, including a compress/decompress round-trip. eslint and tsc are clean on the changed files, and bun test tests shows no new failures.