### PR TITLE
feat(assignments): add formative (ungraded) mode with model answers

### DIFF
--- a/apps/api/migrations/versions/b1c2d3e4f5a6_add_ungraded_and_solution_to_assignment.py
+++ b/apps/api/migrations/versions/b1c2d3e4f5a6_add_ungraded_and_solution_to_assignment.py
@@ -1,0 +1,93 @@
+"""Add formative (ungraded) mode and the model answer to assignment
+
+Adds four nullable columns to ``assignment``:
+
+- ``ungraded``        : formative mode. No grade is ever computed or shown; a
+                        submission stays SUBMITTED instead of becoming GRADED.
+- ``solution``        : free-text model answer (the "corrigé").
+- ``solution_file``   : on-disk name of an uploaded corrigé document.
+- ``solution_reveal`` : NEVER / ON_SUBMISSION / AFTER_GRADING — when the two
+                        fields above become readable by a learner.
+
+All default to the pre-existing behavior (no formative mode, no corrigé, never
+revealed), so existing assignments are unchanged.
+
+``solution_reveal`` is a native enum to match how ``create_all`` builds the same
+column (``gradingtypeenum`` next to it is one too). Creating it as plain text
+here would leave migrated databases with a different column type from freshly
+created ones.
+
+Revision ID: b1c2d3e4f5a6
+Revises: a2b3c4d5e6f7
+Create Date: 2026-09-02
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel  # noqa: F401
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b1c2d3e4f5a6'
+down_revision: Union[str, None] = 'a2b3c4d5e6f7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+SOLUTION_REVEAL_ENUM = sa.Enum(
+    'NEVER', 'ON_SUBMISSION', 'AFTER_GRADING', name='solutionrevealenum'
+)
+
+# (column name, factory). Kept as data so upgrade/downgrade stay in sync.
+_NEW_COLUMNS = (
+    (
+        'ungraded',
+        lambda: sa.Column('ungraded', sa.Boolean(), nullable=True, server_default=sa.false()),
+    ),
+    ('solution', lambda: sa.Column('solution', sa.String(), nullable=True)),
+    ('solution_file', lambda: sa.Column('solution_file', sa.String(), nullable=True)),
+    (
+        'solution_reveal',
+        lambda: sa.Column(
+            'solution_reveal',
+            SOLUTION_REVEAL_ENUM,
+            nullable=True,
+            server_default='NEVER',
+        ),
+    ),
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if 'assignment' not in inspector.get_table_names():
+        return
+
+    existing_columns = {col['name'] for col in inspector.get_columns('assignment')}
+    if 'solution_reveal' not in existing_columns:
+        # No-op on SQLite, where sa.Enum is rendered as VARCHAR + CHECK.
+        SOLUTION_REVEAL_ENUM.create(bind, checkfirst=True)
+    for name, make_column in _NEW_COLUMNS:
+        if name not in existing_columns:
+            op.add_column('assignment', make_column())
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if 'assignment' not in inspector.get_table_names():
+        return
+
+    existing_columns = {col['name'] for col in inspector.get_columns('assignment')}
+    dropped_reveal = False
+    for name, _ in reversed(_NEW_COLUMNS):
+        if name in existing_columns:
+            op.drop_column('assignment', name)
+            dropped_reveal = dropped_reveal or name == 'solution_reveal'
+    if dropped_reveal:
+        SOLUTION_REVEAL_ENUM.drop(bind, checkfirst=True)

--- a/apps/api/migrations/versions/b1c2d3e4f5a6_add_ungraded_and_solution_to_assignment.py
+++ b/apps/api/migrations/versions/b1c2d3e4f5a6_add_ungraded_and_solution_to_assignment.py
@@ -18,7 +18,7 @@ here would leave migrated databases with a different column type from freshly
 created ones.
 
 Revision ID: b1c2d3e4f5a6
-Revises: a2b3c4d5e6f7
+Revises: a3b4c5d6e7f8
 Create Date: 2026-09-02
 
 """
@@ -31,7 +31,7 @@ import sqlmodel  # noqa: F401
 
 # revision identifiers, used by Alembic.
 revision: str = 'b1c2d3e4f5a6'
-down_revision: Union[str, None] = 'a2b3c4d5e6f7'
+down_revision: Union[str, None] = 'a3b4c5d6e7f8'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/apps/api/src/db/courses/assignments.py
+++ b/apps/api/src/db/courses/assignments.py
@@ -13,6 +13,24 @@ class GradingTypeEnum(str, Enum):
     GPA_SCALE = "GPA_SCALE"
 
 
+class SolutionRevealEnum(str, Enum):
+    """When the assignment's model answer (the "corrigé") becomes readable by
+    the learner.
+
+    NEVER          - never sent to a student (the default: existing assignments
+                     never start handing out a solution on their own).
+    ON_SUBMISSION  - unlocked the moment the learner turns their work in. This
+                     is the formative-assessment mode: hand in the document,
+                     immediately get the worked solution to self-assess against.
+    AFTER_GRADING  - unlocked only once the submission is GRADED, i.e. the
+                     teacher (or the auto-grader) has finished with it.
+    """
+
+    NEVER = "NEVER"
+    ON_SUBMISSION = "ON_SUBMISSION"
+    AFTER_GRADING = "AFTER_GRADING"
+
+
 class AssignmentBase(SQLModel):
     """Represents the common fields for an assignment."""
 
@@ -54,6 +72,24 @@ class AssignmentBase(SQLModel):
     # applies (50 for NUMERIC/PERCENTAGE/PASS_FAIL, 60 for ALPHABET/GPA_SCALE).
     # Nullable so every existing assignment keeps its legacy behavior.
     pass_threshold_percentage: Optional[float] = None
+    # Formative mode. When True this assignment carries no grade at all: the
+    # submit path skips auto-grading, the grading endpoints refuse to run, and
+    # a submission stays in SUBMITTED forever (it is never GRADED). Course
+    # certification treats a turned-in ungraded assignment as satisfied, so an
+    # ungraded assignment never blocks a certificate the way an unmarked graded
+    # one does. grading_type stays on the row but is unused while this is True.
+    ungraded: Optional[bool] = False
+    # The model answer ("corrigé") for the whole assignment: the worked solution
+    # the learner compares their own work against. Free text, plus an optional
+    # uploaded document. Both are withheld from students until
+    # `solution_reveal` says otherwise — the read services blank them out
+    # server-side, so the payload never carries the solution to a learner who
+    # has not unlocked it.
+    solution: Optional[str] = None
+    # Uploaded corrigé document, stored as the on-disk name produced by
+    # `upload_solution_file` (same convention as AssignmentTask.reference_file).
+    solution_file: Optional[str] = None
+    solution_reveal: Optional[SolutionRevealEnum] = SolutionRevealEnum.NEVER
 
     org_id: int
     course_id: int
@@ -78,6 +114,13 @@ class AssignmentRead(AssignmentBase):
     # build file-ref URLs without a second round-trip per request.
     course_uuid: Optional[str] = None
     activity_uuid: Optional[str] = None
+    # Reveal state of the model answer, computed per-reader by the read
+    # services. `has_solution` says a corrigé exists at all (so the learner
+    # UI can show "submit to unlock" without leaking it); `solution_unlocked`
+    # says this reader is allowed to see it. For an instructor both are True
+    # whenever a corrigé exists.
+    has_solution: Optional[bool] = None
+    solution_unlocked: Optional[bool] = None
 
 
 class AssignmentUpdate(SQLModel):
@@ -103,6 +146,9 @@ class AssignmentUpdate(SQLModel):
     allow_retries: Optional[bool] = None
     max_retries: Optional[int] = None
     pass_threshold_percentage: Optional[float] = None
+    ungraded: Optional[bool] = None
+    solution: Optional[str] = None
+    solution_reveal: Optional[SolutionRevealEnum] = None
     update_date: Optional[str] = None
 
 

