### PR TITLE
fix(api): anonymized users no longer 500 org member lists

### DIFF
--- a/apps/api/src/db/users.py
+++ b/apps/api/src/db/users.py
@@ -57,6 +57,14 @@ class UserUpdatePassword(SQLModel):
 
 
 class UserRead(UserBase):
+    # SECURITY/ROBUSTNESS: a response model must not re-validate what is already
+    # stored. EmailStr (email-validator) rejects special-use names such as
+    # ".local", so one anonymized account — "deleted-user-<id>@anonymized.local",
+    # written by the GDPR scrub — turned every endpoint that returns its org's
+    # members into a 500: the members list, the CSV export, course learners.
+    # Addresses are validated where they enter the system (UserCreate,
+    # UserUpdate, the auth and admin request bodies), not on the way out.
+    email: str
     id: int
     user_uuid: str
     email_verified: bool = False

--- a/apps/api/src/services/admin/admin.py
+++ b/apps/api/src/services/admin/admin.py
@@ -2454,7 +2454,12 @@ async def anonymize_user(
 
     user = await _get_user_in_org(user_id, token_user.org_id, db_session)
 
-    placeholder_email = f"deleted-user-{user_id}@anonymized.local"
+    # example.com is reserved by RFC 2606 and has no MX record, so the address
+    # is undeliverable while still being a well-formed one. The previous
+    # ".local" is a special-use name that email-validator rejects; rows scrubbed
+    # before this change still carry it, which is why UserRead has to tolerate
+    # stored addresses rather than re-validate them.
+    placeholder_email = f"deleted-user-{user_id}@anonymized.example.com"
     placeholder_username = f"deleted_user_{user_id}"
 
     existing_tokens = (await db_session.execute(

--- a/apps/api/src/tests/admin/test_admin_api.py
+++ b/apps/api/src/tests/admin/test_admin_api.py
@@ -2507,7 +2507,7 @@ class TestAnonymizeUser:
 
         await db.refresh(user)
         assert user.email != original_email
-        assert user.email == f"deleted-user-{user.id}@anonymized.local"
+        assert user.email == f"deleted-user-{user.id}@anonymized.example.com"
         assert user.first_name == "Deleted"
         assert user.password == ""
         assert user.email_verified is False

--- a/apps/api/src/tests/services/test_org_users_service.py
+++ b/apps/api/src/tests/services/test_org_users_service.py
@@ -188,6 +188,45 @@ class TestOrgUsersService:
         assert result["items"][0].user.username == "ungrouped"
 
     @pytest.mark.asyncio
+    async def test_get_organization_users_lists_anonymized_members(
+        self, mock_request, db, org, admin_user
+    ):
+        """A GDPR-scrubbed member must not take the whole listing down.
+
+        The scrub rewrites the address to a reserved-domain placeholder. When
+        UserRead still typed email as EmailStr, model_validate raised on that
+        row and the endpoint answered 500 — so one deleted account emptied the
+        members page for its entire organization. Rows scrubbed before the
+        placeholder domain changed still carry ".local", so the listing has to
+        stay tolerant of them.
+        """
+        member_role = await _make_role(db, org, id=40, name="Member", role_uuid="role_member_anon")
+        scrubbed = await _make_user(
+            db,
+            id=41,
+            username="deleted_user_41",
+            first_name="Deleted",
+            last_name="User",
+            email="deleted-user-41@anonymized.local",
+            email_verified=False,
+            signup_method="anonymized",
+            user_uuid="user_deleted_41",
+        )
+        await _link_user(db, scrubbed.id, org.id, member_role.id)
+
+        with patch(
+            "src.services.orgs.users.is_org_member", return_value=True
+        ), patch(
+            "src.security.superadmin.is_user_superadmin", return_value=False
+        ), patch(
+            "src.security.org_auth.is_org_admin", return_value=True
+        ):
+            result = await get_organization_users(mock_request, org.id, db, admin_user)
+
+        emails = [item.user.email for item in result["items"]]
+        assert "deleted-user-41@anonymized.local" in emails
+
+    @pytest.mark.asyncio
     async def test_get_organization_users_and_export_guard_paths(
         self, mock_request, db, org, admin_user, anonymous_user
     ):

--- a/apps/api/src/tests/services/test_user_email_validation.py
+++ b/apps/api/src/tests/services/test_user_email_validation.py
@@ -22,7 +22,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from pydantic import ValidationError
 
-from src.db.users import User, UserUpdate
+from src.db.users import User, UserRead, UserUpdate
 from src.services.users.users import update_user
 
 
@@ -175,3 +175,39 @@ async def test_update_user_cannot_self_promote_email_verified(
     source = __import__("inspect").getsource(users_service.update_user)
     assert "email_verified" in source
     assert '"email_verified"' in source or "'email_verified'" in source
+
+
+# ---------------------------------------------------------------------------
+# Read-side: stored addresses are returned, not re-validated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stored_email",
+    [
+        "deleted-user-41@anonymized.local",
+        "deleted-user-41@anonymized.example.com",
+        "student-3@demo.example.com",
+    ],
+)
+def test_userread_accepts_stored_placeholder_addresses(stored_email):
+    """UserRead must render whatever is on the row.
+
+    The GDPR scrub and the demo seeder both write undeliverable placeholders.
+    email-validator rejects special-use names such as ".local", so typing the
+    response model's email as EmailStr made a single such row 500 every
+    endpoint that returns its org's users.
+    """
+    read = UserRead(
+        id=41,
+        user_uuid="user_deleted_41",
+        username="deleted_user_41",
+        first_name="Deleted",
+        last_name="User",
+        email=stored_email,
+        avatar_image="",
+        bio="",
+        details={},
+        profile={},
+    )
+    assert read.email == stored_email


### PR DESCRIPTION
The Users page showed "No users in this organization yet" for orgs that had members. GET /api/v1/orgs/{org_id}/users was 500ing for those orgs.

`UserRead` inherits `email: EmailStr` from `UserBase`, and email-validator rejects special-use domains like `.local`. The GDPR anonymize scrub (`admin.py:2457`) rewrites deleted accounts to `deleted-user-<id>@anonymized.local`, so any org with one anonymized member failed `UserRead.model_validate()` and lost its member list, CSV export, and course learner view — anything that reads through `UserRead`. The demo seeder had already hit this and picked `demo.example.com` for the same reason; this fix removes the trap at the read model instead.

- `UserRead.email` is now a plain `str`. Response models shouldn't re-validate stored data; write paths (`UserCreate`, `UserUpdate`, auth/admin bodies) still validate.
- Anonymize placeholder moved to `anonymized.example.com` (RFC 2606 reserved, no MX, still well-formed).
- Added regression tests at the service and schema level, updated the anonymize assertion in `test_admin_api.py`.

Ran the user/org/admin test slice: 1568 passed. Two EE SCORM failures are pre-existing and unrelated. No data backfill; old scrubbed rows keep `.local` but render fine now.