--- a/apps/api/src/routers/courses/assignments.py
+++ b/apps/api/src/routers/courses/assignments.py
@@ -22,12 +22,14 @@ from src.services.courses.activities.assignments import (
     delete_assignment_from_activity_uuid,
     delete_assignment_submission,
     delete_assignment_task,
+    delete_assignment_solution_file,
     delete_assignment_task_submission,
     get_assignments_from_course,
     get_grade_assignment_submission,
     grade_assignment_submission,
     handle_assignment_task_submission,
     mark_activity_as_done_for_user,
+    put_assignment_solution_file,
     put_assignment_task_reference_file,
     put_assignment_task_submission_file,
     read_assignment,
@@ -158,6 +160,64 @@ async def api_update_assignment(
     """
     return await update_assignment(
         request, assignment_uuid, assignment_object, current_user, db_session
+    )
+
+
+@router.post(
+    "/{assignment_uuid}/solution_file",
+    response_model=AssignmentRead,
+    summary="Upload the assignment model answer document",
+    description=(
+        "Upload or replace the model answer document for an assignment. "
+        "Instructor only. The document is withheld from learners until the "
+        "assignment's solution_reveal rule unlocks it."
+    ),
+    responses={
+        200: {"description": "Solution file stored.", "model": AssignmentRead},
+        400: {"description": "No solution file provided"},
+        401: {"description": "Authentication required"},
+        403: {"description": "User lacks permission to edit this assignment"},
+        404: {"description": "Assignment not found"},
+    },
+)
+async def api_put_assignment_solution_file(
+    request: Request,
+    assignment_uuid: str,
+    solution_file: UploadFile | None = None,
+    current_user: PublicUser = Depends(get_current_user),
+    db_session=Depends(get_db_session),
+) -> AssignmentRead:
+    """
+    Upload the assignment's model answer document
+    """
+    return await put_assignment_solution_file(
+        request, db_session, assignment_uuid, current_user, solution_file
+    )
+
+
+@router.delete(
+    "/{assignment_uuid}/solution_file",
+    response_model=AssignmentRead,
+    summary="Remove the assignment model answer document",
+    description="Detach the model answer document from an assignment. Instructor only.",
+    responses={
+        200: {"description": "Solution file detached.", "model": AssignmentRead},
+        401: {"description": "Authentication required"},
+        403: {"description": "User lacks permission to edit this assignment"},
+        404: {"description": "Assignment not found"},
+    },
+)
+async def api_delete_assignment_solution_file(
+    request: Request,
+    assignment_uuid: str,
+    current_user: PublicUser = Depends(get_current_user),
+    db_session=Depends(get_db_session),
+) -> AssignmentRead:
+    """
+    Remove the assignment's model answer document
+    """
+    return await delete_assignment_solution_file(
+        request, db_session, assignment_uuid, current_user
     )
 
 

--- a/apps/api/src/services/courses/activities/assignments.py
+++ b/apps/api/src/services/courses/activities/assignments.py
@@ -39,6 +39,7 @@ from src.db.courses.assignments import (
     AssignmentUserSubmissionRead,
     AssignmentUserSubmissionStatus,
     GradingTypeEnum,
+    SolutionRevealEnum,
 )
 from src.db.courses.courses import Course
 from src.db.organizations import Organization
@@ -59,6 +60,9 @@ from src.security.rbac import (
 from src.services.courses.activities.uploads.sub_file import upload_submission_file
 from src.services.courses.activities.uploads.tasks_ref_files import (
     upload_reference_file,
+)
+from src.services.courses.activities.uploads.solution_files import (
+    upload_solution_file,
 )
 from src.services.courses.activities.quiz_modes import (
     resolve_grading_mode,
@@ -320,6 +324,110 @@ async def _student_may_see_answer_key(
         if retries_remain:
             return False
     return True
+
+
+# Submission states that count as "the learner has handed their work in".
+# LATE is included: the work is in, it was just past the deadline.
+_HANDED_IN_STATUSES = (
+    AssignmentUserSubmissionStatus.SUBMITTED,
+    AssignmentUserSubmissionStatus.LATE,
+    AssignmentUserSubmissionStatus.GRADED,
+)
+
+
+async def _student_may_see_solution(
+    current_user, assignment, db_session: AsyncSession
+) -> bool:
+    """Whether this (non-instructor) reader has unlocked the model answer.
+
+    The reveal rule is the teacher's ``solution_reveal`` setting measured
+    against the reader's OWN submission:
+
+      NEVER          -> never.
+      ON_SUBMISSION  -> once their submission is handed in (SUBMITTED / LATE /
+                        GRADED). This is the formative case: turn the document
+                        in, get the corrige back immediately.
+      AFTER_GRADING  -> only once their submission is GRADED.
+
+    One extra guard on a *graded* assignment: while a retry attempt is still
+    available, handing over the corrige is a free 100% (read it, hit "Try
+    again", resubmit it). So we withhold it until no attempt remains, mirroring
+    ``_student_may_see_answer_key``. An ungraded (formative) assignment has no
+    score to game, so the retry guard does not apply there — seeing the worked
+    solution and trying again is exactly the intended loop.
+    """
+    reveal = getattr(assignment, "solution_reveal", None) or SolutionRevealEnum.NEVER
+    if reveal == SolutionRevealEnum.NEVER:
+        return False
+    if not isinstance(current_user, PublicUser):
+        return False
+
+    sub = (await db_session.execute(
+        select(AssignmentUserSubmission).where(
+            AssignmentUserSubmission.user_id == current_user.id,
+            AssignmentUserSubmission.assignment_id == assignment.id,
+        )
+    )).scalars().first()
+    if sub is None:
+        return False
+
+    if reveal == SolutionRevealEnum.AFTER_GRADING:
+        if sub.submission_status != AssignmentUserSubmissionStatus.GRADED:
+            return False
+    elif sub.submission_status not in _HANDED_IN_STATUSES:
+        return False
+
+    if not getattr(assignment, "ungraded", False) and getattr(
+        assignment, "allow_retries", False
+    ):
+        max_retries = int(getattr(assignment, "max_retries", 0) or 0)
+        attempt = int(getattr(sub, "attempt_number", 1) or 1)
+        retries_remain = (max_retries == 0) or (attempt < max_retries)
+        if retries_remain:
+            return False
+
+    return True
+
+
+async def _resolve_solution_visibility(
+    request: Request,
+    db_session: AsyncSession,
+    current_user,
+    course_uuid: str,
+    assignment: Assignment,
+) -> bool:
+    """Whether this reader may see the assignment's model answer.
+
+    Short-circuits when the assignment has no corrige at all, so every
+    assignment that never uses the feature — which is all of them until a
+    teacher opts in — pays neither the instructor-role lookup nor the
+    submission query on a read.
+    """
+    if not ((assignment.solution or "").strip() or assignment.solution_file):
+        return False
+    if await _is_assignment_instructor(request, current_user, course_uuid, db_session):
+        return True
+    return await _student_may_see_solution(current_user, assignment, db_session)
+
+
+def _apply_solution_visibility(
+    result: AssignmentRead, assignment: Assignment, *, unlocked: bool
+) -> AssignmentRead:
+    """Stamp the reveal flags on an outgoing AssignmentRead and, when the
+    reader has not unlocked it, strip the corrige from the payload.
+
+    The strip is what actually enforces the reveal — a client-side gate would
+    ship the solution to every learner in the assignment GET and lose the whole
+    point of the feature.
+    """
+    result.has_solution = bool(
+        (assignment.solution or "").strip() or assignment.solution_file
+    )
+    result.solution_unlocked = bool(unlocked)
+    if not unlocked:
+        result.solution = None
+        result.solution_file = None
+    return result
 
 
 ## > Grade computation
@@ -1021,6 +1129,13 @@ async def create_assignment(
     # Create Assignment
     assignment = Assignment(**assignment_object.model_dump())
 
+    # Formative mode and auto-grading are contradictory: one says "never produce
+    # a grade", the other says "produce one on submit". Normalize here (rather
+    # than trusting the client to keep them consistent) so the submit path only
+    # ever has to check one flag.
+    if assignment.ungraded:
+        assignment.auto_grading = False
+
     assignment.assignment_uuid = str(f"assignment_{uuid4()}")
     assignment.creation_date = str(datetime.now())
     assignment.update_date = str(datetime.now())
@@ -1067,7 +1182,12 @@ async def read_assignment(
     result = AssignmentRead.model_validate(assignment)
     result.course_uuid = course_uuid
     result.activity_uuid = activity_uuid
-    return result
+    # The model answer is reveal-gated: an instructor always sees it, a learner
+    # only once their own submission has unlocked it.
+    unlocked = await _resolve_solution_visibility(
+        request, db_session, current_user, course_uuid, assignment
+    )
+    return _apply_solution_visibility(result, assignment, unlocked=unlocked)
 
 
 async def read_assignment_from_activity_uuid(
@@ -1097,7 +1217,12 @@ async def read_assignment_from_activity_uuid(
     result = AssignmentRead.model_validate(assignment)
     result.course_uuid = course_uuid
     result.activity_uuid = activity_uuid_val
-    return result
+    # Same reveal gate as read_assignment — this is the endpoint the learner's
+    # activity page actually calls, so skipping it here would leak the corrige.
+    unlocked = await _resolve_solution_visibility(
+        request, db_session, current_user, course_uuid, assignment
+    )
+    return _apply_solution_visibility(result, assignment, unlocked=unlocked)
 
 
 async def update_assignment(
@@ -1156,6 +1281,9 @@ async def update_assignment(
             setattr(assignment, var, value)
         elif var in CLEARABLE_FIELDS and var in provided:
             setattr(assignment, var, None)
+    # Turning on formative mode turns auto-grading off — see create_assignment.
+    if assignment.ungraded:
+        assignment.auto_grading = False
     assignment.update_date = str(datetime.now())
 
     # Insert Assignment in DB
@@ -1163,8 +1291,134 @@ async def update_assignment(
     await db_session.commit()
     await db_session.refresh(assignment)
 
-    # return assignment read
-    return AssignmentRead.model_validate(assignment)
+    # return assignment read. The caller passed the UPDATE authorization above,
+    # so they are an instructor and the corrige is theirs to see.
+    return _apply_solution_visibility(
+        AssignmentRead.model_validate(assignment), assignment, unlocked=True
+    )
+
+
+async def put_assignment_solution_file(
+    request: Request,
+    db_session: AsyncSession,
+    assignment_uuid: str,
+    current_user: PublicUser | AnonymousUser | APITokenUser,
+    solution_file: UploadFile | None = None,
+):
+    """Attach (or replace) the assignment's model-answer document.
+
+    Mirrors ``put_assignment_task_reference_file`` but at the assignment level.
+    Instructor-only: the stored filename is the corrige, and handing it to a
+    learner before the reveal rule unlocks it would defeat the whole feature.
+    """
+    statement = select(Assignment).where(Assignment.assignment_uuid == assignment_uuid)
+    assignment = (await db_session.execute(statement)).scalars().first()
+
+    if not assignment:
+        raise HTTPException(
+            status_code=404,
+            detail="Assignment not found",
+        )
+
+    statement = select(Activity).where(Activity.id == assignment.activity_id)
+    activity = (await db_session.execute(statement)).scalars().first()
+
+    statement = select(Course).where(Course.id == assignment.course_id)
+    course = (await db_session.execute(statement)).scalars().first()
+
+    if not course:
+        raise HTTPException(
+            status_code=404,
+            detail="Course not found",
+        )
+
+    org_statement = select(Organization).where(Organization.id == course.org_id)
+    org = (await db_session.execute(org_statement)).scalars().first()
+
+    # RBAC check
+    await authorize_assignment_access(
+        request,
+        db_session,
+        current_user,
+        course.course_uuid,
+        AccessAction.UPDATE,
+        token_action="create",
+    )
+
+    if not (solution_file and solution_file.filename):
+        raise HTTPException(
+            status_code=400,
+            detail="No solution file provided",
+        )
+    if not (activity and org):
+        raise HTTPException(
+            status_code=404,
+            detail="Activity not found",
+        )
+
+    name_in_disk = await upload_solution_file(
+        solution_file,
+        activity.activity_uuid,
+        org.org_uuid,
+        course.course_uuid,
+        assignment.assignment_uuid,
+    )
+    assignment.solution_file = name_in_disk
+    assignment.update_date = str(datetime.now())
+
+    db_session.add(assignment)
+    await db_session.commit()
+    await db_session.refresh(assignment)
+
+    return _apply_solution_visibility(
+        AssignmentRead.model_validate(assignment), assignment, unlocked=True
+    )
+
+
+async def delete_assignment_solution_file(
+    request: Request,
+    db_session: AsyncSession,
+    assignment_uuid: str,
+    current_user: PublicUser | AnonymousUser | APITokenUser,
+):
+    """Detach the model-answer document from the assignment.
+
+    Only the reference is dropped; the uploaded blob is left in place, matching
+    how task reference files behave when replaced.
+    """
+    statement = select(Assignment).where(Assignment.assignment_uuid == assignment_uuid)
+    assignment = (await db_session.execute(statement)).scalars().first()
+
+    if not assignment:
+        raise HTTPException(
+            status_code=404,
+            detail="Assignment not found",
+        )
+
+    statement = select(Course).where(Course.id == assignment.course_id)
+    course = (await db_session.execute(statement)).scalars().first()
+
+    if not course:
+        raise HTTPException(
+            status_code=404,
+            detail="Course not found",
+        )
+
+    # RBAC check
+    await authorize_assignment_access(
+        request, db_session, current_user, course.course_uuid, AccessAction.UPDATE
+    )
+
+    assignment.solution_file = None
+    assignment.update_date = str(datetime.now())
+
+    db_session.add(assignment)
+    await db_session.commit()
+    await db_session.refresh(assignment)
+
+    return _apply_solution_visibility(
+        AssignmentRead.model_validate(assignment), assignment, unlocked=True
+    )
 
 
 async def delete_assignment(
@@ -2818,7 +3072,11 @@ async def create_assignment_submission(
     # shared grading helper. For SHORT_ANSWER and NUMBER_ANSWER, the helper
     # re-verifies the student's answer server-side so client-side tampering
     # is caught.
-    if assignment.auto_grading:
+    # A formative (ungraded) assignment never produces a grade, so it skips this
+    # block entirely and the row stays SUBMITTED. create/update_assignment
+    # already force auto_grading off alongside `ungraded`; this second check
+    # covers rows written by anything that bypassed them.
+    if assignment.auto_grading and not assignment.ungraded:
         tasks_statement = select(AssignmentTask).where(
             AssignmentTask.assignment_id == assignment.id
         )
@@ -3319,10 +3577,24 @@ async def retry_assignment_submission(
     # Only graded submissions are eligible to be retried. Retrying a row
     # that is still SUBMITTED would silently throw away the student's
     # pending work before the teacher even sees it.
-    if assignment_user_submission.submission_status != AssignmentUserSubmissionStatus.GRADED:
+    #
+    # A formative (ungraded) assignment is the exception: it is never GRADED, so
+    # requiring that status would make `allow_retries` unreachable there. Its
+    # submissions become retryable as soon as they are handed in — which is the
+    # point of a formative loop (read the corrige, try again).
+    retryable_statuses = (
+        _HANDED_IN_STATUSES
+        if assignment.ungraded
+        else (AssignmentUserSubmissionStatus.GRADED,)
+    )
+    if assignment_user_submission.submission_status not in retryable_statuses:
         raise HTTPException(
             status_code=400,
-            detail="Only graded submissions can be retried",
+            detail=(
+                "Only submitted assignments can be retried"
+                if assignment.ungraded
+                else "Only graded submissions can be retried"
+            ),
         )
 
     # Retry is destructive and irreversible: it deletes every task submission,
@@ -3450,7 +3722,17 @@ async def _apply_grade_and_finalize(
     manual grading endpoint (UPDATE permission) and the student's auto-grade
     path (READ permission, self-grading under teacher-configured auto_grading)
     can share one implementation.
+
+    Refuses to run on a formative (``ungraded``) assignment. The guard lives
+    here rather than only in the grading endpoint so every route into grading —
+    manual, auto, and the bulk regrade after a task edit — is covered by one
+    check, and a formative submission can never be flipped to GRADED.
     """
+    if assignment.ungraded:
+        raise HTTPException(
+            status_code=400,
+            detail="This assignment is ungraded (formative) and cannot be graded.",
+        )
     # Compute max_grade from the current task configuration. The auto-grade
     # path has already loaded this exact list to decide whether every task is
     # auto-gradable, so it hands it over rather than paying for the same query
@@ -3737,6 +4019,15 @@ async def get_grade_assignment_submission(
 
     # RBAC check
     await authorize_assignment_access(request, db_session, current_user, course.course_uuid, AccessAction.READ)
+
+    # A formative assignment has no grade to read. Returning a computed 0 here
+    # would hand every caller a "0/100, not passed" object for work that was
+    # never meant to be scored, and any UI rendering it would look like a fail.
+    if assignment.ungraded:
+        raise HTTPException(
+            status_code=400,
+            detail="This assignment is ungraded (formative) and has no grade.",
+        )
 
     # Ownership check: non-instructors may only read their own grade
     is_instructor = await _is_assignment_instructor(request, current_user, course.course_uuid, db_session)

--- a/apps/api/src/services/courses/activities/assignments.py
+++ b/apps/api/src/services/courses/activities/assignments.py
@@ -1151,8 +1151,11 @@ async def create_assignment(
     # Feature usage
     await increase_feature_usage("assignments", course.org_id, db_session)
 
-    # return assignment read
-    return AssignmentRead.model_validate(assignment)
+    # return assignment read. The caller passed the CREATE authorization above,
+    # so they are an instructor and the corrige is theirs to see.
+    return _apply_solution_visibility(
+        AssignmentRead.model_validate(assignment), assignment, unlocked=True
+    )
 
 
 async def read_assignment(
@@ -4199,9 +4202,28 @@ async def get_assignments_from_course(
     # exposure — but the parent Activity's `published` flag is what hides drafts
     # in navigation, and these direct endpoints bypassed it.
     statement = select(Assignment).where(Assignment.course_id == course.id)
-    if not await _is_assignment_instructor(request, current_user, course.course_uuid, db_session):
+    is_instructor = await _is_assignment_instructor(
+        request, current_user, course.course_uuid, db_session
+    )
+    if not is_instructor:
         statement = statement.where(Assignment.published == True)  # noqa: E712
     assignments = (await db_session.execute(statement)).scalars().all()
 
-    # return assignments read
-    return [AssignmentRead.model_validate(assignment) for assignment in assignments]
+    # The model answer is reveal-gated here exactly as on the single read: this
+    # list is reachable with plain course READ, so returning the raw rows would
+    # hand every learner the corrige of every assignment in the course.
+    results = []
+    for assignment in assignments:
+        has_solution = bool(
+            (assignment.solution or "").strip() or assignment.solution_file
+        )
+        unlocked = has_solution and (
+            is_instructor
+            or await _student_may_see_solution(current_user, assignment, db_session)
+        )
+        results.append(
+            _apply_solution_visibility(
+                AssignmentRead.model_validate(assignment), assignment, unlocked=unlocked
+            )
+        )
+    return results

--- a/apps/api/src/services/courses/activities/uploads/solution_files.py
+++ b/apps/api/src/services/courses/activities/uploads/solution_files.py
@@ -1,0 +1,26 @@
+from fastapi import UploadFile
+from src.services.utils.upload_content import upload_file
+
+
+async def upload_solution_file(
+    file: UploadFile,
+    activity_uuid: str,
+    org_uuid: str,
+    course_uuid: str,
+    assignment_uuid: str,
+) -> str:
+    """Upload the assignment's model answer ("corrigé") document.
+
+    Mirrors ``upload_reference_file`` but hangs off the assignment rather than a
+    task, since the corrigé covers the assignment as a whole. The stored name is
+    what ``Assignment.solution_file`` holds, and it is only ever handed to a
+    learner once the reveal rule unlocks it.
+    """
+    return await upload_file(
+        file=file,
+        directory=f"courses/{course_uuid}/activities/{activity_uuid}/assignments/{assignment_uuid}/solution",
+        type_of_dir="orgs",
+        uuid=org_uuid,
+        allowed_types=["document", "image", "video", "office", "scorm"],
+        filename_prefix="solution",
+    )

--- a/apps/api/src/services/courses/certifications.py
+++ b/apps/api/src/services/courses/certifications.py
@@ -660,6 +660,8 @@ async def are_course_assignments_passed(
     - A missing submission, a not-yet-GRADED submission (SUBMITTED/PENDING), or a
       graded-but-failed submission all return False, so the certificate is
       withheld until the learner actually passes.
+    - A formative (``ungraded``) assignment is the exception: it is satisfied by
+      being handed in, since it is never graded at all.
     - Pass/fail reuses the canonical grader with the assignment's configured
       threshold, so "certified" always agrees with the score shown to the learner.
 
@@ -675,7 +677,10 @@ async def are_course_assignments_passed(
         AssignmentUserSubmission,
         AssignmentUserSubmissionStatus,
     )
-    from src.services.courses.activities.assignments import compute_assignment_grade
+    from src.services.courses.activities.assignments import (
+        _HANDED_IN_STATUSES,
+        compute_assignment_grade,
+    )
 
     # Assignments that belong to activities actually in this course. Use an
     # IN-subquery (not a join) so an activity reused across chapters isn't
@@ -717,6 +722,15 @@ async def are_course_assignments_passed(
     sub_by_assignment = {s.assignment_id: s for s in subs}
 
     for assignment in assignments:
+        # A formative (ungraded) assignment has no grade to pass or fail — it is
+        # satisfied by handing the work in. Requiring GRADED here would make an
+        # ungraded assignment permanently block every certificate in its course,
+        # since nothing ever moves that submission out of SUBMITTED.
+        if getattr(assignment, "ungraded", False):
+            sub = sub_by_assignment.get(assignment.id)
+            if sub is None or sub.submission_status not in _HANDED_IN_STATUSES:
+                return False
+            continue
         # An assignment with no gradable points (no tasks / all-zero max) can't
         # be passed or failed — treat it as vacuously passed so it doesn't
         # permanently block the certificate.

--- a/apps/api/src/tests/services/test_assignment_formative_mode.py
+++ b/apps/api/src/tests/services/test_assignment_formative_mode.py
@@ -1,0 +1,676 @@
+"""Formative assignments: no grading, and a model answer unlocked by submitting.
+
+Covers the "dépôt d'un document qui débloque un corrigé, sans notation" flow:
+
+- ``_student_may_see_solution`` — the reveal rule per ``solution_reveal`` mode,
+  measured against the reader's own submission, including the retry guard and
+  the anonymous reader.
+- ``read_assignment`` / ``read_assignment_from_activity_uuid`` — the corrigé is
+  stripped from the payload for a learner who has not unlocked it, and the
+  ``has_solution`` flag still tells the UI one exists.
+- ``create_assignment`` / ``update_assignment`` — formative mode forces
+  auto-grading off.
+- ``create_assignment_submission`` — a formative submission stays SUBMITTED and
+  is never auto-graded.
+- ``_apply_grade_and_finalize`` / ``grade_assignment_submission`` /
+  ``get_grade_assignment_submission`` — grading a formative assignment, and
+  reading a grade off one, are both refused.
+- ``retry_assignment_submission`` — retries work from SUBMITTED when formative.
+- ``are_course_assignments_passed`` — a handed-in formative assignment satisfies
+  the certificate gate instead of blocking it forever.
+- the solution-file upload / detach services.
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.db.courses.assignments import (
+    Assignment,
+    AssignmentCreate,
+    AssignmentTask,
+    AssignmentTaskTypeEnum,
+    AssignmentUpdate,
+    AssignmentUserSubmission,
+    AssignmentUserSubmissionStatus,
+    GradingTypeEnum,
+    SolutionRevealEnum,
+)
+from src.db.trails import Trail
+from src.services.courses.activities.assignments import (
+    _apply_grade_and_finalize,
+    _student_may_see_solution,
+    create_assignment,
+    create_assignment_submission,
+    delete_assignment_solution_file,
+    get_grade_assignment_submission,
+    grade_assignment_submission,
+    put_assignment_solution_file,
+    read_assignment,
+    read_assignment_from_activity_uuid,
+    retry_assignment_submission,
+    update_assignment,
+)
+from src.services.courses.certifications import are_course_assignments_passed
+
+_RBAC = "src.services.courses.activities.assignments.check_resource_access"
+_AUTHZ = "src.services.courses.activities.assignments.authorize_assignment_access"
+_ROLES = (
+    "src.services.courses.activities.assignments.authorization_verify_based_on_roles"
+)
+_LIMITS = "src.services.courses.activities.assignments.check_limits_with_usage"
+_INCREASE = "src.services.courses.activities.assignments.increase_feature_usage"
+_TRAIL = "src.services.courses.activities.assignments.check_trail_presence"
+_CERT = (
+    "src.services.courses.activities.assignments."
+    "check_course_completion_and_create_certificate"
+)
+_COMPLETE = "src.services.courses.activities.assignments.is_course_fully_completed"
+_TRACK = "src.services.courses.activities.assignments.track"
+_DISPATCH = "src.services.courses.activities.assignments.dispatch_webhooks"
+_AUDIT = "src.services.courses.activities.assignments.record_audit_event"
+_REVOKE = "src.services.courses.activities.assignments.revoke_user_certificate"
+_SYNC = "src.services.courses.activities.assignments.sync_trailrun_status"
+_UPLOAD = "src.services.courses.activities.assignments.upload_solution_file"
+
+SOLUTION_TEXT = "Step 1: restate the brief. Step 2: cite two sources."
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+async def _make_formative(
+    db,
+    org,
+    course,
+    chapter,
+    activity,
+    *,
+    uuid="assignment_formative",
+    ungraded=True,
+    reveal=SolutionRevealEnum.ON_SUBMISSION,
+    solution=SOLUTION_TEXT,
+    solution_file=None,
+    allow_retries=False,
+    max_retries=0,
+):
+    a = Assignment(
+        title="Essay",
+        description="Upload your essay",
+        due_date="2030-01-01",
+        published=True,
+        grading_type=GradingTypeEnum.NUMERIC,
+        auto_grading=False,
+        ungraded=ungraded,
+        solution=solution,
+        solution_file=solution_file,
+        solution_reveal=reveal,
+        allow_retries=allow_retries,
+        max_retries=max_retries,
+        org_id=org.id,
+        course_id=course.id,
+        chapter_id=chapter.id,
+        activity_id=activity.id,
+        assignment_uuid=uuid,
+        creation_date=str(datetime.now()),
+        update_date=str(datetime.now()),
+    )
+    db.add(a)
+    await db.commit()
+    await db.refresh(a)
+    return a
+
+
+async def _make_submission(db, assignment, user, status, *, attempt=1):
+    sub = AssignmentUserSubmission(
+        user_id=user.id,
+        assignment_id=assignment.id,
+        grade=0,
+        submission_status=status,
+        attempt_number=attempt,
+        assignmentusersubmission_uuid=f"aus_formative_{assignment.id}_{user.id}",
+        creation_date=str(datetime.now()),
+        update_date=str(datetime.now()),
+    )
+    db.add(sub)
+    await db.commit()
+    await db.refresh(sub)
+    return sub
+
+
+async def _make_file_task(db, assignment, *, uuid="assignmenttask_formative"):
+    t = AssignmentTask(
+        title="Deposit",
+        description="Upload the document",
+        hint="",
+        reference_file=None,
+        assignment_type=AssignmentTaskTypeEnum.FILE_SUBMISSION,
+        contents={},
+        max_grade_value=100,
+        assignment_id=assignment.id,
+        org_id=assignment.org_id,
+        course_id=assignment.course_id,
+        chapter_id=assignment.chapter_id,
+        activity_id=assignment.activity_id,
+        assignment_task_uuid=uuid,
+        creation_date=str(datetime.now()),
+        update_date=str(datetime.now()),
+    )
+    db.add(t)
+    await db.commit()
+    await db.refresh(t)
+    return t
+
+
+# --------------------------------------------------------------------------- #
+# _student_may_see_solution
+# --------------------------------------------------------------------------- #
+class TestStudentMaySeeSolution:
+    async def test_never_mode_stays_locked_even_after_submitting(
+        self, db, org, course, chapter, activity, regular_user
+    ):
+        a = await _make_formative(
+            db, org, course, chapter, activity, reveal=SolutionRevealEnum.NEVER
+        )
+        await _make_submission(
+            db, a, regular_user, AssignmentUserSubmissionStatus.SUBMITTED
+        )
+        assert await _student_may_see_solution(regular_user, a, db) is False
+
+    async def test_on_submission_locked_until_the_learner_hands_in(
+        self, db, org, course, chapter, activity, regular_user
+    ):
+        a = await _make_formative(db, org, course, chapter, activity)
+        # No submission row at all yet.
+        assert await _student_may_see_solution(regular_user, a, db) is False
+
+        sub = await _make_submission(
+            db, a, regular_user, AssignmentUserSubmissionStatus.PENDING
+        )
+        assert await _student_may_see_solution(regular_user, a, db) is False
+
+        sub.submission_status = AssignmentUserSubmissionStatus.SUBMITTED
+        db.add(sub)
+        await db.commit()
+        assert await _student_may_see_solution(regular_user, a, db) is True
+
+    async def test_on_submission_also_unlocks_for_late_and_graded(
+        self, db, org, course, chapter, activity, regular_user
+    ):
+        a = await _make_formative(db, org, course, chapter, activity)
+        sub = await _make_submission(
+            db, a, regular_user, AssignmentUserSubmissionStatus.LATE
+        )
+        assert await _student_may_see_solution(regular_user, a, db) is True
+
+        sub.submission_status = AssignmentUserSubmissionStatus.GRADED
+        db.add(sub)
+        await db.commit()
+        assert await _student_may_see_solution(regular_user, a, db) is True
+
+    async def test_after_grading_mode_waits_for_the_grade(
+        self, db, org, course, chapter, activity, regular_user
+    ):
+        a = await _make_formative(
+            db,
+            org,
+            course,
+            chapter,
+            activity,
+            ungraded=False,
+            reveal=SolutionRevealEnum.AFTER_GRADING,
+        )
+        sub = await _make_submission(
+            db, a, regular_user, AssignmentUserSubmissionStatus.SUBMITTED
+        )
+        assert await _student_may_see_solution(regular_user, a, db) is False
+
+        sub.submission_status = AssignmentUserSubmissionStatus.GRADED
+        db.add(sub)
+        await db.commit()
+        assert await _student_may_see_solution(regular_user, a, db) is True
+
+    async def test_graded_assignment_withholds_while_a_retry_remains(
+        self, db, org, course, chapter, activity, regular_user
+    ):
+        """Reading the corrigé then retrying would be a free full mark."""
+        a = await _make_formative(
+            db,
+            org,
+            course,
+            chapter,
+            activity,
+            ungraded=False,
+            reveal=SolutionRevealEnum.AFTER_GRADING,
+            allow_retries=True,
+            max_retries=2,
+        )
+        sub = await _make_submission(
+            db, a, regular_user, AssignmentUserSubmissionStatus.GRADED, attempt=1
+        )
+        assert await _student_may_see_solution(regular_user, a, db) is False
+
+        # Attempt cap reached — nothing left to game, so it unlocks.
+        sub.attempt_number = 2
+        db.add(sub)
+        await db.commit()
+        assert await _student_may_see_solution(regular_user, a, db) is True
+
+    async def test_formative_assignment_ignores_the_retry_guard(
+        self, db, org, course, chapter, activity, regular_user
+    ):
+        """Read the corrigé, try again — that IS the formative loop."""
+        a = await _make_formative(
+            db, org, course, chapter, activity, allow_retries=True, max_retries=0
+        )
+        await _make_submission(
+            db, a, regular_user, AssignmentUserSubmissionStatus.SUBMITTED
+        )
+        assert await _student_may_see_solution(regular_user, a, db) is True
+
+    async def test_anonymous_reader_never_unlocks(
+        self, db, org, course, chapter, activity, anonymous_user
+    ):
+        a = await _make_formative(db, org, course, chapter, activity)
+        assert await _student_may_see_solution(anonymous_user, a, db) is False
+
+
+# --------------------------------------------------------------------------- #
+# Read services strip the corrigé
+# --------------------------------------------------------------------------- #
+class TestSolutionVisibilityOnRead:
+    async def test_student_without_submission_gets_no_solution_but_knows_it_exists(
+        self, mock_request, db, org, course, chapter, activity, regular_user
+    ):
+        a = await _make_formative(
+            db, org, course, chapter, activity, solution_file="solution_x.pdf"
+        )
+        with patch(_AUTHZ, new_callable=AsyncMock), patch(
+            _ROLES, new_callable=AsyncMock, return_value=False
+        ):
+            result = await read_assignment(
+                mock_request, a.assignment_uuid, regular_user, db
+            )
+        assert result.solution is None
+        assert result.solution_file is None
+        assert result.has_solution is True
+        assert result.solution_unlocked is False
+
+    async def test_student_gets_the_solution_once_submitted(
+        self, mock_request, db, org, course, chapter, activity, regular_user
+    ):
+        a = await _make_formative(
+            db, org, course, chapter, activity, solution_file="solution_x.pdf"
+        )
+        await _make_submission(
+            db, a, regular_user, AssignmentUserSubmissionStatus.SUBMITTED
+        )
+        with patch(_AUTHZ, new_callable=AsyncMock), patch(
+            _ROLES, new_callable=AsyncMock, return_value=False
+        ):
+            result = await read_assignment(
+                mock_request, a.assignment_uuid, regular_user, db
+            )
+        assert result.solution == SOLUTION_TEXT
+        assert result.solution_file == "solution_x.pdf"
+        assert result.solution_unlocked is True
+
+    async def test_instructor_always_sees_the_solution(
+        self, mock_request, db, org, course, chapter, activity, admin_user
+    ):
+        a = await _make_formative(db, org, course, chapter, activity)
+        with patch(_AUTHZ, new_callable=AsyncMock), patch(
+            _ROLES, new_callable=AsyncMock, return_value=True
+        ):
+            result = await read_assignment(
+                mock_request, a.assignment_uuid, admin_user, db
+            )
+        assert result.solution == SOLUTION_TEXT
+        assert result.solution_unlocked is True
+
+    async def test_activity_read_is_gated_too(
+        self, mock_request, db, org, course, chapter, activity, regular_user
+    ):
+        """The learner's activity page reads through this endpoint, so a gap
+        here would leak the corrigé to every student on page load."""
+        await _make_formative(db, org, course, chapter, activity)
+        with patch(_AUTHZ, new_callable=AsyncMock), patch(
+            _ROLES, new_callable=AsyncMock, return_value=False
+        ):
+            result = await read_assignment_from_activity_uuid(
+                mock_request, activity.activity_uuid, regular_user, db
+            )
+        assert result.solution is None
+        assert result.has_solution is True
+        assert result.solution_unlocked is False
+
+    async def test_has_solution_is_false_when_none_was_authored(
+        self, mock_request, db, org, course, chapter, activity, regular_user
+    ):
+        a = await _make_formative(
+            db, org, course, chapter, activity, solution="   ", solution_file=None
+        )
+        with patch(_AUTHZ, new_callable=AsyncMock), patch(
+            _ROLES, new_callable=AsyncMock, return_value=False
+        ):
+            result = await read_assignment(
+                mock_request, a.assignment_uuid, regular_user, db
+            )
+        assert result.has_solution is False
+
+
+# --------------------------------------------------------------------------- #
+# Formative mode vs auto-grading
+# --------------------------------------------------------------------------- #
+class TestFormativeForcesAutoGradingOff:
+    async def test_create_drops_auto_grading(
+        self, mock_request, db, org, course, chapter, activity, admin_user
+    ):
+        obj = AssignmentCreate(
+            title="T",
+            description="D",
+            due_date="2030-01-01",
+            grading_type=GradingTypeEnum.NUMERIC,
+            auto_grading=True,
+            ungraded=True,
+            org_id=org.id,
+            course_id=course.id,
+            chapter_id=chapter.id,
+            activity_id=activity.id,
+        )
+        with patch(_AUTHZ, new_callable=AsyncMock), patch(
+            _LIMITS, new_callable=AsyncMock
+        ), patch(_INCREASE, new_callable=AsyncMock):
+            result = await create_assignment(mock_request, obj, admin_user, db)
+        assert result.ungraded is True
+        assert result.auto_grading is False
+
+    async def test_update_drops_auto_grading(
+        self, mock_request, db, org, course, chapter, activity, admin_user
+    ):
+        a = await _make_formative(db, org, course, chapter, activity, ungraded=False)
+        a.auto_grading = True
+        db.add(a)
+        await db.commit()
+
+        with patch(_AUTHZ, new_callable=AsyncMock):
+            result = await update_assignment(
+                mock_request,
+                a.assignment_uuid,
+                AssignmentUpdate(ungraded=True),
+                admin_user,
+                db,
+            )
+        assert result.ungraded is True
+        assert result.auto_grading is False
+
+
+# --------------------------------------------------------------------------- #
+# Submitting a formative assignment
+# --------------------------------------------------------------------------- #
+class TestFormativeSubmission:
+    async def test_submission_stays_submitted_and_is_not_graded(
+        self, mock_request, db, org, course, chapter, activity, regular_user
+    ):
+        a = await _make_formative(db, org, course, chapter, activity)
+        await _make_file_task(db, a)
+        # Even with the flag flipped on the row directly, formative wins.
+        a.auto_grading = True
+        db.add(a)
+        await db.commit()
+
+        trail = Trail(
+            org_id=course.org_id,
+            user_id=regular_user.id,
+            trail_uuid="trail_formative",
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(trail)
+        await db.commit()
+        await db.refresh(trail)
+
+        with patch(_RBAC, new_callable=AsyncMock), patch(
+            _ROLES, new_callable=AsyncMock, return_value=False
+        ), patch(_TRAIL, new_callable=AsyncMock, return_value=trail), patch(
+            _CERT, new_callable=AsyncMock
+        ), patch(_COMPLETE, new_callable=AsyncMock, return_value=False), patch(
+            _TRACK, new_callable=AsyncMock
+        ), patch(_DISPATCH, new_callable=AsyncMock), patch(
+            _AUDIT, new_callable=AsyncMock
+        ):
+            result = await create_assignment_submission(
+                mock_request, a.assignment_uuid, regular_user, db
+            )
+
+        assert result.submission_status == AssignmentUserSubmissionStatus.SUBMITTED
+        assert result.grade == 0
+
+    async def test_solution_unlocks_right_after_that_submission(
+        self, mock_request, db, org, course, chapter, activity, regular_user
+    ):
+        """The whole point: hand the document in, get the corrigé back now."""
+        a = await _make_formative(db, org, course, chapter, activity)
+        await _make_file_task(db, a)
+        trail = Trail(
+            org_id=course.org_id,
+            user_id=regular_user.id,
+            trail_uuid="trail_formative_unlock",
+            creation_date=str(datetime.now()),
+            update_date=str(datetime.now()),
+        )
+        db.add(trail)
+        await db.commit()
+        await db.refresh(trail)
+
+        with patch(_AUTHZ, new_callable=AsyncMock), patch(
+            _ROLES, new_callable=AsyncMock, return_value=False
+        ):
+            before = await read_assignment(
+                mock_request, a.assignment_uuid, regular_user, db
+            )
+        assert before.solution is None
+
+        with patch(_RBAC, new_callable=AsyncMock), patch(
+            _ROLES, new_callable=AsyncMock, return_value=False
+        ), patch(_TRAIL, new_callable=AsyncMock, return_value=trail), patch(
+            _CERT, new_callable=AsyncMock
+        ), patch(_COMPLETE, new_callable=AsyncMock, return_value=False), patch(
+            _TRACK, new_callable=AsyncMock
+        ), patch(_DISPATCH, new_callable=AsyncMock), patch(
+            _AUDIT, new_callable=AsyncMock
+        ):
+            await create_assignment_submission(
+                mock_request, a.assignment_uuid, regular_user, db
+            )
+
+        with patch(_AUTHZ, new_callable=AsyncMock), patch(
+            _ROLES, new_callable=AsyncMock, return_value=False
+        ):
+            after = await read_assignment(
+                mock_request, a.assignment_uuid, regular_user, db
+            )
+        assert after.solution == SOLUTION_TEXT
+        assert after.solution_unlocked is True
+
+
+# --------------------------------------------------------------------------- #
+# Grading is refused
+# --------------------------------------------------------------------------- #
+class TestGradingRefused:
+    async def test_apply_grade_and_finalize_raises(
+        self, db, org, course, chapter, activity, regular_user
+    ):
+        a = await _make_formative(db, org, course, chapter, activity)
+        sub = await _make_submission(
+            db, a, regular_user, AssignmentUserSubmissionStatus.SUBMITTED
+        )
+        with pytest.raises(HTTPException) as exc:
+            await _apply_grade_and_finalize(
+                assignment=a,
+                course=course,
+                user_id=regular_user.id,
+                assignment_user_submission=sub,
+                db_session=db,
+            )
+        assert exc.value.status_code == 400
+        assert "ungraded" in exc.value.detail
+
+    async def test_grade_endpoint_raises_and_leaves_status_alone(
+        self, mock_request, db, org, course, chapter, activity, regular_user, admin_user
+    ):
+        a = await _make_formative(db, org, course, chapter, activity)
+        sub = await _make_submission(
+            db, a, regular_user, AssignmentUserSubmissionStatus.SUBMITTED
+        )
+        with patch(_AUTHZ, new_callable=AsyncMock):
+            with pytest.raises(HTTPException) as exc:
+                await grade_assignment_submission(
+                    mock_request, regular_user.id, a.assignment_uuid, admin_user, db
+                )
+        assert exc.value.status_code == 400
+        await db.refresh(sub)
+        assert sub.submission_status == AssignmentUserSubmissionStatus.SUBMITTED
+
+    async def test_reading_the_grade_is_refused_rather_than_returning_zero(
+        self, mock_request, db, org, course, chapter, activity, regular_user, admin_user
+    ):
+        """A computed 0 would render as "0/100 — not passed" for work that was
+        never meant to be scored."""
+        a = await _make_formative(db, org, course, chapter, activity)
+        await _make_submission(
+            db, a, regular_user, AssignmentUserSubmissionStatus.SUBMITTED
+        )
+        with patch(_AUTHZ, new_callable=AsyncMock), patch(
+            _ROLES, new_callable=AsyncMock, return_value=True
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await get_grade_assignment_submission(
+                    mock_request, regular_user.id, a.assignment_uuid, admin_user, db
+                )
+        assert exc.value.status_code == 400
+
+
+# --------------------------------------------------------------------------- #
+# Retry
+# --------------------------------------------------------------------------- #
+class TestFormativeRetry:
+    async def test_formative_submission_can_be_retried_from_submitted(
+        self, mock_request, db, org, course, chapter, activity, regular_user
+    ):
+        a = await _make_formative(
+            db, org, course, chapter, activity, allow_retries=True, max_retries=0
+        )
+        await _make_submission(
+            db, a, regular_user, AssignmentUserSubmissionStatus.SUBMITTED
+        )
+        with patch(_RBAC, new_callable=AsyncMock), patch(
+            _ROLES, new_callable=AsyncMock, return_value=False
+        ), patch(_REVOKE, new_callable=AsyncMock), patch(_SYNC, new_callable=AsyncMock):
+            result = await retry_assignment_submission(
+                mock_request, a.assignment_uuid, regular_user, db
+            )
+        assert result["attempt_number"] == 2
+
+    async def test_graded_assignment_still_refuses_a_submitted_retry(
+        self, mock_request, db, org, course, chapter, activity, regular_user
+    ):
+        a = await _make_formative(
+            db,
+            org,
+            course,
+            chapter,
+            activity,
+            ungraded=False,
+            allow_retries=True,
+            max_retries=0,
+        )
+        await _make_submission(
+            db, a, regular_user, AssignmentUserSubmissionStatus.SUBMITTED
+        )
+        with patch(_RBAC, new_callable=AsyncMock), patch(
+            _ROLES, new_callable=AsyncMock, return_value=False
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await retry_assignment_submission(
+                    mock_request, a.assignment_uuid, regular_user, db
+                )
+        assert exc.value.status_code == 400
+
+
+# --------------------------------------------------------------------------- #
+# Certificate gate
+# --------------------------------------------------------------------------- #
+class TestCertificateGate:
+    """The ``activity`` fixture already links itself into the chapter, so the
+    assignment below is a real course assignment as far as the gate is
+    concerned."""
+
+    async def test_handed_in_formative_assignment_satisfies_the_gate(
+        self, db, org, course, chapter, activity, regular_user
+    ):
+        a = await _make_formative(db, org, course, chapter, activity)
+        await _make_file_task(db, a)
+        await _make_submission(
+            db, a, regular_user, AssignmentUserSubmissionStatus.SUBMITTED
+        )
+        assert await are_course_assignments_passed(regular_user.id, course.id, db) is True
+
+    async def test_missing_formative_submission_still_blocks_the_gate(
+        self, db, org, course, chapter, activity, regular_user
+    ):
+        a = await _make_formative(db, org, course, chapter, activity)
+        await _make_file_task(db, a)
+        assert (
+            await are_course_assignments_passed(regular_user.id, course.id, db) is False
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Solution file upload / detach
+# --------------------------------------------------------------------------- #
+class TestSolutionFileServices:
+    async def test_upload_stores_the_returned_disk_name(
+        self, mock_request, db, org, course, chapter, activity, admin_user
+    ):
+        a = await _make_formative(db, org, course, chapter, activity, solution_file=None)
+
+        class _Upload:
+            filename = "corrige.pdf"
+
+        with patch(_AUTHZ, new_callable=AsyncMock), patch(
+            _UPLOAD, new_callable=AsyncMock, return_value="solution_abc.pdf"
+        ):
+            result = await put_assignment_solution_file(
+                mock_request, db, a.assignment_uuid, admin_user, _Upload()
+            )
+        assert result.solution_file == "solution_abc.pdf"
+        await db.refresh(a)
+        assert a.solution_file == "solution_abc.pdf"
+
+    async def test_upload_without_a_file_is_a_400(
+        self, mock_request, db, org, course, chapter, activity, admin_user
+    ):
+        a = await _make_formative(db, org, course, chapter, activity)
+        with patch(_AUTHZ, new_callable=AsyncMock):
+            with pytest.raises(HTTPException) as exc:
+                await put_assignment_solution_file(
+                    mock_request, db, a.assignment_uuid, admin_user, None
+                )
+        assert exc.value.status_code == 400
+
+    async def test_delete_detaches_the_file(
+        self, mock_request, db, org, course, chapter, activity, admin_user
+    ):
+        a = await _make_formative(
+            db, org, course, chapter, activity, solution_file="solution_abc.pdf"
+        )
+        with patch(_AUTHZ, new_callable=AsyncMock):
+            result = await delete_assignment_solution_file(
+                mock_request, db, a.assignment_uuid, admin_user
+            )
+        assert result.solution_file is None
+        await db.refresh(a)
+        assert a.solution_file is None

--- a/apps/api/src/tests/services/test_assignment_formative_mode.py
+++ b/apps/api/src/tests/services/test_assignment_formative_mode.py
@@ -45,6 +45,7 @@ from src.services.courses.activities.assignments import (
     create_assignment,
     create_assignment_submission,
     delete_assignment_solution_file,
+    get_assignments_from_course,
     get_grade_assignment_submission,
     grade_assignment_submission,
     put_assignment_solution_file,
@@ -359,6 +360,58 @@ class TestSolutionVisibilityOnRead:
                 mock_request, a.assignment_uuid, regular_user, db
             )
         assert result.has_solution is False
+
+    async def test_course_list_is_gated_per_assignment(
+        self, mock_request, db, org, course, chapter, activity, regular_user
+    ):
+        # The course-wide list is reachable with plain course READ, so it has
+        # to apply the same reveal rule as the single read — per assignment,
+        # since the learner may have handed in one and not the other.
+        handed_in = await _make_formative(
+            db, org, course, chapter, activity, uuid="assignment_formative_a"
+        )
+        locked = await _make_formative(
+            db,
+            org,
+            course,
+            chapter,
+            activity,
+            uuid="assignment_formative_b",
+            solution_file="solution_b.pdf",
+        )
+        await _make_submission(
+            db, handed_in, regular_user, AssignmentUserSubmissionStatus.SUBMITTED
+        )
+        with patch(_AUTHZ, new_callable=AsyncMock), patch(
+            _ROLES, new_callable=AsyncMock, return_value=False
+        ):
+            results = await get_assignments_from_course(
+                mock_request, course.course_uuid, regular_user, db
+            )
+        by_uuid = {r.assignment_uuid: r for r in results}
+        assert by_uuid[handed_in.assignment_uuid].solution == SOLUTION_TEXT
+        assert by_uuid[handed_in.assignment_uuid].solution_unlocked is True
+        assert by_uuid[locked.assignment_uuid].solution is None
+        assert by_uuid[locked.assignment_uuid].solution_file is None
+        assert by_uuid[locked.assignment_uuid].has_solution is True
+        assert by_uuid[locked.assignment_uuid].solution_unlocked is False
+
+    async def test_course_list_shows_instructor_everything(
+        self, mock_request, db, org, course, chapter, activity, admin_user
+    ):
+        a = await _make_formative(
+            db, org, course, chapter, activity, solution_file="solution_x.pdf"
+        )
+        with patch(_AUTHZ, new_callable=AsyncMock), patch(
+            _ROLES, new_callable=AsyncMock, return_value=True
+        ):
+            results = await get_assignments_from_course(
+                mock_request, course.course_uuid, admin_user, db
+            )
+        (result,) = [r for r in results if r.assignment_uuid == a.assignment_uuid]
+        assert result.solution == SOLUTION_TEXT
+        assert result.solution_file == "solution_x.pdf"
+        assert result.solution_unlocked is True
 
 
 # --------------------------------------------------------------------------- #

--- a/apps/api/src/tests/services/test_assignment_formative_mode.py
+++ b/apps/api/src/tests/services/test_assignment_formative_mode.py
@@ -25,7 +25,12 @@ from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from httpx import ASGITransport, AsyncClient
+
+from src.core.events.database import get_db_session
+from src.routers.courses.assignments import router as assignments_router
+from src.security.auth import get_current_user
 
 from src.db.courses.assignments import (
     Assignment,
@@ -54,6 +59,9 @@ from src.services.courses.activities.assignments import (
     retry_assignment_submission,
     update_assignment,
 )
+from src.services.courses.activities.uploads.solution_files import (
+    upload_solution_file,
+)
 from src.services.courses.certifications import are_course_assignments_passed
 
 _RBAC = "src.services.courses.activities.assignments.check_resource_access"
@@ -75,6 +83,7 @@ _AUDIT = "src.services.courses.activities.assignments.record_audit_event"
 _REVOKE = "src.services.courses.activities.assignments.revoke_user_certificate"
 _SYNC = "src.services.courses.activities.assignments.sync_trailrun_status"
 _UPLOAD = "src.services.courses.activities.assignments.upload_solution_file"
+_UPLOAD_FILE = "src.services.courses.activities.uploads.solution_files.upload_file"
 
 SOLUTION_TEXT = "Step 1: restate the brief. Step 2: cite two sources."
 
@@ -725,5 +734,150 @@ class TestSolutionFileServices:
                 mock_request, db, a.assignment_uuid, admin_user
             )
         assert result.solution_file is None
+        await db.refresh(a)
+        assert a.solution_file is None
+
+    async def test_upload_on_an_unknown_assignment_is_a_404(
+        self, mock_request, db, admin_user
+    ):
+        with patch(_AUTHZ, new_callable=AsyncMock):
+            with pytest.raises(HTTPException) as exc:
+                await put_assignment_solution_file(
+                    mock_request, db, "assignment_does_not_exist", admin_user, None
+                )
+        assert exc.value.status_code == 404
+
+    async def test_upload_with_a_dangling_course_is_a_404(
+        self, mock_request, db, org, course, chapter, activity, admin_user
+    ):
+        a = await _make_formative(db, org, course, chapter, activity)
+        a.course_id = 999
+        db.add(a)
+        await db.commit()
+        with patch(_AUTHZ, new_callable=AsyncMock):
+            with pytest.raises(HTTPException) as exc:
+                await put_assignment_solution_file(
+                    mock_request, db, a.assignment_uuid, admin_user, None
+                )
+        assert exc.value.status_code == 404
+        assert exc.value.detail == "Course not found"
+
+    async def test_upload_with_a_dangling_activity_is_a_404(
+        self, mock_request, db, org, course, chapter, activity, admin_user
+    ):
+        a = await _make_formative(db, org, course, chapter, activity)
+        a.activity_id = 999
+        db.add(a)
+        await db.commit()
+
+        class _Upload:
+            filename = "corrige.pdf"
+
+        with patch(_AUTHZ, new_callable=AsyncMock), patch(
+            _UPLOAD, new_callable=AsyncMock
+        ) as upload:
+            with pytest.raises(HTTPException) as exc:
+                await put_assignment_solution_file(
+                    mock_request, db, a.assignment_uuid, admin_user, _Upload()
+                )
+        assert exc.value.status_code == 404
+        assert exc.value.detail == "Activity not found"
+        upload.assert_not_awaited()
+
+    async def test_delete_on_an_unknown_assignment_is_a_404(
+        self, mock_request, db, admin_user
+    ):
+        with patch(_AUTHZ, new_callable=AsyncMock):
+            with pytest.raises(HTTPException) as exc:
+                await delete_assignment_solution_file(
+                    mock_request, db, "assignment_does_not_exist", admin_user
+                )
+        assert exc.value.status_code == 404
+
+    async def test_delete_with_a_dangling_course_is_a_404(
+        self, mock_request, db, org, course, chapter, activity, admin_user
+    ):
+        a = await _make_formative(
+            db, org, course, chapter, activity, solution_file="solution_abc.pdf"
+        )
+        a.course_id = 999
+        db.add(a)
+        await db.commit()
+        with patch(_AUTHZ, new_callable=AsyncMock):
+            with pytest.raises(HTTPException) as exc:
+                await delete_assignment_solution_file(
+                    mock_request, db, a.assignment_uuid, admin_user
+                )
+        assert exc.value.status_code == 404
+        assert exc.value.detail == "Course not found"
+
+    async def test_upload_helper_stores_under_the_assignment_solution_dir(self):
+        # The stored path is what the web client rebuilds to download the
+        # corrige, so the directory layout is part of the contract.
+        with patch(_UPLOAD_FILE, new_callable=AsyncMock, return_value="solution_x.pdf") as up:
+            name = await upload_solution_file(
+                object(), "activity_1", "org_1", "course_1", "assignment_1"
+            )
+        assert name == "solution_x.pdf"
+        kwargs = up.await_args.kwargs
+        assert kwargs["directory"] == (
+            "courses/course_1/activities/activity_1/assignments/assignment_1/solution"
+        )
+        assert kwargs["type_of_dir"] == "orgs"
+        assert kwargs["uuid"] == "org_1"
+        assert kwargs["filename_prefix"] == "solution"
+
+
+# --------------------------------------------------------------------------- #
+# Solution file routes
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def solution_app(db, admin_user):
+    app = FastAPI()
+    app.include_router(assignments_router, prefix="/api/v1/assignments")
+    app.dependency_overrides[get_db_session] = lambda: db
+    app.dependency_overrides[get_current_user] = lambda: admin_user
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def solution_client(solution_app):
+    async with AsyncClient(
+        transport=ASGITransport(app=solution_app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+class TestSolutionFileRoutes:
+    async def test_post_uploads_and_returns_the_unlocked_read(
+        self, solution_client, db, org, course, chapter, activity
+    ):
+        a = await _make_formative(db, org, course, chapter, activity, solution_file=None)
+        with patch(_AUTHZ, new_callable=AsyncMock), patch(
+            _UPLOAD, new_callable=AsyncMock, return_value="solution_abc.pdf"
+        ):
+            res = await solution_client.post(
+                f"/api/v1/assignments/{a.assignment_uuid}/solution_file",
+                files={"solution_file": ("corrige.pdf", b"%PDF-1.4", "application/pdf")},
+            )
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert body["solution_file"] == "solution_abc.pdf"
+        assert body["has_solution"] is True
+        assert body["solution_unlocked"] is True
+
+    async def test_delete_detaches_and_returns_the_read(
+        self, solution_client, db, org, course, chapter, activity
+    ):
+        a = await _make_formative(
+            db, org, course, chapter, activity, solution_file="solution_abc.pdf"
+        )
+        with patch(_AUTHZ, new_callable=AsyncMock):
+            res = await solution_client.delete(
+                f"/api/v1/assignments/{a.assignment_uuid}/solution_file"
+            )
+        assert res.status_code == 200, res.text
+        assert res.json()["solution_file"] is None
         await db.refresh(a)
         assert a.solution_file is None

--- a/apps/e2e/.gitignore
+++ b/apps/e2e/.gitignore
@@ -4,3 +4,6 @@ test-results/
 playwright-report/
 playwright/.cache/
 *.log
+
+# Recorded walkthroughs (demo/formative-demo.ts) — regenerate, do not commit.
+demo/output/

--- a/apps/e2e/demo/formative-demo.ts
+++ b/apps/e2e/demo/formative-demo.ts
@@ -1,0 +1,208 @@
+/**
+ * Recorded walkthrough of the formative-assignment flow.
+ *
+ * This is a *demo*, not a test — `playwright.config.ts` only collects specs
+ * under `features/`, so nothing here runs in CI. It drives the same UI the
+ * `22-formative` spec asserts on, but slowly and with an on-screen caption for
+ * each step, and writes a video you can watch end to end.
+ *
+ * It reuses the feature module's own API seeding and page objects, so the
+ * walkthrough can never drift from the flow the spec covers.
+ *
+ * Usage (against an already-running instance):
+ *
+ *   export E2E_BASE_URL=http://localhost:3010
+ *   export E2E_API_URL=http://localhost:1348/api/v1
+ *   export E2E_ADMIN_EMAIL=admin@school.dev
+ *   export E2E_ADMIN_PASSWORD='...'
+ *   bun run demo/formative-demo.ts            # -> demo/output/<name>.webm
+ */
+import { fileURLToPath } from 'node:url'
+import { mkdirSync, readdirSync, renameSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { chromium, Browser, Page } from '@playwright/test'
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, BASE_URL, makeStudent } from '../core/instance'
+import * as api from '../features/assignments/api'
+import { AssignmentPage } from '../features/assignments/pages/student'
+import { AssignmentEditorPage, TeacherSubmissionsPage } from '../features/assignments/pages/teacher'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const OUT_DIR = join(HERE, 'output')
+const FIXTURE = join(HERE, '..', 'features', 'assignments', 'fixtures', 'submission.png')
+
+const SOLUTION =
+  "Corrigé — Étape 1 : reformuler la consigne. Étape 2 : citer deux sources par argument. " +
+  'Étape 3 : conclure en trois phrases.'
+
+const VIEWPORT = { width: 1280, height: 720 }
+
+/** Paint a caption over the page so the recording explains itself. */
+async function caption(page: Page, step: string, text: string, holdMs = 2600): Promise<void> {
+  await page.evaluate(
+    ({ step, text }) => {
+      const id = '__lh_demo_caption__'
+      document.getElementById(id)?.remove()
+      const el = document.createElement('div')
+      el.id = id
+      el.style.cssText = [
+        'position:fixed', 'inset:auto 0 0 0', 'z-index:2147483647',
+        'padding:14px 22px', 'background:rgba(15,23,42,.92)', 'color:#fff',
+        'font:600 15px/1.45 ui-sans-serif,system-ui,-apple-system,sans-serif',
+        'display:flex', 'gap:12px', 'align-items:baseline', 'pointer-events:none',
+      ].join(';')
+      el.innerHTML =
+        `<span style="font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5eead4">${step}</span>` +
+        `<span>${text}</span>`
+      document.body.appendChild(el)
+    },
+    { step, text },
+  )
+  await page.waitForTimeout(holdMs)
+}
+
+/**
+ * Centre the element whose text matches `text` in the viewport.
+ *
+ * `scrollIntoViewIfNeeded` was not enough here: the panel lands above the fold
+ * inside an inner scroll container, and the refetch that follows a hand-in
+ * re-renders it, so the scroll has to happen after that settles — hence the
+ * second pass.
+ */
+async function scrollTo(page: Page, text: string): Promise<void> {
+  const centre = () =>
+    page.evaluate((needle) => {
+      const el = Array.from(document.querySelectorAll('h3, p, span')).find(
+        (e) => e.textContent?.trim() === needle,
+      )
+      el?.scrollIntoView({ block: 'center' })
+    }, text)
+  await centre()
+  await page.waitForTimeout(600)
+  await centre()
+}
+
+async function loggedInPage(browser: Browser, email: string, password: string): Promise<Page> {
+  const context = await browser.newContext({
+    viewport: VIEWPORT,
+    recordVideo: { dir: OUT_DIR, size: VIEWPORT },
+  })
+  const page = await context.newPage()
+  await page.goto(`${BASE_URL}/login`)
+  await page.getByRole('textbox', { name: 'Email' }).fill(email)
+  await page.getByRole('textbox', { name: 'Password' }).fill(password)
+  await page.getByRole('button', { name: 'Login', exact: true }).click()
+  await page.waitForURL((u) => !/\/login(\?|$)/.test(u.toString()), { timeout: 30_000 })
+  // Suppress the first-run onboarding overlay so it doesn't cover the demo.
+  await page.evaluate(() => {
+    try {
+      window.localStorage.setItem(
+        'lh_onboarding',
+        JSON.stringify({ completedSteps: [], skippedSteps: [], minimized: true, expanded: false, showAllSteps: false, dismissed: true, welcomeSeen: true }),
+      )
+    } catch { /* ignore */ }
+  })
+  return page
+}
+
+/** Close the page's context and return the recorded video's final path. */
+async function finishRecording(page: Page, name: string): Promise<string> {
+  const video = page.video()
+  await page.context().close()
+  if (!video) throw new Error('no video was recorded')
+  const src = await video.path()
+  const dest = join(OUT_DIR, `${name}.webm`)
+  renameSync(src, dest)
+  return dest
+}
+
+async function main(): Promise<void> {
+  mkdirSync(OUT_DIR, { recursive: true })
+
+  // --- Seed a course + assignment with one file-deposit task ---------------
+  const adminToken = await api.login(ADMIN_EMAIL, ADMIN_PASSWORD)
+  const org = await api.getOrg()
+  const stamp = Date.now().toString(36)
+  const seeded = await api.seedAssignment(adminToken, org, {
+    courseName: `Évaluation formative (démo ${stamp})`,
+    assignmentTitle: `Dépôt de document (démo ${stamp})`,
+    autoGrading: false,
+    tasks: [{ title: 'Déposez votre document', assignment_type: 'FILE_SUBMISSION', contents: {} }],
+  })
+  const student = makeStudent(`demo${stamp}`)
+  await api.createStudent(adminToken, org.id, student)
+
+  const bareAssignment = seeded.assignmentUuid.replace(/^assignment_/, '')
+  const bareCourse = seeded.courseUuid.replace(/^course_/, '')
+  const bareActivity = seeded.activityUuid.replace(/^activity_/, '')
+
+  const browser = await chromium.launch({ slowMo: 320 })
+  const videos: string[] = []
+  try {
+    // --- Teacher configures formative mode + the corrigé -------------------
+    const teacher = await loggedInPage(browser, ADMIN_EMAIL, ADMIN_PASSWORD)
+    const editor = new AssignmentEditorPage(teacher)
+    await editor.open(bareAssignment)
+    await caption(teacher, 'Teacher', 'An ordinary assignment with one "deposit a document" task.')
+    await caption(teacher, 'Teacher', 'Open Edit to turn it into a formative assessment.', 1400)
+    await editor.configureFormative({
+      solution: SOLUTION,
+      reveal: 'On hand-in',
+      showCorrigeFor: 3000,
+    })
+    await caption(
+      teacher,
+      'Teacher',
+      'Formative mode on, corrigé written, set to unlock the moment the learner hands in.',
+      3200,
+    )
+    videos.push(await finishRecording(teacher, '1-teacher-setup'))
+
+    // --- Learner deposits the document and gets the corrigé ---------------
+    const learner = await loggedInPage(browser, student.email, student.password)
+    const activity = new AssignmentPage(learner)
+    await activity.open(bareCourse, bareActivity)
+    await scrollTo(learner, 'Model answer locked')
+    await caption(learner, 'Learner', 'The corrigé exists — but it is locked, and the server withholds it.')
+    await activity.uploadFile(FIXTURE)
+    await caption(learner, 'Learner', 'The document is deposited.', 1800)
+    await activity.saveProgress()
+    await activity.handIn()
+    // The corrigé panel sits above the tasks, so bring it into frame — it is
+    // the whole point of the flow.
+    await scrollTo(learner, 'Model answer')
+    await caption(learner, 'Learner', 'Handed in — and the corrigé unlocks immediately.', 4200)
+    await caption(learner, 'Learner', 'No score, no pass/fail, no "grading in progress". Nothing is marked.', 3600)
+    videos.push(await finishRecording(learner, '2-learner-handin'))
+
+    // --- Teacher reviews: no grading anywhere ------------------------------
+    const reviewer = await loggedInPage(browser, ADMIN_EMAIL, ADMIN_PASSWORD)
+    const subs = new TeacherSubmissionsPage(reviewer)
+    await subs.open(bareAssignment)
+    await caption(reviewer, 'Teacher', 'The deposit lands in the submissions list.', 2200)
+    await subs.evaluateFirst()
+    await caption(
+      reviewer,
+      'Teacher',
+      'Review only: "Formative — not graded", and no grading actions to click.',
+      3600,
+    )
+    videos.push(await finishRecording(reviewer, '3-teacher-review'))
+  } finally {
+    await browser.close()
+  }
+
+  // Drop any stray unnamed recordings Playwright wrote alongside ours.
+  for (const f of readdirSync(OUT_DIR)) {
+    if (f.endsWith('.webm') && !videos.some((v) => v.endsWith(f))) {
+      console.log(`(leftover recording: ${f})`)
+    }
+  }
+  console.log('\nRecorded:')
+  for (const v of videos) console.log(`  ${v}`)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/apps/e2e/demo/formative-demo.ts
+++ b/apps/e2e/demo/formative-demo.ts
@@ -3,7 +3,7 @@
  *
  * This is a *demo*, not a test — `playwright.config.ts` only collects specs
  * under `features/`, so nothing here runs in CI. It drives the same UI the
- * `22-formative` spec asserts on, but slowly and with an on-screen caption for
+ * `24-formative` spec asserts on, but slowly and with an on-screen caption for
  * each step, and writes a video you can watch end to end.
  *
  * It reuses the feature module's own API seeding and page objects, so the

--- a/apps/e2e/features/assignments/api.ts
+++ b/apps/e2e/features/assignments/api.ts
@@ -46,7 +46,7 @@ async function createCourse(token: string, orgId: number, name: string): Promise
 
 export interface TaskSpec {
   title: string
-  assignment_type: 'QUIZ' | 'SHORT_ANSWER' | 'NUMBER_ANSWER' | 'FORM'
+  assignment_type: 'QUIZ' | 'SHORT_ANSWER' | 'NUMBER_ANSWER' | 'FORM' | 'FILE_SUBMISSION'
   contents: Record<string, unknown>
   description?: string
   hint?: string
@@ -63,7 +63,15 @@ export interface SeedAssignmentOptions {
   allowRetries?: boolean
   maxRetries?: number
   antiCopyPaste?: boolean
+  /** Formative mode: handed in, never graded. */
+  ungraded?: boolean
+  /** Model answer ("corrigé") text. */
+  solution?: string
+  /** When the model answer becomes readable by the learner. */
+  solutionReveal?: SolutionReveal
 }
+
+export type SolutionReveal = 'NEVER' | 'ON_SUBMISSION' | 'AFTER_GRADING'
 
 export interface SeededAssignment extends Ids {
   taskUuids: string[]
@@ -116,6 +124,9 @@ export async function seedAssignment(
     show_correct_answers: opts.showCorrectAnswers ?? true,
     allow_retries: opts.allowRetries ?? false,
     max_retries: opts.maxRetries ?? 0,
+    ungraded: opts.ungraded ?? false,
+    solution: opts.solution ?? null,
+    solution_reveal: opts.solutionReveal ?? 'NEVER',
     org_id: org.id,
     course_id: courseId,
     chapter_id: chapterId,
@@ -187,6 +198,37 @@ export async function submitAssignment(token: string, assignmentUuid: string): P
 /** Reset the current user's graded submission for another attempt. */
 export async function retryMe(token: string, assignmentUuid: string): Promise<void> {
   await req('POST', `/assignments/${assignmentUuid}/submissions/me/retry`, token, {})
+}
+
+/** Turn an assignment into a formative one and attach a model answer (PUT). */
+export async function setFormative(
+  token: string,
+  assignmentUuid: string,
+  opts: { ungraded?: boolean; solution?: string; solutionReveal?: SolutionReveal } = {},
+): Promise<any> {
+  return req('PUT', `/assignments/${assignmentUuid}`, token, {
+    ...(opts.ungraded === undefined ? {} : { ungraded: opts.ungraded }),
+    ...(opts.solution === undefined ? {} : { solution: opts.solution }),
+    ...(opts.solutionReveal === undefined ? {} : { solution_reveal: opts.solutionReveal }),
+  })
+}
+
+/** Upload the assignment's model answer document (multipart field "solution_file"). */
+export async function uploadSolutionFile(
+  token: string,
+  assignmentUuid: string,
+  bytes: Uint8Array,
+  filename = 'corrige.png',
+  contentType = 'image/png',
+): Promise<void> {
+  const fd = new FormData()
+  fd.set('solution_file', new Blob([bytes as unknown as BlobPart], { type: contentType }), filename)
+  const res = await fetch(`${API_URL}/assignments/${assignmentUuid}/solution_file`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: fd,
+  })
+  if (!res.ok) throw new Error(`uploadSolutionFile -> ${res.status}: ${await res.text()}`)
 }
 
 /** Upload a teacher reference file to a task (multipart field "reference_file"). */

--- a/apps/e2e/features/assignments/pages/student.ts
+++ b/apps/e2e/features/assignments/pages/student.ts
@@ -160,6 +160,56 @@ export class AssignmentPage {
     })
   }
 
+  /**
+   * Hand in a formative assignment. The trigger reads "Hand in my work" rather
+   * than "Submit for grading" — nothing downstream will grade it — but the
+   * confirmation dialog is the same one.
+   */
+  async handIn(): Promise<void> {
+    const trigger = this.body().getByText('Hand in my work')
+    const count = await trigger.count()
+    for (let i = 0; i < count; i++) {
+      const btn = trigger.nth(i)
+      if (await btn.isVisible().catch(() => false)) {
+        await btn.click()
+        break
+      }
+    }
+    const confirm = this.page.getByRole('button', { name: 'Submit Assignment' })
+    await expect(confirm).toBeVisible({ timeout: 10_000 })
+    await confirm.click()
+    await expect(confirm).toBeHidden({ timeout: 15_000 })
+    await this.page.waitForLoadState('networkidle').catch(() => {})
+  }
+
+  /** The "Handed in" status chip a formative assignment settles on. */
+  async expectHandedIn(): Promise<void> {
+    await expect(this.page.getByText('Handed in', { exact: true }).first()).toBeVisible({
+      timeout: 20_000,
+    })
+  }
+
+  /** The model answer is present but still withheld. */
+  async expectSolutionLocked(): Promise<void> {
+    await expect(this.body().getByText('Model answer locked').first()).toBeVisible({
+      timeout: 20_000,
+    })
+  }
+
+  /** The model answer is revealed; asserts the corrigé text is on screen. */
+  async expectSolutionVisible(text: string): Promise<void> {
+    await expect(this.body().getByText('Model answer', { exact: true }).first()).toBeVisible({
+      timeout: 20_000,
+    })
+    await expect(this.body().getByText(text).first()).toBeVisible({ timeout: 20_000 })
+  }
+
+  /** A formative assignment must never show a score anywhere on the page. */
+  async expectNoGradeShown(): Promise<void> {
+    await expect(this.page.getByText(/\b\d+\/100\b/)).toHaveCount(0)
+    await expect(this.page.getByText('Grading in progress', { exact: true })).toHaveCount(0)
+  }
+
   /** Close the celebratory result modal if it is open. */
   async dismissResultModal(): Promise<void> {
     const close = this.page.getByRole('button', { name: 'Close' }).first()

--- a/apps/e2e/features/assignments/pages/teacher.ts
+++ b/apps/e2e/features/assignments/pages/teacher.ts
@@ -100,6 +100,39 @@ export class AssignmentEditorPage {
     await expect(dialog).toBeHidden({ timeout: 10_000 })
   }
 
+  /**
+   * Turn the assignment into a formative one through the Edit modal: switch on
+   * "Formative — no grading", write the model answer, and choose when it
+   * unlocks. Drives the real form rather than the API so the spec proves the
+   * authoring surface works, not just the endpoint behind it.
+   */
+  async configureFormative(opts: {
+    solution: string
+    reveal?: 'Never' | 'On hand-in' | 'After grading'
+    /** Hold on the model-answer section before saving (for a recorded demo). */
+    showCorrigeFor?: number
+  }): Promise<void> {
+    await this.page.getByText('Edit', { exact: true }).first().click()
+    const dialog = this.page.getByRole('dialog', { name: 'Edit Assignment' })
+    await expect(dialog).toBeVisible({ timeout: 15_000 })
+
+    // The formative switch carries its label as an aria-label.
+    await dialog.getByRole('button', { name: 'Formative — no grading' }).click()
+
+    await dialog
+      .getByPlaceholder('Write the worked solution learners should compare their work against…')
+      .fill(opts.solution)
+
+    await dialog.getByRole('button', { name: opts.reveal ?? 'On hand-in' }).click()
+
+    if (opts.showCorrigeFor) {
+      await this.page.waitForTimeout(opts.showCorrigeFor)
+    }
+
+    await dialog.getByRole('button', { name: 'Save Changes' }).click()
+    await expect(dialog).toBeHidden({ timeout: 15_000 })
+  }
+
   async unpublish(): Promise<void> {
     await this.page.getByText('Unpublish', { exact: true }).click()
     await this.page.waitForTimeout(800)

--- a/apps/e2e/features/assignments/tests/24-formative.spec.ts
+++ b/apps/e2e/features/assignments/tests/24-formative.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * Goal: prove the formative-assessment flow end to end — a learner deposits a
+ * document, that hand-in unlocks the model answer ("corrigé") for them right
+ * away, and no grade exists anywhere in the process.
+ *
+ * The teacher configures it through the real Edit-Assignment form (formative
+ * mode + model answer + "unlocks on hand-in"), which is the surface a customer
+ * would use. The student then drives the activity, and the API is read back to
+ * confirm the two invariants that matter:
+ *   - the corrigé is withheld server-side until the learner hands in, so it is
+ *     never merely hidden by the UI, and
+ *   - the submission settles on SUBMITTED with grade 0 and is never GRADED.
+ */
+import { fileURLToPath } from 'node:url'
+import { test, expect } from '../../../core/fixtures'
+import { ADMIN_STATE, STUDENT_STATE } from '../../../core/sharedAuth'
+import { setupScenario, Scenario } from '../scenario'
+import { AssignmentPage } from '../pages/student'
+import { AssignmentEditorPage, TeacherSubmissionsPage } from '../pages/teacher'
+import {
+  enableRetries,
+  getAssignment,
+  getUserSubmission,
+  login,
+  saveTaskSubmission,
+  setFormative,
+  submitAssignment,
+} from '../api'
+
+const FIXTURE = fileURLToPath(new URL('../fixtures/submission.png', import.meta.url))
+const SOLUTION = 'Corrige: restate the brief, then cite two sources for each claim.'
+
+test.use({ storageState: STUDENT_STATE })
+
+let s: Scenario
+
+test.beforeAll(async () => {
+  s = await setupScenario('formative', {
+    courseName: 'E2E Formative Course',
+    assignmentTitle: 'Formative Deposit Assignment',
+    autoGrading: false,
+    tasks: [
+      {
+        title: 'Deposit your document',
+        assignment_type: 'FILE_SUBMISSION',
+        contents: {},
+      },
+    ],
+  })
+})
+
+test('handing in a document unlocks the model answer, and nothing is graded', async ({
+  page,
+  browser,
+}) => {
+  // --- Teacher: switch the assignment to formative and author the corrigé ----
+  const adminCtx = await browser.newContext({ storageState: ADMIN_STATE })
+  try {
+    const adminPage = await adminCtx.newPage()
+    const editor = new AssignmentEditorPage(adminPage)
+    await editor.open(s.bareAssignmentUuid)
+    await editor.configureFormative({ solution: SOLUTION, reveal: 'On hand-in' })
+  } finally {
+    await adminCtx.close()
+  }
+
+  const configured = await getAssignment(s.adminToken, s.seeded.assignmentUuid)
+  expect(configured.ungraded).toBe(true)
+  expect(configured.solution_reveal).toBe('ON_SUBMISSION')
+  expect(configured.solution).toContain('restate the brief')
+
+  // --- Student: before handing in, the corrigé is withheld ------------------
+  const studentToken = await login(s.student.email, s.student.password)
+  const beforeHandIn = await getAssignment(studentToken, s.seeded.assignmentUuid)
+  // Withheld by the server, not just hidden by the UI — but the learner is
+  // still told a model answer exists, which is what makes the hand-in worth it.
+  expect(beforeHandIn.solution).toBeNull()
+  expect(beforeHandIn.has_solution).toBe(true)
+  expect(beforeHandIn.solution_unlocked).toBe(false)
+
+  const assignment = new AssignmentPage(page)
+  await assignment.open(s.bareCourseUuid, s.bareActivityUuid)
+  await assignment.expectSolutionLocked()
+
+  // --- Student: deposit the document and hand it in -------------------------
+  await assignment.uploadFile(FIXTURE)
+  await assignment.saveProgress()
+  await assignment.handIn()
+
+  // --- The corrigé is now theirs, and there is no grade anywhere ------------
+  await assignment.expectHandedIn()
+  await assignment.expectSolutionVisible(SOLUTION)
+  await assignment.expectNoGradeShown()
+
+  const afterHandIn = await getAssignment(studentToken, s.seeded.assignmentUuid)
+  expect(afterHandIn.solution_unlocked).toBe(true)
+  expect(afterHandIn.solution).toContain('restate the brief')
+
+  const submitted = await getUserSubmission(s.seeded.assignmentUuid, s.studentId, s.adminToken)
+  expect(submitted.submission_status).toBe('SUBMITTED')
+  expect(submitted.grade).toBe(0)
+
+  // --- Teacher: the review modal offers no grading at all -------------------
+  const reviewCtx = await browser.newContext({ storageState: ADMIN_STATE })
+  try {
+    const reviewPage = await reviewCtx.newPage()
+    const subs = new TeacherSubmissionsPage(reviewPage)
+    await subs.open(s.bareAssignmentUuid)
+    const modal = await subs.evaluateFirst()
+    await expect(reviewPage.getByText('Formative — not graded').first()).toBeVisible({
+      timeout: 15_000,
+    })
+    await expect(reviewPage.getByRole('button', { name: 'Set final grade' })).toHaveCount(0)
+    await expect(reviewPage.getByRole('button', { name: 'Finalize & Complete' })).toHaveCount(0)
+    void modal
+  } finally {
+    await reviewCtx.close()
+  }
+})
+
+test('a retry re-locks the model answer until the next hand-in', async ({ page }) => {
+  // Its own assignment: the shared student already handed the one above in, and
+  // a submission is unique per (learner, assignment).
+  const r = await setupScenario('formative-retry', {
+    courseName: 'E2E Formative Retry Course',
+    assignmentTitle: 'Formative Retry Assignment',
+    autoGrading: false,
+    ungraded: true,
+    solution: SOLUTION,
+    solutionReveal: 'ON_SUBMISSION',
+    allowRetries: true,
+    tasks: [{ title: 'Deposit your document', assignment_type: 'FILE_SUBMISSION', contents: {} }],
+  })
+  // Retries with no cap, so the learner always has an attempt left — the case
+  // where a *graded* assignment would deliberately withhold the answer key.
+  await enableRetries(r.adminToken, r.seeded.assignmentUuid, 0)
+  await setFormative(r.adminToken, r.seeded.assignmentUuid, { ungraded: true })
+
+  const studentToken = await login(r.student.email, r.student.password)
+  await saveTaskSubmission(studentToken, r.seeded.assignmentUuid, r.seeded.taskUuids[0], {
+    fileUUID: 'seeded-by-e2e',
+  })
+  await submitAssignment(studentToken, r.seeded.assignmentUuid)
+
+  // Formative overrides the retry guard: the corrigé is readable even though an
+  // attempt remains, because there is no score to game.
+  expect((await getAssignment(studentToken, r.seeded.assignmentUuid)).solution_unlocked).toBe(true)
+
+  const assignment = new AssignmentPage(page)
+  await assignment.open(r.bareCourseUuid, r.bareActivityUuid)
+  await assignment.expectSolutionVisible(SOLUTION)
+  await assignment.retry()
+
+  // Back to a fresh attempt — and the corrigé is withheld again until it is
+  // earned a second time.
+  await assignment.expectSolutionLocked()
+  expect((await getAssignment(studentToken, r.seeded.assignmentUuid)).solution).toBeNull()
+})

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -29,7 +29,9 @@ export default defineConfig({
     baseURL: BASE_URL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    // Recording every run is wasteful in CI; E2E_VIDEO=1 turns it on for a
+    // local run when the point IS the recording (a feature walkthrough).
+    video: process.env.E2E_VIDEO === '1' ? 'on' : 'retain-on-failure',
     actionTimeout: 15_000,
     navigationTimeout: 30_000,
   },

--- a/apps/web/app/orgs/[orgslug]/(withmenu)/course/[courseuuid]/activity/[activityid]/activity.tsx
+++ b/apps/web/app/orgs/[orgslug]/(withmenu)/course/[courseuuid]/activity/[activityid]/activity.tsx
@@ -1524,6 +1524,11 @@ function AssignmentTools(props: {
           // definitions were fetched pre-grade with the key stripped, so refetch
           // them — otherwise the reveal renders every option as "incorrect".
           queryClient.invalidateQueries({ queryKey: queryKeys.assignments.tasks(props.assignment?.assignment_uuid) })
+          // Handing in can also unlock the model answer (solution_reveal =
+          // ON_SUBMISSION). The corrigé rides on the assignment payload and was
+          // fetched with it stripped, so refetch that too — otherwise the
+          // learner has to reload the page to see what they just earned.
+          queryClient.invalidateQueries({ queryKey: queryKeys.assignments.detail(props.assignment?.assignment_uuid) })
         }
         else {
           toast.error(t('assignments.failed_submit_assignment'))
@@ -1559,6 +1564,10 @@ function AssignmentTools(props: {
         // again — refetch the task definitions so a revealed key from the graded
         // attempt isn't left visible during the retry.
         queryClient.invalidateQueries({ queryKey: queryKeys.assignments.tasks(props.assignment?.assignment_uuid) });
+        // A retry puts the submission back to PENDING, which re-locks the model
+        // answer server-side. Refetch so the learner isn't left reading the
+        // corrigé they are no longer entitled to for this attempt.
+        queryClient.invalidateQueries({ queryKey: queryKeys.assignments.detail(props.assignment?.assignment_uuid) });
         setGradeData(null);
         setIsGradeModalOpen(false);
         // Re-arm the auto-open on this fresh attempt so the next graded
@@ -1617,6 +1626,9 @@ function AssignmentTools(props: {
     submission.length === 0 ||
     submission[0].submission_status === 'PENDING' ||
     submission[0].submission_status === 'NOT_SUBMITTED';
+  // A formative assignment is handed in, not "submitted for grading" — nothing
+  // downstream will ever mark it, so every label here says so.
+  const isUngradedAssignment = !!props.assignment?.ungraded;
   const attemptNumber = submission?.[0]?.attempt_number ?? 1;
   const isRetryAttempt = isAwaitingSubmission && submission?.length > 0 && attemptNumber > 1;
 
@@ -1659,8 +1671,19 @@ function AssignmentTools(props: {
       <ConfirmationModal
         confirmationButtonText={t('assignments.submit_assignment')}
         pendingButtonText={t('assignments.submitting', { defaultValue: 'Submitting…' })}
-        confirmationMessage={t('assignments.submit_assignment_confirm')}
-        dialogTitle={t('assignments.submit_assignment_title')}
+        confirmationMessage={
+          isUngradedAssignment
+            ? t('assignments.hand_in_confirm', {
+                defaultValue:
+                  'Your work will be handed in to your teacher. It is not graded.',
+              })
+            : t('assignments.submit_assignment_confirm')
+        }
+        dialogTitle={
+          isUngradedAssignment
+            ? t('assignments.hand_in_title', { defaultValue: 'Hand in your work' })
+            : t('assignments.submit_assignment_title')
+        }
         dialogTrigger={
           <div className="bg-cyan-800 rounded-md px-4 nice-shadow flex flex-col p-2.5 text-white hover:cursor-pointer transition delay-150 duration-300 ease-in-out">
             <span className="text-[10px] font-bold mb-1 uppercase">
@@ -1670,7 +1693,11 @@ function AssignmentTools(props: {
             </span>
             <div className="flex items-center space-x-2">
               <BookOpenCheck size={17} />
-              <span className="text-xs font-bold">{t('assignments.submit_for_grading')}</span>
+              <span className="text-xs font-bold">
+                {isUngradedAssignment
+                  ? t('assignments.hand_in', { defaultValue: 'Hand in my work' })
+                  : t('assignments.submit_for_grading')}
+              </span>
             </div>
           </div>
         }
@@ -1681,6 +1708,56 @@ function AssignmentTools(props: {
   }
 
   if (submission[0].submission_status === 'SUBMITTED') {
+    // Formative assignments never leave SUBMITTED — there is no grading queue
+    // behind them — so "Grading in progress" would be a lie that never resolves.
+    if (isUngradedAssignment) {
+      const allowRetries = !!props.assignment?.allow_retries;
+      const maxRetries = Number(props.assignment?.max_retries || 0);
+      const currentAttempt = Number(submission?.[0]?.attempt_number || 1);
+      const canRetry =
+        allowRetries &&
+        !isAssignmentPastDue(props.assignment?.due_date) &&
+        (maxRetries === 0 || currentAttempt < maxRetries);
+
+      return (
+        <div className="flex items-center gap-2">
+          <div className="bg-teal-700 rounded-md px-4 nice-shadow flex flex-col p-2.5 text-white transition delay-150 duration-300 ease-in-out">
+            <span className="text-[10px] font-bold mb-1 uppercase">{t('common.status')}</span>
+            <div className="flex items-center space-x-2">
+              <CheckCircle size={17} />
+              <span className="text-xs font-bold">
+                {t('assignments.handed_in', { defaultValue: 'Handed in' })}
+              </span>
+            </div>
+          </div>
+          {canRetry && (
+            <ConfirmationModal
+              confirmationButtonText={t('assignments.retry_assignment')}
+              // The generic warning talks about replacing a grade; here the
+              // consequence is that the corrigé re-locks until the next hand-in.
+              confirmationMessage={t('assignments.retry_assignment_confirm_ungraded', {
+                defaultValue:
+                  'Your current hand-in will be reset so you can start over, and the model answer locks again until you hand in the next attempt.',
+              })}
+              dialogTitle={t('assignments.retry_assignment_title')}
+              dialogTrigger={
+                <button
+                  type="button"
+                  disabled={isRetrying}
+                  className="h-full inline-flex items-center gap-1.5 px-3 py-2.5 rounded-md bg-white/90 hover:bg-white disabled:opacity-50 text-teal-800 text-xs font-bold nice-shadow transition-colors"
+                >
+                  <RotateCcw size={14} />
+                  {t('assignments.retry_assignment')}
+                </button>
+              }
+              functionToExecute={retrySubmissionUI}
+              status="warning"
+            />
+          )}
+        </div>
+      )
+    }
+
     return (
       <div className="bg-amber-800 rounded-md px-4 nice-shadow flex flex-col p-2.5 text-white transition delay-150 duration-300 ease-in-out">
         <span className="text-[10px] font-bold mb-1 uppercase">{t('common.status')}</span>

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskFileObject.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskFileObject.tsx
@@ -302,9 +302,15 @@ export default function TaskFileObject({ view, user_id, assignmentTaskUUID, onGr
             )}
             {view === 'custom-grading' && (
                 <div className='flex flex-col space-y-4 w-full px-2 sm:px-0'>
+                    {/* On a formative assignment there is no grade to input, so
+                        the instruction to enter one would be wrong. */}
                     <div className='flex flex-col sm:flex-row py-5 sm:py-6 text-xs sm:text-sm justify-center mx-auto space-y-2 sm:space-y-0 sm:space-x-3 text-slate-600 px-4 sm:px-2 text-center sm:text-start bg-slate-50 rounded-lg border border-slate-100'>
                         <Download size={18} className="mx-auto sm:mx-0 text-slate-500" />
-                        <p>Please download the file and grade it manually, then input the grade above</p>
+                        <p>
+                            {assignment?.assignment_object?.ungraded
+                                ? t('dashboard.assignments.submissions.download_to_review', { defaultValue: 'Download the file to review what the learner handed in.' })
+                                : t('dashboard.assignments.submissions.download_to_grade', { defaultValue: 'Please download the file and grade it manually, then input the grade above' })}
+                        </p>
                     </div>
                     {userSubmissions.fileUUID && !isLoading && assignmentTaskUUID && (
                         <Link

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/page.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/page.tsx
@@ -18,6 +18,7 @@ import {
     Backpack,
     Zap,
     BarChart3,
+    ClipboardCheck,
 } from 'lucide-react'
 import React, { useEffect } from 'react'
 import { AssignmentProvider, useAssignments } from '@components/Contexts/Assignments/AssignmentContext';
@@ -306,6 +307,9 @@ const BADGE_ROSE =
 const BADGE_CYAN =
     'bg-gradient-to-b from-cyan-50 to-cyan-100 text-cyan-700 ring-cyan-300/40 shadow-[0_1px_2px_rgba(6,182,212,0.18),inset_0_1px_0_rgba(255,255,255,0.85)]';
 
+const BADGE_TEAL =
+    'bg-gradient-to-b from-teal-50 to-teal-100 text-teal-700 ring-teal-300/40 shadow-[0_1px_2px_rgba(20,184,166,0.18),inset_0_1px_0_rgba(255,255,255,0.85)]';
+
 const GRADING_TYPE_DISPLAY: Record<string, { icon: React.ReactNode; labelKey: string; color: string }> = {
     ALPHABET: { icon: <ALargeSmall size={13} />, labelKey: 'dashboard.assignments.modals.edit.form.grading_types.alphabet', color: BADGE_VIOLET },
     NUMERIC: { icon: <Hash size={13} />, labelKey: 'dashboard.assignments.modals.edit.form.grading_types.numeric', color: BADGE_BLUE },
@@ -320,12 +324,21 @@ function AssignmentInfoBadges() {
     const obj = assignment?.assignment_object;
     if (!obj) return null;
 
+    // A formative assignment carries a grading_type on the row but never uses
+    // it, so showing "Numeric" here would advertise a scale nothing is measured
+    // on. Say what is actually true instead.
+    const isUngraded = !!obj.ungraded;
     const gradingType = obj.grading_type as string | undefined;
     const gradingDisplay = gradingType ? GRADING_TYPE_DISPLAY[gradingType] : null;
 
     return (
         <div className="flex items-center gap-1.5 flex-wrap">
-            {gradingDisplay && (
+            {isUngraded ? (
+                <div className={`${BADGE_BASE} ${BADGE_TEAL}`}>
+                    <ClipboardCheck size={13} />
+                    <span>{t('assignments.ungraded_badge', { defaultValue: 'Not graded' })}</span>
+                </div>
+            ) : gradingDisplay && (
                 <div className={`${BADGE_BASE} ${gradingDisplay.color}`}>
                     {gradingDisplay.icon}
                     <span>{t(gradingDisplay.labelKey)}</span>

--- a/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/subpages/Modals/EvaluateAssignment.tsx
+++ b/apps/web/app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/subpages/Modals/EvaluateAssignment.tsx
@@ -1,5 +1,5 @@
 import { useAssignments } from '@components/Contexts/Assignments/AssignmentContext';
-import { BookOpenCheck, Check, CircleHelp, Download, Info, MessageSquare, UserCheck, X } from 'lucide-react';
+import { BookOpenCheck, Check, CircleHelp, ClipboardCheck, Download, Info, MessageSquare, UserCheck, X } from 'lucide-react';
 import Link from 'next/link';
 import React, { useEffect, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query';
@@ -114,13 +114,17 @@ function EvaluateAssignment({ user_id }: any) {
     const [gradePreview, setGradePreview] = useState<any>(null);
 
     const assignmentUuid = assignments?.assignment_object?.assignment_uuid;
+    // Formative assignment: the API refuses to grade it, so the grade banner,
+    // the per-task score chips and the two grading actions are all replaced by
+    // a plain "handed in" review of the learner's work.
+    const isUngraded = !!assignments?.assignment_object?.ungraded;
 
     // Re-pull the aggregate grade + per-task breakdown. Called on open and after
     // a child task is inline-graded, so the header banner and per-task badges
     // reflect the new score immediately instead of staying stale until the
     // teacher clicks "Set final grade".
     const refreshGradePreview = React.useCallback(async (seedFeedback = false) => {
-        if (!assignmentUuid || !user_id || !access_token) return;
+        if (!assignmentUuid || !user_id || !access_token || isUngraded) return;
         const res = await getFinalGrade(user_id, assignmentUuid, access_token);
         if (res.success) {
             setGradePreview(res.data);
@@ -128,12 +132,12 @@ function EvaluateAssignment({ user_id }: any) {
                 setFeedback(res.data.overall_feedback);
             }
         }
-    }, [assignmentUuid, user_id, access_token]);
+    }, [assignmentUuid, user_id, access_token, isUngraded]);
 
     // Load any existing grade + feedback when the modal opens so the teacher
     // can edit them instead of starting from scratch.
     useEffect(() => {
-        if (!assignmentUuid || !user_id || !access_token) return;
+        if (!assignmentUuid || !user_id || !access_token || isUngraded) return;
         let cancelled = false;
         (async () => {
             const res = await getFinalGrade(user_id, assignmentUuid, access_token);
@@ -146,7 +150,7 @@ function EvaluateAssignment({ user_id }: any) {
             }
         })();
         return () => { cancelled = true; };
-    }, [assignmentUuid, user_id, access_token]);
+    }, [assignmentUuid, user_id, access_token, isUngraded]);
 
     async function gradeAssignment() {
         const res = await putFinalGrade(user_id, assignmentUuid, access_token, feedback ?? null);
@@ -228,8 +232,23 @@ function EvaluateAssignment({ user_id }: any) {
 
     return (
         <div className='flex flex-col min-h-fit'>
+            {/* Formative notice, in place of the grade preview */}
+            {isUngraded && (
+                <div className='flex items-center space-x-3 bg-teal-50/70 border border-teal-200/70 nice-shadow rounded-xl px-5 py-3 mb-4'>
+                    <ClipboardCheck size={18} className='text-teal-600 shrink-0' />
+                    <div className='flex flex-col'>
+                        <p className='text-xs font-bold text-teal-900'>
+                            {t('dashboard.assignments.submissions.ungraded_title', { defaultValue: 'Formative — not graded' })}
+                        </p>
+                        <p className='text-[11px] text-teal-700/90'>
+                            {t('dashboard.assignments.submissions.ungraded_description', { defaultValue: 'This assignment is handed in for review only. No score is recorded.' })}
+                        </p>
+                    </div>
+                </div>
+            )}
+
             {/* Grade preview */}
-            {liveGrade && (
+            {liveGrade && !isUngraded && (
                 <div className='flex items-center justify-between bg-white nice-shadow rounded-xl px-5 py-3 mb-4'>
                     <div className='flex items-center space-x-3'>
                         <div className={`rounded-lg px-3 py-1.5 text-lg font-bold ${liveGrade.passed ? 'bg-emerald-50 text-emerald-700' : 'bg-rose-50 text-rose-700'}`}>
@@ -270,7 +289,7 @@ function EvaluateAssignment({ user_id }: any) {
                                     {index + 1}
                                 </div>
                                 <p className='text-sm font-semibold text-gray-800'>{task.description || t('dashboard.assignments.submissions.task_label', { number: index + 1 })}</p>
-                                {tb && (
+                                {tb && !isUngraded && (
                                     <div className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${
                                         !taskSubmitted
                                             ? 'bg-gray-100 text-gray-500'
@@ -335,7 +354,10 @@ function EvaluateAssignment({ user_id }: any) {
                 })}
             </div>
 
-            {/* Overall feedback */}
+            {/* Overall feedback. Only the grading endpoint persists it, and that
+                endpoint refuses a formative assignment — so on one, this box
+                could never deliver anything to the learner. */}
+            {!isUngraded && (
             <div className='flex flex-col space-y-2 pt-5 mt-3 border-t border-gray-100'>
                 <div className='flex items-center space-x-1.5 text-gray-700'>
                     <MessageSquare size={14} />
@@ -355,6 +377,7 @@ function EvaluateAssignment({ user_id }: any) {
                     {t('dashboard.assignments.submissions.feedback.hint')}
                 </p>
             </div>
+            )}
 
             {/* Action bar */}
             <div className='flex items-center justify-between pt-4 mt-3 border-t border-gray-100'>
@@ -382,6 +405,7 @@ function EvaluateAssignment({ user_id }: any) {
                 </div>
 
                 <div className='flex items-center space-x-3'>
+                    {!isUngraded && (
                     <div className='flex items-center space-x-1.5'>
                         <button
                             onClick={gradeAssignment}
@@ -396,6 +420,8 @@ function EvaluateAssignment({ user_id }: any) {
                             </div>
                         </ToolTip>
                     </div>
+                    )}
+                    {!isUngraded && (
                     <div className='flex items-center space-x-1.5'>
                         <button
                             onClick={finalizeAndComplete}
@@ -410,6 +436,7 @@ function EvaluateAssignment({ user_id }: any) {
                             </div>
                         </ToolTip>
                     </div>
+                    )}
                 </div>
             </div>
         </div>

--- a/apps/web/components/Objects/Activities/Assignment/AssignmentBoxUI.tsx
+++ b/apps/web/components/Objects/Activities/Assignment/AssignmentBoxUI.tsx
@@ -1,3 +1,4 @@
+import { useAssignments } from '@components/Contexts/Assignments/AssignmentContext'
 import { useAssignmentSubmission } from '@components/Contexts/Assignments/AssignmentSubmissionContext'
 import { useAssignmentDirtyTasks } from '@components/Contexts/Assignments/AssignmentDirtyTasksContext'
 import { useAutoSave, type SaveResult } from './useAutoSave'
@@ -47,7 +48,14 @@ function AssignmentBoxUI({ type, view, currentPoints, currentFeedback, maxPoints
     const [manualGrade, setManualGrade] = React.useState<string>('')
     const [manualFeedback, setManualFeedback] = React.useState<string>('')
     const submission = useAssignmentSubmission() as any
+    const assignmentCtx = useAssignments() as any
     const session = useLHSession() as any
+
+    // A formative assignment carries no grade at all — the API refuses to grade
+    // it — so every scoring affordance in this box is hidden rather than left
+    // wired to an endpoint that 400s. One check here covers the learner view,
+    // the teacher view and both grading views for all six task types.
+    const isUngraded = !!assignmentCtx?.assignment_object?.ungraded
 
     // The student can save/draft answers until they SUBMIT for grading or are
     // GRADED. A retry flips the row back to PENDING, which re-enables saving.
@@ -106,7 +114,7 @@ function AssignmentBoxUI({ type, view, currentPoints, currentFeedback, maxPoints
         gradeCustomFC(parsed, trimmed.length > 0 ? trimmed : undefined)
     }
 
-    const isGradingMode = view === 'grading' || view === 'custom-grading'
+    const isGradingMode = (view === 'grading' || view === 'custom-grading') && !isUngraded
 
     // Check if user is authenticated
     const isAuthenticated = session?.status === 'authenticated'
@@ -148,7 +156,7 @@ function AssignmentBoxUI({ type, view, currentPoints, currentFeedback, maxPoints
                             <p>{t('activities.teacher_view')}</p>
                         </div>
                     }
-                    {maxPoints &&
+                    {maxPoints && !isUngraded &&
                         <div className='flex bg-emerald-200/20 text-xs rounded-full space-x-1 px-2 py-0.5 font-bold outline items-center text-emerald-600 outline-1 outline-emerald-300/40'>
                             <BookPlus size={12} />
                             <p>{maxPoints} {t('assignments.points')}</p>

--- a/apps/web/components/Objects/Activities/Assignment/AssignmentStudentActivity.tsx
+++ b/apps/web/components/Objects/Activities/Assignment/AssignmentStudentActivity.tsx
@@ -2,7 +2,7 @@ import { useAssignments } from '@components/Contexts/Assignments/AssignmentConte
 import { useAssignmentSubmission, useAssignmentTaskSubmissions } from '@components/Contexts/Assignments/AssignmentSubmissionContext';
 import { useCourse } from '@components/Contexts/CourseContext';
 import { useOrg } from '@components/Contexts/OrgContext';
-import { getTaskRefFileDir } from '@services/media/media';
+import { getAssignmentSolutionFileDir, getTaskRefFileDir } from '@services/media/media';
 import TaskFileObject from 'app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskFileObject';
 import TaskQuizObject from 'app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskQuizObject'
 import TaskFormObject from 'app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskFormObject'
@@ -10,7 +10,7 @@ import TaskCodeObject from 'app/orgs/[orgslug]/dash/assignments/[assignmentuuid]
 import TaskShortAnswerObject from 'app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskShortAnswerObject'
 import TaskNumberAnswerObject from 'app/orgs/[orgslug]/dash/assignments/[assignmentuuid]/_components/TaskEditor/Subs/TaskTypes/TaskNumberAnswerObject'
 import toast from 'react-hot-toast';
-import { AlarmClockOff, Backpack, Calendar, CheckCircle2, Download, EllipsisVertical, Info, MessageSquare, RotateCcw, XCircle } from 'lucide-react';
+import { AlarmClockOff, Backpack, BookOpenCheck, Calendar, CheckCircle2, ClipboardCheck, Download, EllipsisVertical, Info, Lock, MessageSquare, RotateCcw, XCircle } from 'lucide-react';
 import Link from 'next/link';
 import React, { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next';
@@ -87,6 +87,21 @@ function AssignmentStudentActivity() {
   // GPA_SCALE). Otherwise a student with 55% on a numeric-graded task sees
   // "Not Passed" inline while the same score is "Pass" at the assignment
   // level — exactly the mismatch the teacher tried to avoid.
+  // Formative assignment: handed in, never marked. The server refuses to grade
+  // it at all, so every grade affordance below is hidden rather than left
+  // showing a score that can never arrive.
+  const isUngraded = !!assignments?.assignment_object?.ungraded;
+
+  // Model answer ("corrigé"). `has_solution` is sent even while locked so this
+  // view can promise the reward; `solution` / `solution_file` are only present
+  // once the server has actually unlocked them for this learner.
+  const hasSolution = !!assignments?.assignment_object?.has_solution;
+  const solutionUnlocked = !!assignments?.assignment_object?.solution_unlocked;
+  const solutionText = (assignments?.assignment_object?.solution || '').trim();
+  const solutionFile = assignments?.assignment_object?.solution_file;
+  const solutionRevealsOnSubmission =
+    assignments?.assignment_object?.solution_reveal === 'ON_SUBMISSION';
+
   const gradingType = assignments?.assignment_object?.grading_type;
   // Honor the teacher-configured passing threshold; fall back to the
   // grading-type default when unset so existing assignments are unchanged.
@@ -154,6 +169,12 @@ function AssignmentStudentActivity() {
                 </div>
               </div>
             )}
+            {isUngraded && (
+              <div className='flex gap-1.5 items-center text-xs px-2.5 py-1 rounded-full bg-teal-50 text-teal-700 font-semibold nice-shadow'>
+                <ClipboardCheck size={12} />
+                <span>{t('assignments.ungraded_badge', { defaultValue: 'Not graded' })}</span>
+              </div>
+            )}
             {showAttemptBadge && (
               <div className='flex gap-1.5 items-center text-xs px-2.5 py-1 rounded-full bg-fuchsia-50 text-fuchsia-700 font-semibold nice-shadow'>
                 <RotateCcw size={12} />
@@ -207,6 +228,59 @@ function AssignmentStudentActivity() {
       )}
       
       
+      {/* Model answer ("corrigé"). Locked, this is only a promise — the text and
+          the document are withheld by the API until the learner hands their
+          work in, so there is nothing here to read early. */}
+      {hasSolution && !solutionUnlocked && (
+        <div className='flex items-start gap-3 p-4 rounded-md bg-slate-50 border border-slate-200/70 nice-shadow'>
+          <Lock size={16} className='shrink-0 mt-0.5 text-slate-400' />
+          <div className='flex flex-col space-y-1'>
+            <p className='text-sm font-semibold text-slate-700'>
+              {t('assignments.solution_locked_title', { defaultValue: 'Model answer locked' })}
+            </p>
+            <p className='text-xs leading-relaxed text-slate-500'>
+              {solutionRevealsOnSubmission
+                ? t('assignments.solution_locked_on_submission', { defaultValue: 'Hand your work in and the model answer unlocks right away.' })
+                : t('assignments.solution_locked_after_grading', { defaultValue: 'The model answer unlocks once your work has been graded.' })}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {solutionUnlocked && (solutionText || solutionFile) && (
+        <div className='flex flex-col space-y-3 p-4 md:p-6 rounded-md bg-teal-50/60 border border-teal-200/70 nice-shadow'>
+          <div className='flex items-center gap-2 text-teal-800'>
+            <BookOpenCheck size={16} className='text-teal-600' />
+            <h3 className='text-sm font-semibold'>
+              {t('assignments.solution_title', { defaultValue: 'Model answer' })}
+            </h3>
+          </div>
+          <div className='ps-6 flex flex-col space-y-3'>
+            {solutionText && (
+              <p className='text-sm leading-relaxed text-slate-700 whitespace-pre-wrap'>{solutionText}</p>
+            )}
+            {solutionFile && (
+              <Link
+                href={getAssignmentSolutionFileDir(
+                  org?.org_uuid,
+                  assignments?.course_object.course_uuid,
+                  assignments?.activity_object.activity_uuid,
+                  assignments?.assignment_object.assignment_uuid,
+                  solutionFile
+                )}
+                target='_blank'
+                download={true}
+                className='px-3 py-1.5 w-fit flex items-center nice-shadow bg-white text-teal-800 rounded-full space-x-2 cursor-pointer'>
+                <Download size={13} />
+                <p className='text-xs font-semibold'>
+                  {t('assignments.solution_download', { defaultValue: 'Download the model answer' })}
+                </p>
+              </Link>
+            )}
+          </div>
+        </div>
+      )}
+
       {assignments && assignments?.assignment_tasks?.slice().sort((a: any, b: any) => a.id - b.id).map((task: any, index: number) => {
         const taskSubmission = taskSubmissionsMap ? taskSubmissionsMap[task.assignment_task_uuid] : null;
         const taskGrade = taskSubmission?.grade ?? 0;
@@ -253,7 +327,7 @@ function AssignmentStudentActivity() {
                 </Link>}
               </div>
             </div>
-            {isGraded && taskSubmission && (
+            {isGraded && !isUngraded && taskSubmission && (
               <div className={`relative overflow-hidden rounded-xl nice-shadow border ${
                 taskPassed
                   ? 'bg-gradient-to-br from-emerald-50 via-teal-50 to-cyan-50 border-emerald-200/60'

--- a/apps/web/components/Objects/Modals/Activities/Assignments/EditAssignmentModal.tsx
+++ b/apps/web/components/Objects/Modals/Activities/Assignments/EditAssignmentModal.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { updateAssignment } from '@services/courses/assignments';
+import {
+    deleteAssignmentSolutionFile,
+    updateAssignment,
+    updateAssignmentSolutionFile,
+} from '@services/courses/assignments';
 import { useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/query/keys';
 import toast from 'react-hot-toast';
@@ -30,9 +34,16 @@ import {
     RotateCcw,
     Target,
     Infinity as InfinityIcon,
+    ClipboardCheck,
+    BookOpenCheck,
+    Lock,
+    Paperclip,
+    Trash2,
+    Upload,
 } from 'lucide-react';
 
 type GradingType = 'ALPHABET' | 'NUMERIC' | 'PERCENTAGE' | 'PASS_FAIL' | 'GPA_SCALE';
+type SolutionReveal = 'NEVER' | 'ON_SUBMISSION' | 'AFTER_GRADING';
 
 interface Assignment {
     assignment_uuid: string;
@@ -46,6 +57,10 @@ interface Assignment {
     allow_retries?: boolean;
     max_retries?: number;
     pass_threshold_percentage?: number | null;
+    ungraded?: boolean;
+    solution?: string | null;
+    solution_file?: string | null;
+    solution_reveal?: SolutionReveal;
     assignment_tasks?: any[];
 }
 
@@ -146,6 +161,11 @@ const EditAssignmentForm: React.FC<EditAssignmentFormProps> = ({
         (t: any) => t.assignment_type === 'FILE_SUBMISSION'
     );
 
+    // The corrigé document is staged locally and only sent on save, so a
+    // teacher who cancels the modal doesn't leave a half-applied change behind.
+    const [solutionFile, setSolutionFile] = React.useState<File | null>(null);
+    const [removeSolutionFile, setRemoveSolutionFile] = React.useState(false);
+
     const formik = useFormik({
         initialValues: {
             title: assignment.title || '',
@@ -172,6 +192,10 @@ const EditAssignmentForm: React.FC<EditAssignmentFormProps> = ({
                 typeof assignment.pass_threshold_percentage === 'number'
                     ? assignment.pass_threshold_percentage
                     : '',
+            // Formative mode: the assignment is handed in but never marked.
+            ungraded: assignment.ungraded || false,
+            solution: assignment.solution || '',
+            solution_reveal: (assignment.solution_reveal || 'NEVER') as SolutionReveal,
         },
         enableReinitialize: true,
         onSubmit: async (values, { setSubmitting }) => {
@@ -188,6 +212,19 @@ const EditAssignmentForm: React.FC<EditAssignmentFormProps> = ({
             // Clearing the date means "no deadline". Send null, not the empty
             // string the input clears itself to, so the column reads as unset.
             payload.due_date = values.due_date || null;
+            // Formative mode owns the grading switches: an ungraded assignment
+            // never auto-grades and has no answer key to reveal, so send the
+            // consistent state rather than leaving stale flags in the DB that
+            // would resurface if the teacher turns grading back on.
+            if (payload.ungraded) {
+                payload.auto_grading = false;
+                payload.show_correct_answers = false;
+                // AFTER_GRADING can never fire on something that is never
+                // graded — fall back to unlocking on hand-in.
+                if (payload.solution_reveal === 'AFTER_GRADING') {
+                    payload.solution_reveal = 'ON_SUBMISSION';
+                }
+            }
             // Blank -> null (fall back to the default); otherwise clamp to 0-100.
             payload.pass_threshold_percentage =
                 values.pass_threshold_percentage === '' ||
@@ -198,6 +235,25 @@ const EditAssignmentForm: React.FC<EditAssignmentFormProps> = ({
             try {
                 const res = await updateAssignment(payload, assignment.assignment_uuid, accessToken);
                 if (res.success) {
+                    // The corrigé document lives behind its own endpoint (it is a
+                    // file upload), so it is applied after the field update and
+                    // only when the teacher actually staged a change.
+                    if (removeSolutionFile) {
+                        await deleteAssignmentSolutionFile(assignment.assignment_uuid, accessToken);
+                    } else if (solutionFile) {
+                        const fileRes = await updateAssignmentSolutionFile(
+                            solutionFile,
+                            assignment.assignment_uuid,
+                            accessToken
+                        );
+                        if (!fileRes.success) {
+                            toast.error(
+                                t('dashboard.assignments.modals.edit.toasts.solution_file_error', {
+                                    defaultValue: "The model answer document couldn't be uploaded.",
+                                })
+                            );
+                        }
+                    }
                     queryClient.invalidateQueries({ queryKey: queryKeys.assignments.detail(assignment.assignment_uuid) });
                     toast.success(t('dashboard.assignments.modals.edit.toasts.success'));
                     onClose();
@@ -282,7 +338,18 @@ const EditAssignmentForm: React.FC<EditAssignmentFormProps> = ({
                 </p>
             </Form.Field>
 
+            {/* Formative mode. Deliberately above the grading settings: turning
+                it on removes most of them, so the teacher sees the cause before
+                the effect. */}
+            <UngradedRow
+                checked={formik.values.ungraded}
+                onChange={(v) => formik.setFieldValue('ungraded', v, true)}
+                label={t('dashboard.assignments.modals.edit.form.ungraded_label', { defaultValue: 'Formative — no grading' })}
+                description={t('dashboard.assignments.modals.edit.form.ungraded_description', { defaultValue: 'Learners hand their work in and it is never marked. No score, no pass or fail — pair it with a model answer below for self-assessment.' })}
+            />
+
             {/* Grading type */}
+            {!formik.values.ungraded && (
             <div className="space-y-2">
                 <div className="flex items-center justify-between">
                     <p className={labelClass}>
@@ -328,6 +395,7 @@ const EditAssignmentForm: React.FC<EditAssignmentFormProps> = ({
                     })}
                 </div>
             </div>
+            )}
 
             {/* Grading options */}
             <div className="space-y-2">
@@ -340,6 +408,7 @@ const EditAssignmentForm: React.FC<EditAssignmentFormProps> = ({
                     </p>
                 </div>
                 <div className="space-y-2">
+                    {!formik.values.ungraded && (
                     <ToggleRow
                         icon={<Zap size={16} className="text-amber-500" />}
                         label={t('dashboard.assignments.modals.edit.form.auto_grading_label')}
@@ -353,6 +422,7 @@ const EditAssignmentForm: React.FC<EditAssignmentFormProps> = ({
                         onChange={(v) => formik.setFieldValue('auto_grading', v, true)}
                         warning={hasFileSubmissionTask}
                     />
+                    )}
                     <ToggleRow
                         icon={<Shield size={16} className="text-cyan-500" />}
                         label={t('dashboard.assignments.modals.edit.form.anti_copy_paste_label')}
@@ -360,6 +430,7 @@ const EditAssignmentForm: React.FC<EditAssignmentFormProps> = ({
                         checked={formik.values.anti_copy_paste}
                         onChange={(v) => formik.setFieldValue('anti_copy_paste', v, true)}
                     />
+                    {!formik.values.ungraded && (
                     <ToggleRow
                         icon={<Eye size={16} className="text-indigo-500" />}
                         label={t('dashboard.assignments.modals.edit.form.show_correct_answers_label')}
@@ -367,17 +438,28 @@ const EditAssignmentForm: React.FC<EditAssignmentFormProps> = ({
                         checked={formik.values.show_correct_answers}
                         onChange={(v) => formik.setFieldValue('show_correct_answers', v, true)}
                     />
+                    )}
                     <RetryRow
                         allowRetries={formik.values.allow_retries}
                         maxRetries={formik.values.max_retries}
                         onAllowChange={(v) => formik.setFieldValue('allow_retries', v, true)}
                         onMaxChange={(n) => formik.setFieldValue('max_retries', n, true)}
                         labelAllow={t('dashboard.assignments.modals.edit.form.allow_retries_label')}
-                        descriptionAllow={t('dashboard.assignments.modals.edit.form.allow_retries_description')}
+                        descriptionAllow={
+                            // The default copy says retries happen "after it's
+                            // graded", which never comes true in formative mode.
+                            formik.values.ungraded
+                                ? t('dashboard.assignments.modals.edit.form.allow_retries_description_ungraded', {
+                                      defaultValue:
+                                          'Let learners reset and hand the assignment in again. Each retry wipes their previous work and re-locks the model answer.',
+                                  })
+                                : t('dashboard.assignments.modals.edit.form.allow_retries_description')
+                        }
                         labelMax={t('dashboard.assignments.modals.edit.form.max_retries_label')}
                         helperUnlimited={t('dashboard.assignments.modals.edit.form.max_retries_unlimited')}
                         helperBounded={t('dashboard.assignments.modals.edit.form.max_retries_bounded')}
                     />
+                    {!formik.values.ungraded && (
                     <PassThresholdRow
                         value={formik.values.pass_threshold_percentage}
                         onChange={(v) => formik.setFieldValue('pass_threshold_percentage', v, true)}
@@ -385,8 +467,28 @@ const EditAssignmentForm: React.FC<EditAssignmentFormProps> = ({
                         description={t('dashboard.assignments.modals.edit.form.pass_threshold_description', { defaultValue: 'Minimum score to pass. Leave blank to use the default (50%, or 60% for letter grades).' })}
                         placeholder={t('dashboard.assignments.modals.edit.form.pass_threshold_placeholder', { defaultValue: 'Auto' })}
                     />
+                    )}
                 </div>
             </div>
+
+            {/* Model answer ("corrigé") */}
+            <SolutionSection
+                ungraded={formik.values.ungraded}
+                solution={formik.values.solution}
+                onSolutionChange={(v) => formik.setFieldValue('solution', v, true)}
+                reveal={formik.values.solution_reveal}
+                onRevealChange={(v) => formik.setFieldValue('solution_reveal', v, true)}
+                currentFileName={removeSolutionFile ? null : assignment.solution_file ?? null}
+                stagedFile={solutionFile}
+                onStageFile={(f) => {
+                    setSolutionFile(f);
+                    setRemoveSolutionFile(false);
+                }}
+                onRemoveFile={() => {
+                    setSolutionFile(null);
+                    setRemoveSolutionFile(true);
+                }}
+            />
 
             <div className="flex justify-end space-x-3">
                 <button
@@ -436,6 +538,220 @@ const EditAssignmentModal: React.FC<EditAssignmentModalProps> = ({
         />
     );
 };
+
+// Formative mode gets its own card rather than a row in the grading options
+// list: switching it on removes most of that list, so it needs to read as the
+// decision it is, not as one more checkbox inside what it disables.
+function UngradedRow({
+    checked,
+    onChange,
+    label,
+    description,
+}: {
+    checked: boolean;
+    onChange: (_next: boolean) => void;
+    label: string;
+    description: string;
+}) {
+    return (
+        <div className={`flex items-start justify-between gap-3 p-3.5 rounded-xl border nice-shadow transition-colors ${
+            checked ? 'bg-teal-50/70 border-teal-200' : 'bg-white border-gray-100'
+        }`}>
+            <div className="flex items-start gap-2.5 flex-1 min-w-0">
+                <div className="mt-0.5 flex-none">
+                    <ClipboardCheck size={17} className={checked ? 'text-teal-600' : 'text-gray-400'} />
+                </div>
+                <div className="flex flex-col min-w-0">
+                    <p className="text-xs font-bold text-gray-900">{label}</p>
+                    <p className="text-[10px] text-gray-500 leading-snug mt-0.5">{description}</p>
+                </div>
+            </div>
+            <button
+                type="button"
+                onClick={() => onChange(!checked)}
+                aria-pressed={checked}
+                aria-label={label}
+                className={`relative flex-none inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+                    checked ? 'bg-teal-600' : 'bg-gray-200 hover:bg-gray-300'
+                }`}
+            >
+                <span
+                    className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${
+                        checked ? 'translate-x-5 rtl:-translate-x-5' : 'translate-x-1 rtl:-translate-x-1'
+                    }`}
+                />
+            </button>
+        </div>
+    );
+}
+
+// The model answer ("corrigé"): free text plus an optional document, and the
+// rule that decides when a learner may read either. The API enforces that rule
+// server-side — this form only chooses it.
+function SolutionSection({
+    ungraded,
+    solution,
+    onSolutionChange,
+    reveal,
+    onRevealChange,
+    currentFileName,
+    stagedFile,
+    onStageFile,
+    onRemoveFile,
+}: {
+    ungraded: boolean;
+    solution: string;
+    onSolutionChange: (_v: string) => void;
+    reveal: SolutionReveal;
+    onRevealChange: (_v: SolutionReveal) => void;
+    currentFileName: string | null;
+    stagedFile: File | null;
+    onStageFile: (_f: File) => void;
+    onRemoveFile: () => void;
+}) {
+    const { t } = useTranslation();
+    const fileInputRef = React.useRef<HTMLInputElement | null>(null);
+
+    // AFTER_GRADING can never fire on an assignment that is never graded, so it
+    // is dropped from the choices in formative mode instead of offering a
+    // setting that would silently never unlock.
+    const revealOptions: { value: SolutionReveal; label: string; hint: string; icon: React.ReactNode }[] = [
+        {
+            value: 'NEVER',
+            label: t('dashboard.assignments.modals.edit.form.solution_reveal_never', { defaultValue: 'Never' }),
+            hint: t('dashboard.assignments.modals.edit.form.solution_reveal_never_hint', { defaultValue: 'Kept for you only' }),
+            icon: <Lock size={14} />,
+        },
+        {
+            value: 'ON_SUBMISSION',
+            label: t('dashboard.assignments.modals.edit.form.solution_reveal_on_submission', { defaultValue: 'On hand-in' }),
+            hint: t('dashboard.assignments.modals.edit.form.solution_reveal_on_submission_hint', { defaultValue: 'Unlocks the moment they submit' }),
+            icon: <BookOpenCheck size={14} />,
+        },
+        ...(ungraded
+            ? []
+            : [
+                  {
+                      value: 'AFTER_GRADING' as SolutionReveal,
+                      label: t('dashboard.assignments.modals.edit.form.solution_reveal_after_grading', { defaultValue: 'After grading' }),
+                      hint: t('dashboard.assignments.modals.edit.form.solution_reveal_after_grading_hint', { defaultValue: 'Unlocks once marked' }),
+                      icon: <Check size={14} />,
+                  },
+              ]),
+    ];
+    const effectiveReveal: SolutionReveal =
+        ungraded && reveal === 'AFTER_GRADING' ? 'ON_SUBMISSION' : reveal;
+
+    return (
+        <div className="space-y-2">
+            <div className="flex items-center justify-between">
+                <p className={labelClass}>
+                    {t('dashboard.assignments.modals.edit.form.solution_label', { defaultValue: 'Model answer' })}
+                </p>
+                <p className="text-[10px] text-gray-400">
+                    {t('dashboard.assignments.modals.edit.form.solution_hint', { defaultValue: 'Shown to learners only once unlocked' })}
+                </p>
+            </div>
+
+            <div className="rounded-xl border border-gray-100 bg-white nice-shadow overflow-hidden">
+                <div className="p-3 space-y-3">
+                    <textarea
+                        value={solution}
+                        onChange={(e) => onSolutionChange(e.target.value)}
+                        rows={4}
+                        placeholder={t('dashboard.assignments.modals.edit.form.solution_placeholder', {
+                            defaultValue: 'Write the worked solution learners should compare their work against…',
+                        })}
+                        className={textareaClass}
+                    />
+
+                    {/* Attached corrigé document */}
+                    <div className="flex items-center justify-between gap-3">
+                        <div className="flex items-center gap-2 min-w-0">
+                            <Paperclip size={14} className="text-gray-400 flex-none" />
+                            {stagedFile ? (
+                                <p className="text-[11px] font-semibold text-gray-700 truncate">
+                                    {stagedFile.name}
+                                </p>
+                            ) : currentFileName ? (
+                                <p className="text-[11px] font-semibold text-gray-700 truncate">
+                                    {currentFileName}
+                                </p>
+                            ) : (
+                                <p className="text-[11px] text-gray-400">
+                                    {t('dashboard.assignments.modals.edit.form.solution_no_file', { defaultValue: 'No document attached' })}
+                                </p>
+                            )}
+                        </div>
+                        <div className="flex items-center gap-1.5 flex-none">
+                            {(stagedFile || currentFileName) && (
+                                <button
+                                    type="button"
+                                    onClick={onRemoveFile}
+                                    className="inline-flex items-center gap-1 h-7 px-2 rounded-md text-[10px] font-bold uppercase tracking-wider text-rose-700 bg-rose-50 hover:bg-rose-100 transition-colors"
+                                >
+                                    <Trash2 size={12} />
+                                    {t('dashboard.assignments.modals.edit.form.solution_remove_file', { defaultValue: 'Remove' })}
+                                </button>
+                            )}
+                            <button
+                                type="button"
+                                onClick={() => fileInputRef.current?.click()}
+                                className="inline-flex items-center gap-1 h-7 px-2 rounded-md text-[10px] font-bold uppercase tracking-wider text-gray-700 bg-gray-100 hover:bg-gray-200 transition-colors"
+                            >
+                                <Upload size={12} />
+                                {t('dashboard.assignments.modals.edit.form.solution_upload_file', { defaultValue: 'Attach' })}
+                            </button>
+                            <input
+                                ref={fileInputRef}
+                                type="file"
+                                className="hidden"
+                                onChange={(e) => {
+                                    const f = e.target.files?.[0];
+                                    if (f) onStageFile(f);
+                                    // Reset so re-picking the same file still fires onChange.
+                                    e.target.value = '';
+                                }}
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                {/* Reveal rule */}
+                <div className="border-t border-gray-100 px-3 py-3 bg-gray-50/50 space-y-2">
+                    <p className="text-[11px] font-semibold text-gray-700">
+                        {t('dashboard.assignments.modals.edit.form.solution_reveal_label', { defaultValue: 'Unlock the model answer' })}
+                    </p>
+                    <div className={`grid gap-2 ${revealOptions.length === 3 ? 'grid-cols-3' : 'grid-cols-2'}`}>
+                        {revealOptions.map((opt) => {
+                            const isSelected = effectiveReveal === opt.value;
+                            return (
+                                <button
+                                    key={opt.value}
+                                    type="button"
+                                    onClick={() => onRevealChange(opt.value)}
+                                    className={`flex flex-col items-start gap-1 p-2.5 rounded-lg border text-start transition-colors ${
+                                        isSelected
+                                            ? 'bg-teal-50 border-teal-300'
+                                            : 'bg-white border-gray-200 hover:bg-gray-50'
+                                    }`}
+                                >
+                                    <span className={isSelected ? 'text-teal-600' : 'text-gray-400'}>
+                                        {opt.icon}
+                                    </span>
+                                    <span className={`text-[11px] font-bold ${isSelected ? 'text-gray-900' : 'text-gray-600'}`}>
+                                        {opt.label}
+                                    </span>
+                                    <span className="text-[10px] text-gray-400 leading-tight">{opt.hint}</span>
+                                </button>
+                            );
+                        })}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
 
 function ToggleRow({
     icon,

--- a/apps/web/components/Objects/Modals/Activities/Create/NewActivityModal/AssignmentActivityModal.tsx
+++ b/apps/web/components/Objects/Modals/Activities/Create/NewActivityModal/AssignmentActivityModal.tsx
@@ -25,6 +25,7 @@ import {
   Eye,
   RotateCcw,
   Infinity as InfinityIcon,
+  ClipboardCheck,
 } from 'lucide-react'
 
 function NewAssignment({ submitActivity: _submitActivity, chapterId, course, closeModal }: any) {
@@ -48,6 +49,9 @@ function NewAssignment({ submitActivity: _submitActivity, chapterId, course, clo
   const [showCorrectAnswers, setShowCorrectAnswers] = React.useState(false)
   const [allowRetries, setAllowRetries] = React.useState(false)
   const [maxRetries, setMaxRetries] = React.useState(0)
+  // Formative mode: handed in, never marked. The model answer that pairs with
+  // it is authored afterwards in the assignment editor.
+  const [ungraded, setUngraded] = React.useState(false)
 
   const handleSubmit = async (e: any) => {
     e.preventDefault()
@@ -75,9 +79,12 @@ function NewAssignment({ submitActivity: _submitActivity, chapterId, course, clo
         // column reads as unset instead of as a value nothing can parse.
         due_date: dueDate || null,
         grading_type: gradingType,
-        auto_grading: autoGrading,
+        ungraded: ungraded,
+        // An ungraded assignment never auto-grades and has no answer key to
+        // reveal — send the consistent state instead of dead flags.
+        auto_grading: ungraded ? false : autoGrading,
         anti_copy_paste: antiCopyPaste,
-        show_correct_answers: showCorrectAnswers,
+        show_correct_answers: ungraded ? false : showCorrectAnswers,
         allow_retries: allowRetries,
         max_retries: allowRetries ? maxRetries : 0,
         course_id: course?.courseStructure.id,
@@ -211,7 +218,9 @@ function NewAssignment({ submitActivity: _submitActivity, chapterId, course, clo
         </Form.Field>
       </div>
 
-      {/* Grading type */}
+      {/* Grading type — irrelevant on a formative assignment, which never
+          produces a grade to display in any scale. */}
+      {!ungraded && (
       <div className="rounded-xl nice-shadow p-4 space-y-3">
         <div className="flex items-center justify-between">
           <p className="text-sm font-medium text-gray-700">
@@ -227,6 +236,7 @@ function NewAssignment({ submitActivity: _submitActivity, chapterId, course, clo
           translationPrefix="dashboard.assignments.modals.create.form"
         />
       </div>
+      )}
 
       {/* Grading options */}
       <div className="rounded-xl nice-shadow p-4 space-y-3">
@@ -240,12 +250,21 @@ function NewAssignment({ submitActivity: _submitActivity, chapterId, course, clo
         </div>
         <div className="space-y-2">
           <SmallToggleRow
+            icon={<ClipboardCheck size={16} className="text-teal-500" />}
+            label={t('dashboard.assignments.modals.edit.form.ungraded_label', { defaultValue: 'Formative — no grading' })}
+            description={t('dashboard.assignments.modals.create.form.ungraded_description', { defaultValue: 'Learners hand their work in and it is never marked. Add a model answer in the assignment editor to unlock on hand-in.' })}
+            checked={ungraded}
+            onChange={setUngraded}
+          />
+          {!ungraded && (
+          <SmallToggleRow
             icon={<Zap size={16} className="text-amber-500" />}
             label={t('dashboard.assignments.modals.create.form.auto_grading_label')}
             description={t('dashboard.assignments.modals.create.form.auto_grading_description')}
             checked={autoGrading}
             onChange={setAutoGrading}
           />
+          )}
           <SmallToggleRow
             icon={<Shield size={16} className="text-cyan-500" />}
             label={t('dashboard.assignments.modals.create.form.anti_copy_paste_label')}
@@ -253,6 +272,7 @@ function NewAssignment({ submitActivity: _submitActivity, chapterId, course, clo
             checked={antiCopyPaste}
             onChange={setAntiCopyPaste}
           />
+          {!ungraded && (
           <SmallToggleRow
             icon={<Eye size={16} className="text-indigo-500" />}
             label={t('dashboard.assignments.modals.create.form.show_correct_answers_label')}
@@ -260,6 +280,7 @@ function NewAssignment({ submitActivity: _submitActivity, chapterId, course, clo
             checked={showCorrectAnswers}
             onChange={setShowCorrectAnswers}
           />
+          )}
           <div className="rounded-xl border border-gray-100 bg-white overflow-hidden">
             <div className="flex items-start justify-between gap-3 p-3">
               <div className="flex items-start gap-2.5 flex-1 min-w-0">
@@ -271,7 +292,14 @@ function NewAssignment({ submitActivity: _submitActivity, chapterId, course, clo
                     {t('dashboard.assignments.modals.edit.form.allow_retries_label')}
                   </p>
                   <p className="text-[10px] text-gray-500 leading-snug mt-0.5">
-                    {t('dashboard.assignments.modals.edit.form.allow_retries_description')}
+                    {/* The default copy says retries happen "after it's graded",
+                        which never comes true in formative mode. */}
+                    {ungraded
+                      ? t('dashboard.assignments.modals.edit.form.allow_retries_description_ungraded', {
+                          defaultValue:
+                            'Let learners reset and hand the assignment in again. Each retry wipes their previous work and re-locks the model answer.',
+                        })
+                      : t('dashboard.assignments.modals.edit.form.allow_retries_description')}
                   </p>
                 </div>
               </div>

--- a/apps/web/locales/ar.json
+++ b/apps/web/locales/ar.json
@@ -1100,7 +1100,18 @@
     "no_task_submission_to_grade": "لم يرسل هذا الطالب ملفًا لهذه المهمة بعد.",
     "past_due": "انتهى الموعد النهائي",
     "past_due_description": "كان الموعد النهائي لهذا الواجب في {{date}}. لم يعد بالإمكان حفظ الإجابات أو إرسالها للتقييم.",
-    "past_due_title": "انتهى الموعد النهائي"
+    "past_due_title": "انتهى الموعد النهائي",
+    "ungraded_badge": "غير مُقيَّم",
+    "hand_in": "تسليم عملي",
+    "hand_in_title": "تسليم عملك",
+    "hand_in_confirm": "سيتم تسليم عملك إلى معلمك. لن يتم تقييمه بدرجة.",
+    "handed_in": "تم التسليم",
+    "solution_title": "الحل النموذجي",
+    "solution_download": "تنزيل الحل النموذجي",
+    "solution_locked_title": "الحل النموذجي مقفل",
+    "solution_locked_on_submission": "سلّم عملك ليُفتح الحل النموذجي على الفور.",
+    "solution_locked_after_grading": "يُفتح الحل النموذجي بعد تقييم عملك.",
+    "retry_assignment_confirm_ungraded": "ستتم إعادة تعيين تسليمك الحالي لتبدأ من جديد، وسيُقفل الحل النموذجي مجدداً حتى تسلّم المحاولة التالية."
   },
   "certificate": {
     "certificate": "الشهادة",
@@ -4146,7 +4157,11 @@
           "placeholder": "اكتب تعليقاً حول التسليم بشكل عام. سيراه الطالب بجانب درجته.",
           "hint": "اتركه فارغاً للإبقاء على أي ملاحظات سابقة دون تغيير."
         },
-        "truncated_warning": "يتم عرض أول {{max}} تسليمات فقط. بعض التسليمات غير مدرجة هنا."
+        "truncated_warning": "يتم عرض أول {{max}} تسليمات فقط. بعض التسليمات غير مدرجة هنا.",
+        "ungraded_title": "تكويني — غير مُقيَّم",
+        "ungraded_description": "يُسلَّم هذا الواجب للاطلاع فقط. لا تُسجَّل أي درجة.",
+        "download_to_grade": "نزّل الملف وقيّمه يدوياً، ثم أدخل الدرجة أعلاه",
+        "download_to_review": "نزّل الملف للاطلاع على ما سلّمه المتعلم."
       },
       "analytics": {
         "loading": "جارٍ تحميل التحليلات...",
@@ -4249,13 +4264,30 @@
             "max_retries_bounded": "إجمالي المحاولات المقيّمة (التقديم الأولي + إعادة المحاولات)",
             "pass_threshold_label": "حد النجاح",
             "pass_threshold_description": "أدنى درجة للنجاح. اتركه فارغًا لاستخدام القيمة الافتراضية (50%، أو 60% للتقديرات الحرفية).",
-            "pass_threshold_placeholder": "تلقائي"
+            "pass_threshold_placeholder": "تلقائي",
+            "ungraded_label": "تكويني — بدون تقييم",
+            "ungraded_description": "يسلّم المتعلمون أعمالهم دون أي تقييم بدرجة. لا درجة ولا نجاح أو رسوب — أرفق حلاً نموذجياً أدناه للتقييم الذاتي.",
+            "solution_label": "الحل النموذجي",
+            "solution_hint": "يظهر للمتعلمين بعد فتحه فقط",
+            "solution_placeholder": "اكتب الحل النموذجي الذي يقارن به المتعلمون عملهم…",
+            "solution_no_file": "لا يوجد مستند مرفق",
+            "solution_remove_file": "إزالة",
+            "solution_upload_file": "إرفاق",
+            "solution_reveal_label": "فتح الحل النموذجي",
+            "solution_reveal_never": "أبداً",
+            "solution_reveal_never_hint": "يبقى لك وحدك",
+            "solution_reveal_on_submission": "عند التسليم",
+            "solution_reveal_on_submission_hint": "يُفتح لحظة التسليم",
+            "solution_reveal_after_grading": "بعد التقييم",
+            "solution_reveal_after_grading_hint": "يُفتح بعد وضع الدرجة",
+            "allow_retries_description_ungraded": "السماح للمتعلمين بإعادة التسليم من جديد. كل محاولة تمحو العمل السابق وتُقفل الحل النموذجي مجدداً."
           },
           "toasts": {
             "updating": "جاري تحديث الواجب...",
             "success": "تم تحديث الواجب بنجاح",
             "error": "فشل تحديث الواجب",
-            "error_detail": "حدث خطأ أثناء تحديث الواجب"
+            "error_detail": "حدث خطأ أثناء تحديث الواجب",
+            "solution_file_error": "تعذّر رفع مستند الحل النموذجي."
           }
         },
         "create": {
@@ -4293,7 +4325,8 @@
             "grading_type_hint": "كيف تُعرض الدرجات على الطلاب",
             "grading_options_hint": "السلوك عند التسليم",
             "show_correct_answers_description": "بعد التقييم، يرى الطلاب الإجابات الصحيحة بجانب إجاباتهم.",
-            "show_correct_answers_label": "إظهار الإجابات الصحيحة بعد التقييم"
+            "show_correct_answers_label": "إظهار الإجابات الصحيحة بعد التقييم",
+            "ungraded_description": "يسلّم المتعلمون أعمالهم دون أي تقييم بدرجة. أضف حلاً نموذجياً في محرر الواجب ليُفتح عند التسليم."
           },
           "toasts": {
             "creating": "جاري إنشاء الواجب...",

--- a/apps/web/locales/en.json
+++ b/apps/web/locales/en.json
@@ -1535,7 +1535,18 @@
     "no_task_submission_to_grade": "This student has not submitted a file for this task yet.",
     "past_due": "Deadline passed",
     "past_due_description": "This assignment was due on {{date}}. Answers can no longer be saved or submitted for grading.",
-    "past_due_title": "Deadline passed"
+    "past_due_title": "Deadline passed",
+    "ungraded_badge": "Not graded",
+    "hand_in": "Hand in my work",
+    "hand_in_title": "Hand in your work",
+    "hand_in_confirm": "Your work will be handed in to your teacher. It is not graded.",
+    "handed_in": "Handed in",
+    "solution_title": "Model answer",
+    "solution_download": "Download the model answer",
+    "solution_locked_title": "Model answer locked",
+    "solution_locked_on_submission": "Hand your work in and the model answer unlocks right away.",
+    "solution_locked_after_grading": "The model answer unlocks once your work has been graded.",
+    "retry_assignment_confirm_ungraded": "Your current hand-in will be reset so you can start over, and the model answer locks again until you hand in the next attempt."
   },
   "certificate": {
     "certificate": "Certificate",
@@ -4581,7 +4592,11 @@
           "reject_success": "Assignment rejected successfully",
           "finalize_success": "Assignment graded and activity marked as complete"
         },
-        "truncated_warning": "Only the first {{max}} submissions are shown. Some submissions are not listed here."
+        "truncated_warning": "Only the first {{max}} submissions are shown. Some submissions are not listed here.",
+        "ungraded_title": "Formative — not graded",
+        "ungraded_description": "This assignment is handed in for review only. No score is recorded.",
+        "download_to_grade": "Please download the file and grade it manually, then input the grade above",
+        "download_to_review": "Download the file to review what the learner handed in."
       },
       "analytics": {
         "loading": "Loading analytics...",
@@ -4684,13 +4699,30 @@
             "saving": "Saving...",
             "pass_threshold_label": "Passing threshold",
             "pass_threshold_description": "Minimum score to pass. Leave blank to use the default (50%, or 60% for letter grades).",
-            "pass_threshold_placeholder": "Auto"
+            "pass_threshold_placeholder": "Auto",
+            "ungraded_label": "Formative — no grading",
+            "ungraded_description": "Learners hand their work in and it is never marked. No score, no pass or fail — pair it with a model answer below for self-assessment.",
+            "solution_label": "Model answer",
+            "solution_hint": "Shown to learners only once unlocked",
+            "solution_placeholder": "Write the worked solution learners should compare their work against…",
+            "solution_no_file": "No document attached",
+            "solution_remove_file": "Remove",
+            "solution_upload_file": "Attach",
+            "solution_reveal_label": "Unlock the model answer",
+            "solution_reveal_never": "Never",
+            "solution_reveal_never_hint": "Kept for you only",
+            "solution_reveal_on_submission": "On hand-in",
+            "solution_reveal_on_submission_hint": "Unlocks the moment they submit",
+            "solution_reveal_after_grading": "After grading",
+            "solution_reveal_after_grading_hint": "Unlocks once marked",
+            "allow_retries_description_ungraded": "Let learners reset and hand the assignment in again. Each retry wipes their previous work and re-locks the model answer."
           },
           "toasts": {
             "updating": "Updating assignment...",
             "success": "Assignment updated successfully",
             "error": "Failed to update assignment",
-            "error_detail": "An error occurred while updating the assignment"
+            "error_detail": "An error occurred while updating the assignment",
+            "solution_file_error": "The model answer document couldn't be uploaded."
           }
         },
         "create": {
@@ -4728,7 +4760,8 @@
             "anti_copy_paste_description": "Discourage pasting AI-generated answers by blocking paste events. Note: this is a deterrent — it can be bypassed.",
             "show_correct_answers_label": "Reveal correct answers after grading",
             "show_correct_answers_description": "Once graded, students see the right answers next to their own.",
-            "submit": "Create activity"
+            "submit": "Create activity",
+            "ungraded_description": "Learners hand their work in and it is never marked. Add a model answer in the assignment editor to unlock on hand-in."
           },
           "toasts": {
             "creating": "Creating assignment...",

--- a/apps/web/locales/fr.json
+++ b/apps/web/locales/fr.json
@@ -1038,7 +1038,18 @@
     "no_task_submission_to_grade": "Cet apprenant n’a pas encore envoyé de fichier pour cette tâche.",
     "past_due": "Date limite dépassée",
     "past_due_description": "La date limite de ce devoir était le {{date}}. Les réponses ne peuvent plus être enregistrées ni envoyées pour évaluation.",
-    "past_due_title": "Date limite dépassée"
+    "past_due_title": "Date limite dépassée",
+    "ungraded_badge": "Non noté",
+    "hand_in": "Déposer mon travail",
+    "hand_in_title": "Déposer votre travail",
+    "hand_in_confirm": "Votre travail sera transmis à votre formateur. Il n'est pas noté.",
+    "handed_in": "Déposé",
+    "solution_title": "Corrigé",
+    "solution_download": "Télécharger le corrigé",
+    "solution_locked_title": "Corrigé verrouillé",
+    "solution_locked_on_submission": "Déposez votre travail et le corrigé se débloque aussitôt.",
+    "solution_locked_after_grading": "Le corrigé se débloque une fois votre travail corrigé.",
+    "retry_assignment_confirm_ungraded": "Votre dépôt actuel sera réinitialisé pour recommencer, et le corrigé se reverrouille jusqu'au prochain dépôt."
   },
   "certificate": {
     "certificate": "Certificat",
@@ -3742,7 +3753,11 @@
           "placeholder": "Écrivez un commentaire sur l’ensemble de la soumission. L’étudiant le verra à côté de sa note.",
           "hint": "Laissez vide pour conserver tout commentaire précédent."
         },
-        "truncated_warning": "Seuls les {{max}} premiers travaux sont affichés. Certains travaux ne figurent pas ici."
+        "truncated_warning": "Seuls les {{max}} premiers travaux sont affichés. Certains travaux ne figurent pas ici.",
+        "ungraded_title": "Formatif — non noté",
+        "ungraded_description": "Ce devoir est déposé pour consultation uniquement. Aucune note n'est enregistrée.",
+        "download_to_grade": "Téléchargez le fichier, corrigez-le manuellement, puis saisissez la note ci-dessus",
+        "download_to_review": "Téléchargez le fichier pour consulter ce que l'apprenant a déposé."
       },
       "analytics": {
         "loading": "Chargement des analyses...",
@@ -3840,13 +3855,30 @@
             "allow_retries_description": "Permettez aux étudiants de réinitialiser et de relancer la tâche après qu'elle ait été notée. Chaque nouvelle tentative efface leurs réponses précédentes et compte comme une nouvelle tentative.",
             "max_retries_label": "Nombre maximum de tentatives",
             "max_retries_unlimited": "0 signifie un nombre illimité de tentatives",
-            "max_retries_bounded": "Nombre total de tentatives notées (soumission initiale + nouvelles tentatives)"
+            "max_retries_bounded": "Nombre total de tentatives notées (soumission initiale + nouvelles tentatives)",
+            "ungraded_label": "Formatif — sans notation",
+            "ungraded_description": "Les apprenants déposent leur travail et il n'est jamais noté. Aucun score, aucun seuil de réussite — associez-y un corrigé ci-dessous pour l'auto-évaluation.",
+            "solution_label": "Corrigé",
+            "solution_hint": "Visible par les apprenants une fois débloqué",
+            "solution_placeholder": "Rédigez le corrigé auquel les apprenants compareront leur travail…",
+            "solution_no_file": "Aucun document joint",
+            "solution_remove_file": "Retirer",
+            "solution_upload_file": "Joindre",
+            "solution_reveal_label": "Débloquer le corrigé",
+            "solution_reveal_never": "Jamais",
+            "solution_reveal_never_hint": "Réservé au formateur",
+            "solution_reveal_on_submission": "Au dépôt",
+            "solution_reveal_on_submission_hint": "Débloqué dès le dépôt",
+            "solution_reveal_after_grading": "Après notation",
+            "solution_reveal_after_grading_hint": "Débloqué une fois corrigé",
+            "allow_retries_description_ungraded": "Permettre aux apprenants de recommencer et de redéposer. Chaque nouvelle tentative efface le travail précédent et reverrouille le corrigé."
           },
           "toasts": {
             "updating": "Mise à jour du devoir...",
             "success": "Devoir mis à jour avec succès",
             "error": "Échec de la mise à jour du devoir",
-            "error_detail": "Une erreur s'est produite lors de la mise à jour du devoir"
+            "error_detail": "Une erreur s'est produite lors de la mise à jour du devoir",
+            "solution_file_error": "Le document du corrigé n'a pas pu être envoyé."
           }
         },
         "create": {
@@ -3882,7 +3914,8 @@
             "grading_type_hint": "Comment les notes sont affichées aux étudiants",
             "grading_options_hint": "Comportement à la soumission",
             "show_correct_answers_description": "Une fois noté, les étudiants voient les bonnes réponses à côté des leurs.",
-            "show_correct_answers_label": "Révéler les bonnes réponses après notation"
+            "show_correct_answers_label": "Révéler les bonnes réponses après notation",
+            "ungraded_description": "Les apprenants déposent leur travail et il n'est jamais noté. Ajoutez un corrigé dans l'éditeur pour le débloquer au dépôt."
           },
           "toasts": {
             "creating": "Création du devoir...",

--- a/apps/web/services/courses/assignments.ts
+++ b/apps/web/services/courses/assignments.ts
@@ -27,6 +27,39 @@ export async function updateAssignment(
   return res
 }
 
+// Model answer ("corrigé") document for the whole assignment. Instructor only —
+// the API withholds the stored filename from learners until the assignment's
+// reveal rule unlocks it.
+export async function updateAssignmentSolutionFile(
+  file: any,
+  assignmentUUID: string,
+  access_token: string
+) {
+  const formData = new FormData()
+
+  if (file) {
+    formData.append('solution_file', file)
+  }
+  const result: any = await fetch(
+    `${getAPIUrl()}assignments/${assignmentUUID}/solution_file`,
+    RequestBodyFormWithAuthHeader('POST', formData, null, access_token)
+  )
+  const res = await getResponseMetadata(result)
+  return res
+}
+
+export async function deleteAssignmentSolutionFile(
+  assignmentUUID: string,
+  access_token: string
+) {
+  const result: any = await fetch(
+    `${getAPIUrl()}assignments/${assignmentUUID}/solution_file`,
+    RequestBodyWithAuthHeader('DELETE', null, null, access_token)
+  )
+  const res = await getResponseMetadata(result)
+  return res
+}
+
 export async function getAssignmentFromActivityUUID(
   activityUUID: string,
   access_token: string

--- a/apps/web/services/media/media.ts
+++ b/apps/web/services/media/media.ts
@@ -220,6 +220,20 @@ export function getTaskRefFileDir(
   return uri
 }
 
+// The assignment-level model answer ("corrigé") document. Mirrors the task
+// reference-file layout but hangs off the assignment, matching
+// `upload_solution_file` on the API side.
+export function getAssignmentSolutionFileDir(
+  orgUUID: string,
+  courseUUID: string,
+  activityUUID: string,
+  assignmentUUID: string,
+  fileID: string
+) {
+  let uri = `${getMediaUrl()}content/orgs/${orgUUID}/courses/${courseUUID}/activities/${activityUUID}/assignments/${assignmentUUID}/solution/${fileID}`
+  return uri
+}
+
 export function getTaskFileSubmissionDir(
   orgUUID: string,
   courseUUID: string,

--- a/docs/content/platform/assignments/_meta.json
+++ b/docs/content/platform/assignments/_meta.json
@@ -1,4 +1,5 @@
 {
   "index": "Overview",
-  "grading": "Grading & Submissions"
+  "grading": "Grading & Submissions",
+  "formative": "Formative Assessment"
 }

--- a/docs/content/platform/assignments/formative.mdx
+++ b/docs/content/platform/assignments/formative.mdx
@@ -1,0 +1,62 @@
+import { Callout } from 'nextra/components'
+
+# Formative Assessment
+
+A formative assignment is handed in and never marked. There is no score, no
+pass/fail line, and no grading queue behind it — the learner deposits their
+work, and in return they get the **model answer** (the *corrigé*) to compare it
+against.
+
+It is the right shape for practice work: the point is the self-assessment, not
+the mark.
+
+## Turning it on
+
+In the assignment's **Edit** dialog:
+
+1. Switch on **Formative — no grading**. The grading scale, auto-grading,
+   answer-key reveal and passing threshold disappear, because none of them
+   apply any more.
+2. Write the **model answer**, and optionally attach a document (a PDF worked
+   solution, a marking rubric, an exemplar).
+3. Choose when it unlocks:
+   - **Never** — kept for you only.
+   - **On hand-in** — the learner gets it the moment they submit. This is the
+     formative loop.
+   - **After grading** — only once the work has been marked. Offered on graded
+     assignments only.
+
+<Callout>
+The model answer is withheld **server-side**, not just hidden in the interface.
+Until a learner's own submission satisfies the unlock rule, the assignment
+payload they receive contains no model answer at all — though it does say that
+one exists, so they know what handing in earns them.
+</Callout>
+
+## What the learner sees
+
+Before handing in, a **Model answer locked** panel explains what unlocks it.
+After handing in, the panel is replaced by the model answer itself (plus a
+download link when a document is attached) and the status reads **Handed in**,
+never "Grading in progress".
+
+Nothing anywhere shows a score.
+
+## What the teacher sees
+
+The submission still appears in the **Submissions** list, and opening it shows
+what was handed in — but with no grade banner, no per-task scores, and no
+grading actions. The API refuses to grade a formative assignment outright, so
+there is no way to accidentally put a mark on one.
+
+## Retries
+
+Retries work as usual, and the deadline still applies. On a formative
+assignment the model answer stays readable while attempts remain — there is no
+score to game by reading it — but a retry re-locks it until the next hand-in.
+
+## Certificates
+
+A formative assignment is satisfied by being handed in. It counts as complete
+for [course certification](/platform/courses/certifications) rather than
+blocking it forever waiting for a grade that will never come.

--- a/docs/content/platform/assignments/grading.mdx
+++ b/docs/content/platform/assignments/grading.mdx
@@ -38,3 +38,9 @@ Each submission moves through a clear set of states so teachers can see at a gla
 <Callout>
 Submissions are tied to the student's Trail, so all grading data contributes to the overall course progress view.
 </Callout>
+
+## Not grading at all
+
+An assignment can opt out of this workflow entirely. See
+[Formative Assessment](/platform/assignments/formative) — the learner hands work
+in, receives the model answer, and no grade is ever recorded.

--- a/docs/content/platform/assignments/index.mdx
+++ b/docs/content/platform/assignments/index.mdx
@@ -25,9 +25,11 @@ Leave it empty and the assignment simply stays open. That is what a self-paced c
 - **File uploads** — Students can attach files as part of their submission.
 - **Submission tracking** — Teachers see submission status for each student and task.
 - **Grading** — Grade individual tasks or entire assignments. Scores are recorded in the student's [Trail](/platform/courses/trails).
+- **Formative mode** — Skip grading entirely: the learner hands work in and immediately gets the model answer to self-assess against.
 
 ## Learn More
 
 - [Grading & Submissions](/platform/assignments/grading) — How the grading workflow works.
+- [Formative Assessment](/platform/assignments/formative) — Ungraded hand-ins that unlock a model answer.
 - [Headless Assignments](/developers/api/headless-assignments) — Drive assignments, custom tasks, submissions, and grading from your own frontend with an API token.
 - [Code Execution](/platform/code-execution) — Auto-graded code exercises are built into course content via the **Code Playground** editor block, not assignment tasks.


### PR DESCRIPTION
Adds a way to run assignments without grading, plus an optional model answer instructors can reveal on their own schedule.

- New `ungraded` flag on Assignment. Submissions settle on SUBMITTED and never reach GRADED; create/update forces `auto_grading` off when set.
- Every grading route (manual grade, auto-grade on submit, bulk regrade, grade read) rejects ungraded assignments with 400, via one shared check in `_apply_grade_and_finalize`.
- Certification accepts a handed-in ungraded assignment instead of waiting on a grade. Retries on ungraded work are allowed straight from SUBMITTED/LATE.
- Model answer support: `solution` text, an instructor-only file upload, and a `solution_reveal` setting (never / on submission / after grading). Read endpoints strip the solution until the reader's own submission unlocks it, exposing `has_solution`/`solution_unlocked` for a locked-state UI. Graded assignments withhold it during a retry; ungraded ones don't, since there's no score to protect.
- Migration adds the new columns plus a native enum for `solution_reveal`.
- Web: formative toggle and solution editor/upload in the assignment editor, locked/revealed solution card, hidden grade UI for students and teachers. en/ar/fr locales.
- Docs and 28 API tests covering reveal rules, all read paths, auto-grading override, certification, and retries. 2 Playwright specs not run in this pass.

Follow-up commit: the course assignment list endpoint was reachable with plain course READ and leaked raw solution fields. Gated it the same way as the other read paths, with tests.

Verified locally: ruff and eslint/tsc clean, new tests passing, locale parity green. Full API suite green except one pre-existing failure unrelated to this branch.

Reviewers, start at `_student_may_see_solution`, `_resolve_solution_visibility`, and `_apply_solution_visibility` in `apps/api/src/services/courses/activities/assignments.py`.